### PR TITLE
[FAB-17150] Clean up temp dir on configure_test

### DIFF
--- a/core/scc/cscc/configure_test.go
+++ b/core/scc/cscc/configure_test.go
@@ -254,7 +254,7 @@ func TestConfigerInvokeJoinChainCorrectParams(t *testing.T) {
 
 	testDir, err := ioutil.TempDir("", "cscc_test")
 	require.NoError(t, err, "error in creating test dir")
-	defer os.Remove(testDir)
+	defer os.RemoveAll(testDir)
 
 	ledgerInitializer := ledgermgmttest.NewInitializer(testDir)
 	ledgerInitializer.CustomTxProcessors = map[common.HeaderType]ledger.CustomTxProcessor{


### PR DESCRIPTION
Clean up a temporary directory on cscc/configure_test

#### Type of change

- Bug fix

#### Description

Clean up a temporary directory on cscc/configure_test 

#### Additional details

#### Related issues

https://jira.hyperledger.org/browse/FAB-17150
