### PR TITLE
[FAB-15824] Scripting friendly CLI query methods

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -1,0 +1,48 @@
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+on:
+  issue_comment:
+    types: [created]
+name: Automatically Trigger Azure Pipeline
+jobs:
+  trigger:
+    name: TriggerAZP
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/ci-run')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Trigger Build
+      run: |
+        author=$(jq -r ".issue.user.login" "${GITHUB_EVENT_PATH}")
+        commenter=$(jq -r ".comment.user.login" "${GITHUB_EVENT_PATH}")
+        org=$(jq -r ".repository.owner.login" "${GITHUB_EVENT_PATH}")
+        pr_number=$(jq -r ".issue.number" "${GITHUB_EVENT_PATH}")
+        project=$(jq -r ".repository.name" "${GITHUB_EVENT_PATH}")
+        repo=$(jq -r ".repository.full_name" "${GITHUB_EVENT_PATH}")
+
+        comment_url="https://api.github.com/repos/${repo}/issues/${pr_number}/comments"
+        pr_url="https://api.github.com/repos/${repo}/pulls/${pr_number}"
+
+        pr_resp=$(curl "${pr_url}")
+        isReviewer=$(echo "${pr_resp}" | jq -r .requested_reviewers | jq -c ".[] | select(.login | contains(\"${commenter}\"))" | wc -l)
+
+        if [[ "${commenter}" = "${author}" ]] || [[ "${isReviewer}" -ne 0 ]]; then
+          sha=$(echo "${pr_resp}" | jq -r ".head.sha")
+
+          az extension add --name azure-devops
+          echo ${AZP_TOKEN} | az devops login --organization "https://dev.azure.com/${org}"
+
+          runs=$(az pipelines build list --project ${project} | jq -c ".[] | select(.sourceVersion | contains(\"${sha}\"))" | jq -r .status | grep -v completed | wc -l)
+          if [[ $runs -eq 0 ]]; then
+            az pipelines build queue --commit-id ${sha} --project ${project} --definition-name Pull-Request
+            curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d '{"body": "AZP build triggered!"}' "${comment_url}"
+          else
+            curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d '{"body": "AZP build already running!"}' "${comment_url}"
+          fi
+        else
+          curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d '{"body": "You are not authorized to trigger builds for this pull request!"}' "${comment_url}"
+        fi
+      env:
+        AZP_TOKEN: ${{ secrets.AZP_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -35,7 +35,7 @@ jobs:
 
           runs=$(az pipelines build list --project ${project} | jq -c ".[] | select(.sourceVersion | contains(\"${sha}\"))" | jq -r .status | grep -v completed | wc -l)
           if [[ $runs -eq 0 ]]; then
-            az pipelines build queue --commit-id ${sha} --project ${project} --definition-name Pull-Request
+            az pipelines build queue --branch refs/pull/${pr_number}/merge --commit-id ${sha} --project ${project} --definition-name Pull-Request
             curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d '{"body": "AZP build triggered!"}' "${comment_url}"
           else
             curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d '{"body": "AZP build already running!"}' "${comment_url}"

--- a/bccsp/sw/impl_test.go
+++ b/bccsp/sw/impl_test.go
@@ -56,6 +56,10 @@ func (tc testConfig) Provider(t *testing.T) (bccsp.BCCSP, bccsp.KeyStore, func()
 }
 
 func TestMain(m *testing.M) {
+	code := -1
+	defer func() {
+		os.Exit(code)
+	}()
 	tests := []testConfig{
 		{256, "SHA2"},
 		{256, "SHA3"},
@@ -67,19 +71,18 @@ func TestMain(m *testing.M) {
 	tempDir, err = ioutil.TempDir("", "bccsp-sw")
 	if err != nil {
 		fmt.Printf("Failed to create temporary directory: %s\n\n", err)
-		os.Exit(-1)
+		return
 	}
 	defer os.RemoveAll(tempDir)
 
 	for _, config := range tests {
 		currentTestConfig = config
-		ret := m.Run()
-		if ret != 0 {
+		code = m.Run()
+		if code != 0 {
 			fmt.Printf("Failed testing at [%d, %s]", config.securityLevel, config.hashFamily)
-			os.Exit(-1)
+			return
 		}
 	}
-	os.Exit(0)
 }
 
 func TestInvalidNewParameter(t *testing.T) {

--- a/ci/azure-pipelines-release.yml
+++ b/ci/azure-pipelines-release.yml
@@ -1,4 +1,4 @@
-# Copyright the Hyperledger Fabric cont ributors. All rights reserved.
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -16,7 +16,7 @@ variables:
 jobs:
   - job: VerifyBuild
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
     steps:
       - template: install_deps.yml
       - checkout: self
@@ -27,7 +27,7 @@ jobs:
 
   - job: DocBuild
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
     container:
       image: n42org/tox:3.4.0
     steps:
@@ -41,7 +41,7 @@ jobs:
 
   - job: UnitTests
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
     steps:
       - template: install_deps.yml
       - checkout: self
@@ -54,8 +54,10 @@ jobs:
 
   - job: IntegrationTests
     pool:
-      vmImage: ubuntu-16.04
-    timeoutInMinutes: 120
+      vmImage: ubuntu-18.04
+    strategy:
+      parallel: 5
+    timeoutInMinutes: 90
     steps:
       - template: install_deps.yml
       - checkout: self
@@ -63,3 +65,4 @@ jobs:
         displayName: Checkout Fabric Code
       - script: make integration-test
         displayName: Run Integration Tests
+

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -23,9 +23,13 @@ jobs:
         path: 'go/src/github.com/hyperledger/fabric'
         displayName: Checkout Fabric Code
       - script: make basic-checks native
-        displayName: Verify Build
+        displayName: Run Basic Checks
+      - script: ./ci/scripts/evaluate_commits.sh
+        name: SetJobTriggers
 
   - job: DocBuild
+    condition: eq(dependencies.VerifyBuild.outputs['SetJobTriggers.buildDoc'], 'true')
+    dependsOn: VerifyBuild
     pool:
       vmImage: ubuntu-18.04
     container:
@@ -40,6 +44,8 @@ jobs:
         displayName: Publish Documentation Artifacts
 
   - job: UnitTests
+    condition: eq(dependencies.VerifyBuild.outputs['SetJobTriggers.runTests'], 'true')
+    dependsOn: VerifyBuild
     pool:
       vmImage: ubuntu-18.04
     steps:
@@ -53,6 +59,8 @@ jobs:
         displayName: Run Unit Tests
 
   - job: IntegrationTests
+    condition: eq(dependencies.VerifyBuild.outputs['SetJobTriggers.runTests'], 'true')
+    dependsOn: VerifyBuild
     pool:
       vmImage: ubuntu-18.04
     strategy:

--- a/ci/install_deps.yml
+++ b/ci/install_deps.yml
@@ -6,7 +6,7 @@ steps:
   - script: |
       sudo apt-get clean
       sudo apt-get update
-      sudo apt-get install -y libtool gcc make haveged
+      sudo apt-get install -y libtool gcc make
     displayName: Install Dependencies
   - task: GoTool@0
     inputs:

--- a/ci/scripts/evaluate_commits.sh
+++ b/ci/scripts/evaluate_commits.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+if [[ $(git diff-tree --no-commit-id --name-only 'HEAD^..HEAD') == "docs" ]]; then
+  echo "##vso[task.setvariable variable=buildDoc;isOutput=true]true"
+else
+  echo "##vso[task.setvariable variable=buildDoc;isOutput=true]true"
+  echo "##vso[task.setvariable variable=runTests;isOutput=true]true"
+fi

--- a/common/channelconfig/channel.go
+++ b/common/channelconfig/channel.go
@@ -138,7 +138,7 @@ func (cc *ChannelConfig) ConsortiumsConfig() *ConsortiumsConfig {
 	return cc.consortiumsConfig
 }
 
-// HashingAlgorithm returns a function pointer to the chain hashing algorihtm
+// HashingAlgorithm returns a function pointer to the chain hashing algorithm
 func (cc *ChannelConfig) HashingAlgorithm() func(input []byte) []byte {
 	return cc.hashingAlgorithm
 }

--- a/common/channelconfig/consortium.go
+++ b/common/channelconfig/consortium.go
@@ -22,13 +22,13 @@ type ConsortiumProtos struct {
 	ChannelCreationPolicy *cb.Policy
 }
 
-// ConsortiumConfig holds the consoritums configuration information
+// ConsortiumConfig holds the consortium's configuration information
 type ConsortiumConfig struct {
 	protos *ConsortiumProtos
 	orgs   map[string]Org
 }
 
-// NewConsortiumConfig creates a new instance of the consoritums config
+// NewConsortiumConfig creates a new instance of the consortium's config
 func NewConsortiumConfig(consortiumGroup *cb.ConfigGroup, mspConfig *MSPConfigHandler) (*ConsortiumConfig, error) {
 	cc := &ConsortiumConfig{
 		protos: &ConsortiumProtos{},

--- a/common/channelconfig/msp.go
+++ b/common/channelconfig/msp.go
@@ -37,7 +37,7 @@ func NewMSPConfigHandler(mspVersion msp.MSPVersion, bccsp bccsp.BCCSP) *MSPConfi
 	}
 }
 
-// ProposeValue called when an org defines an MSP
+// ProposeMSP called when an org defines an MSP
 func (bh *MSPConfigHandler) ProposeMSP(mspConfig *mspprotos.MSPConfig) (msp.MSP, error) {
 	var theMsp msp.MSP
 	var err error

--- a/common/channelconfig/util.go
+++ b/common/channelconfig/util.go
@@ -222,7 +222,7 @@ func ChannelCreationPolicyValue(policy *cb.Policy) *StandardConfigValue {
 	}
 }
 
-// ACLsValues returns the config definition for an applications resources based ACL definitions.
+// ACLValues returns the config definition for an applications resources based ACL definitions.
 // It is a value for the /Channel/Application/.
 func ACLValues(acls map[string]string) *StandardConfigValue {
 	a := &pb.ACLs{

--- a/core/chaincode/platforms/util/writer_test.go
+++ b/core/chaincode/platforms/util/writer_test.go
@@ -219,6 +219,9 @@ func Test_WriteFolderToTarPackageFailure4(t *testing.T) {
 	err = WriteFolderToTarPackage(tw, tempDir, []string{}, nil, nil)
 	assert.Error(t, err, "Should have received error writing folder to package")
 	assert.Contains(t, err.Error(), "permission denied")
+
+	err = os.Chmod(tempDir, 0700)
+	require.NoError(t, err)
 }
 
 func createTestTar(t *testing.T, srcPath string, excludeDir []string, includeFileTypeMap map[string]bool, excludeFileTypeMap map[string]bool) []byte {

--- a/core/endorser/msgvalidation.go
+++ b/core/endorser/msgvalidation.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/common"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/core/common/ccprovider"
 	"github.com/hyperledger/fabric/msp"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
@@ -121,6 +122,11 @@ func UnpackProposal(signedProp *pb.SignedProposal) (*UnpackedProposal, error) {
 }
 
 func (up *UnpackedProposal) Validate(idDeserializer msp.IdentityDeserializer) error {
+	logger := decorateLogger(endorserLogger, &ccprovider.TransactionParams{
+		ChannelID: up.ChannelHeader.ChannelId,
+		TxID:      up.TxID(),
+	})
+
 	// validate the header type
 	switch common.HeaderType(up.ChannelHeader.Type) {
 	case common.HeaderType_ENDORSER_TRANSACTION:
@@ -171,29 +177,29 @@ func (up *UnpackedProposal) Validate(idDeserializer msp.IdentityDeserializer) er
 	// get the identity of the creator
 	creator, err := idDeserializer.DeserializeIdentity(up.SignatureHeader.Creator)
 	if err != nil {
-		endorserLogger.Warningf("%s access denied: channel [%s]: %s", up.TxID(), up.ChannelID(), err)
+		logger.Warningf("access denied: channel %s", err)
 		return genericAuthError
 	}
-
-	endorserLogger.Debugf("%s creator is %s", up.TxID(), creator.GetIdentifier())
 
 	// ensure that creator is a valid certificate
 	err = creator.Validate()
 	if err != nil {
-		endorserLogger.Warningf("%s access denied: channel [%s]: identity is not valid: %s", up.TxID(), up.ChannelID(), err)
+		logger.Warningf("access denied: identity is not valid: %s", err)
 		return genericAuthError
 	}
 
-	endorserLogger.Debugf("%s creator is valid", up.TxID())
+	logger = logger.With("mspID", creator.GetMSPIdentifier())
+
+	logger.Debug("creator is valid")
 
 	// validate the signature
 	err = creator.Verify(up.SignedProposal.ProposalBytes, up.SignedProposal.Signature)
 	if err != nil {
-		endorserLogger.Warningf("%s access denied: channel [%s]: creator's signature over the proposal is not valid: %s", up.TxID(), up.ChannelID(), err)
+		logger.Warningf("access denied: creator's signature over the proposal is not valid: %s", err)
 		return genericAuthError
 	}
 
-	endorserLogger.Debugf("%s signature is valid", up.TxID())
+	logger.Debug("signature is valid")
 
 	return nil
 }

--- a/core/handlers/validation/builtin/v12/validation_logic_test.go
+++ b/core/handlers/validation/builtin/v12/validation_logic_test.go
@@ -2272,10 +2272,14 @@ var mockMSPIDGetter = func(cid string) []string {
 }
 
 func TestMain(m *testing.M) {
+	code := -1
+	defer func() {
+		os.Exit(code)
+	}()
 	testDir, err := ioutil.TempDir("", "v1.2-validation")
 	if err != nil {
 		fmt.Printf("Could not create temp dir: %s", err)
-		os.Exit(-1)
+		return
 	}
 	defer os.RemoveAll(testDir)
 	ccprovider.SetChaincodesPath(testDir)
@@ -2286,20 +2290,19 @@ func TestMain(m *testing.M) {
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	if err != nil {
 		fmt.Printf("Initialize cryptoProvider bccsp failed: %s", cryptoProvider)
-		os.Exit(-1)
 		return
 	}
 
 	id, err = mspmgmt.GetLocalMSP(cryptoProvider).GetDefaultSigningIdentity()
 	if err != nil {
 		fmt.Printf("GetSigningIdentity failed with err %s", err)
-		os.Exit(-1)
+		return
 	}
 
 	sid, err = id.Serialize()
 	if err != nil {
 		fmt.Printf("Serialize failed with err %s", err)
-		os.Exit(-1)
+		return
 	}
 
 	// determine the MSP identifier for the first MSP in the default chain
@@ -2308,11 +2311,11 @@ func TestMain(m *testing.M) {
 	msps, err := mspMgr.GetMSPs()
 	if err != nil {
 		fmt.Printf("Could not retrieve the MSPs for the chain manager, err %s", err)
-		os.Exit(-1)
+		return
 	}
 	if len(msps) == 0 {
 		fmt.Printf("At least one MSP was expected")
-		os.Exit(-1)
+		return
 	}
 	for _, m := range msps {
 		msp = m
@@ -2321,13 +2324,13 @@ func TestMain(m *testing.M) {
 	mspid, err = msp.GetIdentifier()
 	if err != nil {
 		fmt.Printf("Failure getting the msp identifier, err %s", err)
-		os.Exit(-1)
+		return
 	}
 
 	// also set the MSP for the "test" chain
 	mspmgmt.XXXSetMSPManager("mycc", mspmgmt.GetManagerForChain("testchannelid"))
 
-	os.Exit(m.Run())
+	code = m.Run()
 }
 
 func TestInValidCollectionName(t *testing.T) {

--- a/core/handlers/validation/builtin/v13/validation_logic_test.go
+++ b/core/handlers/validation/builtin/v13/validation_logic_test.go
@@ -2246,10 +2246,15 @@ var mockMSPIDGetter = func(cid string) []string {
 }
 
 func TestMain(m *testing.M) {
+	code := -1
+	defer func() {
+		os.Exit(code)
+	}()
+
 	testDir, err := ioutil.TempDir("", "v1.3-validation")
 	if err != nil {
 		fmt.Printf("Could not create temp dir: %s", err)
-		os.Exit(-1)
+		return
 	}
 	defer os.RemoveAll(testDir)
 	ccprovider.SetChaincodesPath(testDir)
@@ -2260,20 +2265,19 @@ func TestMain(m *testing.M) {
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	if err != nil {
 		fmt.Printf("Initialize cryptoProvider bccsp failed: %s", err)
-		os.Exit(-1)
 		return
 	}
 
 	id, err = mspmgmt.GetLocalMSP(cryptoProvider).GetDefaultSigningIdentity()
 	if err != nil {
 		fmt.Printf("GetSigningIdentity failed with err %s", err)
-		os.Exit(-1)
+		return
 	}
 
 	sid, err = id.Serialize()
 	if err != nil {
 		fmt.Printf("Serialize failed with err %s", err)
-		os.Exit(-1)
+		return
 	}
 
 	// determine the MSP identifier for the first MSP in the default chain
@@ -2282,11 +2286,11 @@ func TestMain(m *testing.M) {
 	msps, err := mspMgr.GetMSPs()
 	if err != nil {
 		fmt.Printf("Could not retrieve the MSPs for the chain manager, err %s", err)
-		os.Exit(-1)
+		return
 	}
 	if len(msps) == 0 {
 		fmt.Printf("At least one MSP was expected")
-		os.Exit(-1)
+		return
 	}
 	for _, m := range msps {
 		msp = m
@@ -2295,13 +2299,12 @@ func TestMain(m *testing.M) {
 	mspid, err = msp.GetIdentifier()
 	if err != nil {
 		fmt.Printf("Failure getting the msp identifier, err %s", err)
-		os.Exit(-1)
+		return
 	}
 
 	// also set the MSP for the "test" chain
 	mspmgmt.XXXSetMSPManager("mycc", mspmgmt.GetManagerForChain("testchannelid"))
-
-	os.Exit(m.Run())
+	code = m.Run()
 }
 
 func TestInValidCollectionName(t *testing.T) {

--- a/core/handlers/validation/builtin/v20/validation_logic_test.go
+++ b/core/handlers/validation/builtin/v20/validation_logic_test.go
@@ -242,10 +242,14 @@ func (c *mockPolicyChecker) CheckPolicyNoChannel(policyName string, signedProp *
 }
 
 func TestMain(m *testing.M) {
+	code := -1
+	defer func() {
+		os.Exit(code)
+	}()
 	testDir, err := ioutil.TempDir("", "v1.3-validation")
 	if err != nil {
 		fmt.Printf("Could not create temp dir: %s", err)
-		os.Exit(-1)
+		return
 	}
 	defer os.RemoveAll(testDir)
 	ccprovider.SetChaincodesPath(testDir)
@@ -256,20 +260,19 @@ func TestMain(m *testing.M) {
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	if err != nil {
 		fmt.Printf("Initialize cryptoProvider bccsp failed: %s", err)
-		os.Exit(-1)
 		return
 	}
 
 	id, err = mspmgmt.GetLocalMSP(cryptoProvider).GetDefaultSigningIdentity()
 	if err != nil {
 		fmt.Printf("GetSigningIdentity failed with err %s", err)
-		os.Exit(-1)
+		return
 	}
 
 	sid, err = id.Serialize()
 	if err != nil {
 		fmt.Printf("Serialize failed with err %s", err)
-		os.Exit(-1)
+		return
 	}
 
 	// determine the MSP identifier for the first MSP in the default chain
@@ -278,11 +281,11 @@ func TestMain(m *testing.M) {
 	msps, err := mspMgr.GetMSPs()
 	if err != nil {
 		fmt.Printf("Could not retrieve the MSPs for the chain manager, err %s", err)
-		os.Exit(-1)
+		return
 	}
 	if len(msps) == 0 {
 		fmt.Printf("At least one MSP was expected")
-		os.Exit(-1)
+		return
 	}
 	for _, m := range msps {
 		msp = m
@@ -291,11 +294,11 @@ func TestMain(m *testing.M) {
 	mspid, err = msp.GetIdentifier()
 	if err != nil {
 		fmt.Printf("Failure getting the msp identifier, err %s", err)
-		os.Exit(-1)
+		return
 	}
 
 	// also set the MSP for the "test" chain
 	mspmgmt.XXXSetMSPManager("mycc", mspmgmt.GetManagerForChain("testchannelid"))
 
-	os.Exit(m.Run())
+	code = m.Run()
 }

--- a/docs/source/CONTRIBUTING.rst
+++ b/docs/source/CONTRIBUTING.rst
@@ -229,7 +229,8 @@ Submitting your fix
 
 If you just submitted a JIRA for a bug you've discovered, and would like to
 provide a fix, we would welcome that gladly! Please assign the JIRA issue to
-yourself, then you can submit a pull request (PR).
+yourself, then submit a pull request (PR). Please refer to :doc:`github/github`
+for a detailed workflow.
 
 Fixing issues and working stories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/github/github.rst
+++ b/docs/source/github/github.rst
@@ -140,8 +140,13 @@ Perform the following steps to commit and push your code to your forked reposito
    git add <file1> <file2>
 
 - You can now create your commit containing the changes you just added. Your commit
-  message should contain meaningingful information as to why this work was completed,
-  as well as the Jira number in the commit header:
+  message must contain the following information:
+
+  - one line summary of the work in this commit as title, followed by an empty line
+  - in the commit message body, explain why this change is needed, and how you approached it.
+    This helps reviewers better understand your code and often speeds up the review process.
+  - link to JIRA item or JIRA number, i.e. FAB-XXXXX
+  - (optional) if no new tests are added, how the code is tested
 
 .. code::
 

--- a/docs/source/orderer_deploy.md
+++ b/docs/source/orderer_deploy.md
@@ -51,7 +51,7 @@ mandatory for Raft nodes.
 * `BootstrapFile` --- this is the name of the genesis block you will generate for
 this ordering service.
 
-* `GenesisMethod` --- the method by which the bootstrap block is given. For now,
+* `BootstrapMethod` --- the method by which the bootstrap block is given. For now,
 this can only be `file`, in which the file in the `BootstrapFile` is specified.
 
 If you are deploying this node as part of a cluster (for example, as part of a

--- a/docs/source/private-data/private-data.md
+++ b/docs/source/private-data/private-data.md
@@ -21,9 +21,8 @@ A collection is the combination of two elements:
 
 1. **The actual private data**, sent peer-to-peer [via gossip protocol](../gossip.html)
    to only the organization(s) authorized to see it. This data is stored in a
-   private state database on the peers of authorized organizations (sometimes
-   called a "side" database, or "SideDB"), which can be accessed from chaincode
-   on these authorized peers.
+   private state database on the peers of authorized organizations,
+   which can be accessed from chaincode on these authorized peers.
    The ordering service is not involved here and does not see the
    private data. Note that because gossip distributes the private data peer-to-peer
    across authorized organizations, it is required to set up anchor peers on the channel,
@@ -44,6 +43,12 @@ get into a dispute or if they want to transfer the asset to a third party. The
 third party can then compute the hash of the private data and see if it matches the
 state on the channel ledger, proving that the state existed between the collection
 members at a certain point in time.
+
+In some cases, you may decide to have a set of collections each comprised of a
+single organization. For example an organization may record private data in their own
+collection, which could later be shared with other channel members and
+referenced in chaincode transactions. We'll see examples of this in the sharing
+private data topic below.
 
 ### When to use a collection within a channel vs. a separate channel
 
@@ -91,9 +96,7 @@ private data collections **(PDC)** can be defined to share private data between:
 Using this example, peers owned by the **Distributor** will have multiple private
 databases inside their ledger which includes the private data from the
 **Distributor**, **Farmer** and **Shipper** relationship and the
-**Distributor** and **Wholesaler** relationship. Because these databases are kept
-separate from the database that holds the channel ledger, private data is
-sometimes referred to as "SideDB".
+**Distributor** and **Wholesaler** relationship.
 
 ![private-data.private-data](./PrivateDataConcept-3.png)
 
@@ -139,6 +142,210 @@ documentation on [transaction flow](../txflow.html).
    transaction and the block. Upon validation/commit, the private data is moved to
    their copy of the private state database and private writeset storage. The
    private data is then deleted from the `transient data store`.
+
+## Sharing private data
+
+In many scenarios private data keys/values in one collection may need to be shared with
+other channel members or with other private data collections, for example when you
+need to transact on private data with a channel member or group of channel members
+who were not included in the original private data collection. The receiving parties
+will typically want to verify the private data against the on-chain hashes
+as part of the transaction.
+
+There are several aspects of private data collections that enable the
+sharing and verification of private data:
+
+* First, you don't necessarily have to be a member of a collection to write to a key in
+  a collection, as long as the endorsement policy is satisfied.
+  Endorsement policy can be defined at the chaincode level, key level (using state-based
+  endorsement), or collection level (starting in Fabric v2.0).
+
+* Second, starting in v1.4.2 there is a chaincode API GetPrivateDataHash() that allows
+  chaincode on non-member peers to read the hash value of a private key. This is an
+  important feature as you will see later, because it allows chaincode to verify private
+  data against the on-chain hashes that were created from private data in previous transactions.
+
+This ability to share and verify private data should be considered when designing
+applications and the associated private data collections.
+While you can certainly create sets of multilateral private data collections to share data
+among various combinations of channel members, this approach may result in a large
+number of collections that need to be defined.
+Alternatively, consider using a smaller number of private data collections (e.g.
+one collection per organization, or one collection per pair of organizations), and
+then sharing private data with other channel members, or with other
+collections as the need arises. Starting in Fabric v2.0, implicit organization-specific
+collections are available for any chaincode to utilize,
+so that you don't even have to define these per-organization collections when
+deploying chaincode.
+
+### Private data sharing patterns
+
+When modeling private data collections per organization, multiple patterns become available
+for sharing or transferring private data without the overhead of defining many multilateral
+collections. Here are some of the sharing patterns that could be leveraged in chaincode
+applications:
+
+* **Use a corresponding public key for tracking public state** -
+  You can optionally have a matching public key for tracking public state (e.g. asset
+  properties, current ownership. etc), and for every organization that should have access
+  to the asset's corresponding private data, you can create a private key/value in each
+  organization's private data collection.
+
+* **Chaincode access control** -
+  You can implement access control in your chaincode, to specify which clients can
+  query private data in a collection. For example, store an access control list
+  for a private data collection key or range of keys, then in the chaincode get the
+  client submitter's credentials (using GetCreator() chaincode API or CID library API
+  GetID() or GetMSPID() ), and verify they have access before returning the private
+  data. Similarly you could require a client to pass a passphrase into chaincode,
+  which must match a passphrase stored at the key level, in order to access the
+  private data. Note, this pattern can also be used to restrict client access to public
+  state data.
+
+* **Sharing private data out of band** -
+  As an off-chain option, you could share private data out of band with other
+  organizations, and they can hash the key/value to verify it matches
+  the on-chain hash by using GetPrivateDataHash() chaincode API. For example,
+  an organization that wishes to purchase an asset from you may want to verify
+  an asset's properties and that you are the legitimate owner by checking the
+  on-chain hash, prior to agreeing to the purchase.
+
+* **Sharing private data with other collections** -
+  You could 'share' the private data on-chain with chaincode that creates a matching
+  key/value in the other organization's private data collection. You'd pass the
+  private data key/value to chaincode via transient field, and the chaincode
+  could confirm a hash of the passed private data matches the on-chain hash from
+  your collection using GetPrivateDataHash(), and then write the private data to
+  the other organization's private data collection.
+
+* **Transferring private data to other collections** -
+  You could 'transfer' the private data with chaincode that deletes the private data
+  key in your collection, and creates it in another organization's collection.
+  Again, use the transient field to pass the private data upon chaincode invoke,
+  and in the chaincode use GetPrivateDataHash() to confirm that the data exists in
+  your private data collection, before deleting the key from your collection and
+  creating the key in another organization's collection. To ensure that a
+  transaction always deletes from one collection and adds to another collection,
+  you may want to require endorsements from additional parties, such as a
+  regulator or auditor.
+
+* **Using private data for transaction approval** -
+  If you want to get a counterparty's approval for a transaction before it is
+  completed (e.g. an on-chain record that they agree to purchase an asset for
+  a certain price), the chaincode can require them to 'pre-approve' the transaction,
+  by either writing a private key to their private data collection or your collection,
+  which the chaincode will then check using GetPrivateDataHash(). In fact, this is
+  exactly the same mechanism that the built-in lifecycle system chaincode uses to
+  ensure organizations agree to a chaincode definition before it is committed to
+  a channel. Starting with Fabric v2.0, this pattern
+  becomes more powerful with collection-level endorsement policies, to ensure
+  that the chaincode is executed and endorsed on the collection owner's own trusted
+  peer. Alternatively, a mutually agreed key with a key-level endorsement policy
+  could be used, that is then updated with the pre-approval terms and endorsed
+  on peers from the required organizations.
+
+* **Keeping transactors private** -
+  Variations of the prior pattern can also eliminate leaking the transactors for a given
+  transaction. For example a buyer indicates agreement to buy on their own collection,
+  then in a subsequent transaction seller references the buyer's private data in
+  their own private data collection. The proof of transaction with hashed references
+  is recorded on-chain, only the buyer and seller know that they are the transactors,
+  but they can reveal the pre-images if a need-to-know arises, such as in a subsequent
+  transaction with another party who could verify the hashes.
+
+Coupled with the patterns above, it is worth noting that transactions with private
+data can be bound to the same conditions as regular channel state data, specifically:
+
+* **Key level transaction access control** -
+  You can include ownership credentials in a private data value, so that subsequent
+  transactions can verify that the submitter has ownership privilege to share or transfer
+  the data. In this case the chaincode would get the submitter's credentials
+  (e.g. using GetCreator() chaincode API or CID library API GetID() or GetMSPID() ),
+  combine it with other private data that gets passed to the chaincode, hash it,
+  and use GetPrivateDataHash() to verify that it matches the on-chain hash before
+  proceeding with the transaction.
+
+* **Key level endorsement policies** -
+  And also as with normal channel state data, you can use state-based endorsement
+  to specify which organizations must endorse transactions that share or transfer
+  private data, using SetPrivateDataValidationParameter() chaincode API,
+  for example to specify that only an owner's organization peer, custodian's organization
+  peer, or other third party must endorse such transactions.
+
+### Private data sharing example
+
+The private data sharing patterns mentioned above can be combined to enable powerful
+chaincode-based applications. For example, consider how an asset transfer scenario
+could be implemented using per-organization private data collections:
+
+* An asset may be tracked by a UUID key in public chaincode state. Only the asset's
+  ownership is recorded, nothing else is known about the asset.
+
+* The chaincode will require that any transfer request must originate from the owning client,
+  and the key is bound by state-based endorsement requiring that a peer from the
+  owner's organization and a regulator's organization must endorse any transfer requests.
+
+* The asset owner's private data collection contains the private details about
+  the asset, keyed by a hash of the UUID. Other organizations and the ordering
+  service will only see a hash of the asset details.
+
+* Let's assume the regulator is a member of each collection as well, and therefore
+  persists the private data, although this need not be the case.
+
+A transaction to trade the asset would unfold as follows:
+
+1. Off-chain, the owner and a potential buyer strike a deal to trade the asset
+   for a certain price.
+
+2. The seller provides proof of their ownership, by either passing the private details
+   out of band, or by providing the buyer with credentials to query the private
+   data on their node or the regulator's node.
+
+3. Buyer verifies a hash of the private details matches the on-chain public hash.
+
+4. The buyer invokes chaincode to record their bid details in their own private data collection.
+   The chaincode is invoked on buyer's peer, and potentially on regulator's peer if required
+   by the collection endorsement policy.
+
+5. The current owner (seller) invokes chaincode to sell and transfer the asset, passing in the
+   private details and bid information. The chaincode is invoked on peers of the
+   seller, buyer, and regulator, in order to meet the endorsement policy of the public
+   key, as well as the endorsement policies of the buyer and seller private data collections.
+
+6. The chaincode verifies that the submitting client is the owner, verifies the private
+   details against the hash in the seller's collection, and verifies the bid details
+   against the hash in the buyer's collection. The chaincode then writes the proposed
+   updates for the public key (setting ownership to the buyer, and setting endorsement
+   policy to be the buying organization and regulator), writes the private details to the
+   buyer's private data collection, and potentially deletes the private details from seller's
+   collection. Prior to final endorsement, the endorsing peers ensure private data is
+   disseminated to any other authorized peers of the seller and regulator.
+
+7. The seller submits the transaction with the public data and private data hashes
+   for ordering, and it is distributed to all channel peers in a block.
+
+8. Each peer's block validation logic will consistently verify the endorsement policy
+   was met (buyer, seller, regulator all endorsed), and verify that public and private
+   state that was read in the chaincode has not been modified by any other transaction
+   since chaincode execution.
+
+9. All peers commit the transaction as valid since it passed validation checks.
+   Buyer peers and regulator peers retrieve the private data from other authorized
+   peers if they did not receive it at endorsement time, and persist the private
+   data in their private data state database (assuming the private data matched
+   the hashes from the transaction).
+
+10. With the transaction completed, the asset has been transferred, and other
+    channel members interested in the asset may query the history of the public
+    key to understand its provenance, but will not have access to any private
+    details unless an owner shares it on a need-to-know basis.
+
+The basic asset transfer scenario could be extended for other considerations,
+for example the transfer chaincode could verify that a payment record is available
+to satisfy payment versus delivery requirements, or verify that a bank has
+submitted a letter of credit, prior to the execution of the transfer chaincode.
+And instead of transactors directly hosting peers, they could transact through
+custodian organizations who are running peers.
 
 ## Purging private data
 

--- a/gossip/gossip/config.go
+++ b/gossip/gossip/config.go
@@ -95,6 +95,7 @@ type Config struct {
 	ReconnectInterval time.Duration
 }
 
+// GlobalConfig builds a Config from the given endpoint, certificate and bootstrap peers.
 func GlobalConfig(endpoint string, certs *common.TLSCertificates, bootPeers ...string) (*Config, error) {
 	c := &Config{}
 	err := c.loadConfig(endpoint, certs, bootPeers...)

--- a/gossip/gossip/gossip_impl.go
+++ b/gossip/gossip/gossip_impl.go
@@ -41,7 +41,8 @@ const (
 
 type channelRoutingFilterFactory func(channel.GossipChannel) filter.RoutingFilter
 
-type GossipImpl struct {
+// Node is a member of a gossip network
+type Node struct {
 	selfIdentity          api.PeerIdentityType
 	includeIdentityPeriod time.Time
 	certStore             *certStore
@@ -70,12 +71,12 @@ type GossipImpl struct {
 // New creates a gossip instance attached to a gRPC server
 func New(conf *Config, s *grpc.Server, sa api.SecurityAdvisor,
 	mcs api.MessageCryptoService, selfIdentity api.PeerIdentityType,
-	secureDialOpts api.PeerSecureDialOpts, gossipMetrics *metrics.GossipMetrics) *GossipImpl {
+	secureDialOpts api.PeerSecureDialOpts, gossipMetrics *metrics.GossipMetrics) *Node {
 	var err error
 
 	lgr := util.GetLogger(util.GossipLogger, conf.ID)
 
-	g := &GossipImpl{
+	g := &Node{
 		selfOrg:               sa.OrgByPeerIdentity(selfIdentity),
 		secAdvisor:            sa,
 		selfIdentity:          selfIdentity,
@@ -146,7 +147,7 @@ func New(conf *Config, s *grpc.Server, sa api.SecurityAdvisor,
 	return g
 }
 
-func (g *GossipImpl) newStateInfoMsgStore() msgstore.MessageStore {
+func (g *Node) newStateInfoMsgStore() msgstore.MessageStore {
 	pol := protoext.NewGossipMessageComparator(0)
 	return msgstore.NewMessageStoreExpirable(pol,
 		msgstore.Noop,
@@ -156,7 +157,7 @@ func (g *GossipImpl) newStateInfoMsgStore() msgstore.MessageStore {
 		msgstore.Noop)
 }
 
-func (g *GossipImpl) selfNetworkMember() discovery.NetworkMember {
+func (g *Node) selfNetworkMember() discovery.NetworkMember {
 	self := discovery.NetworkMember{
 		Endpoint:         g.conf.ExternalEndpoint,
 		PKIid:            g.comm.GetPKIid(),
@@ -169,7 +170,7 @@ func (g *GossipImpl) selfNetworkMember() discovery.NetworkMember {
 	return self
 }
 
-func newChannelState(g *GossipImpl) *channelState {
+func newChannelState(g *Node) *channelState {
 	return &channelState{
 		stopping: int32(0),
 		channels: make(map[string]channel.GossipChannel),
@@ -177,11 +178,12 @@ func newChannelState(g *GossipImpl) *channelState {
 	}
 }
 
-func (g *GossipImpl) toDie() bool {
+func (g *Node) toDie() bool {
 	return atomic.LoadInt32(&g.stopFlag) == int32(1)
 }
 
-func (g *GossipImpl) JoinChan(joinMsg api.JoinChannelMessage, channelID common.ChannelID) {
+// JoinChan makes gossip participate in the given channel, or update it.
+func (g *Node) JoinChan(joinMsg api.JoinChannelMessage, channelID common.ChannelID) {
 	// joinMsg is supposed to have been already verified
 	g.chanState.joinChannel(joinMsg, channelID, g.gossipMetrics.MembershipMetrics)
 
@@ -191,7 +193,8 @@ func (g *GossipImpl) JoinChan(joinMsg api.JoinChannelMessage, channelID common.C
 	}
 }
 
-func (g *GossipImpl) LeaveChan(channelID common.ChannelID) {
+// LeaveChan makes gossip stop participating in the given channel
+func (g *Node) LeaveChan(channelID common.ChannelID) {
 	gc := g.chanState.getGossipChannelByChainID(channelID)
 	if gc == nil {
 		g.logger.Debug("No such channel", channelID)
@@ -202,11 +205,11 @@ func (g *GossipImpl) LeaveChan(channelID common.ChannelID) {
 
 // SuspectPeers makes the gossip instance validate identities of suspected peers, and close
 // any connections to peers with identities that are found invalid
-func (g *GossipImpl) SuspectPeers(isSuspected api.PeerSuspector) {
+func (g *Node) SuspectPeers(isSuspected api.PeerSuspector) {
 	g.certStore.suspectPeers(isSuspected)
 }
 
-func (g *GossipImpl) learnAnchorPeers(channel string, orgOfAnchorPeers api.OrgIdentityType, anchorPeers []api.AnchorPeer) {
+func (g *Node) learnAnchorPeers(channel string, orgOfAnchorPeers api.OrgIdentityType, anchorPeers []api.AnchorPeer) {
 	if len(anchorPeers) == 0 {
 		g.logger.Info("No configured anchor peers of", string(orgOfAnchorPeers), "for channel", channel, "to learn about")
 		return
@@ -260,7 +263,7 @@ func (g *GossipImpl) learnAnchorPeers(channel string, orgOfAnchorPeers api.OrgId
 	}
 }
 
-func (g *GossipImpl) handlePresumedDead() {
+func (g *Node) handlePresumedDead() {
 	defer g.logger.Debug("Exiting")
 	defer g.stopSignal.Done()
 	for {
@@ -273,7 +276,7 @@ func (g *GossipImpl) handlePresumedDead() {
 	}
 }
 
-func (g *GossipImpl) syncDiscovery() {
+func (g *Node) syncDiscovery() {
 	g.logger.Debug("Entering discovery sync with interval", g.conf.PullInterval)
 	defer g.logger.Debug("Exiting discovery sync loop")
 	for !g.toDie() {
@@ -282,7 +285,7 @@ func (g *GossipImpl) syncDiscovery() {
 	}
 }
 
-func (g *GossipImpl) start() {
+func (g *Node) start() {
 	go g.syncDiscovery()
 	go g.handlePresumedDead()
 
@@ -306,7 +309,7 @@ func (g *GossipImpl) start() {
 	g.logger.Info("Gossip instance", g.conf.ID, "started")
 }
 
-func (g *GossipImpl) acceptMessages(incMsgs <-chan protoext.ReceivedMessage) {
+func (g *Node) acceptMessages(incMsgs <-chan protoext.ReceivedMessage) {
 	defer g.logger.Debug("Exiting")
 	defer g.stopSignal.Done()
 	for {
@@ -319,7 +322,7 @@ func (g *GossipImpl) acceptMessages(incMsgs <-chan protoext.ReceivedMessage) {
 	}
 }
 
-func (g *GossipImpl) handleMessage(m protoext.ReceivedMessage) {
+func (g *Node) handleMessage(m protoext.ReceivedMessage) {
 	if g.toDie() {
 		return
 	}
@@ -391,13 +394,13 @@ func (g *GossipImpl) handleMessage(m protoext.ReceivedMessage) {
 	}
 }
 
-func (g *GossipImpl) forwardDiscoveryMsg(msg protoext.ReceivedMessage) {
+func (g *Node) forwardDiscoveryMsg(msg protoext.ReceivedMessage) {
 	g.discAdapter.incChan <- msg
 }
 
 // validateMsg checks the signature of the message if exists,
 // and also checks that the tag matches the message type
-func (g *GossipImpl) validateMsg(msg protoext.ReceivedMessage) bool {
+func (g *Node) validateMsg(msg protoext.ReceivedMessage) bool {
 	if err := protoext.IsTagLegal(msg.GetGossipMessage().GossipMessage); err != nil {
 		g.logger.Warningf("Tag of %v isn't legal: %v", msg.GetGossipMessage(), errors.WithStack(err))
 		return false
@@ -412,7 +415,7 @@ func (g *GossipImpl) validateMsg(msg protoext.ReceivedMessage) bool {
 	return true
 }
 
-func (g *GossipImpl) sendGossipBatch(a []interface{}) {
+func (g *Node) sendGossipBatch(a []interface{}) {
 	msgs2Gossip := make([]*emittedGossipMessage, len(a))
 	for i, e := range a {
 		msgs2Gossip[i] = e.(*emittedGossipMessage)
@@ -432,7 +435,7 @@ func (g *GossipImpl) sendGossipBatch(a []interface{}) {
 // to the same set of peers.
 // The rest of the messages that have no restrictions on their destinations can be sent
 // to any group of peers.
-func (g *GossipImpl) gossipBatch(msgs []*emittedGossipMessage) {
+func (g *Node) gossipBatch(msgs []*emittedGossipMessage) {
 	if g.disc == nil {
 		g.logger.Error("Discovery has not been initialized yet, aborting!")
 		return
@@ -515,7 +518,7 @@ func (g *GossipImpl) gossipBatch(msgs []*emittedGossipMessage) {
 	}
 }
 
-func (g *GossipImpl) sendAndFilterSecrets(msg *protoext.SignedGossipMessage, peers ...*comm.RemotePeer) {
+func (g *Node) sendAndFilterSecrets(msg *protoext.SignedGossipMessage, peers ...*comm.RemotePeer) {
 	for _, peer := range peers {
 		// Prevent forwarding alive messages of external organizations
 		// to peers that have no external endpoints
@@ -539,7 +542,7 @@ func (g *GossipImpl) sendAndFilterSecrets(msg *protoext.SignedGossipMessage, pee
 }
 
 // gossipInChan gossips a given GossipMessage slice according to a channel's routing policy.
-func (g *GossipImpl) gossipInChan(messages []*emittedGossipMessage, chanRoutingFactory channelRoutingFilterFactory) {
+func (g *Node) gossipInChan(messages []*emittedGossipMessage, chanRoutingFactory channelRoutingFilterFactory) {
 	if len(messages) == 0 {
 		return
 	}
@@ -582,7 +585,7 @@ func (g *GossipImpl) gossipInChan(messages []*emittedGossipMessage, chanRoutingF
 }
 
 // removeSelfLoop deletes from the list of peers peer which has sent the message
-func (g *GossipImpl) removeSelfLoop(msg *emittedGossipMessage, peers []*comm.RemotePeer) []*comm.RemotePeer {
+func (g *Node) removeSelfLoop(msg *emittedGossipMessage, peers []*comm.RemotePeer) []*comm.RemotePeer {
 	var result []*comm.RemotePeer
 	for _, peer := range peers {
 		if msg.filter(peer.PKIID) {
@@ -593,12 +596,12 @@ func (g *GossipImpl) removeSelfLoop(msg *emittedGossipMessage, peers []*comm.Rem
 }
 
 // IdentityInfo returns information known peer identities
-func (g *GossipImpl) IdentityInfo() api.PeerIdentitySet {
+func (g *Node) IdentityInfo() api.PeerIdentitySet {
 	return g.idMapper.IdentityInfo()
 }
 
 // SendByCriteria sends a given message to all peers that match the given SendCriteria
-func (g *GossipImpl) SendByCriteria(msg *protoext.SignedGossipMessage, criteria SendCriteria) error {
+func (g *Node) SendByCriteria(msg *protoext.SignedGossipMessage, criteria SendCriteria) error {
 	if criteria.MaxPeers == 0 {
 		return nil
 	}
@@ -641,7 +644,7 @@ func (g *GossipImpl) SendByCriteria(msg *protoext.SignedGossipMessage, criteria 
 }
 
 // Gossip sends a message to other peers to the network
-func (g *GossipImpl) Gossip(msg *pg.GossipMessage) {
+func (g *Node) Gossip(msg *pg.GossipMessage) {
 	// Educate developers to Gossip messages with the right tags.
 	// See IsTagLegal() for wanted behavior.
 	if err := protoext.IsTagLegal(msg); err != nil {
@@ -689,7 +692,7 @@ func (g *GossipImpl) Gossip(msg *pg.GossipMessage) {
 }
 
 // Send sends a message to remote peers
-func (g *GossipImpl) Send(msg *pg.GossipMessage, peers ...*comm.RemotePeer) {
+func (g *Node) Send(msg *pg.GossipMessage, peers ...*comm.RemotePeer) {
 	m, err := protoext.NoopSign(msg)
 	if err != nil {
 		g.logger.Warningf("Failed creating SignedGossipMessage: %+v", errors.WithStack(err))
@@ -698,14 +701,14 @@ func (g *GossipImpl) Send(msg *pg.GossipMessage, peers ...*comm.RemotePeer) {
 	g.comm.Send(m, peers...)
 }
 
-// GetPeers returns a mapping of endpoint --> []discovery.NetworkMember
-func (g *GossipImpl) Peers() []discovery.NetworkMember {
+// Peers returns the current alive NetworkMembers
+func (g *Node) Peers() []discovery.NetworkMember {
 	return g.disc.GetMembership()
 }
 
 // PeersOfChannel returns the NetworkMembers considered alive
 // and also subscribed to the channel given
-func (g *GossipImpl) PeersOfChannel(channel common.ChannelID) []discovery.NetworkMember {
+func (g *Node) PeersOfChannel(channel common.ChannelID) []discovery.NetworkMember {
 	gc := g.chanState.getGossipChannelByChainID(channel)
 	if gc == nil {
 		g.logger.Debug("No such channel", channel)
@@ -716,12 +719,12 @@ func (g *GossipImpl) PeersOfChannel(channel common.ChannelID) []discovery.Networ
 }
 
 // SelfMembershipInfo returns the peer's membership information
-func (g *GossipImpl) SelfMembershipInfo() discovery.NetworkMember {
+func (g *Node) SelfMembershipInfo() discovery.NetworkMember {
 	return g.disc.Self()
 }
 
 // SelfChannelInfo returns the peer's latest StateInfo message of a given channel
-func (g *GossipImpl) SelfChannelInfo(chain common.ChannelID) *protoext.SignedGossipMessage {
+func (g *Node) SelfChannelInfo(chain common.ChannelID) *protoext.SignedGossipMessage {
 	ch := g.chanState.getGossipChannelByChainID(chain)
 	if ch == nil {
 		return nil
@@ -731,7 +734,7 @@ func (g *GossipImpl) SelfChannelInfo(chain common.ChannelID) *protoext.SignedGos
 
 // PeerFilter receives a SubChannelSelectionCriteria and returns a RoutingFilter that selects
 // only peer identities that match the given criteria, and that they published their channel participation
-func (g *GossipImpl) PeerFilter(channel common.ChannelID, messagePredicate api.SubChannelSelectionCriteria) (filter.RoutingFilter, error) {
+func (g *Node) PeerFilter(channel common.ChannelID, messagePredicate api.SubChannelSelectionCriteria) (filter.RoutingFilter, error) {
 	gc := g.chanState.getGossipChannelByChainID(channel)
 	if gc == nil {
 		return nil, errors.Errorf("Channel %s doesn't exist", string(channel))
@@ -740,7 +743,7 @@ func (g *GossipImpl) PeerFilter(channel common.ChannelID, messagePredicate api.S
 }
 
 // Stop stops the gossip component
-func (g *GossipImpl) Stop() {
+func (g *Node) Stop() {
 	if g.toDie() {
 		return
 	}
@@ -758,13 +761,14 @@ func (g *GossipImpl) Stop() {
 	g.comm.Stop()
 }
 
-func (g *GossipImpl) UpdateMetadata(md []byte) {
+// UpdateMetadata updates gossip membership metadata.
+func (g *Node) UpdateMetadata(md []byte) {
 	g.disc.UpdateMetadata(md)
 }
 
 // UpdateLedgerHeight updates the ledger height the peer
 // publishes to other peers in the channel
-func (g *GossipImpl) UpdateLedgerHeight(height uint64, channelID common.ChannelID) {
+func (g *Node) UpdateLedgerHeight(height uint64, channelID common.ChannelID) {
 	gc := g.chanState.getGossipChannelByChainID(channelID)
 	if gc == nil {
 		g.logger.Warning("No such channel", channelID)
@@ -775,7 +779,7 @@ func (g *GossipImpl) UpdateLedgerHeight(height uint64, channelID common.ChannelI
 
 // UpdateChaincodes updates the chaincodes the peer publishes
 // to other peers in the channel
-func (g *GossipImpl) UpdateChaincodes(chaincodes []*pg.Chaincode, channelID common.ChannelID) {
+func (g *Node) UpdateChaincodes(chaincodes []*pg.Chaincode, channelID common.ChannelID) {
 	gc := g.chanState.getGossipChannelByChainID(channelID)
 	if gc == nil {
 		g.logger.Warning("No such channel", channelID)
@@ -788,7 +792,7 @@ func (g *GossipImpl) UpdateChaincodes(chaincodes []*pg.Chaincode, channelID comm
 // If passThrough is false, the messages are processed by the gossip layer beforehand.
 // If passThrough is true, the gossip layer doesn't intervene and the messages
 // can be used to send a reply back to the sender
-func (g *GossipImpl) Accept(acceptor common.MessageAcceptor, passThrough bool) (<-chan *pg.GossipMessage, <-chan protoext.ReceivedMessage) {
+func (g *Node) Accept(acceptor common.MessageAcceptor, passThrough bool) (<-chan *pg.GossipMessage, <-chan protoext.ReceivedMessage) {
 	if passThrough {
 		return nil, g.comm.Accept(acceptor)
 	}
@@ -840,7 +844,7 @@ func selectOnlyDiscoveryMessages(m interface{}) bool {
 	return selected
 }
 
-func (g *GossipImpl) newDiscoveryAdapter() *discoveryAdapter {
+func (g *Node) newDiscoveryAdapter() *discoveryAdapter {
 	return &discoveryAdapter{
 		c:        g.comm,
 		stopping: int32(0),
@@ -978,7 +982,7 @@ type discoverySecurityAdapter struct {
 	logger                util.Logger
 }
 
-func (g *GossipImpl) newDiscoverySecurityAdapter() *discoverySecurityAdapter {
+func (g *Node) newDiscoverySecurityAdapter() *discoverySecurityAdapter {
 	return &discoverySecurityAdapter{
 		sa:                    g.secAdvisor,
 		idMapper:              g.idMapper,
@@ -1069,7 +1073,7 @@ func (sa *discoverySecurityAdapter) validateAliveMsgSignature(m *protoext.Signed
 	return true
 }
 
-func (g *GossipImpl) createCertStorePuller() pull.Mediator {
+func (g *Node) createCertStorePuller() pull.Mediator {
 	conf := pull.Config{
 		MsgType:           pg.PullMsgType_IDENTITY_MSG,
 		Channel:           []byte(""),
@@ -1112,7 +1116,7 @@ func (g *GossipImpl) createCertStorePuller() pull.Mediator {
 	return pull.NewPullMediator(conf, adapter)
 }
 
-func (g *GossipImpl) sameOrgOrOurOrgPullFilter(msg protoext.ReceivedMessage) func(string) bool {
+func (g *Node) sameOrgOrOurOrgPullFilter(msg protoext.ReceivedMessage) func(string) bool {
 	peersOrg := g.secAdvisor.OrgByPeerIdentity(msg.GetConnectionInfo().Identity)
 	if len(peersOrg) == 0 {
 		g.logger.Warning("Failed determining organization of", msg.GetConnectionInfo())
@@ -1145,7 +1149,7 @@ func (g *GossipImpl) sameOrgOrOurOrgPullFilter(msg protoext.ReceivedMessage) fun
 	}
 }
 
-func (g *GossipImpl) connect2BootstrapPeers() {
+func (g *Node) connect2BootstrapPeers() {
 	for _, endpoint := range g.conf.BootstrapPeers {
 		endpoint := endpoint
 		identifier := func() (*discovery.PeerIdentification, error) {
@@ -1171,7 +1175,7 @@ func (g *GossipImpl) connect2BootstrapPeers() {
 
 }
 
-func (g *GossipImpl) hasExternalEndpoint(PKIID common.PKIidType) bool {
+func (g *Node) hasExternalEndpoint(PKIID common.PKIidType) bool {
 	if nm := g.disc.Lookup(PKIID); nm != nil {
 		return nm.Endpoint != ""
 	}
@@ -1179,7 +1183,7 @@ func (g *GossipImpl) hasExternalEndpoint(PKIID common.PKIidType) bool {
 }
 
 // IsInMyOrg checks whether a network member is in this peer's org
-func (g *GossipImpl) IsInMyOrg(member discovery.NetworkMember) bool {
+func (g *Node) IsInMyOrg(member discovery.NetworkMember) bool {
 	if member.PKIid == nil {
 		return false
 	}
@@ -1189,7 +1193,7 @@ func (g *GossipImpl) IsInMyOrg(member discovery.NetworkMember) bool {
 	return false
 }
 
-func (g *GossipImpl) getOrgOfPeer(PKIID common.PKIidType) api.OrgIdentityType {
+func (g *Node) getOrgOfPeer(PKIID common.PKIidType) api.OrgIdentityType {
 	cert, err := g.idMapper.Get(PKIID)
 	if err != nil {
 		return nil
@@ -1198,7 +1202,7 @@ func (g *GossipImpl) getOrgOfPeer(PKIID common.PKIidType) api.OrgIdentityType {
 	return g.secAdvisor.OrgByPeerIdentity(cert)
 }
 
-func (g *GossipImpl) validateLeadershipMessage(msg *protoext.SignedGossipMessage) error {
+func (g *Node) validateLeadershipMessage(msg *protoext.SignedGossipMessage) error {
 	pkiID := msg.GetLeadershipMsg().PkiId
 	if len(pkiID) == 0 {
 		return errors.New("Empty PKI-ID")
@@ -1212,7 +1216,7 @@ func (g *GossipImpl) validateLeadershipMessage(msg *protoext.SignedGossipMessage
 	})
 }
 
-func (g *GossipImpl) validateStateInfoMsg(msg *protoext.SignedGossipMessage) error {
+func (g *Node) validateStateInfoMsg(msg *protoext.SignedGossipMessage) error {
 	verifier := func(identity []byte, signature, message []byte) error {
 		pkiID := g.idMapper.GetPKIidOfCert(api.PeerIdentityType(identity))
 		if pkiID == nil {
@@ -1227,7 +1231,7 @@ func (g *GossipImpl) validateStateInfoMsg(msg *protoext.SignedGossipMessage) err
 	return msg.Verify(identity, verifier)
 }
 
-func (g *GossipImpl) disclosurePolicy(remotePeer *discovery.NetworkMember) (discovery.Sieve, discovery.EnvelopeFilter) {
+func (g *Node) disclosurePolicy(remotePeer *discovery.NetworkMember) (discovery.Sieve, discovery.EnvelopeFilter) {
 	remotePeerOrg := g.getOrgOfPeer(remotePeer.PKIid)
 
 	if len(remotePeerOrg) == 0 {
@@ -1271,7 +1275,7 @@ func (g *GossipImpl) disclosurePolicy(remotePeer *discovery.NetworkMember) (disc
 		}
 }
 
-func (g *GossipImpl) peersByOriginOrgPolicy(peer discovery.NetworkMember) filter.RoutingFilter {
+func (g *Node) peersByOriginOrgPolicy(peer discovery.NetworkMember) filter.RoutingFilter {
 	peersOrg := g.getOrgOfPeer(peer.PKIid)
 	if len(peersOrg) == 0 {
 		g.logger.Warning("Unable to determine organization of peer", peer)

--- a/gossip/gossip/orgs_test.go
+++ b/gossip/gossip/orgs_test.go
@@ -139,7 +139,7 @@ func newGossipInstanceWithGRPCWithExternalEndpoint(id int, port int, gRPCServer 
 	go func() {
 		gRPCServer.Start()
 	}()
-	return &gossipGRPC{GossipImpl: g, grpc: gRPCServer}
+	return &gossipGRPC{Node: g, grpc: gRPCServer}
 }
 
 func TestMultipleOrgEndpointLeakage(t *testing.T) {
@@ -233,7 +233,7 @@ func TestMultipleOrgEndpointLeakage(t *testing.T) {
 
 	membershipCheck := func() bool {
 		for _, p := range peers {
-			peerNetMember := p.GossipImpl.selfNetworkMember()
+			peerNetMember := p.Node.selfNetworkMember()
 			pkiID := peerNetMember.PKIid
 			peersKnown := p.Peers()
 			peersToKnow := expectedMembershipSize[string(pkiID)]
@@ -391,7 +391,7 @@ func TestConfidentiality(t *testing.T) {
 	for _, p := range peers {
 		wg.Add(1)
 		_, msgs := p.Accept(msgSelector, true)
-		peerNetMember := p.GossipImpl.selfNetworkMember()
+		peerNetMember := p.Node.selfNetworkMember()
 		targetORg := string(cs.OrgByPeerIdentity(api.PeerIdentityType(peerNetMember.InternalEndpoint)))
 		go func(targetOrg string, msgs <-chan protoext.ReceivedMessage) {
 			defer wg.Done()
@@ -447,7 +447,7 @@ func TestConfidentiality(t *testing.T) {
 			for i, p := range orgs2Peers[org] {
 				members := p.Peers()
 				expMemberSize := expectedMembershipSize(peersInOrg, externalEndpointsInOrg, org, i < externalEndpointsInOrg)
-				peerNetMember := p.GossipImpl.selfNetworkMember()
+				peerNetMember := p.Node.selfNetworkMember()
 				membersCount := len(members)
 				if membersCount < expMemberSize {
 					return false

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -30,3 +30,11 @@ ENV FABRIC_CFG_PATH /etc/hyperledger/fabric
 VOLUME /etc/hyperledger/fabric
 COPY --from=tools /go/src/github.com/hyperledger/fabric/build/bin /usr/local/bin
 COPY --from=tools /go/src/github.com/hyperledger/fabric/sampleconfig ${FABRIC_CFG_PATH}
+
+# install yq via pip
+RUN apk add --no-cache curl python
+RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" && \
+    python get-pip.py && \
+    rm get-pip.py && \
+    pip install yq
+

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -322,7 +322,7 @@ var _ = Describe("EndToEnd", func() {
 
 			orderer := network.Orderer("orderer")
 			ordererConfig := network.ReadOrdererConfig(orderer)
-			ordererConfig.General.GenesisMethod = "none"
+			ordererConfig.General.BootstrapMethod = "none"
 			network.WriteOrdererConfig(orderer, ordererConfig)
 			network.Bootstrap()
 

--- a/integration/ledger/ledger_generate_test.go
+++ b/integration/ledger/ledger_generate_test.go
@@ -1,3 +1,5 @@
+// +build generate
+
 /*
 Copyright IBM Corp All Rights Reserved.
 
@@ -16,7 +18,7 @@ import (
 )
 
 // This test generate sample ledger data that can be used to verify rebuild ledger function and upgrade function (in a future release).
-// It is skipped in general. To generate sample ledger data, comment out the line `xxx` and run this test in isolation.
+// It is skipped in general. To generate sample ledger data, use build tag 'generate' and run this test in isolation.
 // It does not delete the network directory so that you can copy the generated data to a different directory for unit tests.
 // At the end of test, it prints `setup.testDir is <directory>`. Copy the network data under <directory> to
 // the unit test directory for rebuild tests as needed.
@@ -77,12 +79,10 @@ var _ = Describe("sample ledger generation", func() {
 		setup.terminateAllProcess()
 		setup.network.Cleanup()
 		// do not delete testDir and log it so that we can copy the test data to unit tests for verification purpose
-		fmt.Printf("The test dir is %s. Use peers/org2.peer0/filesystem/ledgersData as the sample ledger for kvledger rebuild tests\n", setup.testDir)
+		fmt.Fprintf(GinkgoWriter, "The test dir is %s. Use peers/org2.peer0/filesystem/ledgersData as the sample ledger for kvledger rebuild tests\n", setup.testDir)
 	})
 
 	It("creates marbles", func() {
-		Skip("Uncomment to generate sample ledger in v2.0 with new lifecycle chaincode deployment")
-
 		org2peer0 := setup.network.Peer("org2", "peer0")
 		height := helper.getLedgerHeight(org2peer0)
 

--- a/integration/nwo/fabricconfig/orderer.go
+++ b/integration/nwo/fabricconfig/orderer.go
@@ -18,19 +18,19 @@ type Orderer struct {
 }
 
 type General struct {
-	ListenAddress  string                 `yaml:"ListenAddress,omitempty"`
-	ListenPort     int                    `yaml:"ListenPort,omitempty"`
-	TLS            *OrdererTLS            `yaml:"TLS,omitempty"`
-	Keepalive      *OrdererKeepalive      `yaml:"Keepalive,omitempty"`
-	GenesisMethod  string                 `yaml:"GenesisMethod,omitempty"`
-	GenesisProfile string                 `yaml:"GenesisProfile,omitempty"`
-	GenesisFile    string                 `yaml:"GenesisFile,omitempty"` // will be replaced by the BootstrapFile
-	BootstrapFile  string                 `yaml:"BootstrapFile,omitempty"`
-	LocalMSPDir    string                 `yaml:"LocalMSPDir,omitempty"`
-	LocalMSPID     string                 `yaml:"LocalMSPID,omitempty"`
-	Profile        *OrdererProfile        `yaml:"Profile,omitempty"`
-	BCCSP          *BCCSP                 `yaml:"BCCSP,omitempty"`
-	Authentication *OrdererAuthentication `yaml:"Authentication,omitempty"`
+	ListenAddress   string                 `yaml:"ListenAddress,omitempty"`
+	ListenPort      int                    `yaml:"ListenPort,omitempty"`
+	TLS             *OrdererTLS            `yaml:"TLS,omitempty"`
+	Keepalive       *OrdererKeepalive      `yaml:"Keepalive,omitempty"`
+	BootstrapMethod string                 `yaml:"BootstrapMethod,omitempty"`
+	GenesisProfile  string                 `yaml:"GenesisProfile,omitempty"`
+	GenesisFile     string                 `yaml:"GenesisFile,omitempty"` // will be replaced by the BootstrapFile
+	BootstrapFile   string                 `yaml:"BootstrapFile,omitempty"`
+	LocalMSPDir     string                 `yaml:"LocalMSPDir,omitempty"`
+	LocalMSPID      string                 `yaml:"LocalMSPID,omitempty"`
+	Profile         *OrdererProfile        `yaml:"Profile,omitempty"`
+	BCCSP           *BCCSP                 `yaml:"BCCSP,omitempty"`
+	Authentication  *OrdererAuthentication `yaml:"Authentication,omitempty"`
 
 	ExtraProperties map[string]interface{} `yaml:",inline,omitempty"`
 }

--- a/integration/nwo/orderer_template.go
+++ b/integration/nwo/orderer_template.go
@@ -35,7 +35,7 @@ General:
     ServerMinInterval: 60s
     ServerInterval: 7200s
     ServerTimeout: 20s
-  GenesisMethod: file
+  BootstrapMethod: file
   BootstrapFile: {{ .RootDir }}/{{ .SystemChannel.Name }}_block.pb
   LocalMSPDir: {{ $w.OrdererLocalMSPDir Orderer }}
   LocalMSPID: {{ ($w.Organization Orderer.Organization).MSPID }}

--- a/internal/peer/chaincode/chaincode.go
+++ b/internal/peer/chaincode/chaincode.go
@@ -8,6 +8,7 @@ package chaincode
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/hyperledger/fabric/bccsp"
@@ -49,6 +50,8 @@ func Cmd(cf *ChaincodeCmdFactory, cryptoProvider bccsp.BCCSP) *cobra.Command {
 	chaincodeCmd.AddCommand(signpackageCmd(cf, cryptoProvider))
 	chaincodeCmd.AddCommand(upgradeCmd(cf, cryptoProvider))
 	chaincodeCmd.AddCommand(listCmd(cf, cryptoProvider))
+	chaincodeCmd.AddCommand(checkinstalledCmd(cf))
+	chaincodeCmd.AddCommand(checkinstantiatedCmd(cf))
 
 	return chaincodeCmd
 }
@@ -77,6 +80,10 @@ var (
 	connectionProfile     string
 	waitForEvent          bool
 	waitForEventTimeout   time.Duration
+
+	// used for testing explicit os.Exit(<exit code>) scenarios
+	osExit   = os.Exit
+	exitCode = -1
 )
 
 var chaincodeCmd = &cobra.Command{

--- a/internal/peer/chaincode/checkinstalled.go
+++ b/internal/peer/chaincode/checkinstalled.go
@@ -1,0 +1,116 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/internal/peer/common"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func checkinstalledCmd(cf *ChaincodeCmdFactory) *cobra.Command {
+	checkCmd := &cobra.Command{
+		Use:   "checkinstalled",
+		Short: "Check if a certain version of chaincode is installed to peer.",
+		Long:  "Check if a certain version of chaincode is installed to peer.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("trailing args detected: %s", args)
+			}
+			return checkinstalled(cmd, args, cf)
+		},
+	}
+
+	flagList := []string{
+		"name",
+		"version",
+		"peerAddresses",
+		"connectionProfile",
+	}
+	attachFlags(checkCmd, flagList)
+
+	return checkCmd
+}
+
+func checkinstalled(cmd *cobra.Command, args []string, cf *ChaincodeCmdFactory) error {
+	if chaincodeName == common.UndefinedParamValue {
+		return fmt.Errorf("Must supply chaincode name")
+	}
+
+	if chaincodeVersion == common.UndefinedParamValue {
+		return fmt.Errorf("Must supply chaincode version")
+	}
+
+	// Parsing of the command line is done so silence cmd usage
+	cmd.SilenceUsage = true
+
+	var err error
+	if cf == nil {
+		cf, err = InitCmdFactory(cmd.Name(), true, false, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	creator, err := cf.Signer.Serialize()
+	if err != nil {
+		return fmt.Errorf("error serializing identity: %s", err)
+	}
+
+	var prop *pb.Proposal
+	prop, _, err = protoutil.CreateGetInstalledChaincodesProposal(creator)
+	if err != nil {
+		return fmt.Errorf("Error creating proposal %s: %s", chainFuncName, err)
+	}
+
+	var signedProp *pb.SignedProposal
+	signedProp, err = protoutil.GetSignedProposal(prop, cf.Signer)
+	if err != nil {
+		return fmt.Errorf("Error creating signed proposal  %s: %s", chainFuncName, err)
+	}
+
+	// list is currently only supported for one peer
+	proposalResponse, err := cf.EndorserClients[0].ProcessProposal(context.Background(), signedProp)
+	if err != nil {
+		return errors.Errorf("Error endorsing %s: %s", chainFuncName, err)
+	}
+
+	if proposalResponse.Response == nil {
+		return errors.Errorf("Proposal response had nil 'response'")
+	}
+
+	if proposalResponse.Response.Status != int32(cb.Status_SUCCESS) {
+		return errors.Errorf("Bad response: %d - %s", proposalResponse.Response.Status, proposalResponse.Response.Message)
+	}
+
+	cqr := &pb.ChaincodeQueryResponse{}
+	err = proto.Unmarshal(proposalResponse.Response.Payload, cqr)
+	if err != nil {
+		return err
+	}
+
+	for _, chaincode := range cqr.Chaincodes {
+		if chaincodeName == chaincode.GetName() && chaincodeVersion == chaincode.GetVersion() {
+			fmt.Printf("Chaincode %s version %s is installed to peer\n", chaincodeName, chaincodeVersion)
+			osExit(0)
+			return nil
+		}
+	}
+
+	// chaincode is not installed to peer, exit with code 1
+	fmt.Printf("Chaincode %s version %s is not installed to peer\n", chaincodeName, chaincodeVersion)
+	osExit(99)
+
+	return nil
+}

--- a/internal/peer/chaincode/checkinstalled_test.go
+++ b/internal/peer/chaincode/checkinstalled_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/internal/peer/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInstalledMissingChaincodeName(t *testing.T) {
+	defer resetFlags()
+
+	mockCF := createCheckInstalledMockCF(t)
+
+	cmd := checkinstalledCmd(mockCF)
+	addFlags(cmd)
+
+	args := []string{"--version", "1.0"}
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+	t.Logf("Error: %s", err)
+
+	assert.Error(t, err, "Command should return error")
+	assert.Equal(t, err.Error(), "Must supply chaincode name")
+}
+
+func TestInstalledMissingChaincodeVersion(t *testing.T) {
+	defer resetFlags()
+
+	mockCF := createCheckInstalledMockCF(t)
+
+	cmd := checkinstalledCmd(mockCF)
+	addFlags(cmd)
+
+	args := []string{"--name", "name"}
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+	t.Logf("Error: %s", err)
+
+	assert.Error(t, err, "Command should return error")
+	assert.Equal(t, err.Error(), "Must supply chaincode version")
+}
+
+func TestInstalled(t *testing.T) {
+	defer resetFlags()
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	mockCF := createCheckInstalledMockCF(t)
+
+	cmd := checkinstalledCmd(mockCF)
+	addFlags(cmd)
+
+	args := []string{"--name", "mycc1", "--version", "1.0"}
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+
+	assert.NoError(t, err, "Command returned error")
+	assert.NotEqual(t, -1, exitCode, "os.Exit is not called")
+	assert.Equal(t, 0, exitCode, "os.Exit code is not 0")
+}
+
+func TestNotInstalled(t *testing.T) {
+	defer resetFlags()
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	mockCF := createCheckInstalledMockCF(t)
+
+	cmd := checkinstalledCmd(mockCF)
+	addFlags(cmd)
+
+	args := []string{"--name", "not_installed", "--version", "1.0"}
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+
+	assert.NoError(t, err, "Command returned error")
+	assert.NotEqual(t, -1, exitCode, "os.Exit is not called")
+	assert.Equal(t, 99, exitCode, "os.Exit code is not 99")
+}
+
+func createCheckInstalledMockCF(t *testing.T) *ChaincodeCmdFactory {
+	signer, err := common.GetDefaultSigner()
+	if err != nil {
+		t.Fatalf("Get default signer error: %s", err)
+	}
+
+	installedCqr := &pb.ChaincodeQueryResponse{
+		Chaincodes: []*pb.ChaincodeInfo{
+			{Name: "mycc1", Version: "1.0", Path: "codePath1", Input: "input", Escc: "escc", Vscc: "vscc", Id: []byte{1, 2, 3}},
+			{Name: "mycc2", Version: "1.0", Path: "codePath2", Input: "input", Escc: "escc", Vscc: "vscc"},
+		},
+	}
+	installedCqrBytes, err := proto.Marshal(installedCqr)
+	if err != nil {
+		t.Fatalf("Marshal error: %s", err)
+	}
+
+	mockResponse := &pb.ProposalResponse{
+		Response:    &pb.Response{Status: 200, Payload: installedCqrBytes},
+		Endorsement: &pb.Endorsement{},
+	}
+	mockEndorserClients := []pb.EndorserClient{common.GetMockEndorserClient(mockResponse, nil)}
+	mockBroadcastClient := common.GetMockBroadcastClient(nil)
+	mockCF := &ChaincodeCmdFactory{
+		EndorserClients: mockEndorserClients,
+		Signer:          signer,
+		BroadcastClient: mockBroadcastClient,
+	}
+
+	return mockCF
+}

--- a/internal/peer/chaincode/checkinstantiated.go
+++ b/internal/peer/chaincode/checkinstantiated.go
@@ -1,0 +1,127 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/internal/peer/common"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func checkinstantiatedCmd(cf *ChaincodeCmdFactory) *cobra.Command {
+	checkCmd := &cobra.Command{
+		Use:   "checkinstantiated",
+		Short: "Check if a chaincode is instantiated on channel.",
+		Long:  "Check if a chaincode is instantiated on channel.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("trailing args detected: %s", args)
+			}
+			return checkinstantiated(cmd, args, cf)
+		},
+	}
+
+	flagList := []string{
+		"channelID",
+		"name",
+		"version",
+		"peerAddresses",
+		"connectionProfile",
+	}
+	attachFlags(checkCmd, flagList)
+
+	return checkCmd
+}
+
+func checkinstantiated(cmd *cobra.Command, args []string, cf *ChaincodeCmdFactory) error {
+	if channelID == common.UndefinedParamValue {
+		return fmt.Errorf("Must supply channel ID")
+	}
+	if chaincodeName == common.UndefinedParamValue {
+		return fmt.Errorf("Must supply chaincode name")
+	}
+
+	// Parsing of the command line is done so silence cmd usage
+	cmd.SilenceUsage = true
+
+	var err error
+	if cf == nil {
+		cf, err = InitCmdFactory(cmd.Name(), true, false, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	creator, err := cf.Signer.Serialize()
+	if err != nil {
+		return fmt.Errorf("error serializing identity: %s", err)
+	}
+
+	var prop *pb.Proposal
+	prop, _, err = protoutil.CreateGetChaincodesProposal(channelID, creator)
+	if err != nil {
+		return fmt.Errorf("Error creating proposal %s: %s", chainFuncName, err)
+	}
+
+	var signedProp *pb.SignedProposal
+	signedProp, err = protoutil.GetSignedProposal(prop, cf.Signer)
+	if err != nil {
+		return fmt.Errorf("Error creating signed proposal  %s: %s", chainFuncName, err)
+	}
+
+	// list is currently only supported for one peer
+	proposalResponse, err := cf.EndorserClients[0].ProcessProposal(context.Background(), signedProp)
+	if err != nil {
+		return errors.Errorf("Error endorsing %s: %s", chainFuncName, err)
+	}
+
+	if proposalResponse.Response == nil {
+		return errors.Errorf("Proposal response had nil 'response'")
+	}
+
+	if proposalResponse.Response.Status != int32(cb.Status_SUCCESS) {
+		return errors.Errorf("Bad response: %d - %s", proposalResponse.Response.Status, proposalResponse.Response.Message)
+	}
+
+	cqr := &pb.ChaincodeQueryResponse{}
+	err = proto.Unmarshal(proposalResponse.Response.Payload, cqr)
+	if err != nil {
+		return err
+	}
+
+	for _, chaincode := range cqr.Chaincodes {
+		if chaincodeName == chaincode.GetName() {
+			if chaincodeVersion == common.UndefinedParamValue {
+				// is not asking for a specific version, return success
+				fmt.Printf("Chaincode %s is instantiated on channel %s \n", chaincodeName, channelID)
+				osExit(0)
+				return nil
+			} else if chaincodeVersion == chaincode.GetVersion() {
+				fmt.Printf("Chaincode %s version %s is instantiated on channel %s \n", chaincodeName, chaincodeVersion, channelID)
+				osExit(0)
+				return nil
+			}
+		}
+	}
+
+	// chaincode is not instantiated on channel, exit with code 1
+	if chaincodeVersion == common.UndefinedParamValue {
+		fmt.Printf("Chaincode %s is not instantiated on channel %s \n", chaincodeName, channelID)
+	} else {
+		fmt.Printf("Chaincode %s version %s is not instantiated on channel %s \n", chaincodeName, chaincodeVersion, channelID)
+	}
+	osExit(99)
+
+	return nil
+}

--- a/internal/peer/chaincode/checkinstantiated_test.go
+++ b/internal/peer/chaincode/checkinstantiated_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/internal/peer/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInstantiatedMissingChaincodeName(t *testing.T) {
+	defer resetFlags()
+
+	mockCF := createCheckInstantiatedMockCF(t)
+
+	cmd := checkinstantiatedCmd(mockCF)
+	addFlags(cmd)
+
+	args := []string{"--channelID", "mychannel"}
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+	t.Logf("Error: %s", err)
+
+	assert.Error(t, err, "Command should return error")
+	assert.Equal(t, err.Error(), "Must supply chaincode name")
+}
+
+func TestInstantiatedMissingChannelID(t *testing.T) {
+	defer resetFlags()
+
+	mockCF := createCheckInstantiatedMockCF(t)
+
+	cmd := checkinstantiatedCmd(mockCF)
+	addFlags(cmd)
+
+	args := []string{"--name", "name"}
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+	t.Logf("Error: %s", err)
+
+	assert.Error(t, err, "Command should return error")
+	assert.Equal(t, err.Error(), "Must supply channel ID")
+}
+
+func TestInstantiatedWithVersion(t *testing.T) {
+	defer resetFlags()
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	mockCF := createCheckInstantiatedMockCF(t)
+
+	cmd := checkinstantiatedCmd(mockCF)
+	addFlags(cmd)
+
+	args := []string{"--channelID", "mychannel", "--name", "mycc1", "--version", "1.0"}
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+
+	assert.NoError(t, err, "Command returned error")
+	assert.NotEqual(t, -1, exitCode, "os.Exit is not called")
+	assert.Equal(t, 0, exitCode, "os.Exit code is not 0")
+}
+
+func TestInstantiatedWithoutVersion(t *testing.T) {
+	defer resetFlags()
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	mockCF := createCheckInstantiatedMockCF(t)
+
+	cmd := checkinstantiatedCmd(mockCF)
+	addFlags(cmd)
+
+	args := []string{"--channelID", "mychannel", "--name", "mycc1"}
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+
+	assert.NoError(t, err, "Command returned error")
+	assert.NotEqual(t, -1, exitCode, "os.Exit is not called")
+	assert.Equal(t, 0, exitCode, "os.Exit code is not 0")
+}
+
+func TestNotInstantiatedWithVersion(t *testing.T) {
+	defer resetFlags()
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	mockCF := createCheckInstantiatedMockCF(t)
+
+	cmd := checkinstantiatedCmd(mockCF)
+	addFlags(cmd)
+
+	args := []string{"--channelID", "mychannel", "--name", "mycc1", "--version", "2.0"}
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+
+	assert.NoError(t, err, "Command returned error")
+	assert.NotEqual(t, -1, exitCode, "os.Exit is not called")
+	assert.Equal(t, 99, exitCode, "os.Exit code is not 99")
+}
+
+func TestNotInstantiatedWithoutVersion(t *testing.T) {
+	defer resetFlags()
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	mockCF := createCheckInstantiatedMockCF(t)
+
+	cmd := checkinstantiatedCmd(mockCF)
+	addFlags(cmd)
+
+	args := []string{"--channelID", "mychannel", "--name", "not_instantiated"}
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+
+	assert.NoError(t, err, "Command returned error")
+	assert.NotEqual(t, -1, exitCode, "os.Exit is not called")
+	assert.Equal(t, 99, exitCode, "os.Exit code is not 99")
+}
+
+func createCheckInstantiatedMockCF(t *testing.T) *ChaincodeCmdFactory {
+	signer, err := common.GetDefaultSigner()
+	if err != nil {
+		t.Fatalf("Get default signer error: %s", err)
+	}
+
+	installedCqr := &pb.ChaincodeQueryResponse{
+		Chaincodes: []*pb.ChaincodeInfo{
+			{Name: "mycc1", Version: "1.0", Path: "codePath1", Input: "input", Escc: "escc", Vscc: "vscc", Id: []byte{1, 2, 3}},
+			{Name: "mycc2", Version: "1.0", Path: "codePath2", Input: "input", Escc: "escc", Vscc: "vscc"},
+		},
+	}
+	installedCqrBytes, err := proto.Marshal(installedCqr)
+	if err != nil {
+		t.Fatalf("Marshal error: %s", err)
+	}
+
+	mockResponse := &pb.ProposalResponse{
+		Response:    &pb.Response{Status: 200, Payload: installedCqrBytes},
+		Endorsement: &pb.Endorsement{},
+	}
+	mockEndorserClients := []pb.EndorserClient{common.GetMockEndorserClient(mockResponse, nil)}
+	mockBroadcastClient := common.GetMockBroadcastClient(nil)
+	mockCF := &ChaincodeCmdFactory{
+		EndorserClients: mockEndorserClients,
+		Signer:          signer,
+		BroadcastClient: mockBroadcastClient,
+	}
+
+	return mockCF
+}

--- a/internal/peer/channel/channel.go
+++ b/internal/peer/channel/channel.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package channel
 
 import (
+	"os"
 	"strings"
 	"time"
 
@@ -43,6 +44,13 @@ var (
 
 	// fetch related variables
 	bestEffort bool
+
+	// check related variables
+	orgID string
+
+	// used for testing explicit os.Exit(<exit code>) scenarios
+	osExit   = os.Exit
+	exitCode = -1
 )
 
 // Cmd returns the cobra command for Node
@@ -56,6 +64,9 @@ func Cmd(cf *ChannelCmdFactory) *cobra.Command {
 	channelCmd.AddCommand(updateCmd(cf))
 	channelCmd.AddCommand(signconfigtxCmd(cf))
 	channelCmd.AddCommand(getinfoCmd(cf))
+	channelCmd.AddCommand(checkexistsCmd(cf))
+	channelCmd.AddCommand(checkjoinedCmd(cf))
+	channelCmd.AddCommand(checkanchorsCmd(cf))
 
 	return channelCmd
 }
@@ -81,6 +92,7 @@ func resetFlags() {
 	flags.StringVarP(&outputBlock, "outputBlock", "", common.UndefinedParamValue, `The path to write the genesis block for the channel. (default ./<channelID>.block)`)
 	flags.DurationVarP(&timeout, "timeout", "t", 10*time.Second, "Channel creation timeout")
 	flags.BoolVarP(&bestEffort, "bestEffort", "", false, "Whether fetch requests should ignore errors and return blocks on a best effort basis")
+	flags.StringVarP(&orgID, "orgID", "g", common.UndefinedParamValue, `Organization ID`)
 }
 
 func attachFlags(cmd *cobra.Command, names []string) {

--- a/internal/peer/channel/checkanchors.go
+++ b/internal/peer/channel/checkanchors.go
@@ -1,0 +1,113 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package channel
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/common/configtx"
+	"github.com/hyperledger/fabric/internal/peer/common"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func checkanchorsCmd(cf *ChannelCmdFactory) *cobra.Command {
+	fetchCmd := &cobra.Command{
+		Use:   "checkanchors",
+		Short: "Check if anchors peers are configured for an organization in a channel.",
+		Long:  "Check if anchors peers are configured for an organization in a channel.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return checkanchors(cmd, args, cf)
+		},
+	}
+	flagList := []string{
+		"channelID",
+		"orgID",
+		"bestEffort",
+	}
+	attachFlags(fetchCmd, flagList)
+
+	return fetchCmd
+}
+
+func checkanchors(cmd *cobra.Command, args []string, cf *ChannelCmdFactory) error {
+	if channelID == common.UndefinedParamValue {
+		return errors.New("must supply channel ID")
+	}
+	if orgID == common.UndefinedParamValue {
+		return errors.New("must supply organization ID")
+	}
+
+	// Parsing of the command line is done so silence cmd usage
+	cmd.SilenceUsage = true
+
+	// default to fetching from orderer
+	ordererRequired := OrdererRequired
+	peerDeliverRequired := PeerDeliverNotRequired
+	if len(strings.Split(common.OrderingEndpoint, ":")) != 2 {
+		// if no orderer endpoint supplied, connect to peer's deliver service
+		ordererRequired = OrdererNotRequired
+		peerDeliverRequired = PeerDeliverRequired
+	}
+	var err error
+	if cf == nil {
+		cf, err = InitCmdFactory(EndorserNotRequired, peerDeliverRequired, ordererRequired)
+		if err != nil {
+			return err
+		}
+	}
+
+	block, err := cf.DeliverClient.GetNewestBlock()
+	if err != nil {
+		return errors.Wrap(err, "failed to get newest block")
+	}
+	lc, err := protoutil.GetLastConfigIndexFromBlock(block)
+	if err != nil {
+		return errors.Wrap(err, "failed to get last config index from block")
+	}
+	block, err = cf.DeliverClient.GetSpecifiedBlock(lc)
+	if err != nil {
+		return errors.Wrap(err, "failed to get config block")
+	}
+
+	envelope, err := protoutil.ExtractEnvelope(block, 0)
+	if err != nil {
+		return errors.Wrap(err, "failed to extract envelope from config block")
+	}
+
+	payload, err := protoutil.UnmarshalPayload(envelope.Payload)
+	if err != nil {
+		return errors.Wrap(err, "failed to unmarshal payload from envelope")
+	}
+
+	configEnvelope, err := configtx.UnmarshalConfigEnvelope(payload.Data)
+	if err != nil {
+		return errors.Wrap(err, "failed to unmarshal config envelope from payload")
+	}
+
+	configGroups := configEnvelope.GetConfig().GetChannelGroup().GetGroups()["Application"].GetGroups()
+
+	anchorPeersValue := &pb.AnchorPeers{}
+	err = proto.Unmarshal(configGroups[orgID].GetValues()["AnchorPeers"].GetValue(), anchorPeersValue)
+	if err != nil {
+		return errors.Wrap(err, "failed to unmarshal AnchorPeers from ConfigGroup")
+	}
+
+	if len(anchorPeersValue.GetAnchorPeers()) > 0 {
+		fmt.Printf("Anchors peers are configured for organization %s in channel %s.\n", orgID, channelID)
+		osExit(0)
+		return nil
+	}
+
+	fmt.Printf("Anchors peers are not configured for organization %s in channel %s.\n", orgID, channelID)
+	osExit(99)
+	return nil
+}

--- a/internal/peer/channel/checkanchors_test.go
+++ b/internal/peer/channel/checkanchors_test.go
@@ -1,0 +1,237 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package channel
+
+import (
+	"testing"
+
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/internal/peer/common"
+	"github.com/hyperledger/fabric/protoutil"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnchorsMissingChannelID(t *testing.T) {
+	defer resetFlags()
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	InitMSP()
+
+	signer, err := common.GetDefaultSigner()
+	assert.NoError(t, err)
+
+	mockCF := &ChannelCmdFactory{
+		BroadcastFactory: mockBroadcastClientFactory,
+		DeliverClient:    getMockDeliverClient(mockChannel),
+		Signer:           signer,
+	}
+
+	cmd := checkanchorsCmd(mockCF)
+	AddFlags(cmd)
+
+	args := []string{"-g", "mockOrg"}
+	cmd.SetArgs(args)
+
+	err = cmd.Execute()
+	t.Logf("Error: %s", err)
+
+	assert.Error(t, err, "Command should return error")
+	assert.Contains(t, err.Error(), "must supply channel ID")
+}
+
+func TestAnchorsMissingOrgID(t *testing.T) {
+	defer resetFlags()
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	InitMSP()
+
+	signer, err := common.GetDefaultSigner()
+	assert.NoError(t, err)
+
+	mockCF := &ChannelCmdFactory{
+		BroadcastFactory: mockBroadcastClientFactory,
+		DeliverClient:    getMockDeliverClient(mockChannel),
+		Signer:           signer,
+	}
+
+	cmd := checkanchorsCmd(mockCF)
+	AddFlags(cmd)
+
+	args := []string{"-c", "mockChannel"}
+	cmd.SetArgs(args)
+
+	err = cmd.Execute()
+	t.Logf("Error: %s", err)
+
+	assert.Error(t, err, "Command should return error")
+	assert.Contains(t, err.Error(), "must supply organization ID")
+}
+
+func TestAnchors(t *testing.T) {
+	defer resetFlags()
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	InitMSP()
+
+	signer, err := common.GetDefaultSigner()
+	assert.NoError(t, err)
+
+	anchorPeers := &pb.AnchorPeers{
+		AnchorPeers: []*pb.AnchorPeer{{
+			Host: "doesnt matter",
+			Port: 42,
+		}},
+	}
+
+	mockCF := &ChannelCmdFactory{
+		BroadcastFactory: mockBroadcastClientFactory,
+		DeliverClient:    anchorsMockDeliverClient(anchorPeers),
+		Signer:           signer,
+	}
+
+	cmd := checkanchorsCmd(mockCF)
+	AddFlags(cmd)
+
+	args := []string{"-c", "mockChannel", "-g", "mockOrg"}
+	cmd.SetArgs(args)
+
+	err = cmd.Execute()
+
+	assert.NoError(t, err, "Command returned error")
+	assert.NotEqual(t, -1, exitCode, "os.Exit is not called")
+	assert.Equal(t, 0, exitCode, "os.Exit code is not 0")
+}
+
+func TestNoAnchors(t *testing.T) {
+	defer resetFlags()
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	InitMSP()
+
+	signer, err := common.GetDefaultSigner()
+	assert.NoError(t, err)
+
+	mockCF := &ChannelCmdFactory{
+		BroadcastFactory: mockBroadcastClientFactory,
+		DeliverClient:    anchorsMockDeliverClient(nil),
+		Signer:           signer,
+	}
+
+	cmd := checkanchorsCmd(mockCF)
+	AddFlags(cmd)
+
+	args := []string{"-c", "mockChannel", "-g", "mockOrg"}
+	cmd.SetArgs(args)
+
+	err = cmd.Execute()
+
+	assert.NoError(t, err, "Command returned error")
+	assert.NotEqual(t, -1, exitCode, "os.Exit is not called")
+	assert.Equal(t, 99, exitCode, "os.Exit code is not 0")
+
+}
+
+func anchorsMockDeliverClient(anchorPeers *pb.AnchorPeers) *common.DeliverClient {
+	return getMockDeliverClientWithBlock("channelID doesnt matter", anchorsTestBlock(anchorPeers))
+}
+
+func anchorsTestBlock(anchorPeers *pb.AnchorPeers) *cb.Block {
+	var anchorPeersValue []byte = nil
+	if anchorPeers != nil {
+		anchorPeersValue = protoutil.MarshalOrPanic(anchorPeers)
+	}
+
+	payload := &cb.Payload{
+		Header: protoutil.MakePayloadHeader(
+			protoutil.MakeChannelHeader(cb.HeaderType_MESSAGE, int32(1), "test", 0),
+			protoutil.MakeSignatureHeader([]byte("creator"), []byte("nonce"))),
+
+		Data: protoutil.MarshalOrPanic(&cb.ConfigEnvelope{
+			Config: &cb.Config{
+				ChannelGroup: &cb.ConfigGroup{
+					Groups: map[string]*cb.ConfigGroup{
+						"Application": {
+							Groups: map[string]*cb.ConfigGroup{
+								"mockOrg": {
+									Values: map[string]*cb.ConfigValue{
+										"AnchorPeers": {
+											Value: anchorPeersValue,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}),
+	}
+	envelope := &cb.Envelope{Payload: protoutil.MarshalOrPanic(payload)}
+
+	lc := &cb.LastConfig{Index: 0}
+	lcBytes := protoutil.MarshalOrPanic(lc)
+	metadata := &cb.Metadata{
+		Value: lcBytes,
+	}
+	metadataBytes := protoutil.MarshalOrPanic(metadata)
+	blockMetadata := make([][]byte, cb.BlockMetadataIndex_LAST_CONFIG+1)
+	blockMetadata[cb.BlockMetadataIndex_LAST_CONFIG] = metadataBytes
+
+	return &cb.Block{
+		Header: &cb.BlockHeader{
+			Number: 0,
+		},
+		Metadata: &cb.BlockMetadata{
+			Metadata: blockMetadata,
+		},
+		Data: &cb.BlockData{
+			Data: [][]byte{protoutil.MarshalOrPanic(envelope)},
+		},
+	}
+}

--- a/internal/peer/channel/checkexists.go
+++ b/internal/peer/channel/checkexists.go
@@ -1,0 +1,88 @@
+/*
+Copyright IBM Corp. 2017 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+                 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package channel
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hyperledger/fabric/internal/peer/common"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func checkexistsCmd(cf *ChannelCmdFactory) *cobra.Command {
+	// Set the flags on the channel start command.
+	checkCmd := &cobra.Command{
+		Use:   "checkexists",
+		Short: "Check if a certain channel exists.",
+		Long:  "Check if a certain channel exists.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("trailing args detected: %s", args)
+			}
+			return checkexists(cmd, args, cf)
+		},
+	}
+	flagList := []string{
+		"channelID",
+	}
+	attachFlags(checkCmd, flagList)
+
+	return checkCmd
+
+}
+
+func checkexists(cmd *cobra.Command, args []string, cf *ChannelCmdFactory) error {
+	// the global chainID filled by the "-c" command
+	if channelID == common.UndefinedParamValue {
+		return errors.New("must supply channel ID")
+	}
+
+	// Parsing of the command line is done so silence cmd usage
+	cmd.SilenceUsage = true
+
+	// default to fetching from orderer
+	ordererRequired := OrdererRequired
+	peerDeliverRequired := PeerDeliverNotRequired
+	if len(strings.Split(common.OrderingEndpoint, ":")) != 2 {
+		// if no orderer endpoint supplied, connect to peer's deliver service
+		ordererRequired = OrdererNotRequired
+		peerDeliverRequired = PeerDeliverRequired
+	}
+	var err error
+	if cf == nil {
+		cf, err = InitCmdFactory(EndorserNotRequired, peerDeliverRequired, ordererRequired)
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = cf.DeliverClient.GetOldestBlock()
+	if err != nil {
+		if strings.Contains(err.Error(), "&{NOT_FOUND}") {
+			fmt.Printf("Channel %s doesn't exists\n", channelID)
+			osExit(99)
+			return nil
+		}
+		return err
+	}
+
+	fmt.Printf("Channel %s exists\n", channelID)
+	osExit(0)
+	return nil
+}

--- a/internal/peer/channel/checkexists_test.go
+++ b/internal/peer/channel/checkexists_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package channel
+
+import (
+	"errors"
+	"testing"
+
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	ab "github.com/hyperledger/fabric-protos-go/orderer"
+	"github.com/hyperledger/fabric/internal/peer/common"
+	"github.com/hyperledger/fabric/internal/peer/common/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChannelExistsMissingChannelID(t *testing.T) {
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	InitMSP()
+
+	signer, err := common.GetDefaultSigner()
+	assert.NoError(t, err)
+
+	mockCF := &ChannelCmdFactory{
+		BroadcastFactory: mockBroadcastClientFactory,
+		DeliverClient:    getMockDeliverClient(mockChannel),
+		Signer:           signer,
+	}
+
+	cmd := checkexistsCmd(mockCF)
+	AddFlags(cmd)
+
+	err = cmd.Execute()
+	t.Logf("Error: %s", err)
+
+	assert.Error(t, err, "Command should return error")
+	assert.Contains(t, err.Error(), "must supply channel ID")
+}
+
+func TestChannelExists(t *testing.T) {
+	defer resetFlags()
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	InitMSP()
+
+	signer, err := common.GetDefaultSigner()
+	assert.NoError(t, err)
+
+	mockCF := &ChannelCmdFactory{
+		BroadcastFactory: mockBroadcastClientFactory,
+		DeliverClient:    getMockDeliverClient(mockChannel),
+		Signer:           signer,
+	}
+
+	cmd := checkexistsCmd(mockCF)
+	AddFlags(cmd)
+
+	args := []string{"-c", "mockChannel"}
+	cmd.SetArgs(args)
+
+	err = cmd.Execute()
+
+	assert.NoError(t, err, "Command returned error")
+	assert.NotEqual(t, -1, exitCode, "os.Exit is not called")
+	assert.Equal(t, 0, exitCode, "os.Exit code is not 0")
+}
+
+func TestChannelDoesNotExist(t *testing.T) {
+	defer resetFlags()
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	InitMSP()
+
+	signer, err := common.GetDefaultSigner()
+	assert.NoError(t, err)
+
+	mockCF := &ChannelCmdFactory{
+		BroadcastFactory: mockBroadcastClientFactory,
+		DeliverClient:    getMockDeliverClientWithStatusNotFound(),
+		Signer:           signer,
+	}
+
+	cmd := checkexistsCmd(mockCF)
+	AddFlags(cmd)
+
+	args := []string{"-c", "mockChannel"}
+	cmd.SetArgs(args)
+
+	err = cmd.Execute()
+
+	assert.NoError(t, err, "Command returned error")
+	assert.NotEqual(t, -1, exitCode, "os.Exit is not called")
+	assert.Equal(t, 99, exitCode, "os.Exit code is not 99")
+}
+
+func getMockDeliverClientWithStatusNotFound() *common.DeliverClient {
+	mockD := &mock.DeliverService{}
+	statusResponse := &ab.DeliverResponse{
+		Type: &ab.DeliverResponse_Status{Status: cb.Status_NOT_FOUND},
+	}
+	mockD.RecvStub = func() (*ab.DeliverResponse, error) {
+		return statusResponse, errors.New("Error: can't read the block: &{NOT_FOUND}")
+	}
+	mockD.CloseSendReturns(nil)
+
+	p := &common.DeliverClient{
+		Service: mockD,
+	}
+	return p
+}

--- a/internal/peer/channel/checkjoined.go
+++ b/internal/peer/channel/checkjoined.go
@@ -1,0 +1,85 @@
+/*
+Copyright IBM Corp. 2017 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+                 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package channel
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/fabric/internal/peer/common"
+	"github.com/spf13/cobra"
+)
+
+func checkjoinedCmd(cf *ChannelCmdFactory) *cobra.Command {
+	// Set the flags on the channel start command.
+	checkCmd := &cobra.Command{
+		Use:   "checkjoined",
+		Short: "Check if peer joined to a certain channel.",
+		Long:  "Check if peer joined to a certain channel.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("trailing args detected: %s", args)
+			}
+			return checkjoined(cmd, args, cf)
+		},
+	}
+	flagList := []string{
+		"channelID",
+	}
+	attachFlags(checkCmd, flagList)
+
+	return checkCmd
+
+}
+
+func checkjoined(cmd *cobra.Command, args []string, cf *ChannelCmdFactory) error {
+	// the global chainID filled by the "-c" command
+	if channelID == common.UndefinedParamValue {
+		return errors.New("must supply channel ID")
+	}
+
+	// Parsing of the command line is done so silence cmd usage
+	cmd.SilenceUsage = true
+
+	var err error
+	if cf == nil {
+		cf, err = InitCmdFactory(EndorserRequired, PeerDeliverNotRequired, OrdererNotRequired)
+		if err != nil {
+			return err
+		}
+	}
+
+	client := &endorserClient{cf}
+
+	channels, err := client.getChannels()
+	if err != nil {
+		return err
+	}
+
+	for _, channel := range channels {
+		if channelID == channel.ChannelId {
+			fmt.Printf("Peer joined channel %s\n", channelID)
+			osExit(0)
+			return nil
+		}
+	}
+	// peer not joined to channel, exit with code 1
+	fmt.Printf("Peer didn't join channel %s\n", channelID)
+	osExit(99)
+
+	return nil
+}

--- a/internal/peer/channel/checkjoined_test.go
+++ b/internal/peer/channel/checkjoined_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package channel
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/internal/peer/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJoinedChannelMissingChannelID(t *testing.T) {
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	InitMSP()
+
+	signer, err := common.GetDefaultSigner()
+	assert.NoError(t, err)
+
+	mockCF := &ChannelCmdFactory{
+		BroadcastFactory: mockBroadcastClientFactory,
+		DeliverClient:    getMockDeliverClient(mockChannel),
+		Signer:           signer,
+	}
+
+	cmd := checkjoinedCmd(mockCF)
+	AddFlags(cmd)
+
+	err = cmd.Execute()
+	t.Logf("Error: %s", err)
+
+	assert.Error(t, err, "Command should return error")
+	assert.Contains(t, err.Error(), "must supply channel ID")
+}
+
+func TestJoinedChannel(t *testing.T) {
+	defer resetFlags()
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	InitMSP()
+
+	mockChannelResponse := &pb.ChannelQueryResponse{
+		Channels: []*pb.ChannelInfo{{
+			ChannelId: "mockChannel",
+		}},
+	}
+
+	mockPayload, err := proto.Marshal(mockChannelResponse)
+	assert.NoError(t, err)
+
+	mockResponse := &pb.ProposalResponse{
+		Response: &pb.Response{
+			Status:  200,
+			Payload: mockPayload,
+		},
+		Endorsement: &pb.Endorsement{},
+	}
+
+	signer, err := common.GetDefaultSigner()
+	assert.NoError(t, err)
+
+	mockCF := &ChannelCmdFactory{
+		EndorserClient:   common.GetMockEndorserClient(mockResponse, nil),
+		BroadcastFactory: mockBroadcastClientFactory,
+		Signer:           signer,
+	}
+
+	cmd := checkjoinedCmd(mockCF)
+	AddFlags(cmd)
+
+	args := []string{"-c", "mockChannel"}
+	cmd.SetArgs(args)
+
+	err = cmd.Execute()
+
+	assert.NoError(t, err, "Command returned error")
+	assert.NotEqual(t, -1, exitCode, "os.Exit is not called")
+	assert.Equal(t, 0, exitCode, "os.Exit code is not 0")
+}
+
+func TestNotJoinedChannel(t *testing.T) {
+	defer resetFlags()
+
+	// Save current os.Exit function and restore at the end:
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+
+	exitCode = -1
+	mockExit := func(code int) {
+		t.Logf("os.Exit is called with exit code %d", code)
+		exitCode = code
+	}
+	osExit = mockExit
+
+	InitMSP()
+
+	mockChannelResponse := &pb.ChannelQueryResponse{
+		Channels: []*pb.ChannelInfo{},
+	}
+
+	mockPayload, err := proto.Marshal(mockChannelResponse)
+	assert.NoError(t, err)
+
+	mockResponse := &pb.ProposalResponse{
+		Response: &pb.Response{
+			Status:  200,
+			Payload: mockPayload,
+		},
+		Endorsement: &pb.Endorsement{},
+	}
+
+	signer, err := common.GetDefaultSigner()
+	assert.NoError(t, err)
+
+	mockCF := &ChannelCmdFactory{
+		EndorserClient:   common.GetMockEndorserClient(mockResponse, nil),
+		BroadcastFactory: mockBroadcastClientFactory,
+		Signer:           signer,
+	}
+
+	cmd := checkjoinedCmd(mockCF)
+	AddFlags(cmd)
+
+	args := []string{"-c", "mockChannel"}
+	cmd.SetArgs(args)
+
+	err = cmd.Execute()
+
+	assert.NoError(t, err, "Command returned error")
+	assert.NotEqual(t, -1, exitCode, "os.Exit is not called")
+	assert.Equal(t, 99, exitCode, "os.Exit code is not 99")
+}

--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -45,8 +45,9 @@ type General struct {
 	Cluster           Cluster
 	Keepalive         Keepalive
 	ConnectionTimeout time.Duration
-	GenesisMethod     string
+	GenesisMethod     string // For compatibility only, will be replaced by BootstrapMethod
 	GenesisFile       string // For compatibility only, will be replaced by BootstrapFile
+	BootstrapMethod   string
 	BootstrapFile     string
 	Profile           Profile
 	LocalMSPDir       string
@@ -205,10 +206,10 @@ type Statsd struct {
 // Defaults carries the default orderer configuration values.
 var Defaults = TopLevel{
 	General: General{
-		ListenAddress: "127.0.0.1",
-		ListenPort:    7050,
-		GenesisMethod: "file",
-		BootstrapFile: "genesisblock",
+		ListenAddress:   "127.0.0.1",
+		ListenPort:      7050,
+		BootstrapMethod: "file",
+		BootstrapFile:   "genesisblock",
 		Profile: Profile{
 			Enabled: false,
 			Address: "0.0.0.0:6060",
@@ -331,8 +332,14 @@ func (c *TopLevel) completeInitialization(configDir string) {
 		case c.General.ListenPort == 0:
 			logger.Infof("General.ListenPort unset, setting to %v", Defaults.General.ListenPort)
 			c.General.ListenPort = Defaults.General.ListenPort
-		case c.General.GenesisMethod == "":
-			c.General.GenesisMethod = Defaults.General.GenesisMethod
+		case c.General.BootstrapMethod == "":
+			if c.General.GenesisMethod != "" {
+				// This is to keep the compatibility with old config file that uses genesismethod
+				logger.Warn("General.GenesisMethod should be replaced by General.BootstrapMethod")
+				c.General.BootstrapMethod = c.General.GenesisMethod
+			} else {
+				c.General.BootstrapMethod = Defaults.General.BootstrapMethod
+			}
 		case c.General.BootstrapFile == "":
 			if c.General.GenesisFile != "" {
 				// This is to keep the compatibility with old config file that uses genesisfile

--- a/orderer/common/multichannel/registrar_test.go
+++ b/orderer/common/multichannel/registrar_test.go
@@ -455,7 +455,7 @@ func TestBroadcastChannelSupport(t *testing.T) {
 		ledgerFactory, _ := newLedgerAndFactory(tmpdir, "", nil)
 		mockConsenters := map[string]consensus.Consenter{confSys.Orderer.OrdererType: &mockConsenter{}}
 		config := localconfig.TopLevel{}
-		config.General.GenesisMethod = "none"
+		config.General.BootstrapMethod = "none"
 		config.General.GenesisFile = ""
 		registrar := NewRegistrar(config, ledgerFactory, mockCrypto(), &disabled.Provider{}, cryptoProvider)
 		registrar.Initialize(mockConsenters)

--- a/orderer/common/server/etcdraft_test.go
+++ b/orderer/common/server/etcdraft_test.go
@@ -147,7 +147,7 @@ func testEtcdRaftOSNNoTLSSingleListener(gt *GomegaWithT, tempDir, orderer, fabri
 	cmd := exec.Command(orderer)
 	cmd.Env = []string{
 		fmt.Sprintf("ORDERER_GENERAL_LISTENPORT=%d", nextPort()),
-		"ORDERER_GENERAL_GENESISMETHOD=file",
+		"ORDERER_GENERAL_BOOTSTRAPMETHOD=file",
 		"ORDERER_GENERAL_SYSTEMCHANNEL=system",
 		fmt.Sprintf("ORDERER_FILELEDGER_LOCATION=%s", filepath.Join(tempDir, "ledger")),
 		fmt.Sprintf("ORDERER_GENERAL_BOOTSTRAPFILE=%s", genesisBlockPath),
@@ -170,7 +170,7 @@ func testEtcdRaftOSNNoTLSDualListener(gt *GomegaWithT, tempDir, orderer, fabricR
 	cmd := exec.Command(orderer)
 	cmd.Env = []string{
 		fmt.Sprintf("ORDERER_GENERAL_LISTENPORT=%d", nextPort()),
-		"ORDERER_GENERAL_GENESISMETHOD=file",
+		"ORDERER_GENERAL_BOOTSTRAPMETHOD=file",
 		"ORDERER_GENERAL_SYSTEMCHANNEL=system",
 		"ORDERER_GENERAL_TLS_ENABLED=false",
 		"ORDERER_OPERATIONS_TLS_ENABLED=false",
@@ -204,7 +204,7 @@ func launchOrderer(gt *GomegaWithT, orderer, tempDir, genesisBlockPath, fabricRo
 	cmd := exec.Command(orderer)
 	cmd.Env = []string{
 		fmt.Sprintf("ORDERER_GENERAL_LISTENPORT=%d", nextPort()),
-		"ORDERER_GENERAL_GENESISMETHOD=file",
+		"ORDERER_GENERAL_BOOTSTRAPMETHOD=file",
 		"ORDERER_GENERAL_SYSTEMCHANNEL=system",
 		"ORDERER_GENERAL_TLS_CLIENTAUTHREQUIRED=true",
 		"ORDERER_GENERAL_TLS_ENABLED=true",

--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -124,7 +124,7 @@ func Main() {
 	var clusterDialer *cluster.PredicateDialer
 	var clusterType, reuseGrpcListener bool
 	var serversToUpdate []*comm.GRPCServer
-	if conf.General.GenesisMethod == "file" {
+	if conf.General.BootstrapMethod == "file" {
 		bootstrapBlock := extractBootstrapBlock(conf)
 		if err := ValidateBootstrapBlock(bootstrapBlock, cryptoProvider); err != nil {
 			logger.Panicf("Failed validating bootstrap block: %v", err)
@@ -143,7 +143,7 @@ func Main() {
 
 			r = createReplicator(lf, bootstrapBlock, conf, clusterClientConfig.SecOpts, signer, cryptoProvider)
 			// Only clusters that are equipped with a recent config block can replicate.
-			if conf.General.GenesisMethod == "file" {
+			if conf.General.BootstrapMethod == "file" {
 				r.replicateIfNeeded(bootstrapBlock)
 			}
 
@@ -588,13 +588,13 @@ func extractBootstrapBlock(conf *localconfig.TopLevel) *cb.Block {
 	var bootstrapBlock *cb.Block
 
 	// Select the bootstrapping mechanism
-	switch conf.General.GenesisMethod {
+	switch conf.General.BootstrapMethod {
 	case "file": // For now, "file" is the only supported genesis method
 		bootstrapBlock = file.New(conf.General.BootstrapFile).GenesisBlock()
 	case "none": // simply honor the configuration value
 		return nil
 	default:
-		logger.Panic("Unknown genesis method:", conf.General.GenesisMethod)
+		logger.Panic("Unknown genesis method:", conf.General.BootstrapMethod)
 	}
 
 	return bootstrapBlock
@@ -710,7 +710,7 @@ func initializeMultichannelRegistrar(
 	// Note, we pass a 'nil' channel here, we could pass a channel that
 	// closes if we wished to cleanup this routine on exit.
 	go kafkaMetrics.PollGoMetricsUntilStop(time.Minute, nil)
-	if conf.General.GenesisMethod == "file" {
+	if conf.General.BootstrapMethod == "file" {
 		if isClusterType(bootstrapBlock, bccsp) {
 			initializeEtcdraftConsenter(consenters, conf, lf, clusterDialer, bootstrapBlock, ri, srvConf, srv, registrar, metricsProvider, bccsp)
 		}

--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -204,6 +204,8 @@ func TestInitializeBootstrapChannel(t *testing.T) {
 	defer os.Remove(genesisFile)
 
 	fileLedgerLocation, _ := ioutil.TempDir("", "main_test-")
+	defer os.RemoveAll(fileLedgerLocation)
+
 	ledgerFactory, _, err := createLedgerFactory(
 		&localconfig.TopLevel{
 			FileLedger: localconfig.FileLedger{

--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -215,8 +215,8 @@ func TestInitializeBootstrapChannel(t *testing.T) {
 	assert.NoError(t, err)
 	bootstrapConfig := &localconfig.TopLevel{
 		General: localconfig.General{
-			GenesisMethod: "file",
-			BootstrapFile: genesisFile,
+			BootstrapMethod: "file",
+			BootstrapFile:   genesisFile,
 		},
 	}
 
@@ -241,13 +241,13 @@ func TestExtractBootstrapBlock(t *testing.T) {
 	}{
 		{
 			config: &localconfig.TopLevel{
-				General: localconfig.General{GenesisMethod: "file", BootstrapFile: genesisFile},
+				General: localconfig.General{BootstrapMethod: "file", BootstrapFile: genesisFile},
 			},
 			block: file.New(genesisFile).GenesisBlock(),
 		},
 		{
 			config: &localconfig.TopLevel{
-				General: localconfig.General{GenesisMethod: "none"},
+				General: localconfig.General{BootstrapMethod: "none"},
 			},
 			block: nil,
 		},
@@ -406,7 +406,7 @@ func TestInitializeMultichannelRegistrar(t *testing.T) {
 	})
 
 	t.Run("registrar without a system channel", func(t *testing.T) {
-		conf.General.GenesisMethod = "none"
+		conf.General.BootstrapMethod = "none"
 		conf.General.GenesisFile = ""
 		lf, _, err := createLedgerFactory(conf, &disabled.Provider{})
 		assert.NoError(t, err)
@@ -469,10 +469,10 @@ func TestUpdateTrustedRoots(t *testing.T) {
 	port, _ := strconv.ParseUint(strings.Split(listenAddr, ":")[1], 10, 16)
 	conf := &localconfig.TopLevel{
 		General: localconfig.General{
-			GenesisMethod: "file",
-			BootstrapFile: genesisFile,
-			ListenAddress: "localhost",
-			ListenPort:    uint16(port),
+			BootstrapMethod: "file",
+			BootstrapFile:   genesisFile,
+			ListenAddress:   "localhost",
+			ListenPort:      uint16(port),
 			TLS: localconfig.TLS{
 				Enabled:            false,
 				ClientAuthRequired: false,
@@ -837,10 +837,10 @@ func genesisConfig(t *testing.T, genesisFile string) *localconfig.TopLevel {
 	localMSPDir := configtest.GetDevMspDir()
 	return &localconfig.TopLevel{
 		General: localconfig.General{
-			GenesisMethod: "file",
-			BootstrapFile: genesisFile,
-			LocalMSPDir:   localMSPDir,
-			LocalMSPID:    "SampleOrg",
+			BootstrapMethod: "file",
+			BootstrapFile:   genesisFile,
+			LocalMSPDir:     localMSPDir,
+			LocalMSPID:      "SampleOrg",
 			BCCSP: &factory.FactoryOpts{
 				ProviderName: "SW",
 				SwOpts: &factory.SwOpts{

--- a/orderer/common/server/util.go
+++ b/orderer/common/server/util.go
@@ -18,8 +18,11 @@ import (
 
 func createLedgerFactory(conf *config.TopLevel, metricsProvider metrics.Provider) (blockledger.Factory, string, error) {
 	ld := conf.FileLedger.Location
+	var err error
 	if ld == "" {
-		ld = createTempDir(conf.FileLedger.Prefix)
+		if ld, err = ioutil.TempDir("", conf.FileLedger.Prefix); err != nil {
+			logger.Panic("Error creating temp dir:", err)
+		}
 	}
 
 	logger.Debug("Ledger dir:", ld)
@@ -28,12 +31,4 @@ func createLedgerFactory(conf *config.TopLevel, metricsProvider metrics.Provider
 		return nil, "", errors.WithMessage(err, "Error in opening ledger factory")
 	}
 	return lf, ld, nil
-}
-
-func createTempDir(dirPrefix string) string {
-	dirPath, err := ioutil.TempDir("", dirPrefix)
-	if err != nil {
-		logger.Panic("Error creating temp dir:", err)
-	}
-	return dirPath
 }

--- a/orderer/common/server/util_test.go
+++ b/orderer/common/server/util_test.go
@@ -61,19 +61,3 @@ func TestCreateLedgerFactory(t *testing.T) {
 		})
 	}
 }
-
-func TestCreateTempDir(t *testing.T) {
-	t.Run("Good", func(t *testing.T) {
-		tempDir := createTempDir("foo")
-		if _, err := os.Stat(tempDir); err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	t.Run("Bad", func(t *testing.T) {
-		assert.Panics(t, func() {
-			createTempDir("foo/bar")
-		})
-	})
-
-}

--- a/release_notes/v2.0.0.txt
+++ b/release_notes/v2.0.0.txt
@@ -92,7 +92,7 @@ to understand recent changes to a key.
 
 FAB-16722 - The 'provisional' genesis method of generating the system channel
 for orderers has been removed. Existing users of the provisional genesis method
-should instead set GenesisMethod to 'file', and generate a genesis block file
+should instead set BootstrapMethod to 'file', and generate a genesis block file
 using configtxgen. Orderer nodes will then use the generated file for the
 orderer system channel.
 

--- a/sampleconfig/orderer.yaml
+++ b/sampleconfig/orderer.yaml
@@ -68,14 +68,14 @@ General:
         # ServerPrivateKey defines the file location of the private key of the TLS certificate.
         ServerPrivateKey:
 
-    # Genesis method: The method by which the genesis block for the orderer
+    # Bootstrap method: The method by which to obtain the bootstrap block
     # system channel is specified. The option can be one of:
     #   "file" - path to a faile containing the genesis block or config block of system channel
     #   "none" - allows an orderer to start without a system channel configuration
-    GenesisMethod: file
+    BootstrapMethod: file
 
     # Bootstrap file: The file containing the bootstrap block to use when
-    # initializing the orderer system channel and GenesisMethod is set to
+    # initializing the orderer system channel and BootstrapMethod is set to
     # "file".  The bootstrap file can be the genesis block, and it can also be 
     # a config block for late bootstrap of some consensus methods like Raft.
     BootstrapFile:

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -12,23 +12,32 @@ set -e -u
 
 fabric_dir="$(cd "$(dirname "$0")/.." && pwd)"
 
-# find packages that contain "integration" in the import path
-integration_dirs() {
-    local packages="$1"
+cd "$fabric_dir"
 
-    go list -f '{{.Dir}}' "$packages" | grep -E '/integration($|/)' | sed "s,${fabric_dir},.,g"
-}
+dirs=()
+if [ "${#}" -eq 0 ]; then
+  specs=()
+  specs=("$(grep -Ril --exclude-dir=vendor --exclude-dir=scripts "RunSpecs" . | grep integration)")
+  for spec in ${specs[*]}; do
+    dirs+=("$(dirname "${spec}")")
+  done
+else
+  dirs=("$@")
+fi
 
-main() {
-    cd "$fabric_dir"
+totalAgents=${SYSTEM_TOTALJOBSINPHASE:-0}   # standard VSTS variables available using parallel execution; total number of parallel jobs running
+agentNumber=${SYSTEM_JOBPOSITIONINPHASE:-0} # current job position
+testCount=${#dirs[@]}
 
-    local -a dirs=("$@")
-    if [ "${#dirs[@]}" -eq 0 ]; then
-        while IFS=$'\n' read -r pkg; do dirs+=("$pkg"); done < <(integration_dirs "./...")
-    fi
+# below conditions are used if parallel pipeline is not used. i.e. pipeline is running with single agent (no parallel configuration)
+if [ "$totalAgents" -eq 0 ]; then totalAgents=1; fi
+if [ "$agentNumber" -eq 0 ]; then agentNumber=1; fi
 
-    echo "Running integration tests..."
-    ginkgo -keepGoing --slowSpecThreshold 60 "${dirs[@]}"
-}
+declare -a files
+for ((i = "$agentNumber"; i <= "$testCount"; )); do
+  files+=("${dirs[$i - 1]}")
+  i=$((${i} + ${totalAgents}))
+done
 
-main "$@"
+echo "Running the following test suites: ${files[*]}"
+ginkgo -keepGoing --slowSpecThreshold 60 ${files[*]}


### PR DESCRIPTION
#### Type of change
- New feature

#### Description
This commit introduces 5 new peer CLI commands
to make CLI more suitable for scripting.
Please see relevant Jira ticket for details and motivation.

These commands exit with status 0 if condition is satisfied, 99 o/w.
This makes them easy to use in scripting without error prone text parsing.

peer channel checkexists -c \<channelID\>
peer channel checkjoined -c \<channelID\>
peer channel checkanchors -c \<channelID\> -g \<orgID\>

peer chaincode checkinstalled -n \<name\> -v \<version\>
peer chaincode checkinstantiated -C \<channelID\> -n \<name\> [-v \<version\>]

Also installed **yq** to tools Docker image for processing yaml files.
This is required basically to process configtx.yaml file.

Signed-off-by: Hakan Eryargi <hakan.eryargi@gmail.com>