### PR TITLE
Fixed data race in shim

### DIFF
--- a/core/chaincode/shim/chaincode.go
+++ b/core/chaincode/shim/chaincode.go
@@ -293,8 +293,8 @@ func chatWithPeer(chaincodename string, stream PeerChaincodeStream, cc Chaincode
 			if recv {
 				recv = false
 				go func() {
-					var in2 *pb.ChaincodeMessage
-					in2, err = stream.Recv()
+					in2, err := stream.Recv()
+					errc <- err
 					msgAvail <- in2
 				}()
 			}


### PR DESCRIPTION
## Description
After instantiating CC in a peer, calling invoke command cause data race. 
Example:

`peer chaincode invoke -n cc_name -v 0 -c '{"Args":["testFunc","arg1"]}' -C channel_name`

Chaincode should be runned with '-race' flag.

## Motivation and Context
This fixes data race in `chatWithPeer` function

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:
