### PR TITLE
FAB-17161 improve error message

### DIFF
--- a/msp/identities.go
+++ b/msp/identities.go
@@ -12,6 +12,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
+	"fmt"
 	"sync"
 	"time"
 
@@ -107,6 +108,17 @@ func (id *identity) Validate() error {
 	return id.msp.Validate(id)
 }
 
+type OUIDs []*OUIdentifier
+
+func (o OUIDs) String() string {
+	var res []string
+	for _, id := range o {
+		res = append(res, fmt.Sprintf("%s(%X)", id.OrganizationalUnitIdentifier, id.CertifiersIdentifier[0:8]))
+	}
+
+	return fmt.Sprintf("%s", res)
+}
+
 // GetOrganizationalUnits returns the OU for this instance
 func (id *identity) GetOrganizationalUnits() []*OUIdentifier {
 	if id.cert == nil {
@@ -120,7 +132,7 @@ func (id *identity) GetOrganizationalUnits() []*OUIdentifier {
 		return nil
 	}
 
-	res := []*OUIdentifier{}
+	var res []*OUIdentifier
 	for _, unit := range id.cert.Subject.OrganizationalUnit {
 		res = append(res, &OUIdentifier{
 			OrganizationalUnitIdentifier: unit,

--- a/msp/mspimplvalidate.go
+++ b/msp/mspimplvalidate.go
@@ -162,7 +162,7 @@ func (msp *bccspmsp) validateIdentityOUsV1(id *identity) error {
 			if len(id.GetOrganizationalUnits()) == 0 {
 				return errors.New("the identity certificate does not contain an Organizational Unit (OU)")
 			}
-			return errors.Errorf("none of the identity's organizational units [%v] are in MSP %s", id.GetOrganizationalUnits(), msp.name)
+			return errors.Errorf("none of the identity's organizational units %s are in MSP %s", OUIDs(id.GetOrganizationalUnits()), msp.name)
 		}
 	}
 
@@ -202,7 +202,7 @@ func (msp *bccspmsp) validateIdentityOUsV11(id *identity) error {
 		// Yes. Then, enforce the certifiers identifier is this is specified.
 		// It is not specified, it means that any certification path is fine.
 		if len(nodeOU.CertifiersIdentifier) != 0 && !bytes.Equal(nodeOU.CertifiersIdentifier, OU.CertifiersIdentifier) {
-			return errors.Errorf("certifiersIdentifier does not match: [%v], MSP: [%s]", id.GetOrganizationalUnits(), msp.name)
+			return errors.Errorf("certifiersIdentifier does not match: %v, MSP: [%s]", OUIDs(id.GetOrganizationalUnits()), msp.name)
 		}
 		counter++
 		if counter > 1 {
@@ -210,7 +210,7 @@ func (msp *bccspmsp) validateIdentityOUsV11(id *identity) error {
 		}
 	}
 	if counter != 1 {
-		return errors.Errorf("the identity must be a client or a peer identity to be valid, not a combination of them. OUs: [%v], MSP: [%s]", id.GetOrganizationalUnits(), msp.name)
+		return errors.Errorf("the identity must be a client or a peer identity to be valid, not a combination of them. OUs: %s, MSP: [%s]", OUIDs(id.GetOrganizationalUnits()), msp.name)
 	}
 
 	return nil
@@ -256,7 +256,7 @@ func (msp *bccspmsp) validateIdentityOUsV142(id *identity) error {
 		// Yes. Then, enforce the certifiers identifier in this is specified.
 		// If is not specified, it means that any certification path is fine.
 		if len(nodeOU.CertifiersIdentifier) != 0 && !bytes.Equal(nodeOU.CertifiersIdentifier, OU.CertifiersIdentifier) {
-			return errors.Errorf("certifiersIdentifier does not match: [%v], MSP: [%s]", id.GetOrganizationalUnits(), msp.name)
+			return errors.Errorf("certifiersIdentifier does not match: %s, MSP: [%s]", OUIDs(id.GetOrganizationalUnits()), msp.name)
 		}
 		counter++
 		if counter > 1 {
@@ -264,7 +264,7 @@ func (msp *bccspmsp) validateIdentityOUsV142(id *identity) error {
 		}
 	}
 	if counter != 1 {
-		return errors.Errorf("the identity must be a client, a peer, an orderer or an admin identity to be valid, not a combination of them. OUs: [%v], MSP: [%s]", id.GetOrganizationalUnits(), msp.name)
+		return errors.Errorf("the identity must be a client, a peer, an orderer or an admin identity to be valid, not a combination of them. OUs: %s, MSP: [%s]", OUIDs(id.GetOrganizationalUnits()), msp.name)
 	}
 
 	return nil


### PR DESCRIPTION
Combination of OUs is not allowed, where error message returned
contains address of OU object, which is not human friendly. This
commit changes it to print actual OU identifiers in []string.

Test done: use disallowed combination of OUs for a Fabric network
and observe error message returned to contain clear text.

Change-Id: Ie7fd19e6542b7b78a736e5b4b6092ad637e37152
Signed-off-by: Jay Guo <guojiannan1101@gmail.com>