### PR TITLE
[FAB-17116] Use bootstrapmethod for raft consensus

### DIFF
--- a/docs/source/orderer_deploy.md
+++ b/docs/source/orderer_deploy.md
@@ -51,7 +51,7 @@ mandatory for Raft nodes.
 * `BootstrapFile` --- this is the name of the genesis block you will generate for
 this ordering service.
 
-* `GenesisMethod` --- the method by which the bootstrap block is given. For now,
+* `BootstrapMethod` --- the method by which the bootstrap block is given. For now,
 this can only be `file`, in which the file in the `BootstrapFile` is specified.
 
 If you are deploying this node as part of a cluster (for example, as part of a

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -322,7 +322,7 @@ var _ = Describe("EndToEnd", func() {
 
 			orderer := network.Orderer("orderer")
 			ordererConfig := network.ReadOrdererConfig(orderer)
-			ordererConfig.General.GenesisMethod = "none"
+			ordererConfig.General.BootstrapMethod = "none"
 			network.WriteOrdererConfig(orderer, ordererConfig)
 			network.Bootstrap()
 

--- a/integration/nwo/fabricconfig/orderer.go
+++ b/integration/nwo/fabricconfig/orderer.go
@@ -18,19 +18,19 @@ type Orderer struct {
 }
 
 type General struct {
-	ListenAddress  string                 `yaml:"ListenAddress,omitempty"`
-	ListenPort     int                    `yaml:"ListenPort,omitempty"`
-	TLS            *OrdererTLS            `yaml:"TLS,omitempty"`
-	Keepalive      *OrdererKeepalive      `yaml:"Keepalive,omitempty"`
-	GenesisMethod  string                 `yaml:"GenesisMethod,omitempty"`
-	GenesisProfile string                 `yaml:"GenesisProfile,omitempty"`
-	GenesisFile    string                 `yaml:"GenesisFile,omitempty"` // will be replaced by the BootstrapFile
-	BootstrapFile  string                 `yaml:"BootstrapFile,omitempty"`
-	LocalMSPDir    string                 `yaml:"LocalMSPDir,omitempty"`
-	LocalMSPID     string                 `yaml:"LocalMSPID,omitempty"`
-	Profile        *OrdererProfile        `yaml:"Profile,omitempty"`
-	BCCSP          *BCCSP                 `yaml:"BCCSP,omitempty"`
-	Authentication *OrdererAuthentication `yaml:"Authentication,omitempty"`
+	ListenAddress   string                 `yaml:"ListenAddress,omitempty"`
+	ListenPort      int                    `yaml:"ListenPort,omitempty"`
+	TLS             *OrdererTLS            `yaml:"TLS,omitempty"`
+	Keepalive       *OrdererKeepalive      `yaml:"Keepalive,omitempty"`
+	BootstrapMethod string                 `yaml:"BootstrapMethod,omitempty"`
+	GenesisProfile  string                 `yaml:"GenesisProfile,omitempty"`
+	GenesisFile     string                 `yaml:"GenesisFile,omitempty"` // will be replaced by the BootstrapFile
+	BootstrapFile   string                 `yaml:"BootstrapFile,omitempty"`
+	LocalMSPDir     string                 `yaml:"LocalMSPDir,omitempty"`
+	LocalMSPID      string                 `yaml:"LocalMSPID,omitempty"`
+	Profile         *OrdererProfile        `yaml:"Profile,omitempty"`
+	BCCSP           *BCCSP                 `yaml:"BCCSP,omitempty"`
+	Authentication  *OrdererAuthentication `yaml:"Authentication,omitempty"`
 
 	ExtraProperties map[string]interface{} `yaml:",inline,omitempty"`
 }

--- a/integration/nwo/orderer_template.go
+++ b/integration/nwo/orderer_template.go
@@ -35,7 +35,7 @@ General:
     ServerMinInterval: 60s
     ServerInterval: 7200s
     ServerTimeout: 20s
-  GenesisMethod: file
+  BootstrapMethod: file
   BootstrapFile: {{ .RootDir }}/{{ .SystemChannel.Name }}_block.pb
   LocalMSPDir: {{ $w.OrdererLocalMSPDir Orderer }}
   LocalMSPID: {{ ($w.Organization Orderer.Organization).MSPID }}

--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -45,8 +45,9 @@ type General struct {
 	Cluster           Cluster
 	Keepalive         Keepalive
 	ConnectionTimeout time.Duration
-	GenesisMethod     string
+	GenesisMethod     string // For compatibility only, will be replaced by BootstrapMethod
 	GenesisFile       string // For compatibility only, will be replaced by BootstrapFile
+	BootstrapMethod   string
 	BootstrapFile     string
 	Profile           Profile
 	LocalMSPDir       string
@@ -205,10 +206,10 @@ type Statsd struct {
 // Defaults carries the default orderer configuration values.
 var Defaults = TopLevel{
 	General: General{
-		ListenAddress: "127.0.0.1",
-		ListenPort:    7050,
-		GenesisMethod: "file",
-		BootstrapFile: "genesisblock",
+		ListenAddress:   "127.0.0.1",
+		ListenPort:      7050,
+		BootstrapMethod: "file",
+		BootstrapFile:   "genesisblock",
 		Profile: Profile{
 			Enabled: false,
 			Address: "0.0.0.0:6060",
@@ -331,8 +332,14 @@ func (c *TopLevel) completeInitialization(configDir string) {
 		case c.General.ListenPort == 0:
 			logger.Infof("General.ListenPort unset, setting to %v", Defaults.General.ListenPort)
 			c.General.ListenPort = Defaults.General.ListenPort
-		case c.General.GenesisMethod == "":
-			c.General.GenesisMethod = Defaults.General.GenesisMethod
+		case c.General.BootstrapMethod == "":
+			if c.General.GenesisMethod != "" {
+				// This is to keep the compatibility with old config file that uses genesismethod
+				logger.Warn("General.GenesisMethod should be replaced by General.BootstrapMethod")
+				c.General.BootstrapMethod = c.General.GenesisMethod
+			} else {
+				c.General.BootstrapMethod = Defaults.General.BootstrapMethod
+			}
 		case c.General.BootstrapFile == "":
 			if c.General.GenesisFile != "" {
 				// This is to keep the compatibility with old config file that uses genesisfile

--- a/orderer/common/multichannel/registrar_test.go
+++ b/orderer/common/multichannel/registrar_test.go
@@ -455,7 +455,7 @@ func TestBroadcastChannelSupport(t *testing.T) {
 		ledgerFactory, _ := newLedgerAndFactory(tmpdir, "", nil)
 		mockConsenters := map[string]consensus.Consenter{confSys.Orderer.OrdererType: &mockConsenter{}}
 		config := localconfig.TopLevel{}
-		config.General.GenesisMethod = "none"
+		config.General.BootstrapMethod = "none"
 		config.General.GenesisFile = ""
 		registrar := NewRegistrar(config, ledgerFactory, mockCrypto(), &disabled.Provider{}, cryptoProvider)
 		registrar.Initialize(mockConsenters)

--- a/orderer/common/server/etcdraft_test.go
+++ b/orderer/common/server/etcdraft_test.go
@@ -147,7 +147,7 @@ func testEtcdRaftOSNNoTLSSingleListener(gt *GomegaWithT, tempDir, orderer, fabri
 	cmd := exec.Command(orderer)
 	cmd.Env = []string{
 		fmt.Sprintf("ORDERER_GENERAL_LISTENPORT=%d", nextPort()),
-		"ORDERER_GENERAL_GENESISMETHOD=file",
+		"ORDERER_GENERAL_BOOTSTRAPMETHOD=file",
 		"ORDERER_GENERAL_SYSTEMCHANNEL=system",
 		fmt.Sprintf("ORDERER_FILELEDGER_LOCATION=%s", filepath.Join(tempDir, "ledger")),
 		fmt.Sprintf("ORDERER_GENERAL_BOOTSTRAPFILE=%s", genesisBlockPath),
@@ -170,7 +170,7 @@ func testEtcdRaftOSNNoTLSDualListener(gt *GomegaWithT, tempDir, orderer, fabricR
 	cmd := exec.Command(orderer)
 	cmd.Env = []string{
 		fmt.Sprintf("ORDERER_GENERAL_LISTENPORT=%d", nextPort()),
-		"ORDERER_GENERAL_GENESISMETHOD=file",
+		"ORDERER_GENERAL_BOOTSTRAPMETHOD=file",
 		"ORDERER_GENERAL_SYSTEMCHANNEL=system",
 		"ORDERER_GENERAL_TLS_ENABLED=false",
 		"ORDERER_OPERATIONS_TLS_ENABLED=false",
@@ -204,7 +204,7 @@ func launchOrderer(gt *GomegaWithT, orderer, tempDir, genesisBlockPath, fabricRo
 	cmd := exec.Command(orderer)
 	cmd.Env = []string{
 		fmt.Sprintf("ORDERER_GENERAL_LISTENPORT=%d", nextPort()),
-		"ORDERER_GENERAL_GENESISMETHOD=file",
+		"ORDERER_GENERAL_BOOTSTRAPMETHOD=file",
 		"ORDERER_GENERAL_SYSTEMCHANNEL=system",
 		"ORDERER_GENERAL_TLS_CLIENTAUTHREQUIRED=true",
 		"ORDERER_GENERAL_TLS_ENABLED=true",

--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -124,7 +124,7 @@ func Main() {
 	var clusterDialer *cluster.PredicateDialer
 	var clusterType, reuseGrpcListener bool
 	var serversToUpdate []*comm.GRPCServer
-	if conf.General.GenesisMethod == "file" {
+	if conf.General.BootstrapMethod == "file" {
 		bootstrapBlock := extractBootstrapBlock(conf)
 		if err := ValidateBootstrapBlock(bootstrapBlock, cryptoProvider); err != nil {
 			logger.Panicf("Failed validating bootstrap block: %v", err)
@@ -143,7 +143,7 @@ func Main() {
 
 			r = createReplicator(lf, bootstrapBlock, conf, clusterClientConfig.SecOpts, signer, cryptoProvider)
 			// Only clusters that are equipped with a recent config block can replicate.
-			if conf.General.GenesisMethod == "file" {
+			if conf.General.BootstrapMethod == "file" {
 				r.replicateIfNeeded(bootstrapBlock)
 			}
 
@@ -590,13 +590,13 @@ func extractBootstrapBlock(conf *localconfig.TopLevel) *cb.Block {
 	var bootstrapBlock *cb.Block
 
 	// Select the bootstrapping mechanism
-	switch conf.General.GenesisMethod {
+	switch conf.General.BootstrapMethod {
 	case "file": // For now, "file" is the only supported genesis method
 		bootstrapBlock = file.New(conf.General.BootstrapFile).GenesisBlock()
 	case "none": // simply honor the configuration value
 		return nil
 	default:
-		logger.Panic("Unknown genesis method:", conf.General.GenesisMethod)
+		logger.Panic("Unknown genesis method:", conf.General.BootstrapMethod)
 	}
 
 	return bootstrapBlock
@@ -712,7 +712,7 @@ func initializeMultichannelRegistrar(
 	// Note, we pass a 'nil' channel here, we could pass a channel that
 	// closes if we wished to cleanup this routine on exit.
 	go kafkaMetrics.PollGoMetricsUntilStop(time.Minute, nil)
-	if conf.General.GenesisMethod == "file" {
+	if conf.General.BootstrapMethod == "file" {
 		if isClusterType(bootstrapBlock, bccsp) {
 			initializeEtcdraftConsenter(consenters, conf, lf, clusterDialer, bootstrapBlock, ri, srvConf, srv, registrar, metricsProvider, bccsp)
 		}

--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -215,8 +215,8 @@ func TestInitializeBootstrapChannel(t *testing.T) {
 	assert.NoError(t, err)
 	bootstrapConfig := &localconfig.TopLevel{
 		General: localconfig.General{
-			GenesisMethod: "file",
-			BootstrapFile: genesisFile,
+			BootstrapMethod: "file",
+			BootstrapFile:   genesisFile,
 		},
 	}
 
@@ -241,13 +241,13 @@ func TestExtractBootstrapBlock(t *testing.T) {
 	}{
 		{
 			config: &localconfig.TopLevel{
-				General: localconfig.General{GenesisMethod: "file", BootstrapFile: genesisFile},
+				General: localconfig.General{BootstrapMethod: "file", BootstrapFile: genesisFile},
 			},
 			block: file.New(genesisFile).GenesisBlock(),
 		},
 		{
 			config: &localconfig.TopLevel{
-				General: localconfig.General{GenesisMethod: "none"},
+				General: localconfig.General{BootstrapMethod: "none"},
 			},
 			block: nil,
 		},
@@ -406,7 +406,7 @@ func TestInitializeMultichannelRegistrar(t *testing.T) {
 	})
 
 	t.Run("registrar without a system channel", func(t *testing.T) {
-		conf.General.GenesisMethod = "none"
+		conf.General.BootstrapMethod = "none"
 		conf.General.GenesisFile = ""
 		lf, _, err := createLedgerFactory(conf, &disabled.Provider{})
 		assert.NoError(t, err)
@@ -469,10 +469,10 @@ func TestUpdateTrustedRoots(t *testing.T) {
 	port, _ := strconv.ParseUint(strings.Split(listenAddr, ":")[1], 10, 16)
 	conf := &localconfig.TopLevel{
 		General: localconfig.General{
-			GenesisMethod: "file",
-			BootstrapFile: genesisFile,
-			ListenAddress: "localhost",
-			ListenPort:    uint16(port),
+			BootstrapMethod: "file",
+			BootstrapFile:   genesisFile,
+			ListenAddress:   "localhost",
+			ListenPort:      uint16(port),
 			TLS: localconfig.TLS{
 				Enabled:            false,
 				ClientAuthRequired: false,
@@ -837,10 +837,10 @@ func genesisConfig(t *testing.T, genesisFile string) *localconfig.TopLevel {
 	localMSPDir := configtest.GetDevMspDir()
 	return &localconfig.TopLevel{
 		General: localconfig.General{
-			GenesisMethod: "file",
-			BootstrapFile: genesisFile,
-			LocalMSPDir:   localMSPDir,
-			LocalMSPID:    "SampleOrg",
+			BootstrapMethod: "file",
+			BootstrapFile:   genesisFile,
+			LocalMSPDir:     localMSPDir,
+			LocalMSPID:      "SampleOrg",
 			BCCSP: &factory.FactoryOpts{
 				ProviderName: "SW",
 				SwOpts: &factory.SwOpts{

--- a/release_notes/v2.0.0.txt
+++ b/release_notes/v2.0.0.txt
@@ -92,7 +92,7 @@ to understand recent changes to a key.
 
 FAB-16722 - The 'provisional' genesis method of generating the system channel
 for orderers has been removed. Existing users of the provisional genesis method
-should instead set GenesisMethod to 'file', and generate a genesis block file
+should instead set BootstrapMethod to 'file', and generate a genesis block file
 using configtxgen. Orderer nodes will then use the generated file for the
 orderer system channel.
 

--- a/sampleconfig/orderer.yaml
+++ b/sampleconfig/orderer.yaml
@@ -68,14 +68,14 @@ General:
         # ServerPrivateKey defines the file location of the private key of the TLS certificate.
         ServerPrivateKey:
 
-    # Genesis method: The method by which the genesis block for the orderer
+    # Bootstrap method: The method by which to obtain the bootstrap block
     # system channel is specified. The option can be one of:
     #   "file" - path to a faile containing the genesis block or config block of system channel
     #   "none" - allows an orderer to start without a system channel configuration
-    GenesisMethod: file
+    BootstrapMethod: file
 
     # Bootstrap file: The file containing the bootstrap block to use when
-    # initializing the orderer system channel and GenesisMethod is set to
+    # initializing the orderer system channel and BootstrapMethod is set to
     # "file".  The bootstrap file can be the genesis block, and it can also be 
     # a config block for late bootstrap of some consensus methods like Raft.
     BootstrapFile:


### PR DESCRIPTION
Currently HLF uses ORDERER_GENERAL_GENESISMETHOD to specify the method
for bootstrap.

However, with latest changes including raft and the bootstrapfile, the
method is expanded to support both genesisfile and configfile.

This patchset change it to ORDERER_GENERAL_BOOTSTRAPMETHOD to align with
the ORDERER_GENERAL_BOOSTRAPFILE.

Change-Id: I5caa16d7653cfeb6ac8efdf897956d04c1d53743
Signed-off-by: Baohua Yang <yangbaohua@gmail.com>
Signed-off-by: Baohua Yang <baohua.yang@oracle.com>


#### Type of change

- Bug fix

#### Description

This patchset change ORDERER_GENERAL_GENESISMETHOD to ORDERER_GENERAL_BOOTSTRAPMETHOD to align with
the ORDERER_GENERAL_BOOSTRAPFILE.

#### Additional details

Currently HLF uses ORDERER_GENERAL_GENESISMETHOD to specify the method
for bootstrap.

However, with latest changes including raft and the bootstrapfile, the
method is expanded to support both genesisfile and configfile.

#### Related issues

https://jira.hyperledger.org/browse/FAB-17116
