### PR TITLE
Update fabric-starter-kit.rst

### DIFF
--- a/docs/source/starter/fabric-starter-kit.rst
+++ b/docs/source/starter/fabric-starter-kit.rst
@@ -4,4 +4,4 @@ Fabric Starter Kit
 **Coming soon for v1.0**
 
 If you are looking for the v0.6 Starter Kit, you can find it
-`here <http://hyperledger-fabric.readthedocs.io/en/v0.6/starter/fabric-starter-kit/>`__.
+`here <http://hyperledger-fabric.readthedocs.io/en/v0.6/starter/fabric-starter-kit.html>`__.


### PR DESCRIPTION
Corrected the link to hyperledger fabric v0.6

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail. -->
The previous link was http://hyperledger-fabric.readthedocs.io/en/v0.6/starter/fabric-starter-kit/
I added .html to the end of the link
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This new change would make it easier for people to find links to v0.6
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #

## How Has This Been Tested?
<!-- If this PR does not contain a new test case, explain why. -->
<!-- Describe in detail how you tested your changes. -->
This change requires no test

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:
