### PR TITLE
Update build_network.rst

### DIFF
--- a/docs/source/build_network.rst
+++ b/docs/source/build_network.rst
@@ -383,7 +383,7 @@ directory, so we need to provide the relative path to where the tool resides.
 
 .. code:: bash
 
-    ../bin/cryptogen generate --config=./crypto-config.yaml
+    ../../bin/cryptogen generate --config=./crypto-config.yaml
 
 You should see the following in your terminal:
 
@@ -407,7 +407,7 @@ Then, we'll invoke the ``configtxgen`` tool to create the orderer genesis block:
 
 .. code:: bash
 
-    ../bin/configtxgen -profile TwoOrgsOrdererGenesis -outputBlock ./channel-artifacts/genesis.block
+    ../../bin/configtxgen -profile TwoOrgsOrdererGenesis -outputBlock ./channel-artifacts/genesis.block
 
 You should see an output similar to the following in your terminal:
 


### PR DESCRIPTION
The bin is two directories above the crypto-config.yaml and configtx.yaml files. Prepending an additional "../" gives the correct path to execute cryptogen generate and configtxgen.

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail. -->
This is just a documentation update.

## Sign Off
Signed-off-by: Zachary Gittelman zachgitt@github.com