### PR TITLE
FAB-17288 - Fix windows path name handling in chaincode packaging

### DIFF
--- a/core/chaincode/platforms/golang/platform.go
+++ b/core/chaincode/platforms/golang/platform.go
@@ -369,11 +369,11 @@ func (s SourceMap) Sources() Sources {
 
 func (s SourceMap) Directories() []string {
 	dirMap := map[string]bool{}
-	for filename := range s {
-		dir := filepath.Dir(filename)
+	for entryName := range s {
+		dir := path.Dir(entryName)
 		for dir != "." && !dirMap[dir] {
 			dirMap[dir] = true
-			dir = filepath.Dir(dir)
+			dir = path.Dir(dir)
 		}
 	}
 
@@ -442,6 +442,7 @@ func findSource(cd *CodeDescriptor) (SourceMap, error) {
 			name = filepath.Join("src", cd.Path, name)
 		}
 
+		name = filepath.ToSlash(name)
 		sources[name] = SourceDescriptor{Name: name, Path: path}
 		return nil
 	}
@@ -461,7 +462,7 @@ func validateMetadata(name, path string) error {
 
 	// Validate metadata file for inclusion in tar
 	// Validation is based on the passed filename with path
-	err = ccmetadata.ValidateMetadataFile(name, contents)
+	err = ccmetadata.ValidateMetadataFile(filepath.ToSlash(name), contents)
 	if err != nil {
 		return err
 	}

--- a/core/chaincode/platforms/golang/platform_test.go
+++ b/core/chaincode/platforms/golang/platform_test.go
@@ -23,6 +23,7 @@ import (
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/core/chaincode/platforms/util"
 	"github.com/hyperledger/fabric/core/config/configtest"
+	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -171,8 +172,8 @@ func getGopath() (string, error) {
 func Test_findSource(t *testing.T) {
 	t.Run("Gopath", func(t *testing.T) {
 		source, err := findSource(&CodeDescriptor{
-			Source:       filepath.Join("testdata/src/chaincodes/noop"),
-			MetadataRoot: filepath.Join("testdata/src/chaincodes/noop/META-INF"),
+			Source:       filepath.FromSlash("testdata/src/chaincodes/noop"),
+			MetadataRoot: filepath.FromSlash("testdata/src/chaincodes/noop/META-INF"),
 			Path:         "chaincodes/noop",
 		})
 		require.NoError(t, err, "failed to find source")
@@ -184,8 +185,8 @@ func Test_findSource(t *testing.T) {
 	t.Run("Module", func(t *testing.T) {
 		source, err := findSource(&CodeDescriptor{
 			Module:       true,
-			Source:       filepath.Join("testdata/ccmodule"),
-			MetadataRoot: filepath.Join("testdata/ccmodule/META-INF"),
+			Source:       filepath.FromSlash("testdata/ccmodule"),
+			MetadataRoot: filepath.FromSlash("testdata/ccmodule/META-INF"),
 			Path:         "ccmodule",
 		})
 		require.NoError(t, err, "failed to find source")
@@ -202,7 +203,7 @@ func Test_findSource(t *testing.T) {
 	t.Run("NonExistent", func(t *testing.T) {
 		_, err := findSource(&CodeDescriptor{Path: "acme.com/this/should/not/exist"})
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "no such file or directory")
+		assert.True(t, os.IsNotExist(errors.Cause(err)))
 	})
 }
 
@@ -427,7 +428,7 @@ echo Done!
 }
 
 func TestDescribeCode(t *testing.T) {
-	abs, err := filepath.Abs("testdata/ccmodule")
+	abs, err := filepath.Abs(filepath.FromSlash("testdata/ccmodule"))
 	assert.NoError(t, err)
 
 	t.Run("TopLevelModulePackage", func(t *testing.T) {

--- a/core/chaincode/platforms/util/writer_test.go
+++ b/core/chaincode/platforms/util/writer_test.go
@@ -16,6 +16,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -203,6 +204,10 @@ func TestWriteFolderToTarPackageFailure3(t *testing.T) {
 
 // Failure case 4: with lstat failed
 func Test_WriteFolderToTarPackageFailure4(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unable to chmod execute permission on windows directory")
+	}
+
 	tempDir, err := ioutil.TempDir("", "WriteFolderToTarPackageFailure4BadFileMode")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)


### PR DESCRIPTION
Update chaincode packaging code to appropriately handle path separator differences between Windows and Unix platforms. This is done in a couple of areas:

1. When calculating package dependencies for go, we used a custom template to generate JSON when calling list. This template did not properly encode backslashes used in Windows paths which resulted in decoding errors. This was addressed by removing the custom format and using the `-json` option.
2. There were (maybe still are) several places where path name munging assumes a slash is the path separator. We made changes to differentiate OS paths from tar file entry paths and attempted to use the appropriate separators in each context.
3. A few minor test changes were made to enable our unit tests to run on Windows.

Thanks to @lehors for finding this, making a go at a fix, and, ultimately, testing these changes out.