### PR TITLE
[FAB-17166] Gate UT, IT and DocBuild

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -23,9 +23,13 @@ jobs:
         path: 'go/src/github.com/hyperledger/fabric'
         displayName: Checkout Fabric Code
       - script: make basic-checks native
-        displayName: Verify Build
+        displayName: Run Basic Checks
+      - script: ./ci/scripts/evaluate_commits.sh
+        name: SetJobTriggers
 
   - job: DocBuild
+    condition: eq(dependencies.VerifyBuild.outputs['SetJobTriggers.buildDoc'], 'true')
+    dependsOn: VerifyBuild
     pool:
       vmImage: ubuntu-18.04
     container:
@@ -40,6 +44,8 @@ jobs:
         displayName: Publish Documentation Artifacts
 
   - job: UnitTests
+    condition: eq(dependencies.VerifyBuild.outputs['SetJobTriggers.runTests'], 'true')
+    dependsOn: VerifyBuild
     pool:
       vmImage: ubuntu-18.04
     steps:
@@ -53,6 +59,8 @@ jobs:
         displayName: Run Unit Tests
 
   - job: IntegrationTests
+    condition: eq(dependencies.VerifyBuild.outputs['SetJobTriggers.runTests'], 'true')
+    dependsOn: VerifyBuild
     pool:
       vmImage: ubuntu-18.04
     strategy:

--- a/ci/scripts/evaluate_commits.sh
+++ b/ci/scripts/evaluate_commits.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+if [[ $(git diff-tree --no-commit-id --name-only 'HEAD^..HEAD') == "docs" ]]; then
+  echo "##vso[task.setvariable variable=buildDoc;isOutput=true]true"
+else
+  echo "##vso[task.setvariable variable=buildDoc;isOutput=true]true"
+  echo "##vso[task.setvariable variable=runTests;isOutput=true]true"
+fi


### PR DESCRIPTION
Adds a gate behind VerifyBuild that will tell the other jobs which of them should run depending on which directories in the source tree have been updated

Signed-off-by: Brett Logan <Brett.T.Logan@ibm.com>

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

This change introduces logic to check if the current commit set has made changes to just the /docs tree and tells CI to only run DocBuild if this is the case. This makes sure DocBuild doesn't have to wait on UT and IT to run. Otherwise it runs all tests