### PR TITLE
FAB-17170 Peer CLI should encode mdata lowercase

### DIFF
--- a/internal/peer/lifecycle/chaincode/package.go
+++ b/internal/peer/lifecycle/chaincode/package.go
@@ -211,9 +211,9 @@ func writeBytesToPackage(tw *tar.Writer, name string, payload []byte) error {
 
 // PackageMetadata holds the path and type for a chaincode package
 type PackageMetadata struct {
-	Path  string `json:"Path"`
-	Type  string `json:"Type"`
-	Label string `json:"Label"`
+	Path  string `json:"path"`
+	Type  string `json:"type"`
+	Label string `json:"label"`
 }
 
 func toJSON(path, ccType, label string) ([]byte, error) {

--- a/internal/peer/lifecycle/chaincode/package_test.go
+++ b/internal/peer/lifecycle/chaincode/package_test.go
@@ -8,9 +8,10 @@ package chaincode_test
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
-	"encoding/json"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -21,7 +22,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
 )
 
 var _ = Describe("Package", func() {
@@ -77,11 +77,7 @@ var _ = Describe("Package", func() {
 
 			metadata, err := readMetadataFromBytes(pkgTarGzBytes)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(metadata).To(Equal(&chaincode.PackageMetadata{
-				Path:  "normalizedPath",
-				Type:  "testType",
-				Label: "testLabel",
-			}))
+			Expect(metadata).To(MatchJSON(`{"path":"normalizedPath","type":"testType","label":"testLabel"}`))
 		})
 
 		Context("when the path is not provided", func() {
@@ -211,8 +207,8 @@ var _ = Describe("Package", func() {
 	})
 })
 
-func readMetadataFromBytes(pkgTarGzBytes []byte) (*chaincode.PackageMetadata, error) {
-	buffer := gbytes.BufferWithBytes(pkgTarGzBytes)
+func readMetadataFromBytes(pkgTarGzBytes []byte) ([]byte, error) {
+	buffer := bytes.NewBuffer(pkgTarGzBytes)
 	gzr, err := gzip.NewReader(buffer)
 	Expect(err).NotTo(HaveOccurred())
 	defer gzr.Close()
@@ -226,10 +222,7 @@ func readMetadataFromBytes(pkgTarGzBytes []byte) (*chaincode.PackageMetadata, er
 			return nil, err
 		}
 		if header.Name == "metadata.json" {
-			jsonDecoder := json.NewDecoder(tr)
-			metadata := &chaincode.PackageMetadata{}
-			err := jsonDecoder.Decode(metadata)
-			return metadata, err
+			return ioutil.ReadAll(tr)
 		}
 	}
 	return nil, errors.New("metadata.json not found")


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Once upon a time, the JSON fields in the chaincode package metadata.json
were upper case.  The peer CLI was written to reflect this fact.  When
they were changed to lower-case, the peer CLI was not updated, but
because of the fuzzy JSON matching rules in the golang JSON decoded it
was not noticed.  However, for external builders, the inconsistency is
more likely to be noticed as tools like jq etc. may not default to this
same fuzzy case-insensitive matching.

This change simply modifies the peer CLI to encode the metadata fields
as lower case.