### PR TITLE
Update ca-setup.rst - specifying CA name

### DIFF
--- a/docs/source/Setup/ca-setup.rst
+++ b/docs/source/Setup/ca-setup.rst
@@ -985,6 +985,8 @@ The enroll command stores an enrollment certificate (ECert), corresponding priva
 certificate chain PEM files in the subdirectories of the Fabric CA client's ``msp`` directory.
 You will see messages indicating where the PEM files are stored.
 
+If you specify server name using ``--ca.name`` option of ``fabric-ca-server`` command, you must specfiy the name using ``--caname`` option of ``fabric-ca-client``.
+
 Registering a new identity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
As of Fabric CA v1.0.0-alpha2, Fabric CA client accessing Fabric CA server which has explicit CA name should provide the name using ``--caname`` option.
.

## Description
If a ``fabric-ca-client`` accessing Fabric CA server which was started with explicit CA name specified by ``--ca.name`` option of ``fabric-ca-server`` command, doesn't provide the CA name using ``--caname`` option, it would get an error with the following message

>  Error: Error response from server was: CA '' does not exist

## Motivation and Context

## How Has This Been Tested?
I started CA server with the following command,

<pre>
fabric-ca-server start -b admin:admin1234 \
--debug \
--port 7054 \
--registry.maxenrollments 0 \
--ca.name ca0 &>>$FABRIC_CA_SERVER_HOME/fabric-ca.log & \

</pre>

When I tried to enroll ``admin``, using the following command, I got error message ``Error: Error response from server was: CA '' does not exist``
<pre>
fabric-ca-client enroll -u http://admin:admin1234@localhost:7054
</pre>

But I retried to enroll ``admin`` with ``--caname`` option, I got success
<pre>
fabric-ca-client enroll -u http://admin:admin1234@localhost:7054 --caname ca0
</pre>

## Checklist:
