### PR TITLE
fixed restricted channel name in logger

### DIFF
--- a/gossip/gossip/gossip_impl.go
+++ b/gossip/gossip/gossip_impl.go
@@ -681,7 +681,7 @@ func (g *gossipServiceImpl) Gossip(msg *proto.GossipMessage) {
 	if msg.IsChannelRestricted() {
 		gc := g.chanState.getGossipChannelByChainID(msg.Channel)
 		if gc == nil {
-			g.logger.Warning("Failed obtaining gossipChannel of", msg.Channel, "aborting")
+			g.logger.Warningf("Failed obtaining gossipChannel of %s aborting", msg.Channel)
 			return
 		}
 		if msg.IsDataMsg() {


### PR DESCRIPTION
Hello, community!

I have fixed log with the channel name. Previously we were able to see only byte array in logs which represent channel-name. 

So, I converted that byte array to string type and now we able to see a human-friendly log with the channel name. 