### PR TITLE
[FAB-17141] Update fabric docs for updated go programming model

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -25,12 +25,11 @@ Hyperledger Fabric smart contract (chaincode) SDKs
 Hyperledger Fabric offers a number of SDKs to support developing smart contracts (chaincode)
 in various programming languages. Smart contract SDKs are available for Go, Node.js, and Java:
 
-  * `Go SDK documentation <https://github.com/hyperledger/fabric-chaincode-go>`__.
+  * Go SDK documentation
+    * `Low-level <https://github.com/hyperledger/fabric-chaincode-go>`__.
+    * `High-level <https://github.com/hyperledger/fabric-contract-api-go>`__.
   * `Node.js SDK <https://github.com/hyperledger/fabric-chaincode-node>`__ and `Node.js SDK documentation <https://fabric-shim.github.io/>`__.
   * `Java SDK <https://github.com/hyperledger/fabric-chaincode-java>`__ and `Java SDK documentation <https://hyperledger.github.io/fabric-chaincode-java/>`__.
-
-Currently, Node.js and Java support the new smart contract programming model delivered in
-Hyperledger Fabric v1.4. Support for Go is planned to be delivered in a later release.
 
 Hyperledger Fabric application SDKs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/write_first_app.rst
+++ b/docs/source/write_first_app.rst
@@ -93,9 +93,9 @@ Launch the network
 
           This tutorial demonstrates the JavaScript versions of the ``FabCar``
           smart contract and application, but the ``fabric-samples`` repo also
-          contains Java and TypeScript versions of this sample. To try the
-          Java or TypeScript versions, change the ``javascript`` argument
-          for ``./startFabric.sh`` below to either ``java`` or ``typescript``
+          contains Go, Java and TypeScript versions of this sample. To try the
+          Go, Java or TypeScript versions, change the ``javascript`` argument
+          for ``./startFabric.sh`` below to either ``go``, ``java`` or ``typescript``
           and follow the instructions written to the terminal.
 
 Launch your network using the ``startFabric.sh`` shell script. This command will


### PR DESCRIPTION
Signed-off-by: Andrew Hurt <andrew.hurt1@ibm.com>

#### Type of change
- Documentation update

#### Description

Updates documentation to include a link to the High Level Go Chaincode SDK
Updates documenation to reference that fabcar contains Go chaincode

#### Additional details
N/A

#### Related issues
[FAB-17141](https://jira.hyperledger.org/browse/FAB-17141)