### PR TITLE
[FAB-17196] Fix broken md structures in docs

### DIFF
--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -330,7 +330,7 @@ A chaincode needs to be packaged before it can be installed on your peers.
 This example uses the `peer lifecycle chaincode package` command to package
 a Golang chaincode.
 
-  * Use the `--label` flag to provide a chaincode package label of ``myccv1``
+  * Use the `--label` flag to provide a chaincode package label of `myccv1`
     that your organization will use to identify the package.
 
     ```
@@ -404,27 +404,27 @@ channel `mychannel`.
 
   * Use the `--package-id` flag to pass in the chaincode package identifier. Use
     the `--signature-policy` flag to define an endorsement policy for the chaincode.
-    Use the ``init-required`` flag to request the execution of the ``Init``
+    Use the `init-required` flag to request the execution of the `Init`
     function to initialize the chaincode.
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    .
+
     peer lifecycle chaincode approveformyorg  -o orderer.example.com:7050 --tls --cafile $ORDERER_CA --channelID mychannel --name mycc --version 1.0 --init-required --package-id myccv1:a7ca45a7cc85f1d89c905b775920361ed089a364e12a9b6d55ba75c965ddd6a9 --sequence 1 --signature-policy "AND ('Org1MSP.peer','Org2MSP.peer')"
-    .
+
     2019-03-18 16:04:09.046 UTC [cli.lifecycle.chaincode] InitCmdFactory -> INFO 001 Retrieved channel (mychannel) orderer endpoint: orderer.example.com:7050
     2019-03-18 16:04:11.253 UTC [chaincodeCmd] ClientWait -> INFO 002 txid [efba188ca77889cc1c328fc98e0bb12d3ad0abcda3f84da3714471c7c1e6c13c] committed with status (VALID) at peer0.org1.example.com:7051
     ```
 
-  * You can also use the ``--channel-config-policy`` flag use a policy inside
+  * You can also use the `--channel-config-policy` flag use a policy inside
     the channel configuration as the chaincode endorsement policy. The default
-    endorsement policy is ``Channel/Application/Endorsement``
+    endorsement policy is `Channel/Application/Endorsement`
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    .
+
     peer lifecycle chaincode approveformyorg -o orderer.example.com:7050 --tls --cafile $ORDERER_CA --channelID mychannel --name mycc --version 1.0 --init-required --package-id myccv1:a7ca45a7cc85f1d89c905b775920361ed089a364e12a9b6d55ba75c965ddd6a9 --sequence 1 --channel-config-policy Channel/Application/Admins
-    .
+
     2019-03-18 16:04:09.046 UTC [cli.lifecycle.chaincode] InitCmdFactory -> INFO 001 Retrieved channel (mychannel) orderer endpoint: orderer.example.com:7050
     2019-03-18 16:04:11.253 UTC [chaincodeCmd] ClientWait -> INFO 002 txid [efba188ca77889cc1c328fc98e0bb12d3ad0abcda3f84da3714471c7c1e6c13c] committed with status (VALID) at peer0.org1.example.com:7051
     ```
@@ -432,18 +432,21 @@ channel `mychannel`.
 ### peer lifecycle chaincode checkcommitreadiness example
 
 You can check whether a chaincode definition is ready to be committed using the
-``peer lifecycle chaincode checkcommitreadiness command, which will return
+`peer lifecycle chaincode checkcommitreadiness` command, which will return
 successfully if a subsequent commit of the definition is expected to succeed. It
 also outputs which organizations have approved the chaincode definition. If an
 organization has approved the chaincode definition specified in the command, the
 command will return a value of true. You can use this command to learn whether enough
 channel members have approved a chaincode definition to meet the
-``Application/Channel/Endorsement`` policy (a majority by default) before the
+`Application/Channel/Endorsement` policy (a majority by default) before the
 definition can be committed to a channel.
 
-     * ```
+  * Here is an example of the `peer lifecycle chaincode checkcommitreadiness` command,
+    which checks a chaincode named `mycc` at version `1.0` on channel `mychannel`.
+
+    ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    .
+
     peer lifecycle chaincode checkcommitreadiness -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --name mycc --version 1.0 --init-required --sequence 1
     ```
 
@@ -457,12 +460,12 @@ definition can be committed to a channel.
     Org2MSP: true
     ```
 
