### PR TITLE
Remove CouchDB CAP theorem reference from first network tutorial

### DIFF
--- a/docs/source/build_network.rst
+++ b/docs/source/build_network.rst
@@ -1324,15 +1324,6 @@ since its data content is stored in JSON format and fully queryable. Therefore, 
 
 CouchDB can also enhance the security for compliance and data protection in the blockchain. As it is able to implement field-level security through the filtering and masking of individual attributes within a transaction, and only authorizing the read-only permission if needed.
 
-In addition, CouchDB falls into the AP-type (Availability and Partition Tolerance) of the CAP theorem. It uses a master-master replication model with ``Eventual Consistency``.
-More information can be found on the
-`Eventual Consistency page of the CouchDB documentation <http://docs.couchdb.org/en/latest/intro/consistency.html>`__.
-However, under each fabric peer, there is no database replicas, writes to database are guaranteed consistent and durable (not ``Eventual Consistency``).
-
-CouchDB is the first external pluggable state database for Fabric, and there could and should be other external database options. For example, IBM enables the relational database for its blockchain.
-And the CP-type (Consistency and Partition Tolerance) databases may also in need, so as to enable data consistency without application level guarantee.
-
-
 A Note on Data Persistence
 --------------------------
 


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>

#### Type of change

- Documentation update

#### Description

Going through the first network tutorial to look for information that should be moved elsewhere before it is removed. Stumbled across this section talking about the eventual consistency of CouchDB in the first network tutorial. After speaking with Manish, we decided that this section only added confusion and should be removed.
