### PR TITLE
[FAB-17307] InitRequired param check for ApproveForMyorg

### DIFF
--- a/core/chaincode/lifecycle/lifecycle.go
+++ b/core/chaincode/lifecycle/lifecycle.go
@@ -114,6 +114,8 @@ func (cp *ChaincodeParameters) Equal(ocp *ChaincodeParameters) error {
 		return errors.Errorf("Version '%s' != '%s'", cp.EndorsementInfo.Version, ocp.EndorsementInfo.Version)
 	case cp.EndorsementInfo.EndorsementPlugin != ocp.EndorsementInfo.EndorsementPlugin:
 		return errors.Errorf("EndorsementPlugin '%s' != '%s'", cp.EndorsementInfo.EndorsementPlugin, ocp.EndorsementInfo.EndorsementPlugin)
+	case cp.EndorsementInfo.InitRequired != ocp.EndorsementInfo.InitRequired:
+		return errors.Errorf("InitRequired '%t' != '%t'", cp.EndorsementInfo.InitRequired, ocp.EndorsementInfo.InitRequired)
 	case cp.ValidationInfo.ValidationPlugin != ocp.ValidationInfo.ValidationPlugin:
 		return errors.Errorf("ValidationPlugin '%s' != '%s'", cp.ValidationInfo.ValidationPlugin, ocp.ValidationInfo.ValidationPlugin)
 	case !bytes.Equal(cp.ValidationInfo.ValidationParameter, ocp.ValidationInfo.ValidationParameter):

--- a/core/chaincode/lifecycle/lifecycle_test.go
+++ b/core/chaincode/lifecycle/lifecycle_test.go
@@ -59,6 +59,16 @@ var _ = Describe("ChaincodeParameters", func() {
 			})
 		})
 
+		Context("when the InitRequired differs from the current definition", func() {
+			BeforeEach(func() {
+				rhs.EndorsementInfo.InitRequired = true
+			})
+
+			It("returns an error", func() {
+				Expect(lhs.Equal(rhs)).To(MatchError("InitRequired 'false' != 'true'"))
+			})
+		})
+
 		Context("when the ValidationPlugin differs from the current definition", func() {
 			BeforeEach(func() {
 				rhs.ValidationInfo.ValidationPlugin = "different"


### PR DESCRIPTION
This patch adds a check mechanism for the `InitRequired` parameter for the chaincode definition of the current sequence number to `ApproveForMyOrg`.

#### Type of change

- Bug fix

#### Description

ApproveForMyOrg puts a chaincode definition entry for either the currently defined sequence number or the next sequence number.
According to comments on the current implementation, for the definition of the current sequence number (which means it has been committed), this command should reject the requested definition unless the requested one must match exactly the current one.

However, the current ApproveForMyOrg command does not check the InitRequired parameter, so the operators can update the InitRequired parameter.
When an organization does this update, it returns the chaincode to unapproved status for the organization.

To fix the bug, it is necessary to add a check mechanism for the InitRequired parameter to ApproveForMyOrg.

#### Related issues

https://jira.hyperledger.org/browse/FAB-17307
