### PR TITLE
[FAB-16157] Remove references to alpha and disclaimers

### DIFF
--- a/docs/source/build_network.rst
+++ b/docs/source/build_network.rst
@@ -666,9 +666,9 @@ Install and define a chaincode
           your own chaincode, see the :doc:`chaincode4ade` tutorial.
 
 .. note:: These instructions use the Fabric chaincode lifecycle introduced in
-          the v2.0 Alpha release. If you would like to use the previous
-          lifecycle to install and instantiate a chaincode, visit the v1.4
-          version of the `Building your first network tutorial <https://hyperledger-fabric.readthedocs.io/en/release-1.4/build_network.html>`__.
+          the v2.0 release. If you would like to use the previous lifecycle to
+          install and instantiate a chaincode, visit the v1.4 version of the
+          `Building your first network tutorial <https://hyperledger-fabric.readthedocs.io/en/release-1.4/build_network.html>`__.
 
 Applications interact with the blockchain ledger through ``chaincode``.
 Therefore we need to install a chaincode on every peer that will execute and

--- a/docs/source/chaincode.rst
+++ b/docs/source/chaincode.rst
@@ -33,11 +33,10 @@ Fabric Chaincode Lifecycle
 
 The Fabric Chaincode Lifecycle is responsible for managing the installation
 of chaincodes and the definition of their parameters before a chaincode is
-used on a channel. Starting from the Fabric 2.0 Alpha, governance for
-chaincodes is fully decentralized: multiple organizations can use the Fabric
-Chaincode Lifecycle to come to agreement on the parameters of a chaincode,
-such as the chaincode endorsement policy, before the chaincode is used to
-interact with the ledger.
+used on a channel. Starting with Fabric 2.0, governance for chaincodes is fully
+decentralized: multiple organizations can use the Fabric Chaincode Lifecycle to
+come to agreement on the parameters of a chaincode, such as the chaincode
+endorsement policy, before the chaincode is used to interact with the ledger.
 
 The new model offers several improvements over the previous lifecycle:
 
@@ -73,24 +72,11 @@ The new model offers several improvements over the previous lifecycle:
 
 To learn how more about the new Fabric Lifecycle, visit :doc:`chaincode4noah`.
 
-.. note:: The new Fabric chaincode lifecycle in the v2.0 Alpha release is not
-          yet feature complete. Specifically, be aware of the following
-          limitations in the Alpha release:
-
-          - CouchDB indexes are not yet supported
-          - Chaincodes defined with the new lifecycle are not yet discoverable
-            via service discovery
-
-          These limitations will be resolved after the Alpha release. To use the
-          old lifecycle model to install and instantiate a chaincode, visit the
-          v1.4 version of the `Chaincode for Operators tutorial <https://hyperledger-fabric.readthedocs.io/en/release-1.4/chaincode4noah.html>`_
-
 You can use the Fabric chaincode lifecycle by creating a new channel and setting
 the channel capabilities to V2_0. You will not be able to use the old lifecycle
 to install, instantiate, or update a chaincode on a channels with V2_0 capabilities
 enabled. However, you can still invoke chaincode installed using the previous
-lifecycle model after you enable V2_0 capabilities. Migration from the previous
-lifecycle to the new lifecycle is not supported for the Fabric v2.0 Alpha.
+lifecycle model after you enable V2_0 capabilities.
 
 .. Licensed under Creative Commons Attribution 4.0 International License
    https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/channel_update_tutorial.rst
+++ b/docs/source/channel_update_tutorial.rst
@@ -611,9 +611,9 @@ you have joined, you can start using the chaincode after you approve the
 definition.
 
 .. note:: These instructions use the Fabric chaincode lifecycle introduced in
-          the v2.0 Alpha release. If you would like to use the previous
-          lifecycle to install and instantiate a chaincode, visit the v1.4
-          version of the `Adding an org to a channel tutorial <https://hyperledger-fabric.readthedocs.io/en/release-1.4/channel_update_tutorial.html>`__.
+          the v2.0 release. If you would like to use the previous lifecycle to
+          install and instantiate a chaincode, visit the v1.4 version of the
+          `Adding an org to a channel tutorial <https://hyperledger-fabric.readthedocs.io/en/release-1.4/channel_update_tutorial.html>`__.
 
 The first step is to package the chaincode from the Org3 CLI:
 

--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -8,7 +8,7 @@ has been successfully committed to the channel. For more information, visit
 [Chaincode for Operators](../chaincode4noah.html).
 
 *Note: These instructions use the Fabric chaincode lifecycle introduced in the
