### PR TITLE
Decrease log level of a normal behaviour

### DIFF
--- a/core/chaincode/shim/mockstub.go
+++ b/core/chaincode/shim/mockstub.go
@@ -410,7 +410,7 @@ func (iter *MockStateRangeQueryIterator) HasNext() bool {
 	}
 
 	if iter.Current == nil {
-		mockLogger.Error("HasNext() couldn't get Current")
+		mockLogger.Debug("HasNext() couldn't get Current")
 		return false
 	}
 


### PR DESCRIPTION
When we are iterating over a MockStateRangeQueryIterator, the Next() method will set Current to nil after the last element is processed.