### PR TITLE
[FAB-17165] Reduce pvtdata pull-retry threshold to 3s in IT core_template

### DIFF
--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -59,7 +59,7 @@ peer:
       leaderAliveThreshold: 10s
       leaderElectionDuration: 5s
     pvtData:
-      pullRetryThreshold: 60s
+      pullRetryThreshold: 3s
       transientstoreMaxBlockRetention: 1000
       pushAckTimeout: 3s
       btlPullMargin: 10


### PR DESCRIPTION
This fixes flakes in IT where e2e and lifecycle tests would timeout since pullRetryThreshold would match the eventually timeout and any test that went through the pull retry loop had a chance to timeout based on a race condition with the eventually