### PR TITLE
FAB-17157 rm createTempDir method

### DIFF
--- a/orderer/common/server/util.go
+++ b/orderer/common/server/util.go
@@ -18,8 +18,11 @@ import (
 
 func createLedgerFactory(conf *config.TopLevel, metricsProvider metrics.Provider) (blockledger.Factory, string, error) {
 	ld := conf.FileLedger.Location
+	var err error
 	if ld == "" {
-		ld = createTempDir(conf.FileLedger.Prefix)
+		if ld, err = ioutil.TempDir("", conf.FileLedger.Prefix); err != nil {
+			logger.Panic("Error creating temp dir:", err)
+		}
 	}
 
 	logger.Debug("Ledger dir:", ld)
@@ -28,12 +31,4 @@ func createLedgerFactory(conf *config.TopLevel, metricsProvider metrics.Provider
 		return nil, "", errors.WithMessage(err, "Error in opening ledger factory")
 	}
 	return lf, ld, nil
-}
-
-func createTempDir(dirPrefix string) string {
-	dirPath, err := ioutil.TempDir("", dirPrefix)
-	if err != nil {
-		logger.Panic("Error creating temp dir:", err)
-	}
-	return dirPath
 }

--- a/orderer/common/server/util_test.go
+++ b/orderer/common/server/util_test.go
@@ -61,19 +61,3 @@ func TestCreateLedgerFactory(t *testing.T) {
 		})
 	}
 }
-
-func TestCreateTempDir(t *testing.T) {
-	t.Run("Good", func(t *testing.T) {
-		tempDir := createTempDir("foo")
-		if _, err := os.Stat(tempDir); err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	t.Run("Bad", func(t *testing.T) {
-		assert.Panics(t, func() {
-			createTempDir("foo/bar")
-		})
-	})
-
-}


### PR DESCRIPTION
It simply creates a temp dir or panic, and only called at one place
in the same file. It's cleaner if inlined.

Signed-off-by: Jay Guo <guojiannan1101@gmail.com>
