### PR TITLE
[FAB-17272] Improve Docker Build Context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-.build
-unit-test
+
+**/*test.go
+.git/objects/pack
+.github
+
+# These are directories created by the make process
+bin
+build
+release
+
+ci
+docs
+images
+release_notes
+vagrant

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,9 @@ docker: $(RELEASE_IMAGES:%=%-docker)
 .PHONY: $(RELEASE_IMAGES:%=%-docker)
 $(RELEASE_IMAGES:%=%-docker): %-docker: $(BUILD_DIR)/images/%/$(DUMMY)
 
-$(BUILD_DIR)/images/peer/$(DUMMY): BUILD_ARGS=--build-arg GO_TAGS=${GO_TAGS}
+$(BUILD_DIR)/images/ccenv/$(DUMMY):   BUILD_CONTEXT=images/ccenv
+$(BUILD_DIR)/images/baseos/$(DUMMY):  BUILD_CONTEXT=images/baseos
+$(BUILD_DIR)/images/peer/$(DUMMY):    BUILD_ARGS=--build-arg GO_TAGS=${GO_TAGS}
 $(BUILD_DIR)/images/orderer/$(DUMMY): BUILD_ARGS=--build-arg GO_TAGS=${GO_TAGS}
 
 $(BUILD_DIR)/images/%/$(DUMMY):
@@ -222,7 +224,7 @@ $(BUILD_DIR)/images/%/$(DUMMY):
 		--build-arg GO_VER=$(GO_VER) \
 		--build-arg ALPINE_VER=$(ALPINE_VER) \
 		$(BUILD_ARGS) \
-		-t $(DOCKER_NS)/fabric-$* .
+		-t $(DOCKER_NS)/fabric-$* ./$(BUILD_CONTEXT)
 	docker tag $(DOCKER_NS)/fabric-$* $(DOCKER_NS)/fabric-$*:$(BASE_VERSION)
 	docker tag $(DOCKER_NS)/fabric-$* $(DOCKER_NS)/fabric-$*:$(DOCKER_TAG)
 	@touch $@


### PR DESCRIPTION
This change explicitly excludes unneeded directories
by extending .dockerignore and introduces a BUILD_CONTEXT
variable in the Makefile to limit the scope of the build
context for ccenv and baseos which do not require the
fabric source code in its context.

Signed-off-by: Brett Logan <you@example.com>

#### Type of change

- Improvement (improvement to code, performance, etc)
