### PR TITLE
Update chaincode4noah.rst

### DIFF
--- a/docs/source/chaincode4noah.rst
+++ b/docs/source/chaincode4noah.rst
@@ -108,7 +108,7 @@ The optional ``-i`` option allows one to specify an instantiation policy
 for the chaincode. The instantiation policy has the same format as an
 endorsement policy and specifies which identities can instantiate the
 chaincode. In the example above, only the admin of OrgA is allowed to
-instantiate the chaincode. If no policy is provided, peer-cli will add the policy ``"AND('" + mspid + ".admin')"`` into the signCDS, which only allows the admin identity of the current peer's localMSP to
+instantiate the chaincode. If no policy is provided, peer-cli will add the policy ``"AND('" + mspid + ".admin')"`` into the signCDS, which only allows the admin identity of the current peer-cli's localMSP to
 instantiate chaincode.
 
 Package signing

--- a/docs/source/chaincode4noah.rst
+++ b/docs/source/chaincode4noah.rst
@@ -108,8 +108,7 @@ The optional ``-i`` option allows one to specify an instantiation policy
 for the chaincode. The instantiation policy has the same format as an
 endorsement policy and specifies which identities can instantiate the
 chaincode. In the example above, only the admin of OrgA is allowed to
-instantiate the chaincode. If no policy is provided, the default policy
-is used, which only allows the admin identity of the peer's MSP to
+instantiate the chaincode. If no policy is provided, peer-cli will add the policy ``"AND('" + mspid + ".admin')"`` into the signCDS, which only allows the admin identity of the current peer's localMSP to
 instantiate chaincode.
 
 Package signing
@@ -266,7 +265,7 @@ at a time, the channel to which the transaction is submitted.
 
 There's one subtle difference with the ``instantiate`` transaction: the
 ``upgrade`` transaction is checked against the current chaincode instantiation
-policy, not the new policy (if specified). This is to ensure that only existing
+policy and the new policy (if specified). This is to ensure that only existing
 members specified in the current instantiation policy may upgrade the chaincode.
 
 .. note:: Note that during upgrade, the chaincode ``Init`` function is called to


### PR DESCRIPTION
Change the error in `upgrade chaincode` and ignored information in `create package` in the fabric document version 1.2. 

```
[getChaincodeInstallPackage](https://github.com/hyperledger/fabric/blob/9e9ebe651225104823d228a09e94432592252ca3/peer/chaincode/package.go#L94)(){
	… … 
ip := instantiationPolicy
	
       if ip == "" {
    **//if an instantiation policy is not given, default to "admin  must sign chaincode instantiation proposals"**
   mspid, err := mspmgmt.GetLocalMSP().GetIdentifier()
   if err != nil {
      return nil, err
   }
   **ip = "AND('" + mspid + ".admin')"**
}
… … 
}
```

```
// executeUpgrade implements the "upgrade" Invoke transaction.
 [executeUpgrade](https://github.com/hyperledger/fabric/blob/9e9ebe651225104823d228a09e94432592252ca3/core/scc/lscc/lscc.go#L540)(...) {
.... ....
   //retain chaincode specific data and fill channel specific ones
     cdfs.Escc = string(escc)
     cdfs.Vscc = string(vscc)
   cdfs.Policy = policy 
   **// retrieve and evaluate new instantiation policy**
   cdfs.InstantiationPolicy, err = lscc.support.GetInstantiationPolicy(chainName, ccpackfs)
   if err != nil {
      return nil, err
   }
   err = lscc.support.CheckInstantiationPolicy(signedProp, chainName, cdfs.InstantiationPolicy)
   if err != nil {
      return nil, err
   }
  …… …… 
   return cdfs, nil
}
```