-v2.0 Alpha release. If you would like to use the old lifecycle to install and
+v2.0 release. If you would like to use the old lifecycle to install and
 instantiate a chaincode, visit the [peer chaincode](peerchaincode.html) command
 reference.*
 
@@ -362,7 +362,7 @@ You need to use the chaincode package identifier to approve a chaincode
 definition for your organization. You can find the package ID for the
 chaincodes you have installed by using the
 `peer lifecycle chaincode queryinstalled` command:
-    
+
 ```
 peer lifecycle chaincode queryinstalled --peerAddresses peer0.org1.example.com:7051
 ```
@@ -433,7 +433,7 @@ channel `mychannel`.
 
 You can check whether a chaincode definition is ready to be committed using the
 ``peer lifecycle chaincode checkcommitreadiness command, which will return
-successfully if a subsequent commit of the definition is expected to succeed. It 
+successfully if a subsequent commit of the definition is expected to succeed. It
 also outputs which organizations have approved the chaincode definition. If an
 organization has approved the chaincode definition specified in the command, the
 command will return a value of true. You can use this command to learn whether enough
@@ -503,7 +503,7 @@ using the ``peer lifecycle chaincode querycommitted`` command. You can use this
 command to query the current definition sequence number before upgrading a
 chaincode.
 
-  * You need to supply the chaincode name and channel name in order to query a 
+  * You need to supply the chaincode name and channel name in order to query a
     specific chaincode definition and the organizations that have approved it.
 
     ```

--- a/docs/source/couchdb_tutorial.rst
+++ b/docs/source/couchdb_tutorial.rst
@@ -7,7 +7,7 @@ database with Hyperledger Fabric. By now, you should be familiar with Fabric
 concepts and have explored some of the samples and tutorials.
 
 .. note:: These instructions use the new Fabric chaincode lifecycle introduced
-          in the Fabric v2.0 Alpha release. If you would like to use the previous
+          in the Fabric v2.0 release. If you would like to use the previous
           lifecycle model to use indexes with chaincode, visit the v1.4
           version of the `Using CouchDB <https://hyperledger-fabric.readthedocs.io/en/release-1.4/couchdb_tutorial.html>`__.
 

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -307,11 +307,11 @@ Instantiate
 
 The process of starting and initializing a chaincode application on a specific
 channel. After instantiation, peers that have the chaincode installed can accept
-chaincode invocations. 
+chaincode invocations.
 
-**NOTE**: *This method i.e. Instantiate was used in the 1.4.x and older versions of the chaincode 
+**NOTE**: *This method i.e. Instantiate was used in the 1.4.x and older versions of the chaincode
 lifecycle. For the current procedure used to start a chaincode on a channel with
-the new Fabric chaincode lifecycle introduced as part of the Fabric v2.0 Alpha,
+the new Fabric chaincode lifecycle introduced as part of Fabric v2.0,
 see Chaincode-definition_.*
 
 .. _Invoke:

--- a/docs/source/policies/policies.md
+++ b/docs/source/policies/policies.md
@@ -348,7 +348,7 @@ BlockValidation:
 
 ## Fabric chaincode lifecycle
 
-In the Fabric Alpha 2.0 release, a new chaincode lifecycle process was introduced,
+In the Fabric 2.0 release, a new chaincode lifecycle process was introduced,
 whereby a more democratic process is used to govern chaincode on the network.
 The new process allows multiple organizations to vote on how a chaincode will
 be operated before it can be used on a channel. This is significant because it is
@@ -454,13 +454,13 @@ For a deeper dive on how to write an endorsement policy refer to the topic on
 
 **Note:**  Policies work differently depending on which version of Fabric you are
   using:
-- In Fabric releases prior to the 2.0 Alpha release, chaincode endorsement
-  policies can be updated during chaincode instantiation or
-  by using the chaincode lifecycle commands. If not specified at instantiation
-  time, the endorsement policy defaults to “any member of the organizations in the
-  channel”. For example, a channel with “Org1” and “Org2” would have a default
-  endorsement policy of “OR(‘Org1.member’, ‘Org2.member’)”.
-- Starting with the Alpha 2.0 release, Fabric introduced a new chaincode
+- In Fabric releases prior to 2.0, chaincode endorsement policies can be
+  updated during chaincode instantiation or by using the chaincode lifecycle
+  commands. If not specified at instantiation time, the endorsement policy
+  defaults to “any member of the organizations in the channel”. For example,
+  a channel with “Org1” and “Org2” would have a default endorsement policy of
+  “OR(‘Org1.member’, ‘Org2.member’)”.
+- Starting with Fabric 2.0, Fabric introduced a new chaincode
   lifecycle process that allows multiple organizations to agree on how a
   chaincode will be operated before it can be used on a channel.  The new process
   requires that organizations agree to the parameters that define a chaincode,

