### PR TITLE
Update getting_startedv2.rst

### DIFF
--- a/docs/source/getting_startedv2.rst
+++ b/docs/source/getting_startedv2.rst
@@ -162,7 +162,7 @@ From your ``e2e`` folder first execute the following:
 .. code:: bash
 
   # this command will not return a response
-  export ORDERER_CFG_PATH=$PWD
+  export FABRIC_CFG_PATH=$PWD
 
 Then use the tool:
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail. -->
Under "Generate the orderer genesis block", the command should be "export FABRIC_CFG_PATH=$PWD", not "export ORDERER_CFG_PATH=$PWD", the later will cause the command panic.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #

## How Has This Been Tested?
<!-- If this PR does not contain a new test case, explain why. -->
<!-- Describe in detail how you tested your changes. -->

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:
