### PR TITLE
pip install command in macOS requires user flag

### DIFF
--- a/docs/source/dev-setup/devenv.rst
+++ b/docs/source/dev-setup/devenv.rst
@@ -51,7 +51,7 @@ Prerequisites
 ``pip``, ``behave`` and ``docker-compose``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Using pip install on macOS will likely require `user flag <https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site>`__
+- Using pip install on macOS will likely require the `user flag <https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site>`__
 
 ::
 

--- a/docs/source/dev-setup/devenv.rst
+++ b/docs/source/dev-setup/devenv.rst
@@ -51,7 +51,7 @@ Prerequisites
 ``pip``, ``behave`` and ``docker-compose``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Running `pip install <https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site>` on macOS may require user flag
+- Using pip install on macOS will likely require `user flag <https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site>`__
 
 ::
 

--- a/docs/source/dev-setup/devenv.rst
+++ b/docs/source/dev-setup/devenv.rst
@@ -51,6 +51,8 @@ Prerequisites
 ``pip``, ``behave`` and ``docker-compose``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Running `pip install <https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site>` on macOS may require user flag
+
 ::
 
     pip install --upgrade pip


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Updated development environment instructions to capture required flags for Python installer when running on a Mac

## Motivation and Context
To simplify and standardize environment setup for Mac users

## How Has This Been Tested?
validate documentation in forked repository

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:
