### PR TITLE
corrected count of downloaded binaries from "four" to "six"

### DIFF
--- a/docs/source/samples.rst
+++ b/docs/source/samples.rst
@@ -68,7 +68,7 @@ you will extract the platform-specific binaries:
 The command above downloads and executes a bash script
 that will download and extract all of the platform-specific binaries you
 will need to set up your network and place them into the cloned repo you
-created above. It retrieves four platform-specific binaries:
+created above. It retrieves six platform-specific binaries:
 
   * ``cryptogen``,
   * ``configtxgen``,


### PR DESCRIPTION
There are actually six platform-specific binaries in the list:   cryptogen, configtxgen, configtxlator, peer, orderer, and fabric-ca-client

Just added DCO which prevented the original Pull Request from passing all checks.