### PR TITLE
[FAB-17275] Add Raft option of InsecureSkipVerify

### DIFF
--- a/core/comm/client.go
+++ b/core/comm/client.go
@@ -70,6 +70,7 @@ func (client *GRPCClient) parseSecureOptions(opts SecureOptions) error {
 	}
 
 	client.tlsConfig = &tls.Config{
+		InsecureSkipVerify:    opts.InsecureSkipVerify,
 		VerifyPeerCertificate: opts.VerifyCertificate,
 		MinVersion:            tls.VersionTLS12} // TLS 1.2 only
 	if len(opts.ServerRootCAs) > 0 {

--- a/core/comm/config.go
+++ b/core/comm/config.go
@@ -110,6 +110,8 @@ type SecureOptions struct {
 	CipherSuites []uint16
 	// TimeShift makes TLS handshakes time sampling shift to the past by a given duration
 	TimeShift time.Duration
+	// InsecureSkipVerify disable the checking of the certificate chain and the hostname
+	InsecureSkipVerify bool
 }
 
 // KeepaliveOptions is used to set the gRPC keepalive settings for both

--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -74,6 +74,7 @@ type Cluster struct {
 	SendBufferSize                       int
 	CertExpirationWarningThreshold       time.Duration
 	TLSHandshakeTimeShift                time.Duration
+	InsecureSkipVerify                   bool
 }
 
 // Keepalive contains configuration for gRPC servers.
@@ -224,6 +225,7 @@ var Defaults = TopLevel{
 			ReplicationRetryTimeout:              time.Second * 5,
 			ReplicationPullTimeout:               time.Second * 5,
 			CertExpirationWarningThreshold:       time.Hour * 24 * 7,
+			InsecureSkipVerify:                   false,
 		},
 		LocalMSPDir: "msp",
 		LocalMSPID:  "SampleOrg",

--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -482,13 +482,14 @@ func initializeClusterClientConfig(conf *localconfig.TopLevel) comm.ClientConfig
 	}
 
 	cc.SecOpts = comm.SecureOptions{
-		TimeShift:         conf.General.Cluster.TLSHandshakeTimeShift,
-		RequireClientCert: true,
-		CipherSuites:      comm.DefaultTLSCipherSuites,
-		ServerRootCAs:     serverRootCAs,
-		Certificate:       certBytes,
-		Key:               keyBytes,
-		UseTLS:            true,
+		TimeShift:          conf.General.Cluster.TLSHandshakeTimeShift,
+		RequireClientCert:  true,
+		CipherSuites:       comm.DefaultTLSCipherSuites,
+		ServerRootCAs:      serverRootCAs,
+		Certificate:        certBytes,
+		Key:                keyBytes,
+		UseTLS:             true,
+		InsecureSkipVerify: conf.General.Cluster.InsecureSkipVerify,
 	}
 
 	return cc

--- a/sampleconfig/orderer.yaml
+++ b/sampleconfig/orderer.yaml
@@ -47,6 +47,10 @@ General:
         # Consensus messages are dropped if the buffer is full, and transaction
         # messages are waiting for space to be freed.
         SendBufferSize: 10
+        # InsecureSkipVerify will disable the checking on tls certificate chain and the hostname.
+        # Be careful to change to true, and only use this when doing test or the OSNs are behind
+        # network middle devices.
+        InsecureSkipVerify: false
         # ClientCertificate governs the file location of the client TLS certificate
         # used to establish mutual TLS connections with other ordering service nodes.
         ClientCertificate:


### PR DESCRIPTION
This patchset exposes the option to allow skip the hostname checking in
the configuration, which can allow OSN to work behind network middleware
and also ease the code testing.

Change-Id: Icbcf5c2511f02c44576785514826afceb99719bb
Signed-off-by: Baohua Yang <yangbaohua@gmail.com>
Signed-off-by: Baohua Yang <baohua.yang@oracle.com>

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Currently, OSN enabled TLS authentication for the raft communications.

In cases that OSN stays behind firewall/proxy/NATed devices, the published endpoint might not match that in the TLS cert. And the user may not care about it because there's following validation logics to compare the tls cert with those inside the channel config.

Hence we should expose the option to allow skip the hostname checking in the configuration.

With this option enabled, the OSN still requires to leverage the cert matching logic that is hardcoded to compare with the certs inside the channel config.

#### Related issues

https://jira.hyperledger.org/browse/FAB-17275