### PR TITLE
unit test for couchDB revision fetching functions

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
@@ -1235,3 +1235,77 @@ func TestLoadCommittedVersion(t *testing.T) {
 	require.Equal(t, version.NewHeight(1, 4), ver)
 	require.True(t, ok)
 }
+
+func TestMissingRevisionRetrievalFromDB(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+	chainID := "testmissingrevisionfromdb"
+	db, err := env.DBProvider.GetDBHandle(chainID)
+	require.NoError(t, err)
+
+	// store key1, key2, key3 to the DB
+	batch := statedb.NewUpdateBatch()
+	vv1 := statedb.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}
+	vv2 := statedb.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 2)}
+	vv3 := statedb.VersionedValue{Value: []byte("value3"), Version: version.NewHeight(1, 3)}
+	batch.Put("ns1", "key1", vv1.Value, vv1.Version)
+	batch.Put("ns1", "key2", vv2.Value, vv2.Version)
+	batch.Put("ns1", "key3", vv3.Value, vv3.Version)
+	savePoint := version.NewHeight(2, 5)
+	db.ApplyUpdates(batch, savePoint)
+
+	// retrieve the versions of key1, key2, and key3
+	revisions := make(map[string]string)
+	require.NoError(t, db.(*VersionedDB).addMissingRevisionsFromDB("ns1", []string{"key1", "key2", "key3"}, revisions))
+	require.Equal(t, 3, len(revisions))
+
+	// update key1 and key2 but not key3
+	batch = statedb.NewUpdateBatch()
+	vv4 := statedb.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}
+	vv5 := statedb.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 2)}
+	batch.Put("ns1", "key1", vv4.Value, vv4.Version)
+	batch.Put("ns1", "key2", vv5.Value, vv5.Version)
+	savePoint = version.NewHeight(3, 5)
+	db.ApplyUpdates(batch, savePoint)
+
+	// for key3, the revision should be the same but not for key1 and key2
+	newRevisions := make(map[string]string)
+	require.NoError(t, db.(*VersionedDB).addMissingRevisionsFromDB("ns1", []string{"key1", "key2", "key3"}, newRevisions))
+	require.Equal(t, 3, len(newRevisions))
+	require.NotEqual(t, revisions["key1"], newRevisions["key1"])
+	require.NotEqual(t, revisions["key2"], newRevisions["key2"])
+	require.Equal(t, revisions["key3"], newRevisions["key3"])
+}
+
+func TestMissingRevisionRetrievalFromCache(t *testing.T) {
+	cache := statedb.NewCache(32, []string{"lscc"})
+	env := newTestVDBEnvWithCache(t, cache)
+	defer env.Cleanup()
+	chainID := "testmissingrevisionfromcache"
+	db, err := env.DBProvider.GetDBHandle(chainID)
+	require.NoError(t, err)
+
+	// scenario 1: missing from cache.
+	revisions := make(map[string]string)
+	stillMissingKeys, err := db.(*VersionedDB).addMissingRevisionsFromCache("ns1", []string{"key1", "key2"}, revisions)
+	require.NoError(t, err)
+	require.Equal(t, []string{"key1", "key2"}, stillMissingKeys)
+	require.Empty(t, revisions)
+
+	// scenario 2: key1 is available in the cache
+	require.NoError(t, cache.PutState(chainID, "ns1", "key1", &statedb.CacheValue{AdditionalInfo: []byte("rev1")}))
+	revisions = make(map[string]string)
+	stillMissingKeys, err = db.(*VersionedDB).addMissingRevisionsFromCache("ns1", []string{"key1", "key2"}, revisions)
+	require.NoError(t, err)
+	require.Equal(t, []string{"key2"}, stillMissingKeys)
+	require.Equal(t, "rev1", revisions["key1"])
+
+	// scenario 3: both key1 and key2 are available in the cache
+	require.NoError(t, cache.PutState(chainID, "ns1", "key2", &statedb.CacheValue{AdditionalInfo: []byte("rev2")}))
+	revisions = make(map[string]string)
+	stillMissingKeys, err = db.(*VersionedDB).addMissingRevisionsFromCache("ns1", []string{"key1", "key2"}, revisions)
+	require.NoError(t, err)
+	require.Empty(t, stillMissingKeys)
+	require.Equal(t, "rev1", revisions["key1"])
+	require.Equal(t, "rev2", revisions["key2"])
+}


### PR DESCRIPTION
#### Type of change

- Test update

#### Description

Given that we have integrated cache with the commit path, we need to very careful with the future changes. If either the cache is updated incorrectly or accessed incorrectly, we could do a wrong commit. It is possible to add a bug and pass the current unit-test in the future. Hence, we need to perform per function unit-testing to cover all functions. This PR adds unit tests for two functions.

#### Additional details

This PR adds unit test for `addMissingRevisionFromCache()` and `addMissingRevisionFromDB()` in the statecouchdb package.

#### Related issues

[FAB-17188](https://jira.hyperledger.org/browse/FAB-17188)