### PR TITLE
[FAB-17297] Use wget in bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -67,7 +67,9 @@ download() {
     local BINARY_FILE=$1
     local URL=$2
     echo "===> Downloading: " "${URL}"
-    curl -s -L "${URL}" | tar xz || rc=$?
+    wget "${URL}" || rc=$?
+    tar xvzf "${BINARY_FILE}" || rc=$?
+    rm "${BINARY_FILE}"
     if [ -n "$rc" ]; then
         echo "==> There was an error downloading the binary file."
         return 22


### PR DESCRIPTION
Switches to wget from curl to gracefully handle broken connections when downloading the fabric binaries. Broken connections have always been a problem, and complex logic used to exist to handle it when using curl. Originally we thought when we moved to GitHub from Nexus for serving release binaries we wouldn't need the complex logic anymore as GitHub's CDN (AWS) would better serve the files. Unfortunately community members in regions not centrally located to GitHub's CDN (India in particular) have reported high instances of failures with `curl`. In all case having them switch to this method solved their problem.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>