### PR TITLE
Correct path for installing marble chaincode

### DIFF
--- a/docs/source/build_network.rst
+++ b/docs/source/build_network.rst
@@ -970,7 +970,7 @@ channel, use the following steps to interact with the **marbles02** chaincode:
 
        # be sure to modify the $CHANNEL_NAME variable accordingly for the instantiate command
 
-       peer chaincode install -n marbles -v 1.0 -p github.com/hyperledger/fabric/examples/chaincode/go/marbles02
+       peer chaincode install -n marbles -v 1.0 -p github.com/chaincode/marbles02/go
        peer chaincode instantiate -o orderer.example.com:7050 --tls --cafile /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem -C $CHANNEL_NAME -n marbles -v 1.0 -c '{"Args":["init"]}' -P "OR ('Org0MSP.member','Org1MSP.member')"
 
 -  Create some marbles and move them around:


### PR DESCRIPTION
Hi Team,

The current path for marble chaincode under the heading "Using CouchDB" is invalid. Change it from 
`github.com/hyperledger/fabric/examples/chaincode/go/marbles02`
to
`github.com/chaincode/marbles02/go`

## How Has This Been Tested?
<!-- Describe in detail how you tested your changes. -->
I followed the instruction under "Using CouchDB" with this path and the chaincode was installed.

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Wahab Jawed <wahabjawed@gmail.com>