### PR TITLE
[FAB-13935] Fixed a typo in markdown

### DIFF
--- a/docs/source/membership/membership.md
+++ b/docs/source/membership/membership.md
@@ -1,4 +1,4 @@
-an# Membership
+# Membership
 
 If you've read through the documentation on [identity](../identity/identity.html)
 you've seen how a PKI can provide verifiable identities through a chain


### PR DESCRIPTION
The title was prefixed with a typo `an` and hence caused the title to not be heading level 1.

Signed-off-by: Yadhukrishna S Pai <yadhuksp@gmail.com>