-    * You can also use the `--output` flag to have the CLI format the output as
+  * You can also use the `--output` flag to have the CLI format the output as
     JSON.
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    .
+
     peer lifecycle chaincode checkcommitreadiness -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --name mycc --version 1.0 --init-required --sequence 1 --output json
     ```
 
@@ -482,16 +485,16 @@ definition can be committed to a channel.
 
 Once a sufficient number of organizations approve a chaincode definition for
 their organizations (a majority by default), one organization can commit the
-definition the channel using the ``peer lifecycle chaincode commit`` command:
+definition the channel using the `peer lifecycle chaincode commit` command:
 
   * This command needs to target the peers of other organizations on the channel
     to collect their organization endorsement for the definition.
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    .
+
     peer lifecycle chaincode commit -o orderer.example.com:7050 --channelID mychannel --name mycc --version 1.0 --sequence 1 --init-required --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051 --peerAddresses peer0.org2.example.com:9051
-    .
+
     2019-03-18 16:14:27.258 UTC [chaincodeCmd] ClientWait -> INFO 001 txid [b6f657a14689b27d69a50f39590b3949906b5a426f9d7f0dcee557f775e17882] committed with status (VALID) at peer0.org2.example.com:9051
     2019-03-18 16:14:27.321 UTC [chaincodeCmd] ClientWait -> INFO 002 txid [b6f657a14689b27d69a50f39590b3949906b5a426f9d7f0dcee557f775e17882] committed with status (VALID) at peer0.org1.example.com:7051
     ```
@@ -499,7 +502,7 @@ definition the channel using the ``peer lifecycle chaincode commit`` command:
 ### peer lifecycle chaincode querycommitted example
 
 You can query the chaincode definitions that have been committed to a channel by
-using the ``peer lifecycle chaincode querycommitted`` command. You can use this
+using the `peer lifecycle chaincode querycommitted` command. You can use this
 command to query the current definition sequence number before upgrading a
 chaincode.
 
@@ -508,9 +511,9 @@ chaincode.
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    .
+
     peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --name mycc --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051
-    .
+
     Committed chaincode definition for chaincode 'mycc' on channel 'mychannel':
     Version: 1, Sequence: 1, Endorsement Plugin: escc, Validation Plugin: vscc
     Approvals: [Org1MSP: true, Org2MSP: true]
@@ -521,9 +524,9 @@ chaincode.
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    .
+
     peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051
-    .
+
     Committed chaincode definitions on channel 'mychannel':
     Name: mycc, Version: 1, Sequence: 1, Endorsement Plugin: escc, Validation Plugin: vscc
     Name: yourcc, Version: 2, Sequence: 3, Endorsement Plugin: escc, Validation Plugin: vscc

--- a/docs/wrappers/peer_lifecycle_chaincode_postscript.md
+++ b/docs/wrappers/peer_lifecycle_chaincode_postscript.md
@@ -7,7 +7,7 @@ A chaincode needs to be packaged before it can be installed on your peers.
 This example uses the `peer lifecycle chaincode package` command to package
 a Golang chaincode.
 
