### PR TITLE
[FAB-17288] Fix peer lifecycle chaincode package on Windows

### DIFF
--- a/core/chaincode/platforms/golang/list_test.go
+++ b/core/chaincode/platforms/golang/list_test.go
@@ -9,6 +9,7 @@ package golang
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -45,7 +46,7 @@ func Test_gopathDependencyPackageInfo(t *testing.T) {
 
 	t.Run("TestFailure", func(t *testing.T) {
 		_, err := gopathDependencyPackageInfo(runtime.GOOS, runtime.GOARCH, "./doesnotexist")
-		assert.EqualError(t, err, "listing deps for pacakge ./doesnotexist failed: exit status 1")
+		assert.EqualError(t, err, "listing deps for package ./doesnotexist failed: exit status 1")
 	})
 }
 
@@ -82,7 +83,7 @@ func Test_listModuleInfo(t *testing.T) {
 
 	moduleDir, err := os.Getwd()
 	require.NoError(t, err, "failed to get module working directory")
-
+	moduleDir = filepath.ToSlash(moduleDir)
 	mi, err := listModuleInfo("GOPROXY=https://proxy.golang.org")
 	assert.NoError(t, err, "failed to get module info")
 
@@ -90,7 +91,7 @@ func Test_listModuleInfo(t *testing.T) {
 		ModulePath: "ccmodule",
 		ImportPath: "ccmodule",
 		Dir:        moduleDir,
-		GoMod:      filepath.Join(moduleDir, "go.mod"),
+		GoMod:      path.Join(moduleDir, "go.mod"),
 	}
 	assert.Equal(t, expected, mi)
 
@@ -104,7 +105,7 @@ func Test_listModuleInfo(t *testing.T) {
 		ModulePath: "ccmodule",
 		ImportPath: "ccmodule/nested",
 		Dir:        moduleDir,
-		GoMod:      filepath.Join(moduleDir, "go.mod"),
+		GoMod:      path.Join(moduleDir, "go.mod"),
 	}
 	assert.Equal(t, expected, mi)
 }

--- a/core/chaincode/platforms/golang/platform.go
+++ b/core/chaincode/platforms/golang/platform.go
@@ -38,7 +38,7 @@ func (p *Platform) Name() string {
 }
 
 // ValidatePath is used to ensure that path provided points to something that
