### PR TITLE
Specify channel name in BYFN generate command

### DIFF
--- a/docs/source/channel_update_tutorial.rst
+++ b/docs/source/channel_update_tutorial.rst
@@ -50,7 +50,7 @@ Now generate the default BYFN artifacts:
 
 .. code:: bash
 
-  ./byfn.sh generate
+  ./byfn.sh generate -c testchannel
 
 And launch the network making use of the scripted execution within the CLI container:
 


### PR DESCRIPTION
### Fix for generate BYFN artifacts command


**Issue:** Following the suggested command to generate the default BYFN artifacts command leads to error.

As the artifacts are generated for mychannel and later commands suggest pull the network up for testnetwork.

**Suggested fix:** Specify channel name in BYFN generate command

Signed-off-by: firehudson <firehudson@gmail.com>