### PR TITLE
FAB-17160 Ensure peer can be started without any docker requirements

### DIFF
--- a/core/container/container.go
+++ b/core/container/container.go
@@ -112,6 +112,9 @@ func (r *Router) Build(ccid string) error {
 	}
 
 	if instance == nil {
+		if r.DockerBuilder == nil {
+			return errors.New("no DockerBuilder, cannot build")
+		}
 		metadata, _, codeStream, err := r.PackageProvider.GetChaincodePackage(ccid)
 		if err != nil {
 			return errors.WithMessage(err, "failed to get chaincode package for docker build")

--- a/core/container/container_test.go
+++ b/core/container/container_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Router", func() {
 			})
 		})
 
-		Context("when the exxternal builder returns a nil instance", func() {
+		Context("when the external builder returns a nil instance", func() {
 			BeforeEach(func() {
 				fakeExternalBuilder.BuildReturns(nil, nil)
 				fakeDockerBuilder.BuildReturns(fakeInstance, nil)
@@ -127,6 +127,17 @@ var _ = Describe("Router", func() {
 				codePackage, err := ioutil.ReadAll(codeStream)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(codePackage).To(Equal([]byte("code-bytes")))
+			})
+
+			Context("when the docker vm builder is nil", func() {
+				BeforeEach(func() {
+					router.DockerBuilder = nil
+				})
+
+				It("returns the error", func() {
+					err := router.Build("package-id")
+					Expect(err).To(MatchError("no DockerBuilder, cannot build"))
+				})
 			})
 
 			Context("when the package provider returns an error before calling the docker builder", func() {

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -77,14 +77,14 @@ var _ = Describe("EndToEnd", func() {
 		os.RemoveAll(testDir)
 	})
 
-	Describe("basic solo network with 2 orgs", func() {
+	Describe("basic solo network with 2 orgs and no docker", func() {
 		var datagramReader *DatagramReader
 
 		BeforeEach(func() {
 			datagramReader = NewDatagramReader()
 			go datagramReader.Start()
 
-			network = nwo.New(nwo.BasicSolo(), testDir, client, StartPort(), components)
+			network = nwo.New(nwo.BasicSolo(), testDir, nil, StartPort(), components)
 			network.MetricsProvider = "statsd"
 			network.StatsdEndpoint = datagramReader.Address()
 			network.Profiles = append(network.Profiles, &nwo.Profile{
@@ -100,6 +100,11 @@ var _ = Describe("EndToEnd", func() {
 			})
 
 			network.GenerateConfigTree()
+			for _, peer := range network.PeersWithChannel("testchannel") {
+				core := network.ReadPeerConfig(peer)
+				core.VM = nil
+				network.WritePeerConfig(peer, core)
+			}
 			network.Bootstrap()
 
 			networkRunner := network.NetworkGroupRunner()
@@ -113,7 +118,7 @@ var _ = Describe("EndToEnd", func() {
 			}
 		})
 
-		It("executes a basic solo network with 2 orgs", func() {
+		It("executes a basic solo network with 2 orgs and no docker", func() {
 			By("getting the orderer by name")
 			orderer := network.Orderer("orderer")
 

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -651,13 +651,15 @@ func (n *Network) GenerateConfigTree() {
 // the Network using the channel's Profile attribute. The transactions are
 // written to ${rootDir}/${Channel.Name}_tx.pb.
 func (n *Network) Bootstrap() {
-	_, err := n.DockerClient.CreateNetwork(
-		docker.CreateNetworkOptions{
-			Name:   n.NetworkID,
-			Driver: "bridge",
-		},
-	)
-	Expect(err).NotTo(HaveOccurred())
+	if n.DockerClient != nil {
+		_, err := n.DockerClient.CreateNetwork(
+			docker.CreateNetworkOptions{
+				Name:   n.NetworkID,
+				Driver: "bridge",
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+	}
 
 	sess, err := n.Cryptogen(commands.Generate{
 		Config: n.CryptoConfigPath(),
@@ -754,6 +756,10 @@ func (n *Network) listTLSCACertificates() []string {
 // Cleanup attempts to cleanup docker related artifacts that may
 // have been created by the network.
 func (n *Network) Cleanup() {
+	if n.DockerClient == nil {
+		return
+	}
+
 	nw, err := n.DockerClient.NetworkInfo(n.NetworkID)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -495,42 +495,46 @@ func serve(args []string) error {
 		CCID:            scc.ChaincodeID(lifecycle.LifecycleNamespace),
 		HandlerRegistry: chaincodeHandlerRegistry,
 	}
-	var client *docker.Client
-	if coreConfig.VMDockerTLSEnabled {
-		client, err = docker.NewTLSClient(coreConfig.VMEndpoint, coreConfig.DockerCert, coreConfig.DockerKey, coreConfig.DockerCA)
-	} else {
-		client, err = docker.NewClient(coreConfig.VMEndpoint)
-	}
-	if err != nil {
-		logger.Panicf("cannot create docker client: %s", err)
+
+	if coreConfig.VMEndpoint == "" && len(coreConfig.ExternalBuilders) == 0 {
+		logger.Panic("VMEndpoint not set and no ExternalBuilders defined")
 	}
 
 	chaincodeConfig := chaincode.GlobalConfig()
 
-	dockerVM := &dockercontroller.DockerVM{
-		PeerID:        coreConfig.PeerID,
-		NetworkID:     coreConfig.NetworkID,
-		BuildMetrics:  dockercontroller.NewBuildMetrics(opsSystem.Provider),
-		Client:        client,
-		AttachStdOut:  coreConfig.VMDockerAttachStdout,
-		HostConfig:    getDockerHostConfig(),
-		ChaincodePull: coreConfig.ChaincodePull,
-		NetworkMode:   coreConfig.VMNetworkMode,
-		PlatformBuilder: &platforms.Builder{
-			Registry: platformRegistry,
-			Client:   client,
-		},
-		// This field is superfluous for chaincodes built with v2.0+ binaries
-		// however, to prevent users from being forced to rebuild leaving for now
-		// but it should be removed in the future.
-		LoggingEnv: []string{
-			"CORE_CHAINCODE_LOGGING_LEVEL=" + chaincodeConfig.LogLevel,
-			"CORE_CHAINCODE_LOGGING_SHIM=" + chaincodeConfig.ShimLogLevel,
-			"CORE_CHAINCODE_LOGGING_FORMAT=" + chaincodeConfig.LogFormat,
-		},
-	}
-	if err := opsSystem.RegisterChecker("docker", dockerVM); err != nil {
-		logger.Panicf("failed to register docker health check: %s", err)
+	var client *docker.Client
+	var dockerVM *dockercontroller.DockerVM
+	if coreConfig.VMEndpoint != "" {
+		client, err = createDockerClient(coreConfig)
+		if err != nil {
+			logger.Panicf("cannot create docker client: %s", err)
+		}
+
+		dockerVM = &dockercontroller.DockerVM{
+			PeerID:        coreConfig.PeerID,
+			NetworkID:     coreConfig.NetworkID,
+			BuildMetrics:  dockercontroller.NewBuildMetrics(opsSystem.Provider),
+			Client:        client,
+			AttachStdOut:  coreConfig.VMDockerAttachStdout,
+			HostConfig:    getDockerHostConfig(),
+			ChaincodePull: coreConfig.ChaincodePull,
+			NetworkMode:   coreConfig.VMNetworkMode,
+			PlatformBuilder: &platforms.Builder{
+				Registry: platformRegistry,
+				Client:   client,
+			},
+			// This field is superfluous for chaincodes built with v2.0+ binaries
+			// however, to prevent users from being forced to rebuild leaving for now
+			// but it should be removed in the future.
+			LoggingEnv: []string{
+				"CORE_CHAINCODE_LOGGING_LEVEL=" + chaincodeConfig.LogLevel,
+				"CORE_CHAINCODE_LOGGING_SHIM=" + chaincodeConfig.ShimLogLevel,
+				"CORE_CHAINCODE_LOGGING_FORMAT=" + chaincodeConfig.LogFormat,
+			},
+		}
+		if err := opsSystem.RegisterChecker("docker", dockerVM); err != nil {
+			logger.Panicf("failed to register docker health check: %s", err)
+		}
 	}
 
 	externalVM := &externalbuilder.Detector{
@@ -933,7 +937,7 @@ func registerDiscoveryService(
 	discprotos.RegisterDiscoveryServer(peerServer.Server(), svc)
 }
 
-//create a CC listener using peer.chaincodeListenAddress (and if that's not set use peer.peerAddress)
+// create a CC listener using peer.chaincodeListenAddress (and if that's not set use peer.peerAddress)
 func createChaincodeServer(coreConfig *peer.Config, ca tlsgen.CA, peerHostname string) (srv *comm.GRPCServer, ccEndpoint string, err error) {
 	// before potentially setting chaincodeListenAddress, compute chaincode endpoint at first
 	ccEndpoint, err = computeChaincodeEndpoint(coreConfig.ChaincodeAddress, coreConfig.ChaincodeListenAddress, peerHostname)
@@ -1074,6 +1078,13 @@ func computeChaincodeEndpoint(chaincodeAddress string, chaincodeListenAddress st
 
 	logger.Infof("Exit with ccEndpoint: %s", ccEndpoint)
 	return ccEndpoint, nil
+}
+
+func createDockerClient(coreConfig *peer.Config) (*docker.Client, error) {
+	if coreConfig.VMDockerTLSEnabled {
+		return docker.NewTLSClient(coreConfig.VMEndpoint, coreConfig.DockerCert, coreConfig.DockerKey, coreConfig.DockerCA)
+	}
+	return docker.NewClient(coreConfig.VMEndpoint)
 }
 
 // secureDialOpts is the callback function for secure dial options for gossip service


### PR DESCRIPTION
With the introduction of external builders for chaincode, docker is no longer required. This PR
ensures that a peer can be started with an external builder/launcher for chaincode and zero docker requirements. 

Signed-off-by: Will Lahti <wtlahti@us.ibm.com>