### PR TITLE
Attempt to fix flaky integration ApproveForMyOrg

### DIFF
--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -1321,6 +1322,17 @@ func (n *Network) PeersWithChannel(chanName string) []*Peer {
 			}
 		}
 	}
+
+	// This is a bit of a hack to make the output of this function deterministic.
+	// When this function's output is supplied as input to functions such as ApproveChaincodeForMyOrg
+	// it causes a different subset of peers to be picked, which can create flakiness in tests.
+	sort.Slice(peers, func(i, j int) bool {
+		if peers[i].Organization < peers[j].Organization {
+			return true
+		}
+
+		return peers[i].Organization == peers[j].Organization && peers[i].Name < peers[j].Name
+	})
 	return peers
 }
 


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

The lifecycle tests use the PeersWithChannel function to get a list of
peers to invoke ApproveChaincodeForMyOrg on.  That function then picks
the first peer from each org in this list.  Consequently, a random
subset of peers from orgs are picked.  Then sometimes, the peers will
have the implicit collection private data in their transient store, and
sometimes, they will not.

By making this function deterministic, we should ensure that these tests
consistently get Peer1 for their org, which is almost always the peer
which is selected for individual approvals.

This is untested (except soon to be in CI) but will hopefully reduce the
flakiness of these tests.