### PR TITLE
Wrong protobuf import in etcdarft

### DIFF
--- a/orderer/consensus/etcdraft/node.go
+++ b/orderer/consensus/etcdraft/node.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/clock"
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/protos/orderer"
 	"github.com/hyperledger/fabric/protos/orderer/etcdraft"


### PR DESCRIPTION
The import is gogo protobuf but it should be the golang's protobuf. 

Change-Id: I46dfdf03e50f7c5484cdb26d305141e4dbbff05d
Signed-off-by: yacovm <yacovm@il.ibm.com>