--- a/docs/source/private-data-arch.rst
+++ b/docs/source/private-data-arch.rst
@@ -12,11 +12,11 @@ definition listing the organizations in the collection, as well as properties
 used to control dissemination of private data at endorsement time and,
 optionally, whether the data will be purged.
 
-Beginning with the Fabric chaincode lifecycle introduced with the Fabric v2.0
-Alpha, the collection definition is part of the chaincode definition. The
-collection is approved by channel members, and then deployed when the chaincode
-definition is committed to the channel. The collection file needs to be the same
-for all channel members. If you are using the peer CLI to approve and commit the
+Beginning with the Fabric chaincode lifecycle introduced with Fabric v2.0, the
+collection definition is part of the chaincode definition. The collection is
+approved by channel members, and then deployed when the chaincode definition
+is committed to the channel. The collection file needs to be the same for all
+channel members. If you are using the peer CLI to approve and commit the
 chaincode definition, use the ``--collections-config`` flag to specify the path
 to the collection definition file. If you are using the Fabric SDK for Node.js,
 visit `How to install and start your chaincode <https://fabric-sdk-node.github.io/master/tutorial-chaincode-lifecycle.html>`_.
@@ -259,11 +259,6 @@ Limitations:
 
 Using Indexes with collections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. note:: The Fabric chaincode lifecycle being introduced in the Fabric v2.0
-         Alpha does not support using couchDB indexes with your chaincode. To use
-         the previous lifecycle model to deploy couchDB indexes with private data
-         collections, visit the v1.4 version of the `Private Data Architecture Guide <https://hyperledger-fabric.readthedocs.io/en/release-1.4/private-data-arch.html>`_.
 
 The topic :doc:`couchdb_as_state_database` describes indexes that can be
 applied to the channel’s state database to enable JSON content queries, by

--- a/docs/source/private_data_tutorial.rst
+++ b/docs/source/private_data_tutorial.rst
@@ -10,7 +10,7 @@ The information in this tutorial assumes knowledge of private data
 stores and their use cases. For more information, check out :doc:`private-data/private-data`.
 
 .. note:: These instructions use the new Fabric chaincode lifecycle introduced
-          in the Fabric v2.0 Alpha release. If you would like to use the previous
+          in the Fabric v2.0 release. If you would like to use the previous
           lifecycle model to use private data with chaincode, visit the v1.4
           version of the `Using Private Data in Fabric tutorial <https://hyperledger-fabric.readthedocs.io/en/release-1.4/private_data_tutorial.html>`__.
 

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -74,31 +74,6 @@ Use the following tutorials to get started with the new chaincode lifecycle:
   Learn how the new lifecycle allows you to use policies in the channel
   configuration as chaincode endorsement policies.
 
-Restrictions and limitations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The new Fabric chaincode lifecycle in the v2.0 Alpha release is not yet feature
-complete. Specifically, be aware of the following limitations in the Alpha release:
-
-- CouchDB indexes are not yet supported
-- Chaincodes defined with the new lifecycle are not yet discoverable via service
-  discovery
-
-These limitations will be resolved after the Alpha release.
-
-FabToken
---------
-
-The Fabric 2.0 Alpha also provides users the ability to easily represent
-assets as tokens on Fabric channels. FabToken is a token management system that
-uses an Unspent Transaction Output (UTXO) model to issue, transfer, and redeem
-tokens using the identity and membership infrastructure provided by Hyperledger
-Fabric.
-
-* :doc:`token/FabToken`:
-  This operations guide provides a detailed overview of how to use tokens on a
-  Fabric network. The guide also includes an example on how to create and
-  transfer tokens using the :doc:`commands/token` CLI.
 
 Alpine images
 -------------


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>

Remove references to 2.0 Alpha and disclaimers around chaincode lifecycle.

#### Type of change

- Documentation update

#### Description

Prepare docs for 2.0 beta.

#### Additional details

Changes to the chaincode for operators doc are being handled in https://github.com/hyperledger/fabric/pull/299. Whats new will be updated in follow up PR.
