### PR TITLE
MacOS users need to edit the query.js file

### DIFF
--- a/docs/source/write_first_app.rst
+++ b/docs/source/write_first_app.rst
@@ -134,6 +134,10 @@ First, let's run our ``query.js`` program to return a listing of all the cars on
 the ledger. A function that will query all the cars, ``queryAllCars``, is
 pre-loaded in the app, so we can simply run the program as is:
 
+.. note:: If you're running on MacOS, you need to edit the content of the variable
+          `network_url` in the query.js and replace `localhost` with the IP address
+	  of the VM used by Docker. Use `docker-machine env` to find this value
+	  
 .. code:: bash
 
   node query.js


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
query.js uses `localhost` in `network_url` but this won't work on MacOS.
One needs to use the IP address of the VM used by docker-machine.


## Motivation and Context
Running query.js as it is fails on MacOS

## How Has This Been Tested?
Tested on my Mac laptop

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: bennythejudge
