### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/orderer/kafka/broker_test.go
+++ b/orderer/kafka/broker_test.go
@@ -16,13 +16,16 @@ limitations under the License.
 
 package kafka
 
-import "testing"
+import (
+	"testing"
 
-/* Disabling this until the upgrade to Go 1.7 kicks in
+	"github.com/Shopify/sarama"
+)
+
 func TestBrokerGetOffset(t *testing.T) {
 	t.Run("oldest", testBrokerGetOffsetFunc(sarama.OffsetOldest, oldestOffset))
 	t.Run("newest", testBrokerGetOffsetFunc(sarama.OffsetNewest, newestOffset))
-} */
+}
 
 func testBrokerGetOffsetFunc(given, expected int64) func(t *testing.T) {
 	return func(t *testing.T) {

--- a/orderer/kafka/client_deliver_test.go
+++ b/orderer/kafka/client_deliver_test.go
@@ -23,13 +23,12 @@ import (
 	ab "github.com/hyperledger/fabric/protos/orderer"
 )
 
-/* Disabling this until the upgrade to Go 1.7 kicks in
 func TestClientDeliverSeekWrong(t *testing.T) {
 	t.Run("out-of-range-1", testClientDeliverSeekWrongFunc(uint64(oldestOffset)-1, 10))
 	t.Run("out-of-range-2", testClientDeliverSeekWrongFunc(uint64(newestOffset), 10))
 	t.Run("bad-window-1", testClientDeliverSeekWrongFunc(uint64(oldestOffset), 0))
 	t.Run("bad-window-2", testClientDeliverSeekWrongFunc(uint64(oldestOffset), uint64(testConf.General.MaxWindowSize+1)))
-} */
+}
 
 func testClientDeliverSeekWrongFunc(seek, window uint64) func(t *testing.T) {
 	return func(t *testing.T) {
@@ -64,12 +63,11 @@ func testClientDeliverSeekWrongFunc(seek, window uint64) func(t *testing.T) {
 	}
 }
 
-/* Disabling this until the upgrade to Go 1.7 kicks in
 func TestClientDeliverSeek(t *testing.T) {
 	t.Run("oldest", testClientDeliverSeekFunc("oldest", 0, 10, 10))
 	t.Run("in-between", testClientDeliverSeekFunc("specific", uint64(middleOffset), 10, 10))
 	t.Run("newest", testClientDeliverSeekFunc("newest", 0, 10, 1))
-} */
+}
 
 func testClientDeliverSeekFunc(label string, seek, window uint64, expected int) func(*testing.T) {
 	return func(t *testing.T) {
@@ -105,11 +103,10 @@ func testClientDeliverSeekFunc(label string, seek, window uint64, expected int) 
 	}
 }
 
-/* Disabling this until the upgrade to Go 1.7 kicks in
 func TestClientDeliverAckWrong(t *testing.T) {
 	t.Run("out-of-range-ack-1", testClientDeliverAckWrongFunc(uint64(middleOffset)-2))
 	t.Run("out-of-range-ack-2", testClientDeliverAckWrongFunc(uint64(newestOffset)))
-} */
+}
 
 func testClientDeliverAckWrongFunc(ack uint64) func(t *testing.T) {
 	return func(t *testing.T) {
@@ -143,11 +140,10 @@ func testClientDeliverAckWrongFunc(ack uint64) func(t *testing.T) {
 	}
 }
 
-/* Disabling this until the upgrade to Go 1.7 kicks in
 func TestClientDeliverAck(t *testing.T) {
 	t.Run("in-between", testClientDeliverAckFunc("specific", uint64(middleOffset), 10, 10, 2*10))
 	t.Run("newest", testClientDeliverAckFunc("newest", 0, 10, 1, 1))
-} */
+}
 
 func testClientDeliverAckFunc(label string, seek, window uint64, threshold, expected int) func(t *testing.T) {
 	return func(t *testing.T) {

--- a/orderer/kafka/consumer_test.go
+++ b/orderer/kafka/consumer_test.go
@@ -30,12 +30,11 @@ func TestConsumerInitWrong(t *testing.T) {
 	}
 }
 
-/* Disabling this until the upgrade to Go 1.7 kicks in
 func TestConsumerRecv(t *testing.T) {
 	t.Run("oldest", testConsumerRecvFunc(oldestOffset, oldestOffset))
 	t.Run("in-between", testConsumerRecvFunc(middleOffset, middleOffset))
 	t.Run("newest", testConsumerRecvFunc(newestOffset-1, newestOffset-1))
-} */
+}
 
 func testConsumerRecvFunc(given, expected int64) func(t *testing.T) {
 	return func(t *testing.T) {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.