### PR TITLE
Unshorted link to bootstrap.sh has to be the raw file

### DIFF
--- a/docs/source/samples.rst
+++ b/docs/source/samples.rst
@@ -59,7 +59,7 @@ you will extract the platform-specific binaries:
 	  information on where to find the latest version of curl and
 	  get the right environment. Alternately, you can substitute
 	  the un-shortened URL:
-	  https://github.com/hyperledger/fabric/blob/master/scripts/bootstrap.sh
+	  https://raw.githubusercontent.com/hyperledger/fabric/master/scripts/bootstrap.sh
 
 .. note:: You can use the command above for any published version of Hyperledger
           Fabric. Simply replace '1.1.0' with the version identifier


### PR DESCRIPTION
The documentation is pointing to https://github.com/hyperledger/fabric/blob/master/scripts/bootstrap.sh but it needs to be the raw file at https://raw.githubusercontent.com/hyperledger/fabric/master/scripts/bootstrap.sh