### PR TITLE
Attempt to fix 2 integration test flakes on release-1.4

### DIFF
--- a/common/deliver/deliver.go
+++ b/common/deliver/deliver.go
@@ -278,6 +278,14 @@ func (h *Handler) deliverBlocks(ctx context.Context, srv *Server, envelope *cb.E
 	case *ab.SeekPosition_Oldest:
 		stopNum = number
 	case *ab.SeekPosition_Newest:
+		// when seeking only the newest block (i.e. starting
+		// and stopping at newest), don't reevaluate the ledger
+		// height as this can lead to multiple blocks being
+		// sent when only one is expected
+		if proto.Equal(seekInfo.Start, seekInfo.Stop) {
+			stopNum = number
+			break
+		}
 		stopNum = chain.Reader().Height() - 1
 	case *ab.SeekPosition_Specified:
 		stopNum = stop.Specified.Number
@@ -329,7 +337,7 @@ func (h *Handler) deliverBlocks(ctx context.Context, srv *Server, envelope *cb.E
 			return cb.Status_FORBIDDEN, nil
 		}
 
-		logger.Debugf("[channel: %s] Delivering block for (%p) for %s", chdr.ChannelId, seekInfo, addr)
+		logger.Debugf("[channel: %s] Delivering block [%d] for (%p) for %s", chdr.ChannelId, block.Header.Number, seekInfo, addr)
 
 		if err := srv.SendBlockResponse(block); err != nil {
 			logger.Warningf("[channel: %s] Error sending to %s: %s", chdr.ChannelId, addr, err)

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -1200,6 +1201,17 @@ func (n *Network) PeersWithChannel(chanName string) []*Peer {
 			}
 		}
 	}
+
+	// This is a bit of a hack to make the output of this function deterministic.
+	// When this function's output is supplied as input to functions such as ApproveChaincodeForMyOrg
+	// it causes a different subset of peers to be picked, which can create flakiness in tests.
+	sort.Slice(peers, func(i, j int) bool {
+		if peers[i].Organization < peers[j].Organization {
+			return true
+		}
+
+		return peers[i].Organization == peers[j].Organization && peers[i].Name < peers[j].Name
+	})
 	return peers
 }
 


### PR DESCRIPTION
## flake 1
The lifecycle tests use the PeersWithChannel function to get a list of
peers to invoke ApproveChaincodeForMyOrg on.  That function then picks
the first peer from each org in this list.  Consequently, a random
subset of peers from orgs are picked.  Then sometimes, the peers will
have the implicit collection private data in their transient store, and
sometimes, they will not.

By making this function deterministic, we should ensure that these tests
consistently get Peer1 for their org, which is almost always the peer
which is selected for individual approvals.

This is untested (except soon to be in CI) but will hopefully reduce the
flakiness of these tests.

## flake 2
deliver server sends a STATUS_SUCCESS to client after sending blocks,
which is flushed by client via an additional call to Recv(). However, if an extra
block is sent by server, that flush call actually gets a BLOCK. When next request
is sent by client on the same stream, it would get the leftover STATUS prior to
the block expected, and fails the test

This is a cherry-pick from master which seemed to resolve many flakes.