### PR TITLE
Update gossip.rst

### DIFF
--- a/docs/source/gossip.rst
+++ b/docs/source/gossip.rst
@@ -92,7 +92,7 @@ Alternatively these parameters could be configured and overridden with environme
     export CORE_PEER_GOSSIP_USELEADERELECTION=false
     export CORE_PEER_GOSSIP_ORGLEADER=false
 
-2. Setting ``CORE_PEER_GOSSIP_USELEADERELECTION`` and ``CORE_PEER_GOSSIP_USELEADERELECTION``
+2. Setting ``CORE_PEER_GOSSIP_USELEADERELECTION`` and ``CORE_PEER_GOSSIP_ORGLEADER``
    with ``true`` value is ambiguous and will lead to an error.
 3. In static configuration organization admin is responsible to provide high availability
    of the leader node in case for failure or crashes.


### PR DESCRIPTION
`CORE_PEER_GOSSIP_USELEADERELECTION` were stated twice. I think the author must meant that an error will occur if both environment variables are set with `true`