### PR TITLE
Error from multiple lines removed.

### DIFF
--- a/orderer/solo/broadcast_test.go
+++ b/orderer/solo/broadcast_test.go
@@ -208,7 +208,7 @@ func TestBatchTimer(t *testing.T) {
 	defer bs.halt()
 	it, _ := rl.Iterator(ab.SeekInfo_SPECIFIED, 1)
 
-	bs.sendChan <- &ab.BroadcastMessage{[]byte("Some bytes")}
+	bs.sendChan <- &ab.BroadcastMessage{Data: []byte("Some bytes")}
 
 	select {
 	case <-it.ReadyChan():
@@ -248,10 +248,10 @@ func TestReconfigureGoodPath(t *testing.T) {
 		close(done)
 	}()
 
-	bs.sendChan <- &ab.BroadcastMessage{[]byte("Msg1")}
-	bs.sendChan <- &ab.BroadcastMessage{configTx}
-	bs.sendChan <- &ab.BroadcastMessage{[]byte("Msg2")}
-	bs.sendChan <- &ab.BroadcastMessage{[]byte("Msg3")}
+	bs.sendChan <- &ab.BroadcastMessage{Data: []byte("Msg1")}
+	bs.sendChan <- &ab.BroadcastMessage{Data: configTx}
+	bs.sendChan <- &ab.BroadcastMessage{Data: []byte("Msg2")}
+	bs.sendChan <- &ab.BroadcastMessage{Data: []byte("Msg3")}
 
 	bs.halt()
 	<-done
@@ -280,9 +280,9 @@ func TestReconfigureFailToValidate(t *testing.T) {
 		close(done)
 	}()
 
-	bs.sendChan <- &ab.BroadcastMessage{[]byte("Msg1")}
-	bs.sendChan <- &ab.BroadcastMessage{configTx}
-	bs.sendChan <- &ab.BroadcastMessage{[]byte("Msg2")}
+	bs.sendChan <- &ab.BroadcastMessage{Data: []byte("Msg1")}
+	bs.sendChan <- &ab.BroadcastMessage{Data: configTx}
+	bs.sendChan <- &ab.BroadcastMessage{Data: []byte("Msg2")}
 
 	bs.halt()
 	<-done
@@ -311,9 +311,9 @@ func TestReconfigureFailToApply(t *testing.T) {
 		close(done)
 	}()
 
-	bs.sendChan <- &ab.BroadcastMessage{[]byte("Msg1")}
-	bs.sendChan <- &ab.BroadcastMessage{configTx}
-	bs.sendChan <- &ab.BroadcastMessage{[]byte("Msg2")}
+	bs.sendChan <- &ab.BroadcastMessage{Data: []byte("Msg1")}
+	bs.sendChan <- &ab.BroadcastMessage{Data: configTx}
+	bs.sendChan <- &ab.BroadcastMessage{Data: []byte("Msg2")}
 
 	bs.halt()
 	<-done


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail. -->
go vet ./orderer/... was giving error of Following:
Makefile:107: recipe for target 'linter' failed
After exit status 1.
This happened mainly because structure is defined with a name Status, which was not used while calling it. Thus generating an error. I've attached the error
<img width="812" alt="capture" src="https://cloud.githubusercontent.com/assets/19235748/20033316/b20681c6-a3c3-11e6-84e3-48f0dc703c51.PNG">


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
After the change, if run smoothly.
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #

## How Has This Been Tested?
<!-- If this PR does not contain a new test case, explain why. -->
<!-- Describe in detail how you tested your changes. -->

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:

Error was : composite literal uses unkeyed fields