### PR TITLE
FAB-6055 createEnvelopeForMsg() has two return statements

### DIFF
--- a/bddtests/steps/bootstrap_util.py
+++ b/bddtests/steps/bootstrap_util.py
@@ -736,8 +736,6 @@ def createEnvelopeForMsg(directory, nodeAdminTuple, chainId, msg, typeAsString):
     envelope = common_dot_common_pb2.Envelope(payload=payloadBytes, signature=user.sign(payloadBytes))
     return envelope
 
-    return configEnvelope
-
 
 def createNewConfigUpdateEnvelope(channelConfig, chainId, readset_version=0):
     read_set = common_dot_configtx_pb2.ConfigGroup()


### PR DESCRIPTION
Fixes: FAB-6055

flake8 testing of https://github.com/hyperledger/fabric

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./bddtests/steps/bootstrap_util.py:739:12: F821 undefined name 'configEnvelope'
    return configEnvelope
           ^
```

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes FAB-6055

## How Has This Been Tested?
<!-- If this PR does not contain a new test case, explain why. -->
<!-- Describe in detail how you tested your changes. -->

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:
