### PR TITLE
[FAB-15035] Remove couchdb HTTP Request headers from debug log

### DIFF
--- a/core/ledger/util/couchdb/couchdb.go
+++ b/core/ledger/util/couchdb/couchdb.go
@@ -1822,12 +1822,6 @@ func (couchInstance *CouchInstance) handleRequest(ctx context.Context, method, d
 			req.SetBasicAuth(couchInstance.conf.Username, couchInstance.conf.Password)
 		}
 
-		if logger.IsEnabledFor(zapcore.DebugLevel) {
-			dump, _ := httputil.DumpRequestOut(req, false)
-			// compact debug log by replacing carriage return / line feed with dashes to separate http headers
-			logger.Debugf("HTTP Request: %s", bytes.Replace(dump, []byte{0x0d, 0x0a}, []byte{0x20, 0x7c, 0x20}, -1))
-		}
-
 		//Execute http request
 		resp, errResp = couchInstance.client.Do(req)
 


### PR DESCRIPTION
#### Type of change

Improvement

#### Description

This was printing out basic auth credentials and is probably unnecessary to log
in the first place

/cc @denyeart 