### PR TITLE
FAB-17311 Range query UT for keys with special or non-English characters

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
@@ -389,6 +389,12 @@ func TestPaginatedRangeQuery(t *testing.T) {
 	commontests.TestPaginatedRangeQuery(t, env.DBProvider)
 }
 
+func TestRangeQuerySpecialCharacters(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+	commontests.TestRangeQuerySpecialCharacters(t, env.DBProvider)
+}
+
 // TestUtilityFunctions tests utility functions
 func TestUtilityFunctions(t *testing.T) {
 

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb_test.go
@@ -114,6 +114,12 @@ func TestPaginatedRangeQuery(t *testing.T) {
 	commontests.TestPaginatedRangeQuery(t, env.DBProvider)
 }
 
+func TestRangeQuerySpecialCharacters(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+	commontests.TestRangeQuerySpecialCharacters(t, env.DBProvider)
+}
+
 func TestApplyUpdatesWithNilHeight(t *testing.T) {
 	env := NewTestVDBEnv(t)
 	defer env.Cleanup()


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Test update

#### Description
Add range query unit tests for keys using special characters or non-English characters. The purpose is to verify that couchdb and leveldb will return the same range query result for this kind of keys.

#### Related issues
https://jira.hyperledger.org/browse/FAB-17311
