### PR TITLE
[FAB-17128] CHANNEL_NAME variable missing in two places in channel update tutorial

### DIFF
--- a/docs/source/channel_update_tutorial.rst
+++ b/docs/source/channel_update_tutorial.rst
@@ -380,7 +380,7 @@ earlier. We'll name this file ``org3_update_in_envelope.json``:
 
 .. code:: bash
 
-  echo '{"payload":{"header":{"channel_header":{"channel_id":"mychannel", "type":2}},"data":{"config_update":'$(cat org3_update.json)'}}}' | jq . > org3_update_in_envelope.json
+  echo '{"payload":{"header":{"channel_header":{"channel_id":"'$CHANNEL_NAME'", "type":2}},"data":{"config_update":'$(cat org3_update.json)'}}}' | jq . > org3_update_in_envelope.json
 
 Using our properly formed JSON -- ``org3_update_in_envelope.json`` -- we will
 leverage the ``configtxlator`` tool one last time and convert it into the
@@ -820,7 +820,7 @@ stripped away header, outputting it to ``anchor_update_in_envelope.json``
 
 .. code:: bash
 
-    echo '{"payload":{"header":{"channel_header":{"channel_id":"mychannel", "type":2}},"data":{"config_update":'$(cat anchor_update.json)'}}}' | jq . > anchor_update_in_envelope.json
+    echo '{"payload":{"header":{"channel_header":{"channel_id":"'$CHANNEL_NAME'", "type":2}},"data":{"config_update":'$(cat anchor_update.json)'}}}' | jq . > anchor_update_in_envelope.json
 
 Now that we have reincorporated the envelope we need to convert it
 to a protobuf so it can be properly signed and submitted to the orderer for the update.


### PR DESCRIPTION
CHANNEL_NAME variable missing in 2 places in channel update tutorial

The channel 'mychannel' is hardcoded in the middle of the channel update tutorial.
This looks like a silly typo, but when working with different channel names this can be a pain.

Signed-off-by: Anoop Vijayan Maniankara <anoop@tuxera.com>

#### Type of change

- Documentation update

#### Description

The channel 'mychannel' is hardcoded in the middle of the channel update tutorial.
This looks like a silly typo, but when working with different channel names this can be a pain.
