### PR TITLE
Update prereq doc for Go 1.13.x

### DIFF
--- a/docs/source/dev-setup/devenv.rst
+++ b/docs/source/dev-setup/devenv.rst
@@ -4,13 +4,10 @@ Setting up the development environment
 Prerequisites
 ~~~~~~~~~~~~~
 
--  `Git client <https://git-scm.com/downloads>`__
--  `Go <https://golang.org/dl/>`__ - version 1.12.x
+-  Git client, Go, and Docker as described at :doc:`../prereqs`
 -  (macOS)
    `Xcode <https://itunes.apple.com/us/app/xcode/id497799835?mt=12>`__
    must be installed
--  `Docker <https://www.docker.com/get-docker>`__ - 17.06.2-ce or later
--  `Docker Compose <https://docs.docker.com/compose/>`__ - 1.14.0 or later
 -  (macOS) you may need to install gnutar, as macOS comes with bsdtar
    as the default, but the build uses some gnutar flags. You can use
    Homebrew to install it as follows:

--- a/docs/source/prereqs.rst
+++ b/docs/source/prereqs.rst
@@ -83,7 +83,7 @@ Go Programming Language
 Hyperledger Fabric uses the Go Programming Language for many of its
 components.
 
-  - `Go <https://golang.org/dl/>`__ version 1.12.x is required.
+  - `Go <https://golang.org/dl/>`__ version 1.13.x is required.
 
 Given that we will be writing chaincode programs in Go, there are two
 environment variables you will need to set properly; you can make these


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Update prereq doc for Go 1.13.x.
Also removed duplicate prereq info in docs.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>