### PR TITLE
Update configbuilder.go

### DIFF
--- a/msp/configbuilder.go
+++ b/msp/configbuilder.go
@@ -80,11 +80,29 @@ func getPemMaterialFromDir(dir string) ([][]byte, error) {
 	}
 
 	for _, f := range files {
+		var info os.FileInfo
+		var err error
+		var fullName string
+
 		if f.IsDir() {
 			continue
 		}
-
-		fullName := filepath.Join(dir, string(filepath.Separator), f.Name())
+		
+		if info, err = os.Lstat(file.Name()); err != nil {
+			log.Fatal(err)
+		}
+		
+		// if file is a symlink, follow the symlink
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkPath, err := os.Readlink(file.Name())
+			if err != nil {
+				log.Fatal(err)
+			}
+			fullName = filepath.Join(dir, string(filepath.Separator), linkPath)
+		} else {
+			fullName = filepath.Join(dir, string(filepath.Separator), f.Name())
+		}
+		
 		mspLogger.Debugf("Inspecting file %s", fullName)
 
 		item, err := readPemFile(fullName)


### PR DESCRIPTION
When working with kubernetes, we can use _kubernetes secrets_ for storing the keys/certs files.
These _kubernetes secrets_ are added/mounted to the container through *symlinks*, which is not parsed correctly by the _getPemMaterialFromDir_ function, hence the proposed change.

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #

## How Has This Been Tested?
<!-- If this PR does not contain a new test case, explain why. -->
<!-- Describe in detail how you tested your changes. -->

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:
