### PR TITLE
[FAB-11241] Move Profiling init Service external

### DIFF
--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -236,7 +236,9 @@ func Main() {
 		go clusterGRPCServer.Start()
 	}
 
-	initializeProfilingService(conf)
+	if conf.General.Profile.Enabled {
+		go initializeProfilingService(conf)
+	}
 	ab.RegisterAtomicBroadcastServer(grpcServer.Server(), server)
 	logger.Info("Beginning to serve requests")
 	grpcServer.Start()
@@ -372,13 +374,9 @@ func initializeLogging() {
 
 // Start the profiling service if enabled.
 func initializeProfilingService(conf *localconfig.TopLevel) {
-	if conf.General.Profile.Enabled {
-		go func() {
-			logger.Info("Starting Go pprof profiling service on:", conf.General.Profile.Address)
-			// The ListenAndServe() call does not return unless an error occurs.
-			logger.Panic("Go pprof service failed:", http.ListenAndServe(conf.General.Profile.Address, nil))
-		}()
-	}
+	logger.Info("Starting Go pprof profiling service on:", conf.General.Profile.Address)
+	// The ListenAndServe() call does not return unless an error occurs.
+	logger.Panic("Go pprof service failed:", http.ListenAndServe(conf.General.Profile.Address, nil))
 }
 
 func handleSignals(handlers map[os.Signal]func()) {

--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -73,7 +73,7 @@ func TestInitializeProfilingService(t *testing.T) {
 		l.Close()
 		return l.Addr().String()
 	}()
-	initializeProfilingService(
+	go initializeProfilingService(
 		&localconfig.TopLevel{
 			General: localconfig.General{
 				Profile: localconfig.Profile{


### PR DESCRIPTION
Now the profile enable flag is inside the function, moving it into the main process
will make the entire logic more explicit.

Signed-off-by: Baohua Yang <baohua.yang@oracle.com>
Signed-off-by: Baohua Yang <yangbaohua@gmail.com>

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Now the profile enable flag is inside the function, moving it into the main process
will make the entire logic more explicit.

#### Related issues

https://jira.hyperledger.org/browse/FAB-11241