### PR TITLE
[FAB-17314] make correction of the docker-compose command in docs/source/build_network.rst

### DIFF
--- a/docs/source/build_network.rst
+++ b/docs/source/build_network.rst
@@ -473,7 +473,7 @@ First let's start our network:
 
 .. code:: bash
 
-    docker-compose -f docker-compose-cli.yaml up -f docker-compose-etcdraft2.yaml up -d
+    docker-compose -f docker-compose-cli.yaml -f docker-compose-etcdraft2.yaml up -d
 
 If you want to see the realtime logs for your network, then do not supply the ``-d`` flag.
 If you let the logs stream, then you will need to open a second terminal to execute the CLI calls.


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description
In the document file "docs/source/build_network.rst", there is such statement:
We want to go through the commands manually in order to expose the
syntax and functionality of each call.

First let's start our network:

.. code:: bash

    docker-compose -f docker-compose-cli.yaml up -f docker-compose-etcdraft2.yaml up -d

In the above command, there is an extra "up"

https://jira.hyperledger.org/browse/FAB-17314
