### PR TITLE
[DOC] Standardize orderer address env var

### DIFF
--- a/docs/source/config_update.md
+++ b/docs/source/config_update.md
@@ -867,7 +867,7 @@ Before you attempt to use the sample commands, make sure to export the following
 * `TLS_ROOT_CA`: the path to the root CA cert of the TLS CA of the organization proposing the update.
 * `CORE_PEER_LOCALMSPID`: the name of your MSP.
 * `CORE_PEER_MSPCONFIGPATH`: the absolute path to the MSP of your organization.
-* `ORDERING_NODE_ADDRESS`: the url of an ordering node the channel is hosted on. For example, `orderer.example.com:7050`. Note that when targeting the ordering service, you can target any active node in the ordering service. Your requests will be forwarded to the leader automatically.
+* `ORDERER_CONTAINER`: the name of an ordering node container. Note that when targeting the ordering service, you can target any active node in the ordering service. Your requests will be forwarded to the leader automatically.
 
 Note: this topic will provide default names for the various JSON and protobuf files being pulled and modified (`config_block.pb`, `config_block.json`, etc). You are free to use whatever names you want. However, be aware that unless you go back and erase these files at the end of each config update, you will have to select different when making an additional update.
 
@@ -880,7 +880,7 @@ Make sure you are in the peer container.
 Now issue:
 
 ```
-peer channel fetch config config_block.pb -o $ORDERING_NODE_ADDRESS -c $CH_NAME --tls --cafile $TLS_ROOT_CA
+peer channel fetch config config_block.pb -o $ORDERER_CONTAINER -c $CH_NAME --tls --cafile $TLS_ROOT_CA
 ```
 
 Next, we'll covert the protobuf version of the channel config into a JSON version called `config_block.json` (JSON files are easier for humans to read and understand):
@@ -939,7 +939,7 @@ configtxlator proto_encode --input config_update_in_envelope.json --type common.
 Submit the config update transaction:
 
 ```
-peer channel update -f config_update_in_envelope.pb -c $CH_NAME -o $ORDERING_NODE_ADDRESS --tls true --cafile $TLS_ROOT_CA
+peer channel update -f config_update_in_envelope.pb -c $CH_NAME -o $ORDERER_CONTAINER --tls true --cafile $TLS_ROOT_CA
 ```
 
 Our config update transaction represents the difference between the original config and the modified one, but the ordering service will translate this into a full channel config.

--- a/docs/source/enable_cc_lifecycle.md
+++ b/docs/source/enable_cc_lifecycle.md
@@ -138,7 +138,7 @@ You will need to export the following variables:
 * `CORE_PEER_LOCALMSPID`: the MSP ID of the organization proposing the channel update. This will be the MSP of one of the ordering service organizations.
 * `CORE_PEER_MSPCONFIGPATH`: the absolute path to the MSP representing your organization.
 * `TLS_ROOT_CA`: the absolute path to the root CA certificate of the organization proposing the system channel update.
-* `ORDERING_NODE_ADDRESS`: the url of an ordering node. For example, `orderer.example.com:7050`. When targeting the ordering service, you can target any particular node in the ordering service. Your requests will be forwarded to the leader automatically.
+* `ORDERER_CONTAINER`: the name of an ordering node container. When targeting the ordering service, you can target any particular node in the ordering service. Your requests will be forwarded to the leader automatically.
 * `ORGNAME`: the name of the organization you are currently updating.
 * `CONSORTIUM_NAME`: the name of the consortium being updated.
 
@@ -170,7 +170,7 @@ You will need to export the following variables:
 * `TLS_ROOT_CA`: the absolute path to the TLS cert of your ordering node.
 * `CORE_PEER_MSPCONFIGPATH`: the absolute path to the MSP representing your organization.
 * `CORE_PEER_LOCALMSPID`: the MSP ID of the organization proposing the channel update. This will be the MSP of one of the peer organizations.
