### PR TITLE
change chaincode path

### DIFF
--- a/docs/source/build_network.rst
+++ b/docs/source/build_network.rst
@@ -651,7 +651,7 @@ place the specified source code flavor onto our peer's filesystem.
 .. code:: bash
 
     # this installs the Go chaincode
-    peer chaincode install -n mycc -v 1.0 -p github.com/chaincode_example02/go/
+    peer chaincode install -n mycc -v 1.0 -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02/
 
 **Node.js**
 


### PR DESCRIPTION
use original chaincode path, can not find corresponding go source file.
and i find it in "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02/"
may be this is the correct path?
after i use this path, i can install chaincode.

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail. -->
![image](https://user-images.githubusercontent.com/13780769/32211028-9f4fcc88-be4b-11e7-9957-3fd07da82df8.png)

![image](https://user-images.githubusercontent.com/13780769/32211039-b3314fa6-be4b-11e7-8422-29e7178e75db.png)





