### PR TITLE
fix chaincode lock problem

### DIFF
--- a/core/chaincode/handler.go
+++ b/core/chaincode/handler.go
@@ -129,8 +129,8 @@ func (handler *Handler) createTxContext(txid string, tx *pb.Transaction) (*trans
 }
 
 func (handler *Handler) getTxContext(txid string) *transactionContext {
-	handler.Lock()
-	defer handler.Unlock()
+	handler.RLock()
+	defer handler.RUnlock()
 	return handler.txCtxs[txid]
 }
 
@@ -481,8 +481,8 @@ func (handler *Handler) markIsTransaction(txid string, isTrans bool) bool {
 }
 
 func (handler *Handler) getIsTransaction(txid string) bool {
-	handler.Lock()
-	defer handler.Unlock()
+	handler.RLock()
+	defer handler.RUnlock()
 	if handler.isTransaction == nil {
 		return false
 	}


### PR DESCRIPTION
Change-Id: I546c07101dcb0baefc63c943517be2c167c46db1

During the concurrency process of invoke and query, the gRPC service flow breaks in the chaincode module, resulting in an ERROR of “transport is closing” reported. And an exception “concurrent map read and map write” would be thrown in shim layer.
 
In the structs of Handler in shim, there is a variable “isTransaction” of type Map. This variable adds writing locks when taking inserting and deleting operation, while it does not add locks during the query operation, which results in exceptions thrown in the concurrency process of read and write. And writing locks are added in all the structs with type Map in the Handler of the chaincodes.

The solution to this problem is to add writing locks in the inserting and deleting operation and add reading locks in the query operation, during the operation of structs with type Map in the Handler in chaincode and shim.

Signed-off-by:  xiaojun  liao  <surgen@163.com>
