### PR TITLE
FAB-13625 Add memberOnlyWrite integration test

### DIFF
--- a/integration/pvtdata/testdata/collection_configs/collections_config3.json
+++ b/integration/pvtdata/testdata/collection_configs/collections_config3.json
@@ -5,7 +5,8 @@
 		"requiredPeerCount": 1,
 		"maxPeerCount": 2,
 		"blockToLive":1000000,
-		"memberOnlyRead": true
+		"memberOnlyRead": true,
+		"memberOnlyWrite": true
 	},
 	{
 		"name": "collectionMarblePrivateDetails",
@@ -13,6 +14,7 @@
 		"requiredPeerCount": 1,
 		"maxPeerCount": 2,
 		"blockToLive":1000000,
-		"memberOnlyRead": true
+		"memberOnlyRead": true,
+		"memberOnlyWrite": true
 	}
 ]


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Test update

#### Description
Add integration tests for memberOnlyWrite ACL. 

Update pvtdata_test.go to cover memberOnlyWrite=true config setting. Invoke chaincode from a user who is not in any collection member organization and verify that the user has no write permission.

#### Related issues
https://jira.hyperledger.org/browse/FAB-13625
