### PR TITLE
Update path to cryptogen and configtxgen

### DIFF
--- a/docs/source/build_network.rst
+++ b/docs/source/build_network.rst
@@ -383,7 +383,7 @@ directory, so we need to provide the relative path to where the tool resides.
 
 .. code:: bash
 
-    ../bin/cryptogen generate --config=./crypto-config.yaml
+    ../../bin/cryptogen generate --config=./crypto-config.yaml
 
 You should see the following in your terminal:
 
@@ -407,7 +407,7 @@ Then, we'll invoke the ``configtxgen`` tool to create the orderer genesis block:
 
 .. code:: bash
 
-    ../bin/configtxgen -profile TwoOrgsOrdererGenesis -outputBlock ./channel-artifacts/genesis.block
+    ../../bin/configtxgen -profile TwoOrgsOrdererGenesis -outputBlock ./channel-artifacts/genesis.block
 
 You should see an output similar to the following in your terminal:
 


### PR DESCRIPTION
Bin is 2 directories above the crypto-config.yaml and configtx.yaml files.

Description
This is just a quick documentation update.

Signed-off-by:
Zachary Gittelman zachgitt@github.com