### PR TITLE
Remove CKA_PRIVATE from pubkeyT to broaden compatibility with HSMs

### DIFF
--- a/bccsp/pkcs11/pkcs11.go
+++ b/bccsp/pkcs11/pkcs11.go
@@ -214,7 +214,6 @@ func (csp *impl) generateECKey(curve asn1.ObjectIdentifier, ephemeral bool) (ski
 		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, !ephemeral),
 		pkcs11.NewAttribute(pkcs11.CKA_VERIFY, true),
 		pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, marshaledOID),
-		pkcs11.NewAttribute(pkcs11.CKA_PRIVATE, false),
 
 		pkcs11.NewAttribute(pkcs11.CKA_ID, publabel),
 		pkcs11.NewAttribute(pkcs11.CKA_LABEL, publabel),


### PR DESCRIPTION
#### Type of change

- Bug fix
- Improvement (improvement to code, performance, etc)

#### Description

Some HSM does not support CKA_PRIVATE defined as 'false' for the pubkey template. Removing this definition of the template eliminates the issue, as the HSM assumes a default value for the created object.

There is another attribute that defines if a key object is the public or private member of a pair, and this is the CKA_CLASS attr, that may have the values of CKO_PUBLIC_KEY, CKO_PRIVATE_KEY or CKO_SECRET_KEY.

#### Additional details

Tested with fabric-ca against SoftHSMv2 and Dinamo Networks HSM.

#### Related issues
[FAB-17280](https://jira.hyperledger.org/browse/FAB-17280)
[FAB-5407](https://jira.hyperledger.org/browse/FAB-5407)
