### PR TITLE
FAB-15817 Prefer last config in signatures metadata field

### DIFF
--- a/common/genesis/genesis.go
+++ b/common/genesis/genesis.go
@@ -48,5 +48,10 @@ func (f *factory) Block(channelID string) *cb.Block {
 	block.Metadata.Metadata[cb.BlockMetadataIndex_LAST_CONFIG] = protoutil.MarshalOrPanic(&cb.Metadata{
 		Value: protoutil.MarshalOrPanic(&cb.LastConfig{Index: 0}),
 	})
+	block.Metadata.Metadata[cb.BlockMetadataIndex_SIGNATURES] = protoutil.MarshalOrPanic(&cb.Metadata{
+		Value: protoutil.MarshalOrPanic(&cb.OrdererBlockMetadata{
+			LastConfig: &cb.LastConfig{Index: 0},
+		}),
+	})
 	return block
 }

--- a/common/genesis/genesis_test.go
+++ b/common/genesis/genesis_test.go
@@ -9,20 +9,39 @@ package genesis
 import (
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
+	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBasicSanity(t *testing.T) {
-	impl := NewFactoryImpl(protoutil.NewConfigGroup())
-	impl.Block("testchannelid")
-}
-
-func TestForTransactionID(t *testing.T) {
+func TestFactory(t *testing.T) {
 	impl := NewFactoryImpl(protoutil.NewConfigGroup())
 	block := impl.Block("testchannelid")
-	configEnv, _ := protoutil.ExtractEnvelope(block, 0)
-	configEnvPayload, _ := protoutil.UnmarshalPayload(configEnv.Payload)
-	configEnvPayloadChannelHeader, _ := protoutil.UnmarshalChannelHeader(configEnvPayload.GetHeader().ChannelHeader)
-	assert.NotEmpty(t, configEnvPayloadChannelHeader.TxId, "tx_id of configuration transaction should not be empty")
+
+	t.Run("test for transaction id", func(t *testing.T) {
+		configEnv, _ := protoutil.ExtractEnvelope(block, 0)
+		configEnvPayload, _ := protoutil.UnmarshalPayload(configEnv.Payload)
+		configEnvPayloadChannelHeader, _ := protoutil.UnmarshalChannelHeader(configEnvPayload.GetHeader().ChannelHeader)
+		assert.NotEmpty(t, configEnvPayloadChannelHeader.TxId, "tx_id of configuration transaction should not be empty")
+	})
+	t.Run("test for last config in SIGNATURES field", func(t *testing.T) {
+		metadata := &cb.Metadata{}
+		err := proto.Unmarshal(block.Metadata.Metadata[cb.BlockMetadataIndex_SIGNATURES], metadata)
+		assert.NoError(t, err)
+		ordererBlockMetadata := &cb.OrdererBlockMetadata{}
+		err = proto.Unmarshal(metadata.Value, ordererBlockMetadata)
+		assert.NoError(t, err)
+		assert.NotNil(t, ordererBlockMetadata.LastConfig)
+		assert.Equal(t, uint64(0), ordererBlockMetadata.LastConfig.Index)
+	})
+	t.Run("test for last config in LAST_CONFIG field", func(t *testing.T) {
+		metadata := &cb.Metadata{}
+		err := proto.Unmarshal(block.Metadata.Metadata[cb.BlockMetadataIndex_LAST_CONFIG], metadata)
+		assert.NoError(t, err)
+		lastConfig := &cb.LastConfig{}
+		err = proto.Unmarshal(metadata.Value, lastConfig)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(0), lastConfig.Index)
+	})
 }

--- a/common/ledger/blockledger/util.go
+++ b/common/ledger/blockledger/util.go
@@ -44,6 +44,7 @@ func (nfei *NotFoundErrorIterator) Close() {}
 func CreateNextBlock(rl Reader, messages []*cb.Envelope) *cb.Block {
 	var nextBlockNumber uint64
 	var previousBlockHash []byte
+	var err error
 
 	if rl.Height() > 0 {
 		it, _ := rl.Iterator(&ab.SeekPosition{
@@ -63,7 +64,6 @@ func CreateNextBlock(rl Reader, messages []*cb.Envelope) *cb.Block {
 		Data: make([][]byte, len(messages)),
 	}
 
-	var err error
 	for i, msg := range messages {
 		data.Data[i], err = proto.Marshal(msg)
 		if err != nil {

--- a/internal/peer/channel/fetch_test.go
+++ b/internal/peer/channel/fetch_test.go
@@ -166,20 +166,18 @@ func getMockDeliverService(block *cb.Block) *mock.DeliverService {
 }
 
 func createTestBlock() *cb.Block {
-	lc := &cb.LastConfig{Index: 0}
-	lcBytes := protoutil.MarshalOrPanic(lc)
-	metadata := &cb.Metadata{
-		Value: lcBytes,
-	}
-	metadataBytes := protoutil.MarshalOrPanic(metadata)
-	blockMetadata := make([][]byte, cb.BlockMetadataIndex_LAST_CONFIG+1)
-	blockMetadata[cb.BlockMetadataIndex_LAST_CONFIG] = metadataBytes
+	metadataBytes := protoutil.MarshalOrPanic(&cb.Metadata{
+		Value: protoutil.MarshalOrPanic(&cb.OrdererBlockMetadata{
+			LastConfig: &cb.LastConfig{Index: 0},
+		}),
+	})
+
 	block := &cb.Block{
 		Header: &cb.BlockHeader{
 			Number: 0,
 		},
 		Metadata: &cb.BlockMetadata{
-			Metadata: blockMetadata,
+			Metadata: [][]byte{metadataBytes},
 		},
 	}
 

--- a/orderer/common/cluster/replication.go
+++ b/orderer/common/cluster/replication.go
@@ -479,7 +479,7 @@ func PullLastConfigBlock(puller ChainPuller) (*common.Block, error) {
 	if lastBlock == nil {
 		return nil, ErrRetryCountExhausted
 	}
-	lastConfNumber, err := lastConfigFromBlock(lastBlock)
+	lastConfNumber, err := protoutil.GetLastConfigIndexFromBlock(lastBlock)
 	if err != nil {
 		return nil, err
 	}
@@ -508,13 +508,6 @@ func latestHeightAndEndpoint(puller ChainPuller) (string, uint64, error) {
 		}
 	}
 	return mostUpToDateEndpoint, maxHeight, nil
-}
-
-func lastConfigFromBlock(block *common.Block) (uint64, error) {
-	if block.Metadata == nil || len(block.Metadata.Metadata) <= int(common.BlockMetadataIndex_LAST_CONFIG) {
-		return 0, errors.New("no metadata in block")
-	}
-	return protoutil.GetLastConfigIndexFromBlock(block)
 }
 
 // Close closes the ChainInspector
@@ -663,11 +656,17 @@ func ExtractGenesisBlock(logger *flogging.FabricLogger, block *common.Block) (st
 	metadata := &common.BlockMetadata{
 		Metadata: make([][]byte, 4),
 	}
+	metadata.Metadata[common.BlockMetadataIndex_SIGNATURES] = protoutil.MarshalOrPanic(&common.OrdererBlockMetadata{
+		LastConfig: &common.LastConfig{Index: 0},
+		// This is a genesis block, peer never verify this signature because we can't bootstrap
+		// trust from an earlier block, hence there are no signatures here.
+	})
 	metadata.Metadata[common.BlockMetadataIndex_LAST_CONFIG] = protoutil.MarshalOrPanic(&common.Metadata{
 		Value: protoutil.MarshalOrPanic(&common.LastConfig{Index: 0}),
 		// This is a genesis block, peer never verify this signature because we can't bootstrap
 		// trust from an earlier block, hence there are no signatures here.
 	})
+
 	blockdata := &common.BlockData{Data: [][]byte{payload.Data}}
 	b := &common.Block{
 		Header:   &common.BlockHeader{DataHash: protoutil.BlockDataHash(blockdata)},

--- a/orderer/common/cluster/util.go
+++ b/orderer/common/cluster/util.go
@@ -652,9 +652,6 @@ func LastConfigBlock(block *common.Block, blockRetriever BlockRetriever) (*commo
 	if blockRetriever == nil {
 		return nil, errors.New("nil blockRetriever")
 	}
-	if block.Metadata == nil || len(block.Metadata.Metadata) <= int(common.BlockMetadataIndex_LAST_CONFIG) {
-		return nil, errors.New("no metadata in block")
-	}
 	lastConfigBlockNum, err := protoutil.GetLastConfigIndexFromBlock(block)
 	if err != nil {
 		return nil, err

--- a/orderer/common/cluster/util_test.go
+++ b/orderer/common/cluster/util_test.go
@@ -891,30 +891,9 @@ func TestLastConfigBlock(t *testing.T) {
 		},
 		{
 			name:           "nil metadata",
-			expectedError:  "no metadata in block",
+			expectedError:  "failed to retrieve metadata: no metadata in block",
 			blockRetriever: blockRetriever,
 			block:          &common.Block{},
-		},
-		{
-			name:           "no last config block metadata",
-			expectedError:  "no metadata in block",
-			blockRetriever: blockRetriever,
-			block: &common.Block{
-				Metadata: &common.BlockMetadata{
-					Metadata: [][]byte{{}},
-				},
-			},
-		},
-		{
-			name:           "bad metadata in block",
-			blockRetriever: blockRetriever,
-			expectedError: "error unmarshaling metadata from block at index " +
-				"[LAST_CONFIG]: proto: common.Metadata: illegal tag 0 (wire type 1)",
-			block: &common.Block{
-				Metadata: &common.BlockMetadata{
-					Metadata: [][]byte{{}, {1, 2, 3}},
-				},
-			},
 		},
 		{
 			name: "no block with index",

--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -295,6 +295,11 @@ func TestExtractSysChanLastConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	nextBlock := blockledger.CreateNextBlock(rl, []*common.Envelope{configTx})
+	nextBlock.Metadata.Metadata[common.BlockMetadataIndex_SIGNATURES] = protoutil.MarshalOrPanic(&common.Metadata{
+		Value: protoutil.MarshalOrPanic(&common.OrdererBlockMetadata{
+			LastConfig: &common.LastConfig{Index: rl.Height()},
+		}),
+	})
 	nextBlock.Metadata.Metadata[common.BlockMetadataIndex_LAST_CONFIG] = protoutil.MarshalOrPanic(&common.Metadata{
 		Value: protoutil.MarshalOrPanic(&common.LastConfig{Index: rl.Height()}),
 	})

--- a/orderer/consensus/etcdraft/blockpuller_test.go
+++ b/orderer/consensus/etcdraft/blockpuller_test.go
@@ -50,7 +50,7 @@ func TestEndpointconfigFromFromSupport(t *testing.T) {
 		{
 			name:          "Last config block number cannot be retrieved from last block",
 			blockAtHeight: &common.Block{},
-			expectedError: "no metadata in block",
+			expectedError: "failed to retrieve metadata: no metadata in block",
 			height:        100,
 		},
 		{

--- a/orderer/consensus/etcdraft/eviction_test.go
+++ b/orderer/consensus/etcdraft/eviction_test.go
@@ -116,8 +116,10 @@ func TestEvictionSuspector(t *testing.T) {
 			Metadata: [][]byte{{}, {}, {}, {}},
 		},
 	}
-	configBlock.Metadata.Metadata[common.BlockMetadataIndex_LAST_CONFIG] = protoutil.MarshalOrPanic(&common.Metadata{
-		Value: protoutil.MarshalOrPanic(&common.LastConfig{Index: 9}),
+	configBlock.Metadata.Metadata[common.BlockMetadataIndex_SIGNATURES] = protoutil.MarshalOrPanic(&common.Metadata{
+		Value: protoutil.MarshalOrPanic(&common.OrdererBlockMetadata{
+			LastConfig: &common.LastConfig{Index: 9},
+		}),
 	})
 
 	puller := &mocks.ChainPuller{}

--- a/protoutil/blockutils.go
+++ b/protoutil/blockutils.go
@@ -81,7 +81,7 @@ func GetChainIDFromBlockBytes(bytes []byte) (string, error) {
 // GetChainIDFromBlock returns chain ID in the block
 func GetChainIDFromBlock(block *cb.Block) (string, error) {
 	if block == nil || block.Data == nil || block.Data.Data == nil || len(block.Data.Data) == 0 {
-		return "", errors.Errorf("failed to retrieve channel id - block is empty")
+		return "", errors.New("failed to retrieve channel id - block is empty")
 	}
 	var err error
 	envelope, err := GetEnvelopeFromBlock(block.Data.Data[0])
@@ -94,7 +94,7 @@ func GetChainIDFromBlock(block *cb.Block) (string, error) {
 	}
 
 	if payload.Header == nil {
-		return "", errors.Errorf("failed to retrieve channel id - payload header is empty")
+		return "", errors.New("failed to retrieve channel id - payload header is empty")
 	}
 	chdr, err := UnmarshalChannelHeader(payload.Header.ChannelHeader)
 	if err != nil {
@@ -106,10 +106,18 @@ func GetChainIDFromBlock(block *cb.Block) (string, error) {
 
 // GetMetadataFromBlock retrieves metadata at the specified index.
 func GetMetadataFromBlock(block *cb.Block, index cb.BlockMetadataIndex) (*cb.Metadata, error) {
+	if block.Metadata == nil {
+		return nil, errors.New("no metadata in block")
+	}
+
+	if len(block.Metadata.Metadata) <= int(index) {
+		return nil, errors.Errorf("no metadata at index [%s]", index)
+	}
+
 	md := &cb.Metadata{}
 	err := proto.Unmarshal(block.Metadata.Metadata[index], md)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error unmarshaling metadata from block at index [%s]", index)
+		return nil, errors.Wrapf(err, "error unmarshaling metadata at index [%s]", index)
 	}
 	return md, nil
 }
@@ -130,7 +138,7 @@ func GetMetadataFromBlockOrPanic(block *cb.Block, index cb.BlockMetadataIndex) *
 func GetConsenterMetadataFromBlock(block *cb.Block) (*cb.Metadata, error) {
 	m, err := GetMetadataFromBlock(block, cb.BlockMetadataIndex_SIGNATURES)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve metadata at index: %d", cb.BlockMetadataIndex_SIGNATURES)
+		return nil, errors.WithMessage(err, "failed to retrieve metadata")
 	}
 
 	// TODO FAB-15864 Remove this fallback when we can stop supporting upgrade from pre-1.4.1 orderer
@@ -141,13 +149,13 @@ func GetConsenterMetadataFromBlock(block *cb.Block) (*cb.Metadata, error) {
 	obm := &cb.OrdererBlockMetadata{}
 	err = proto.Unmarshal(m.Value, obm)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal orderer block metadata")
+		return nil, errors.Wrap(err, "failed to unmarshal orderer block metadata")
 	}
 
 	res := &cb.Metadata{}
 	err = proto.Unmarshal(obm.ConsenterMetadata, res)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal consenter metadata")
+		return nil, errors.Wrap(err, "failed to unmarshal consenter metadata")
 	}
 
 	return res, nil
@@ -156,16 +164,30 @@ func GetConsenterMetadataFromBlock(block *cb.Block) (*cb.Metadata, error) {
 // GetLastConfigIndexFromBlock retrieves the index of the last config block as
 // encoded in the block metadata
 func GetLastConfigIndexFromBlock(block *cb.Block) (uint64, error) {
-	md, err := GetMetadataFromBlock(block, cb.BlockMetadataIndex_LAST_CONFIG)
+	m, err := GetMetadataFromBlock(block, cb.BlockMetadataIndex_SIGNATURES)
 	if err != nil {
-		return 0, err
+		return 0, errors.WithMessage(err, "failed to retrieve metadata")
 	}
-	lc := &cb.LastConfig{}
-	err = proto.Unmarshal(md.Value, lc)
+	// TODO FAB-15864 Remove this fallback when we can stop supporting upgrade from pre-1.4.1 orderer
+	if len(m.Value) == 0 {
+		m, err := GetMetadataFromBlock(block, cb.BlockMetadataIndex_LAST_CONFIG)
+		if err != nil {
+			return 0, errors.WithMessage(err, "failed to retrieve metadata")
+		}
+		lc := &cb.LastConfig{}
+		err = proto.Unmarshal(m.Value, lc)
+		if err != nil {
+			return 0, errors.Wrap(err, "error unmarshaling LastConfig")
+		}
+		return lc.Index, nil
+	}
+
+	obm := &cb.OrdererBlockMetadata{}
+	err = proto.Unmarshal(m.Value, obm)
 	if err != nil {
-		return 0, errors.Wrap(err, "error unmarshaling LastConfig")
+		return 0, errors.Wrap(err, "failed to unmarshal orderer block metadata")
 	}
-	return lc.Index, nil
+	return obm.LastConfig.Index, nil
 }
 
 // GetLastConfigIndexFromBlockOrPanic retrieves the index of the last config

--- a/protoutil/blockutils_test.go
+++ b/protoutil/blockutils_test.go
@@ -172,22 +172,40 @@ func TestGetBlockFromBlockBytes(t *testing.T) {
 	assert.Error(t, err, "Expected error for malformed block bytes")
 }
 
-func TestGetMetadataFromNewBlock(t *testing.T) {
-	block := protoutil.NewBlock(0, nil)
-	md, err := protoutil.GetMetadataFromBlock(block, cb.BlockMetadataIndex_ORDERER)
-	assert.NoError(t, err, "Unexpected error extracting metadata from new block")
-	assert.Nil(t, md.Value, "Expected metadata field value to be nil")
-	assert.Equal(t, 0, len(md.Value), "Expected length of metadata field value to be 0")
-	md = protoutil.GetMetadataFromBlockOrPanic(block, cb.BlockMetadataIndex_ORDERER)
-	assert.NotNil(t, md, "Expected to get metadata from block")
-
-	// malformed metadata
-	block.Metadata.Metadata[cb.BlockMetadataIndex_ORDERER] = []byte("bad metadata")
-	_, err = protoutil.GetMetadataFromBlock(block, cb.BlockMetadataIndex_ORDERER)
-	assert.Error(t, err, "Expected error with malformed metadata")
-	assert.Panics(t, func() {
-		_ = protoutil.GetMetadataFromBlockOrPanic(block, cb.BlockMetadataIndex_ORDERER)
-	}, "Expected panic with malformed metadata")
+func TestGetMetadataFromBlock(t *testing.T) {
+	t.Run("new block", func(t *testing.T) {
+		block := protoutil.NewBlock(0, nil)
+		md, err := protoutil.GetMetadataFromBlock(block, cb.BlockMetadataIndex_ORDERER)
+		assert.NoError(t, err, "Unexpected error extracting metadata from new block")
+		assert.Nil(t, md.Value, "Expected metadata field value to be nil")
+		assert.Equal(t, 0, len(md.Value), "Expected length of metadata field value to be 0")
+		md = protoutil.GetMetadataFromBlockOrPanic(block, cb.BlockMetadataIndex_ORDERER)
+		assert.NotNil(t, md, "Expected to get metadata from block")
+	})
+	t.Run("no metadata", func(t *testing.T) {
+		block := protoutil.NewBlock(0, nil)
+		block.Metadata = nil
+		_, err := protoutil.GetMetadataFromBlock(block, cb.BlockMetadataIndex_ORDERER)
+		assert.Error(t, err, "Expected error with nil metadata")
+		assert.Contains(t, err.Error(), "no metadata in block")
+	})
+	t.Run("no metadata at index", func(t *testing.T) {
+		block := protoutil.NewBlock(0, nil)
+		block.Metadata.Metadata = [][]byte{{1, 2, 3}}
+		_, err := protoutil.GetMetadataFromBlock(block, cb.BlockMetadataIndex_LAST_CONFIG)
+		assert.Error(t, err, "Expected error with nil metadata")
+		assert.Contains(t, err.Error(), "no metadata at index")
+	})
+	t.Run("malformed metadata", func(t *testing.T) {
+		block := protoutil.NewBlock(0, nil)
+		block.Metadata.Metadata[cb.BlockMetadataIndex_ORDERER] = []byte("bad metadata")
+		_, err := protoutil.GetMetadataFromBlock(block, cb.BlockMetadataIndex_ORDERER)
+		assert.Error(t, err, "Expected error with malformed metadata")
+		assert.Contains(t, err.Error(), "error unmarshaling metadata at index [ORDERER]")
+		assert.Panics(t, func() {
+			_ = protoutil.GetMetadataFromBlockOrPanic(block, cb.BlockMetadataIndex_ORDERER)
+		}, "Expected panic with malformed metadata")
+	})
 }
 
 func TestGetConsenterkMetadataFromBlock(t *testing.T) {
@@ -292,34 +310,68 @@ func TestCopyBlockMetadata(t *testing.T) {
 }
 
 func TestGetLastConfigIndexFromBlock(t *testing.T) {
-	block := protoutil.NewBlock(0, nil)
 	index := uint64(2)
-	lc, _ := proto.Marshal(&cb.LastConfig{
-		Index: index,
-	})
-	metadata, _ := proto.Marshal(&cb.Metadata{
-		Value: lc,
-	})
-	block.Metadata.Metadata[cb.BlockMetadataIndex_LAST_CONFIG] = metadata
-	result, err := protoutil.GetLastConfigIndexFromBlock(block)
-	assert.NoError(t, err, "Unexpected error returning last config index")
-	assert.Equal(t, index, result, "Unexpected last config index returned from block")
-	result = protoutil.GetLastConfigIndexFromBlockOrPanic(block)
-	assert.Equal(t, index, result, "Unexpected last config index returned from block")
+	block := protoutil.NewBlock(0, nil)
 
-	// malformed metadata
-	block.Metadata.Metadata[cb.BlockMetadataIndex_LAST_CONFIG] = []byte("bad metadata")
-	_, err = protoutil.GetLastConfigIndexFromBlock(block)
-	assert.Error(t, err, "Expected error with malformed metadata")
-
-	// malformed last config
-	metadata, _ = proto.Marshal(&cb.Metadata{
-		Value: []byte("bad last config"),
+	t.Run("block with last config metadata in signatures field", func(t *testing.T) {
+		block.Metadata.Metadata[cb.BlockMetadataIndex_SIGNATURES] = protoutil.MarshalOrPanic(&cb.Metadata{
+			Value: protoutil.MarshalOrPanic(&cb.OrdererBlockMetadata{
+				LastConfig: &cb.LastConfig{Index: 2},
+			}),
+		})
+		result, err := protoutil.GetLastConfigIndexFromBlock(block)
+		assert.NoError(t, err, "Unexpected error returning last config index")
+		assert.Equal(t, index, result, "Unexpected last config index returned from block")
+		result = protoutil.GetLastConfigIndexFromBlockOrPanic(block)
+		assert.Equal(t, index, result, "Unexpected last config index returned from block")
 	})
-	block.Metadata.Metadata[cb.BlockMetadataIndex_LAST_CONFIG] = metadata
-	_, err = protoutil.GetLastConfigIndexFromBlock(block)
-	assert.Error(t, err, "Expected error with malformed last config metadata")
-	assert.Panics(t, func() {
-		_ = protoutil.GetLastConfigIndexFromBlockOrPanic(block)
-	}, "Expected panic with malformed last config metadata")
+
+	t.Run("block with malformed signatures", func(t *testing.T) {
+		block.Metadata.Metadata[cb.BlockMetadataIndex_SIGNATURES] = []byte("apple")
+		_, err := protoutil.GetLastConfigIndexFromBlock(block)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to retrieve metadata: error unmarshaling metadata at index [SIGNATURES]")
+	})
+
+	t.Run("block with malformed orderer block metadata", func(t *testing.T) {
+		block.Metadata.Metadata[cb.BlockMetadataIndex_SIGNATURES] = protoutil.MarshalOrPanic(&cb.Metadata{Value: []byte("banana")})
+		_, err := protoutil.GetLastConfigIndexFromBlock(block)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unmarshal orderer block metadata")
+	})
+
+	// TODO: FAB-15864 remove the tests below when we stop supporting upgrade from
+	//       pre-1.4.1 orderer
+	t.Run("block with deprecated (pre-1.4.1) last config", func(t *testing.T) {
+		block = protoutil.NewBlock(0, nil)
+		block.Metadata.Metadata[cb.BlockMetadataIndex_LAST_CONFIG] = protoutil.MarshalOrPanic(&cb.Metadata{
+			Value: protoutil.MarshalOrPanic(&cb.LastConfig{
+				Index: index,
+			}),
+		})
+		result, err := protoutil.GetLastConfigIndexFromBlock(block)
+		assert.NoError(t, err, "Unexpected error returning last config index")
+		assert.Equal(t, index, result, "Unexpected last config index returned from block")
+		result = protoutil.GetLastConfigIndexFromBlockOrPanic(block)
+		assert.Equal(t, index, result, "Unexpected last config index returned from block")
+	})
+
+	t.Run("malformed metadata", func(t *testing.T) {
+		block.Metadata.Metadata[cb.BlockMetadataIndex_LAST_CONFIG] = []byte("bad metadata")
+		_, err := protoutil.GetLastConfigIndexFromBlock(block)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to retrieve metadata: error unmarshaling metadata at index [LAST_CONFIG]")
+	})
+
+	t.Run("malformed last config", func(t *testing.T) {
+		block.Metadata.Metadata[cb.BlockMetadataIndex_LAST_CONFIG] = protoutil.MarshalOrPanic(&cb.Metadata{
+			Value: []byte("bad last config"),
+		})
+		_, err := protoutil.GetLastConfigIndexFromBlock(block)
+		assert.Error(t, err, "Expected error with malformed last config metadata")
+		assert.Contains(t, err.Error(), "error unmarshaling LastConfig")
+		assert.Panics(t, func() {
+			_ = protoutil.GetLastConfigIndexFromBlockOrPanic(block)
+		}, "Expected panic with malformed last config metadata")
+	})
 }


### PR DESCRIPTION
This commit updates the orderer and peer to prefer retrieving the
last config from the SIGNATURES field and fallback to retrieving
it from the LAST_CONFIG field.

Signed-off-by: Will Lahti <wtlahti@us.ibm.com>