### PR TITLE
change e2ecli to e2e_cli

### DIFF
--- a/examples/e2e_cli/base/peer-base.yaml
+++ b/examples/e2e_cli/base/peer-base.yaml
@@ -12,7 +12,7 @@ services:
       # the following setting starts chaincode containers on the same
       # bridge network as the peers
       # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=e2ecli_default
+      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=e2e_cli_default
       #- CORE_LOGGING_LEVEL=ERROR
       - CORE_LOGGING_LEVEL=DEBUG
       - CORE_PEER_TLS_ENABLED=true


### PR DESCRIPTION
if i use e2ecli_default to start fabric example,it will not works
when i fix it to e2e_cli_default,it works