### PR TITLE
FGJ-67: Relocate Java SDK docs

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -42,7 +42,7 @@ Hyperledger Fabric offers a number of SDKs to support developing applications
 in various programming languages. SDKs are available for Node.js and Java:
 
   * `Node.js SDK <https://github.com/hyperledger/fabric-sdk-node>`__ and `Node.js SDK documentation <https://fabric-sdk-node.github.io/>`__.
-  * `Java SDK <https://github.com/hyperledger/fabric-gateway-java>`__ and `Java SDK documentation <https://fabric-gateway-java.github.io/>`__.
+  * `Java SDK <https://github.com/hyperledger/fabric-gateway-java>`__ and `Java SDK documentation <https://hyperledger.github.io/fabric-gateway-java/>`__.
 
 In addition, there are two more application SDKs that have not yet been officially released
 (for Python and Go), but they are still available for downloading and testing:


### PR DESCRIPTION
Change link to Java SDK documentation in Getting Started page.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>