### PR TITLE
FAB-16408 Deprecate the Kafka based orderer

### DIFF
--- a/release_notes/v2.0.0.txt
+++ b/release_notes/v2.0.0.txt
@@ -101,6 +101,13 @@ consensus type has always been marked non-production and should be in use only
 in test environments, however for compatibility it is still available, but may
 be removed entirely in a future release.
 
+FAB-16408 - The 'Kafka' consensus type is officially deprecated.  The 'Raft'
+consensus type was introduced in v1.4.1 and has become the preferred production
+consensus type.  There is a documented and tested migration path from Kafka to
+Raft, and existing users should migrate to the newer Raft consensus type.  For
+compatibility with existing deployments, Kafka is still supported, but may be
+removed entirely in a future release.
+
 Known Vulnerabilities
 ---------------------
 FAB-8664 - Peer should detect and react when its org has been removed


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

This PR notes the official deprecation of Kafka and urges users to
migrate to Raft.