### PR TITLE
[FAB-15900] Add pkcs11 section to orderer.yaml

### DIFF
--- a/sampleconfig/orderer.yaml
+++ b/sampleconfig/orderer.yaml
@@ -135,12 +135,26 @@ General:
             FileKeyStore:
                 KeyStore:
 
+        # Settings for the PKCS#11 crypto provider (i.e. when DEFAULT: PKCS11)
+        PKCS11:
+            # Location of the PKCS11 module library
+            Library:
+            # Token Label
+            Label:
+            # User PIN
+            Pin:
+            Hash:
+            Security:
+            FileKeyStore:
+                KeyStore:
+
     # Authentication contains configuration parameters related to authenticating
     # client messages
     Authentication:
         # the acceptable difference between the current server time and the
         # client's time as specified in a client request message
         TimeWindow: 15m
+
 
 ################################################################################
 #


### PR DESCRIPTION
#### Type of change

This is a cherry-pick from master to address a bug

#### Description

As part of effort to add HSM docs and configuration
to Fabric. Section is already in core.yaml and user
would have to add manually

Change-Id: I12b9c13c36ae5d7e9fcd91ef83f3b0942fde9f49
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>
Signed-off-by: Jason Yellick <jyellick@us.ibm.com>