### PR TITLE
fix FAB-17153, change temp folder mode to remove

### DIFF
--- a/core/chaincode/platforms/util/writer_test.go
+++ b/core/chaincode/platforms/util/writer_test.go
@@ -219,6 +219,9 @@ func Test_WriteFolderToTarPackageFailure4(t *testing.T) {
 	err = WriteFolderToTarPackage(tw, tempDir, []string{}, nil, nil)
 	assert.Error(t, err, "Should have received error writing folder to package")
 	assert.Contains(t, err.Error(), "permission denied")
+
+	err = os.Chmod(tempDir, 0700)
+	require.NoError(t, err)
 }
 
 func createTestTar(t *testing.T, srcPath string, excludeDir []string, includeFileTypeMap map[string]bool, excludeFileTypeMap map[string]bool) []byte {


### PR DESCRIPTION
Signed-off-by: baidang201 <jinrishouji@sina.com>

#### Type of change
- Bug fix

#### Description
the bug appears this is coming from this test in core/chaincode/platforms/util/writer_test, 
find a lot of 'WriteFolderToTarPackageFailure4BadFileModexxx' in tmpfs.

because the 'WriteFolderToTarPackageFail4BadFilexxx' and 'WriteFolderToTarPackageFail4BadFilexxx/test.java' ard changed chmod  0644, 
only root can rw,so we chmod 0700 for 'WriteFolderToTarPackageFail4BadFilexx' to remove

#### Additional details
After test， we can add chmod 0700 in end of test function .
···
	err = os.Chmod(tempDir, 0700)
	require.NoError(t, err)
···

#### Related issues
https://jira.hyperledger.org/browse/FAB-17153