-* `ORDERING_NODE_ADDRESS`: the url of an ordering node. For example, `orderer.example.com:7050`. When targeting the ordering service, you can target any particular node in the ordering service. Your requests will be forwarded to the leader automatically.
+* `ORDERER_CONTAINER`: the name of an ordering node container. When targeting the ordering service, you can target any particular node in the ordering service. Your requests will be forwarded to the leader automatically.
 
 Once you have set the environment variables, navigate to [Step 1: Pull and translate the config](./config_update.html#step-1-pull-and-translate-the-config).
 

--- a/docs/source/updating_capabilities.md
+++ b/docs/source/updating_capabilities.md
@@ -109,7 +109,7 @@ You will need to export the following variables:
 * `CORE_PEER_LOCALMSPID`: the MSP ID of the organization proposing the channel update. This will be the MSP of one of the orderer organizations.
 * `TLS_ROOT_CA`: the absolute path to the TLS cert of your ordering node(s).
 * `CORE_PEER_MSPCONFIGPATH`: the absolute path to the MSP representing your organization.
-* `ORDERING_NODE_ADDRESS`: the url of an ordering node. For example, `orderer.example.com:7050`. When targeting the ordering service, you can target any particular node in the ordering service. Your requests will be forwarded to the leader automatically.
+* `ORDERER_CONTAINER`: the name of an ordering node container. When targeting the ordering service, you can target any particular node in the ordering service. Your requests will be forwarded to the leader automatically.
 
 ### `Orderer` group
 
@@ -151,7 +151,7 @@ You will need to export the following variables:
 * `CORE_PEER_LOCALMSPID`: the MSP ID of the organization proposing the channel update. This will be the MSP of your peer organization.
 * `TLS_ROOT_CA`: the absolute path to the TLS cert of your peer organization.
 * `CORE_PEER_MSPCONFIGPATH`: the absolute path to the MSP representing your organization.
-* `ORDERING_NODE_ADDRESS`: the url of an ordering node. For example, `orderer.example.com:7050`. When targeting the ordering service, you can target any particular node in the ordering service. Your requests will be forwarded to the leader automatically.
+* `ORDERER_CONTAINER`: the name of an ordering node container. When targeting the ordering service, you can target any particular node in the ordering service. Your requests will be forwarded to the leader automatically.
 
 ### `Orderer` group
 

--- a/docs/source/upgrade_to_newest_version.md
+++ b/docs/source/upgrade_to_newest_version.md
@@ -97,7 +97,7 @@ Then, export the following environment variables:
 * `CORE_PEER_LOCALMSPID`: the MSP ID of the organization proposing the channel update. This will be the MSP of one of the orderer organizations.
 * `CORE_PEER_MSPCONFIGPATH`: the absolute path to the MSP representing your organization.
 * `TLS_ROOT_CA`: the absolute path to the root CA certificate of the organization proposing the system channel update.
-* `ORDERING_NODE_ADDRESS`: the url of an ordering node. For example, `orderer.example.com:7050`. When targeting the ordering service, you can target any particular node in the ordering service. Your requests will be forwarded to the leader automatically.
+* `ORDERER_CONTAINER`: the name of an ordering node container. When targeting the ordering service, you can target any particular node in the ordering service. Your requests will be forwarded to the leader automatically.
 * `ORGNAME`: The name of the organization you are currently updating. For example, `OrdererOrg`.
 
 Once you have set the environment variables, navigate to [Step 1: Pull and translate the config](./config_update.html#step-1-pull-and-translate-the-config).


### PR DESCRIPTION
Making sure the orderer address env var is
the same across all upgrade docs. Should
decide in the future about standardization
across all samples

Change-Id: Ic5c6eee9c2f1524795b36940d3166fff5434bf3a
Signed-off-by: joe-alewine <Joe.Alewine@ibm.com>

#### Type of change

- Documentation update

#### Description

I changed the ORDERING_NODE_ADDRESS to ORDERER_CONTAINER in some places but not all in the upgrade docs. This fixes that.
