### PR TITLE
remove duplicate line

### DIFF
--- a/docs/source/write_first_app.rst
+++ b/docs/source/write_first_app.rst
@@ -284,8 +284,6 @@ code connects the application to a particular channel within the network,
 .. code:: bash
   const network = await gateway.getNetwork('mychannel');
 
-  const network = await gateway.getNetwork('mychannel');
-
 Within this channel, we can access the smart contract ``fabcar`` to interact
 with the ledger:
 


### PR DESCRIPTION
The line: const network = await gateway.getNetwork('mychannel'); was not appearing at all in the docs, maybe due to the duplication and spacing?