### PR TITLE
Error removed from lines 175,177,182

### DIFF
--- a/orderer/solo/broadcast.go
+++ b/orderer/solo/broadcast.go
@@ -172,14 +172,14 @@ func (b *broadcaster) queueBroadcastMessages(srv ab.AtomicBroadcast_BroadcastSer
 		case broadcastfilter.Accept:
 			select {
 			case b.queue <- msg:
-				err = srv.Send(&ab.BroadcastResponse{ab.Status_SUCCESS})
+				err = srv.Send(&ab.BroadcastResponse{Status: ab.Status_SUCCESS})
 			default:
-				err = srv.Send(&ab.BroadcastResponse{ab.Status_SERVICE_UNAVAILABLE})
+				err = srv.Send(&ab.BroadcastResponse{Status: ab.Status_SERVICE_UNAVAILABLE})
 			}
 		case broadcastfilter.Forward:
 			fallthrough
 		case broadcastfilter.Reject:
-			err = srv.Send(&ab.BroadcastResponse{ab.Status_BAD_REQUEST})
+			err = srv.Send(&ab.BroadcastResponse{Status: ab.Status_BAD_REQUEST})
 		default:
 			logger.Fatalf("Unknown filter action :%v", action)
 		}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #

## How Has This Been Tested?
<!-- If this PR does not contain a new test case, explain why. -->
<!-- Describe in detail how you tested your changes. -->

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:

Error was : 'composite literal uses unkeyed fields'