### PR TITLE
Use of invalid path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,7 +68,7 @@ directory. Note: you may need to adjust depending on your OS.
 ```
 sudo pip install Sphinx
 sudo pip install sphinx_rtd_theme
-cd fabric/docs # Be in this directory. Makefile sits there.
+cd ./docs # Be in this directory. Makefile sits there.
 make html
 ```
 


### PR DESCRIPTION
Hi,

First, love the docs, one of the only projects on Earth that actually really document how to generate offline viewable docs, bravo.

For the local build, it states "starting from the main fabric" directory implies your in the directory; the enumerated steps show otherwise as if your above it.  Updated to assume you are in the directory per the previous statement.

Happy New Year!

<!-- Provide a general summary of your changes in the Title above -->


## How Has This Been Tested?
Read the docs and can't copy and paste based on how it is written, fix allows that.

## Checklist:
- [x] I have added a [Signed-off-by]
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Ronald Petty <ronald.petty@minimumdistance.com>