### PR TITLE
Amend GitHub workflow guidance

### DIFF
--- a/docs/source/CONTRIBUTING.rst
+++ b/docs/source/CONTRIBUTING.rst
@@ -229,7 +229,8 @@ Submitting your fix
 
 If you just submitted a JIRA for a bug you've discovered, and would like to
 provide a fix, we would welcome that gladly! Please assign the JIRA issue to
-yourself, then you can submit a pull request (PR).
+yourself, then submit a pull request (PR). Please refer to :doc:`github/github`
+for a detailed workflow.
 
 Fixing issues and working stories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/github/github.rst
+++ b/docs/source/github/github.rst
@@ -140,8 +140,13 @@ Perform the following steps to commit and push your code to your forked reposito
    git add <file1> <file2>
 
 - You can now create your commit containing the changes you just added. Your commit
-  message should contain meaningingful information as to why this work was completed,
-  as well as the Jira number in the commit header:
+  message must contain the following information:
+
+  - one line summary of the work in this commit as title, followed by an empty line
+  - in the commit message body, explain why this change is needed, and how you approached it.
+    This helps reviewers better understand your code and often speeds up the review process.
+  - link to JIRA item or JIRA number, i.e. FAB-XXXXX
+  - (optional) if no new tests are added, how the code is tested
 
 .. code::
 


### PR DESCRIPTION
Emphasis on the information required in commit messages.
As we migrated to GitHub, contributors often follow the PR msg
template to fill out necessary info, and often ignored that in
commit messages. However, PR msg often got lost during merge,
if a merge commit is not created. Commit messages on the other
hand, go into git history, and should be one-click away from
JIRA item.

FAB-17167

Signed-off-by: Jay Guo <guojiannan1101@gmail.com>