### PR TITLE
[FAB-16951] Alternative mechanisms to find pkcs11 key

### DIFF
--- a/bccsp/pkcs11/conf.go
+++ b/bccsp/pkcs11/conf.go
@@ -88,6 +88,7 @@ type PKCS11Opts struct {
 	Pin        string `mapstructure:"pin" json:"pin"`
 	SoftVerify bool   `mapstructure:"softwareverify,omitempty" json:"softwareverify,omitempty"`
 	Immutable  bool   `mapstructure:"immutable,omitempty" json:"immutable,omitempty"`
+	AltId      string `mapstructure:"altid" json:"altid"`
 }
 
 // FileKeystoreOpts currently only ECDSA operations go to PKCS11, need a keystore still

--- a/bccsp/pkcs11/impl.go
+++ b/bccsp/pkcs11/impl.go
@@ -54,7 +54,7 @@ func New(opts PKCS11Opts, keyStore bccsp.KeyStore) (bccsp.BCCSP, error) {
 	}
 
 	sessions := make(chan pkcs11.SessionHandle, sessionCacheSize)
-	csp := &impl{swCSP, conf, keyStore, ctx, sessions, slot, lib, opts.SoftVerify, opts.Immutable}
+	csp := &impl{swCSP, conf, keyStore, ctx, sessions, slot, lib, opts.SoftVerify, opts.Immutable, opts.AltId}
 	csp.returnSession(*session)
 	return csp, nil
 }
@@ -73,6 +73,8 @@ type impl struct {
 	softVerify bool
 	//Immutable flag makes object immutable
 	immutable bool
+	// Alternate identifier of the private key
+	altId string
 }
 
 // KeyGen generates a key using opts.


### PR DESCRIPTION
#### Type of change
- Improvement - Enable Hyperledger Fabric PKCS11 module to work with AWS CloudHSM.

#### Description

This modification adds a parameter called AltID to the PKCS11 BCCSP module.
When this parameter is set, the generateECKey and findKeyPairFromSKI functions
will use this alternative ID as the CKA_ID and CKA_LABEL to store and use the
associated private key.
This code change is required in situations where the HSM does not allow
modification of the CKA_ID after creation.
This code change includes the corresponding unit-test and has been tested against
both AWS CloudHSM and the SoftHSM.

#### Related issues
https://jira.hyperledger.org/browse/FAB-16951

Signed-off-by: Luc Desrosiers <ldesrosi@uk.ibm.com>