### PR TITLE
Update prereqs.rst

### DIFF
--- a/docs/source/prereqs.rst
+++ b/docs/source/prereqs.rst
@@ -6,6 +6,12 @@ you have all the prerequisites below installed on the platform(s)
 on which you'll be developing blockchain applications and/or operating
 Hyperledger Fabric.
 
+Install Git
+-----------
+Download the latest version of `git
+<https://git-scm.com/downloads>`_ if it is not already installed, 
+or if you have problems running the curl commands.
+
 Install cURL
 ------------
 


### PR DESCRIPTION
I added this change because I'm using a new minimal image to build hyperledger upon, that does not come with git preinstalled. When running the curl command, the script borked. I therefore thought it was a good idea to add it to the prerequisits page.