-  * Use the `--label` flag to provide a chaincode package label of ``myccv1``
+  * Use the `--label` flag to provide a chaincode package label of `myccv1`
     that your organization will use to identify the package.
 
     ```
@@ -39,7 +39,7 @@ You need to use the chaincode package identifier to approve a chaincode
 definition for your organization. You can find the package ID for the
 chaincodes you have installed by using the
 `peer lifecycle chaincode queryinstalled` command:
-    
+
 ```
 peer lifecycle chaincode queryinstalled --peerAddresses peer0.org1.example.com:7051
 ```
@@ -81,27 +81,27 @@ channel `mychannel`.
 
   * Use the `--package-id` flag to pass in the chaincode package identifier. Use
     the `--signature-policy` flag to define an endorsement policy for the chaincode.
-    Use the ``init-required`` flag to request the execution of the ``Init``
+    Use the `init-required` flag to request the execution of the `Init`
     function to initialize the chaincode.
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    .
+
     peer lifecycle chaincode approveformyorg  -o orderer.example.com:7050 --tls --cafile $ORDERER_CA --channelID mychannel --name mycc --version 1.0 --init-required --package-id myccv1:a7ca45a7cc85f1d89c905b775920361ed089a364e12a9b6d55ba75c965ddd6a9 --sequence 1 --signature-policy "AND ('Org1MSP.peer','Org2MSP.peer')"
-    .
+
     2019-03-18 16:04:09.046 UTC [cli.lifecycle.chaincode] InitCmdFactory -> INFO 001 Retrieved channel (mychannel) orderer endpoint: orderer.example.com:7050
     2019-03-18 16:04:11.253 UTC [chaincodeCmd] ClientWait -> INFO 002 txid [efba188ca77889cc1c328fc98e0bb12d3ad0abcda3f84da3714471c7c1e6c13c] committed with status (VALID) at peer0.org1.example.com:7051
     ```
 
-  * You can also use the ``--channel-config-policy`` flag use a policy inside
+  * You can also use the `--channel-config-policy` flag use a policy inside
     the channel configuration as the chaincode endorsement policy. The default
-    endorsement policy is ``Channel/Application/Endorsement``
+    endorsement policy is `Channel/Application/Endorsement`
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    .
+
     peer lifecycle chaincode approveformyorg -o orderer.example.com:7050 --tls --cafile $ORDERER_CA --channelID mychannel --name mycc --version 1.0 --init-required --package-id myccv1:a7ca45a7cc85f1d89c905b775920361ed089a364e12a9b6d55ba75c965ddd6a9 --sequence 1 --channel-config-policy Channel/Application/Admins
-    .
+
     2019-03-18 16:04:09.046 UTC [cli.lifecycle.chaincode] InitCmdFactory -> INFO 001 Retrieved channel (mychannel) orderer endpoint: orderer.example.com:7050
     2019-03-18 16:04:11.253 UTC [chaincodeCmd] ClientWait -> INFO 002 txid [efba188ca77889cc1c328fc98e0bb12d3ad0abcda3f84da3714471c7c1e6c13c] committed with status (VALID) at peer0.org1.example.com:7051
     ```
@@ -109,18 +109,21 @@ channel `mychannel`.
 ### peer lifecycle chaincode checkcommitreadiness example
 
 You can check whether a chaincode definition is ready to be committed using the
-``peer lifecycle chaincode checkcommitreadiness command, which will return
-successfully if a subsequent commit of the definition is expected to succeed. It 
+`peer lifecycle chaincode checkcommitreadiness` command, which will return
+successfully if a subsequent commit of the definition is expected to succeed. It
 also outputs which organizations have approved the chaincode definition. If an
 organization has approved the chaincode definition specified in the command, the
 command will return a value of true. You can use this command to learn whether enough
 channel members have approved a chaincode definition to meet the
-``Application/Channel/Endorsement`` policy (a majority by default) before the
+`Application/Channel/Endorsement` policy (a majority by default) before the
 definition can be committed to a channel.
 
-     * ```
+  * Here is an example of the `peer lifecycle chaincode checkcommitreadiness` command,
+    which checks a chaincode named `mycc` at version `1.0` on channel `mychannel`.
+
+    ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    .
+
     peer lifecycle chaincode checkcommitreadiness -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --name mycc --version 1.0 --init-required --sequence 1
     ```
 
@@ -134,12 +137,12 @@ definition can be committed to a channel.
     Org2MSP: true
     ```
 
