### PR TITLE
Explicitly set the version of the docker-compose.yml file to version '3'

### DIFF
--- a/unit-test/docker-compose.yml
+++ b/unit-test/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3'
 vp:
   image: hyperledger/fabric-peer
   log_driver: none


### PR DESCRIPTION
Explicitly set the version of the docker-compose.yml file to version '3'.
In order to fix bug mentioned at https://jira.hyperledger.org/browse/FAB-2789 

## Description
change : add the version number in docker-compose.yml 

## Motivation and Context
Without the version number the docker-composer by default set to version 1 due to which the options like --abort-on-container-exit doesn't work. 

Fixes # FAB-2789 (url : https://jira.hyperledger.org/browse/FAB-2789)

## How Has This Been Tested?
options like --abort-on-container-exit are available in higher version of docker-composer 
This option has been tested with other cases but not with this one.

## Checklist:
- [ ] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or **this change requires no new documentation.**
- [ ] I have either added unit tests to cover my changes or this change requires no new tests.
- [ ] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: