### PR TITLE
[FAB-17262] Fix instructions in build_network

### DIFF
--- a/docs/source/build_network.rst
+++ b/docs/source/build_network.rst
@@ -473,7 +473,7 @@ First let's start our network:
 
 .. code:: bash
 
-    docker-compose -f docker-compose-cli.yaml up -d
+    docker-compose -f docker-compose-cli.yaml up -f docker-compose-etcdraft2.yaml up -d
 
 If you want to see the realtime logs for your network, then do not supply the ``-d`` flag.
 If you let the logs stream, then you will need to open a second terminal to execute the CLI calls.
@@ -500,7 +500,7 @@ If successful you should see the following:
 
 .. code:: bash
 
-        root@0d78bb69300d:/opt/gopath/src/github.com/hyperledger/fabric/peer#
+        bash-5.0#
 
 For the following CLI commands against ``peer0.org1.example.com`` to work, we need
 to preface our commands with the four environment variables given below.  These
@@ -635,6 +635,11 @@ Go, Node.js or Java chaincode.
 
 .. code:: bash
 
+    # before packaging Golang chaincode, vendoring Go dependencies is required like the following commands.
+    cd /opt/gopath/src/github.com/hyperledger/fabric-samples/chaincode/abstore/go
+    GO111MODULE=on go mod vendor
+    cd -
+
     # this packages a Golang chaincode.
     # make note of the --lang flag to indicate "golang" chaincode
     # for go chaincode --path takes the relative path from $GOPATH/src
@@ -649,7 +654,7 @@ Go, Node.js or Java chaincode.
     # make note of the --lang flag to indicate "node" chaincode
     # for node chaincode --path takes the absolute path to the node.js chaincode
     # The --label flag is used to create the package label
-    peer lifecycle chaincode package mycc.tar.gz --path /opt/gopath/src/github.com/hyperledger/fabric-samples/chaincode/abstore/node/ --lang node --label mycc_1
+    peer lifecycle chaincode package mycc.tar.gz --path /opt/gopath/src/github.com/hyperledger/fabric-samples/chaincode/abstore/javascript/ --lang node --label mycc_1
 
 **Java**
 
@@ -1160,7 +1165,7 @@ the network pass ``docker-compose-couch.yaml`` as well:
 
 .. code:: bash
 
-    docker-compose -f docker-compose-cli.yaml -f docker-compose-couch.yaml up -d
+    docker-compose -f docker-compose-cli.yaml -f docker-compose-couch.yaml -f docker-compose-etcdraft2.yaml up -d
 
 **abstore** should now work using CouchDB underneath.
 
@@ -1189,11 +1194,17 @@ channel, use the following steps to interact with the **marbles02** chaincode:
 
 .. code:: bash
 
-      peer lifecycle chaincode package marbles.tar.gz --path github.com/hyperledger/fabric-samples/chaincode/marbles02/go/ --lang golang --label marbles_1
-      peer lifecycle chaincode install marbles.tar.gz
+       # before packaging Golang chaincode, vendoring Go dependencies is required like the following commands.
+       cd /opt/gopath/src/github.com/hyperledger/fabric-samples/chaincode/marbles02/go
+       GO111MODULE=on go mod vendor
+       cd -
 
- The install command will return a chaincode packageID that you will use to
- approve a chaincode definition.
+       # packages and installs the Golang chaincode
+       peer lifecycle chaincode package marbles.tar.gz --path github.com/hyperledger/fabric-samples/chaincode/marbles02/go/ --lang golang --label marbles_1
+       peer lifecycle chaincode install marbles.tar.gz
+
+The install command will return a chaincode packageID that you will use to
+approve a chaincode definition.
 
 .. code:: bash
 


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

This patch fixes instructions described in `docs/source/build_network.rst` as follows:

* Add `docker-compose-etcdraft2.yaml` to the commands to start network
with docker-compose, because other operations assume to use
`SampleMultiNodeEtcdRaft` profile

* Change the directory name from 'node' to 'javascript' for the command
that packages Node.js chaincode according to the current source code in
`fabric-samples`

* Add vendering operations before packaging Go chaincode

Also, this patch includes the other minor fixes.

#### Additional details

#### Related issues

https://jira.hyperledger.org/browse/FAB-17262