-// looks like go chainccode.
+// looks like go chaincode.
 //
 // NOTE: this is only used at the _client_ side by the peer CLI.
 func (p *Platform) ValidatePath(rawPath string) error {
@@ -137,8 +137,8 @@ func (p *Platform) GetDeploymentPayload(codepath string) ([]byte, error) {
 	for _, pkg := range dependencyPackageInfo {
 		for _, filename := range pkg.Files() {
 			sd := SourceDescriptor{
-				Name: path.Join("src", pkg.ImportPath, filename),
-				Path: filepath.Join(pkg.Dir, filename),
+				Name: filepath.ToSlash(filepath.Join("src", pkg.ImportPath, filename)),
+				Path: path.Join(pkg.Dir, filename),
 			}
 			fileMap[sd.Name] = sd
 		}
@@ -272,7 +272,7 @@ func DescribeCode(path string) (*CodeDescriptor, error) {
 
 		return &CodeDescriptor{
 			Module:       true,
-			MetadataRoot: filepath.Join(modInfo.Dir, relImport, "META-INF"),
+			MetadataRoot: filepath.ToSlash(filepath.Join(modInfo.Dir, relImport, "META-INF")),
 			Path:         modInfo.ImportPath,
 			Source:       modInfo.Dir,
 		}, nil
@@ -290,7 +290,7 @@ func describeGopath(importPath string) (*CodeDescriptor, error) {
 
 	return &CodeDescriptor{
 		Path:         importPath,
-		MetadataRoot: filepath.Join(sourcePath, "META-INF"),
+		MetadataRoot: path.Join(sourcePath, "META-INF"),
 		Source:       sourcePath,
 	}, nil
 }
@@ -370,10 +370,10 @@ func (s SourceMap) Sources() Sources {
 func (s SourceMap) Directories() []string {
 	dirMap := map[string]bool{}
 	for filename := range s {
-		dir := filepath.Dir(filename)
+		dir := filepath.ToSlash(filepath.Dir(filename))
 		for dir != "." && !dirMap[dir] {
 			dirMap[dir] = true
-			dir = filepath.Dir(dir)
+			dir = filepath.ToSlash(filepath.Dir(dir))
 		}
 	}
 
@@ -431,7 +431,7 @@ func findSource(cd *CodeDescriptor) (SourceMap, error) {
 			if strings.HasPrefix(info.Name(), ".") {
 				return nil
 			}
-			name = filepath.Join("META-INF", name)
+			name = filepath.ToSlash(filepath.Join("META-INF", name))
 			err := validateMetadata(name, path)
 			if err != nil {
 				return err
@@ -441,7 +441,8 @@ func findSource(cd *CodeDescriptor) (SourceMap, error) {
 		default:
 			name = filepath.Join("src", cd.Path, name)
 		}
-
+		name = filepath.ToSlash(name)
+		path = filepath.ToSlash(path)
 		sources[name] = SourceDescriptor{Name: name, Path: path}
 		return nil
 	}

--- a/core/chaincode/platforms/util/writer.go
+++ b/core/chaincode/platforms/util/writer.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -49,6 +50,7 @@ func WriteFolderToTarPackage(tw *tar.Writer, srcPath string, excludeDirs []strin
 
 	rootDirLen := len(rootDirectory)
 	walkFn := func(localpath string, info os.FileInfo, err error) error {
+		localpath = filepath.ToSlash(localpath)
 		if err != nil {
 			vmLogger.Errorf("Visit %s failed: %s", localpath, err)
 			return err
@@ -93,11 +95,11 @@ func WriteFolderToTarPackage(tw *tar.Writer, srcPath string, excludeDirs []strin
 
 		// if file is metadata, keep the /META-INF directory, e.g: META-INF/statedb/couchdb/indexes/indexOwner.json
 		// otherwise file is source code, put it in /src dir, e.g: src/marbles_chaincode.js
-		if strings.HasPrefix(localpath, filepath.Join(rootDirectory, "META-INF")) {
+		if strings.HasPrefix(localpath, path.Join(rootDirectory, "META-INF")) {
 			packagepath = localpath[rootDirLen+1:]
 
 			// Split the tar packagepath into a tar package directory and filename
-			_, filename := filepath.Split(packagepath)
+			_, filename := path.Split(packagepath)
 
 			// Hidden files are not supported as metadata, therefore ignore them.
 			// User often doesn't know that hidden files are there, and may not be able to delete them, therefore warn user rather than error out.
@@ -166,7 +168,7 @@ func WriteFileToPackage(localpath string, packagepath string, tw *tar.Writer) er
 	header.AccessTime = zeroTime
 	header.ModTime = zeroTime
 	header.ChangeTime = zeroTime
-	header.Name = packagepath
+	header.Name = filepath.ToSlash(packagepath)
 	header.Mode = 0100644
 	header.Uid = 500
 	header.Gid = 500


### PR DESCRIPTION
#### Type of change
Bug fix

#### Description
With this change the command succeeds and creates a tar file
containing forwardslashes like the one created on Linux and Mac.

```
$ tar tf code.tar.gz
src/
src/vendor/
src/vendor/github.com/
src/vendor/github.com/PuerkitoBio/
...
src/vendor/gopkg.in/
src/vendor/gopkg.in/yaml.v2/
src/fabcar.go
src/go.mod
src/go.sum
...
src/vendor/gopkg.in/yaml.v2/yamlprivateh.go
src/vendor/modules.txt

And the chaincode deploys and runs successfully:
$ ./network.sh deployCC
deploying chaincode on channel 'mychannel'

Vendoring Go dependencies ...
~/Projects/Go/src/github.com/hyperledger/fabric-samples/chaincode/fabcar/go ~/Projects
/Go/src/github.com/hyperledger/fabric-samples/test-network
~/Projects/Go/src/github.com/hyperledger/fabric-samples/test-network
Finished vendoring Go dependencies
++ peer lifecycle chaincode package fabcar.tar.gz --path ../chaincode/fabcar/go/ --lang
golang --label fabcar_1
++ res=0
++ set +x

===================== Chaincode is packaged on peer0.org1 =====================

Installing chaincode on peer0.org1...
++ peer lifecycle chaincode install fabcar.tar.gz
++ res=0
++ set +x
2019-12-19 11:11:05.115 CET [cli.lifecycle.chaincode] submitInstallProposal -> INFO 001
Installed remotely: response:<status:200 payload:"\nIfabcar_1:b9a210d6c0c37bd69049e51b1
9de4e78a2e58f01cad4ea446000a53a5440b115\022\010fabcar_1" >
2019-12-19 11:11:05.115 CET [cli.lifecycle.chaincode] submitInstallProposal -> INFO 002
Chaincode code package identifier: fabcar_1:b9a210d6c0c37bd69049e51b19de4e78a2e58f01cad
4ea446000a53a5440b115
...
===================== Invoke transaction successful on peer0.org1 peer0.org2 on channel
'mychannel' =====================

Querying chaincode on peer0.org1...
===================== Querying on peer0.org1 on channel 'mychannel'... =====================

Attempting to Query peer0.org1 ...1576750333 secs
++ peer chaincode query -C mychannel -n fabcar -c '{"Args":["queryAllCars"]}'
++ res=0
++ set +x

[{"Key":"CAR0","Record":{"make":"Toyota","model":"Prius","colour":"blue","owner":"Tomok
o"}},{"Key":"CAR1","Record":{"make":"Ford","model":"Mustang","colour":"red","owner":"Br
ad"}},{"Key":"CAR2","Record":{"make":"Hyundai","model":"Tucson","colour":"green","owner
":"Jin Soo"}},{"Key":"CAR3","Record":{"make":"Volkswagen","model":"Passat","colour":"ye
llow","owner":"Max"}},{"Key":"CAR4","Record":{"make":"Tesla","model":"S","colour":"blac
k","owner":"Adriana"}},{"Key":"CAR5","Record":{"make":"Peugeot","model":"205","colour":
"purple","owner":"Michel"}},{"Key":"CAR6","Record":{"make":"Chery","model":"S22L","colo
ur":"white","owner":"Aarav"}},{"Key":"CAR7","Record":{"make":"Fiat","model":"Punto","co
lour":"violet","owner":"Pari"}},{"Key":"CAR8","Record":{"make":"Tata","model":"Nano","c
olour":"indigo","owner":"Valeria"}},{"Key":"CAR9","Record":{"make":"Holden","model":"Ba
rina","colour":"brown","owner":"Shotaro"}}]
 ===================== Query successful on peer0.org1 on channel 'mychannel' =====================
```

In addition go test now also succeeds.

#### Additional details

Using the filepath package in this case leads to the wrong result
because we do not want the result to be platform dependent. Care
must therefore be taken to ensure the output uses forward slashes.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>

