### PR TITLE
fix FAB-17148 defer to delete 'bccsp-sw' directory

### DIFF
--- a/bccsp/sw/impl_test.go
+++ b/bccsp/sw/impl_test.go
@@ -56,6 +56,10 @@ func (tc testConfig) Provider(t *testing.T) (bccsp.BCCSP, bccsp.KeyStore, func()
 }
 
 func TestMain(m *testing.M) {
+	code := -1
+	defer func() {
+		os.Exit(code)
+	}()
 	tests := []testConfig{
 		{256, "SHA2"},
 		{256, "SHA3"},
@@ -67,7 +71,7 @@ func TestMain(m *testing.M) {
 	tempDir, err = ioutil.TempDir("", "bccsp-sw")
 	if err != nil {
 		fmt.Printf("Failed to create temporary directory: %s\n\n", err)
-		os.Exit(-1)
+		return
 	}
 	defer os.RemoveAll(tempDir)
 
@@ -76,10 +80,10 @@ func TestMain(m *testing.M) {
 		ret := m.Run()
 		if ret != 0 {
 			fmt.Printf("Failed testing at [%d, %s]", config.securityLevel, config.hashFamily)
-			os.Exit(-1)
+			return
 		}
 	}
-	os.Exit(0)
+	code = 0
 }
 
 func TestInvalidNewParameter(t *testing.T) {

--- a/bccsp/sw/impl_test.go
+++ b/bccsp/sw/impl_test.go
@@ -77,13 +77,12 @@ func TestMain(m *testing.M) {
 
 	for _, config := range tests {
 		currentTestConfig = config
-		ret := m.Run()
-		if ret != 0 {
+		code = m.Run()
+		if code != 0 {
 			fmt.Printf("Failed testing at [%d, %s]", config.securityLevel, config.hashFamily)
 			return
 		}
 	}
-	code = 0
 }
 
 func TestInvalidNewParameter(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: baidang201 <jinrishouji@sina.com>
Type of change
Bug fix

Description
fix when unit test in bccsp\sw，we find in the /tmp folder, has a lot of file like 'bccsp-sw' and can not delete auto by test program.

Additional details
the reason is when os.exit, it do not run defer to delete 'bccsp-sw' folder.
we can put os.exit in the head of function and import another defer for os.exit.

Related issues
https://jira.hyperledger.org/browse/FAB-17148
