### PR TITLE
Typos in docs: fabric_model

### DIFF
--- a/docs/source/fabric_model.rst
+++ b/docs/source/fabric_model.rst
@@ -53,7 +53,7 @@ channel. Each peer maintains a copy of the ledger for each channel of which they
 - Prior to appending a block, a versioning check is performed to ensure that states for assets that were read have not changed since chaincode execution time
 - There is immutability once a transaction is validated and committed
 - A channel's ledger contains a configuration block defining policies, access control lists, and other pertinent information
-- Channel's contain :ref:`MSP`s allowing crypto materials to be derived from different certificate authorities
+- Channel's contain :doc:`MSP`s allowing crypto materials to be derived from different certificate authorities
 
 See the :doc:`ledger` topic for a deeper dive on the databases, storage structure, and "query-ability."  
 
@@ -75,7 +75,7 @@ Chaincode gets installed only on peers that need to access the asset states
 to perform reads and writes (in other words, if a chaincode is not installed on
 a peer, it will not be able to properly interface with the ledger).  To further
 obfuscate the data, values within chaincode can be encrypted (in part or in total) using common
-cryptographic algorithms such as SHA0-256, etc. before appending to the ledger.
+cryptographic algorithms such as SHA-256, etc. before appending to the ledger.
 
 .. _Security-Membership-Services:
 


### PR DESCRIPTION
The :ref:`MSP`s  doesnt parse.
There is no SHA0, only SHA-256.

<!-- Provide a general summary of your changes in the Title above -->
Small corrections.

## Description
<!-- Describe your changes in detail. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #

Typos.

## How Has This Been Tested?
<!-- If this PR does not contain a new test case, explain why. -->
<!-- Describe in detail how you tested your changes. -->

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:
