### PR TITLE
aes.go : pkcs7Padding edge cases

### DIFF
--- a/bccsp/sw/aes.go
+++ b/bccsp/sw/aes.go
@@ -48,7 +48,7 @@ func GetRandomBytes(len int) ([]byte, error) {
 }
 
 func pkcs7Padding(src []byte) []byte {
-	padding := aes.BlockSize - len(src)%aes.BlockSize
+	padding := (aes.BlockSize - len(src)%aes.BlockSize) % aes.BlockSize
 	padtext := bytes.Repeat([]byte{byte(padding)}, padding)
 	return append(src, padtext...)
 }


### PR DESCRIPTION
block error when len(src) == aes.BlockSize

Signed-off-by: bagaking <36580987+bagaking@users.noreply.github.com>