### PR TITLE
[FAB-17133] Add branch to AZP trigger

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -35,7 +35,7 @@ jobs:
 
           runs=$(az pipelines build list --project ${project} | jq -c ".[] | select(.sourceVersion | contains(\"${sha}\"))" | jq -r .status | grep -v completed | wc -l)
           if [[ $runs -eq 0 ]]; then
-            az pipelines build queue --commit-id ${sha} --project ${project} --definition-name Pull-Request
+            az pipelines build queue --branch refs/pull/${pr_number}/merge --commit-id ${sha} --project ${project} --definition-name Pull-Request
             curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d '{"body": "AZP build triggered!"}' "${comment_url}"
           else
             curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d '{"body": "AZP build already running!"}' "${comment_url}"


### PR DESCRIPTION
Add the branch name, i.e., refs/pull/3/merge to the AZP trigger. Without the branch it attempts to checkout the commit which does not exist in the repo, as it comes from the remote branch of the user. This makes the checkout use refs/remote/pull/3/merge which resolves correctly.

Signed-off-by: Brett Logan <Brett.T.Logan@ibm.com>


#### Type of change

- Bug fix

This problem didn't crop up before because I was testing against my own repo, not a fork. This time I verified by forking my own repo and running. This correctly resolves everything.