### PR TITLE
Updated Broken link for code of conduct in Readme.md File

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Full details of how to contribute to this project are documented [here](http://h
 
 [Hyperledger Wiki](https://github.com/hyperledger/hyperledger/wiki)
 
-[Hyperledger Code of Conduct](https://github.com/hyperledger/hyperledger/wiki/Hyperledger-Project-Code-of-Conduct)
+[Hyperledger Code of Conduct](https://wiki.hyperledger.org/community/hyperledger-project-code-of-conduct)
 
 [Community Calendar](https://github.com/hyperledger/hyperledger/wiki/PublicMeetingCalendar)
 


### PR DESCRIPTION
 #16
<!-- Fixed Broken link in Read me file for code of conduct -->

## Description
There was problem in readme.md file regarding the code of conduct hyperlink.
Previously this hyperlink was sending to some github from there another hyperlink was given so made it direct.

Fixes #
Update Readme.md file
## How Has This Been Tested?
No need to test

Signed-off-by:
[AKASH SETHI](https://github.com/akashsethi24)
