### PR TITLE
[FAB-17132] Add Parallel Strategy to Integration Tests

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -16,7 +16,7 @@ variables:
 jobs:
   - job: VerifyBuild
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
     steps:
       - template: install_deps.yml
       - checkout: self
@@ -27,7 +27,7 @@ jobs:
 
   - job: DocBuild
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
     container:
       image: n42org/tox:3.4.0
     steps:
@@ -41,7 +41,7 @@ jobs:
 
   - job: UnitTests
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
     steps:
       - template: install_deps.yml
       - checkout: self
@@ -54,8 +54,10 @@ jobs:
 
   - job: IntegrationTests
     pool:
-      vmImage: ubuntu-16.04
-    timeoutInMinutes: 120
+      vmImage: ubuntu-18.04
+    strategy:
+      parallel: 5
+    timeoutInMinutes: 90
     steps:
       - template: install_deps.yml
       - checkout: self
@@ -63,3 +65,4 @@ jobs:
         displayName: Checkout Fabric Code
       - script: make integration-test
         displayName: Run Integration Tests
+

--- a/ci/install_deps.yml
+++ b/ci/install_deps.yml
@@ -6,7 +6,7 @@ steps:
   - script: |
       sudo apt-get clean
       sudo apt-get update
-      sudo apt-get install -y libtool gcc make haveged
+      sudo apt-get install -y libtool gcc make
     displayName: Install Dependencies
   - task: GoTool@0
     inputs:

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -12,23 +12,32 @@ set -e -u
 
 fabric_dir="$(cd "$(dirname "$0")/.." && pwd)"
 
-# find packages that contain "integration" in the import path
-integration_dirs() {
-    local packages="$1"
+cd "$fabric_dir"
 
-    go list -f '{{.Dir}}' "$packages" | grep -E '/integration($|/)' | sed "s,${fabric_dir},.,g"
-}
+dirs=()
+if [ "${#}" -eq 0 ]; then
+  specs=()
+  specs=("$(grep -Ril --exclude-dir=vendor --exclude-dir=scripts "RunSpecs" . | grep integration)")
+  for spec in ${specs[*]}; do
+    dirs+=("$(dirname "${spec}")")
+  done
+else
+  dirs=("$@")
+fi
 
-main() {
-    cd "$fabric_dir"
+totalAgents=${SYSTEM_TOTALJOBSINPHASE:-0}   # standard VSTS variables available using parallel execution; total number of parallel jobs running
+agentNumber=${SYSTEM_JOBPOSITIONINPHASE:-0} # current job position
+testCount=${#dirs[@]}
 
-    local -a dirs=("$@")
-    if [ "${#dirs[@]}" -eq 0 ]; then
-        while IFS=$'\n' read -r pkg; do dirs+=("$pkg"); done < <(integration_dirs "./...")
-    fi
+# below conditions are used if parallel pipeline is not used. i.e. pipeline is running with single agent (no parallel configuration)
+if [ "$totalAgents" -eq 0 ]; then totalAgents=1; fi
+if [ "$agentNumber" -eq 0 ]; then agentNumber=1; fi
 
-    echo "Running integration tests..."
-    ginkgo -keepGoing --slowSpecThreshold 60 "${dirs[@]}"
-}
+declare -a files
+for ((i = "$agentNumber"; i <= "$testCount"; )); do
+  files+=("${dirs[$i - 1]}")
+  i=$((${i} + ${totalAgents}))
+done
 
-main "$@"
+echo "Running the following test suites: ${files[*]}"
+ginkgo -keepGoing --slowSpecThreshold 60 ${files[*]}


### PR DESCRIPTION
**To see the results of this change look at the successful build of this PR**

https://dev.azure.com/Hyperledger/Fabric/_build/results?buildId=2527&view=results

Signed-off-by: Brett Logan <Brett.T.Logan@ibm.com>

#### Type of change

- Improvement to tests

#### Description

This change splits the integration suite into multiple parallel jobs.

Under this framework the build finishes in approximately 40 minutes as opposed to nearly 2 hours today which is in line with the time it takes to run unit tests

I've elected to remove haveged as it is not needed for our test suites, the BYFN E2E tests in Node and Java SDK repos require it. There is a bug in AZP where the request to APT to install deps returns a 503 frequently enough for it to be annoying and the builds fail. Since it adds nothing for us, just removing it to protect against that. The other deps happen to already be installed on the AZP-based nodes, so leaving them around as they are truly required, even if not needed right now. Future Pipelines that make use of Azure Scale Sets might need this.

Also switching to Ubuntu-18.04-based VM's, which in general in my tests seems to have better overall performance vs the 16.04 nodes