### PR TITLE
updated the doc with correct CLI default exit time

### DIFF
--- a/docs/source/channel_update.rst
+++ b/docs/source/channel_update.rst
@@ -126,9 +126,13 @@ variables.
 
   docker exec -it cli bash
 
-By default the CLI container exits after 10000 seconds.  If the container has
-exited, make sure to restart it before continuing.  First, check the status of
-your containers:
+By default the CLI container exits after 10 seconds. You should use the flag ``-t 10000`` to override the default CLI container exit time while using the ``./byfn.sh`` command like this.
+
+.. code:: bash
+
+  ./byfn.sh -m generate -t 10000
+
+Otherwise the CLI container shall keep on exiting and you shall stuck. If the container has exited, make sure to restart it before continuing.  First, check the status of your containers:
 
 .. code:: bash
 


### PR DESCRIPTION




## Description
The default CLI exit time is 10 sec as per the configuration while following this document. & I found this as a big issue and very hard to notice and can be a big impediment for anyone who is following this doc. 
If you want to update this information by yourself, you can do it in your language. I've added the important details already as an edit to this document.

## Motivation and Context
It helps developer to know to go to correct path. CLI container was exiting the moment I was starting it, because the default time was 10 sec. If I were to knew it, I would not have wasted 4 hrs to this. I don't want anyone else to face this issue that they can just add the delay while using the ``./byfn.sh`` script.


Fixes #

## How Has This Been Tested?
It is just a doc update.


## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Vikas <vikas.singh1188@gmail.com>
