### PR TITLE
Add Chris Gabriel as a Documentation maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,7 +18,8 @@ Maintainers
 | Manish Sethi   |  manish-sethi | manish-sethi | manish-sethi | <manish.sethi@gmail.com>
 | Matthew Sykes  |  sykesm    |   sykesm  |  sykesm   | <sykesmat@us.ibm.com>
 | Pam Andrejko  |   pama-ibm  |   pamandrejko | pandrejko | <pama@ibm.com>
-  Srinivasan Muralidharan | muralisr | muralisrini | muralisr | <srinivasan.muralidharan99@gmail.com>
+| Chris Gabriel |  cmgabriel | denali49 | cmgabriel | <chris@hyperchainlabs.com>
+| Srinivasan Muralidharan | muralisr | muralisrini | muralisr | <srinivasan.muralidharan99@gmail.com>
 | Yacov Manevich |  yacovm    |   yacovm   |   yacovm   | <yacovm@il.ibm.com>
 
 **Release Managers**
@@ -40,5 +41,3 @@ Maintainers
 | Yaoguo Jiang   |  jiangyaoguo | jiangyaoguo | jiangyaoguo | <jiangyaoguo@gmail.com>
 | Greg Haskins  |  greg.haskins | ghaskins  |  ghaskins | <gregory.haskins@gmail.com>
 | Keith Smith  |   smithbk   |  smithbk  |  smithbk  | <bksmith@us.ibm.com>
-
-


### PR DESCRIPTION
Signed-off-by: pama-ibm <pama@ibm.com>


#### Type of change

- Documentation update

#### Description

Chris has been an instrumental member of our Fabric Documentation community for several years now, contributing content, reviewing content, and as a user of Fabric in his own Hyperhchain Labs business which he founded. 

With his breadth of Fabric experience, we'd like to have him become a Documentation maintainer.
