### PR TITLE
FAB-17105 - Fixing broken links

### DIFF
--- a/docs/source/developapps/architecture.md
+++ b/docs/source/developapps/architecture.md
@@ -155,7 +155,7 @@ unique **composite** key formed by the concatenation of `org.papernet.paper`,
 
 
   * Hyperlegder Fabric internally uses a concurrency control
-    [mechanism](../arch-deep-dive.html#the-endorsing-peer-simulates-a-transaction-and-produces-an-endorsement-signature)
+    mechanism <!-- Add more information to explain this topic-->
     to update a ledger, such that keeping papers in separate state vectors vastly
     reduces the opportunity for shared-state collisions. Such collisions require
     transaction re-submission, complicate application design, and decrease

--- a/docs/source/developapps/connectionoptions.md
+++ b/docs/source/developapps/connectionoptions.md
@@ -214,7 +214,7 @@ connection options.
   application's organization to commit the transaction. This is a good default
   because applications can be sure that all their peers have an up-to-date copy
   of the ledger, minimizing concurrency
-  [issues](../arch-deep-dive.html#the-endorsing-peer-simulates-a-transaction-and-produces-an-endorsement-signature).
+  issues <!-- Add a link with more information explaining this topic-->
 
   However, as the number of peers in an organization grows, it becomes a little
   unnecessary to wait for all peers, in which case using a pluggable event


### PR DESCRIPTION
Signed-off-by: “Rob <murgai@us.ibm.com>

Fixed broken links in two files in the Docs.

#### Type of change

- Documentation update

#### Description

There was a broken link in two of the documentation pages in Fabric.  I have deleted the links for now.  I have also added a comment as a placeholder where we can add the correct link in the future, if needed.

#### Additional details


#### Related issues


#### Release Note
