### PR TITLE
Upgrading Your Network Components

### DIFF
--- a/docs/source/upgrading_your_network_tutorial.rst
+++ b/docs/source/upgrading_your_network_tutorial.rst
@@ -653,7 +653,7 @@ Create a modified channel config:
 
 .. code:: bash
 
-  jq -s '.[0] * {"channel_group":{"values": {"Capabilities": .[1]}}}' config.json ./scripts/capabilities.json > modified_config.json
+  jq -s '.[0] * {"channel_group":{"groups":{"Application":{"values": {"Capabilities": .[1]}}}}}' config.json ./scripts/capabilities.json > modified_config.json
 
 Note what we’re changing here: ``Capabilities`` are being added as a ``value``
 of the ``Application`` group under ``channel_group`` (in ``mychannel``).


### PR DESCRIPTION
Enable the v1.3 capabilities in Application Group: the jq command does not replaces the right fragment.