-    * You can also use the `--output` flag to have the CLI format the output as
+  * You can also use the `--output` flag to have the CLI format the output as
     JSON.
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    .
+
     peer lifecycle chaincode checkcommitreadiness -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --name mycc --version 1.0 --init-required --sequence 1 --output json
     ```
 
@@ -159,16 +162,16 @@ definition can be committed to a channel.
 
 Once a sufficient number of organizations approve a chaincode definition for
 their organizations (a majority by default), one organization can commit the
-definition the channel using the ``peer lifecycle chaincode commit`` command:
+definition the channel using the `peer lifecycle chaincode commit` command:
 
   * This command needs to target the peers of other organizations on the channel
     to collect their organization endorsement for the definition.
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    .
+
     peer lifecycle chaincode commit -o orderer.example.com:7050 --channelID mychannel --name mycc --version 1.0 --sequence 1 --init-required --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051 --peerAddresses peer0.org2.example.com:9051
-    .
+
     2019-03-18 16:14:27.258 UTC [chaincodeCmd] ClientWait -> INFO 001 txid [b6f657a14689b27d69a50f39590b3949906b5a426f9d7f0dcee557f775e17882] committed with status (VALID) at peer0.org2.example.com:9051
     2019-03-18 16:14:27.321 UTC [chaincodeCmd] ClientWait -> INFO 002 txid [b6f657a14689b27d69a50f39590b3949906b5a426f9d7f0dcee557f775e17882] committed with status (VALID) at peer0.org1.example.com:7051
     ```
@@ -176,18 +179,18 @@ definition the channel using the ``peer lifecycle chaincode commit`` command:
 ### peer lifecycle chaincode querycommitted example
 
 You can query the chaincode definitions that have been committed to a channel by
-using the ``peer lifecycle chaincode querycommitted`` command. You can use this
+using the `peer lifecycle chaincode querycommitted` command. You can use this
 command to query the current definition sequence number before upgrading a
 chaincode.
 
-  * You need to supply the chaincode name and channel name in order to query a 
+  * You need to supply the chaincode name and channel name in order to query a
     specific chaincode definition and the organizations that have approved it.
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    .
+
     peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --name mycc --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051
-    .
+
     Committed chaincode definition for chaincode 'mycc' on channel 'mychannel':
     Version: 1, Sequence: 1, Endorsement Plugin: escc, Validation Plugin: vscc
     Approvals: [Org1MSP: true, Org2MSP: true]
@@ -198,9 +201,9 @@ chaincode.
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    .
+
     peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051
-    .
+
     Committed chaincode definitions on channel 'mychannel':
     Name: mycc, Version: 1, Sequence: 1, Endorsement Plugin: escc, Validation Plugin: vscc
     Name: yourcc, Version: 2, Sequence: 3, Endorsement Plugin: escc, Validation Plugin: vscc

--- a/docs/wrappers/peer_lifecycle_chaincode_preamble.md
+++ b/docs/wrappers/peer_lifecycle_chaincode_preamble.md
@@ -8,7 +8,7 @@ has been successfully committed to the channel. For more information, visit
 [Chaincode for Operators](../chaincode4noah.html).
 
 *Note: These instructions use the Fabric chaincode lifecycle introduced in the
-v2.0 Alpha release. If you would like to use the old lifecycle to install and
+v2.0 release. If you would like to use the old lifecycle to install and
 instantiate a chaincode, visit the [peer chaincode](peerchaincode.html) command
 reference.*
 


### PR DESCRIPTION
This patch fixes broken markdown structures in documents on peerlifecycle commands.
Also, this patch includes a minor fix for removing references to alpha (ref. FAB-16157).
Signed-off-by: Tatsuya Sato <Tatsuya.Sato@hal.hitachi.com>

#### Type of change

- Documentation update

#### Description

This patch fixes broken markdown structures in documents on peerlifecycle commands.
Also, this patch includes a minor fix for removing references to alpha (ref. FAB-16157).

#### Additional details

#### Related issues

https://jira.hyperledger.org/browse/FAB-17196
https://jira.hyperledger.org/browse/FAB-16157

