### PR TITLE
Bump IT pull retry threshold to 7s

### DIFF
--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -59,7 +59,7 @@ peer:
       leaderAliveThreshold: 10s
       leaderElectionDuration: 5s
     pvtData:
-      pullRetryThreshold: 3s
+      pullRetryThreshold: 7s
       transientstoreMaxBlockRetention: 1000
       pushAckTimeout: 3s
       btlPullMargin: 10


### PR DESCRIPTION

#### Type of change

Improvement

#### Description

3s might have been a little too short for tests that actually needed
to fetch private data. Incrementing by just a little to reduce number of
flakes

