### PR TITLE
Add two digit release variable

### DIFF
--- a/ci/scripts/publish_docker.sh
+++ b/ci/scripts/publish_docker.sh
@@ -15,5 +15,5 @@ for image in baseos peer orderer ccenv tools; do
   docker push "hyperledger/fabric-${image}:amd64-${RELEASE}"
 
   ./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-${image}:amd64-${RELEASE}" --target "hyperledger/fabric-${image}:${RELEASE}"
-  ./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-${image}:amd64-${RELEASE}" --target "hyperledger/fabric-${image}:$(sed 's/..$//' <<< ${RELEASE})"
+  ./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-${image}:amd64-${RELEASE}" --target "hyperledger/fabric-${image}:${TWO_DIGIT_RELEASE}"
 done


### PR DESCRIPTION
This change adds a variable for the two digit release value. This is meant to solve cases where the two digit release isn't really a two digit release, i.e. (2.0-alpha) and the value can't be parsed directly from the full release version

Signed-off-by: Brett Logan <Brett.T.Logan@ibm.com>