### PR TITLE
Update consensus_FAQ.md: Changed Text mentioning "Three" to "Two" algorithms

### DIFF
--- a/docs/FAQ/consensus_FAQ.md
+++ b/docs/FAQ/consensus_FAQ.md
@@ -2,4 +2,4 @@
 
 &nbsp;
 ##### Which Consensus Algorithm is used in the fabric? 
-The fabric is built on a pluggable architecture such that developers can configure their deployment with the consensus module that best suits their needs. The initial release package will offer three consensus implementations for users to select from: 1) No-op (consensus ignored); and 2) Batch PBFT.
+The fabric is built on a pluggable architecture such that developers can configure their deployment with the consensus module that best suits their needs. The initial release package will offer two consensus implementations for users to select from: 1) No-op (consensus ignored); and 2) Batch PBFT.


### PR DESCRIPTION
## Description

The text says that there are three consensus implementations but actually there are only two implementations as of now.
## Motivation and Context

The change improves the documentation.

Signed-off-by: Sumit Mehrotra sumit@sumitmehrotra.com
