### PR TITLE
Add channel name to blockpuller logger

### DIFF
--- a/orderer/common/cluster/replication.go
+++ b/orderer/common/cluster/replication.go
@@ -384,7 +384,7 @@ func BlockPullerFromConfigBlock(conf PullerConfig, block *common.Block, verifier
 	}
 
 	return &BlockPuller{
-		Logger:  flogging.MustGetLogger("orderer.common.cluster.replication"),
+		Logger:  flogging.MustGetLogger("orderer.common.cluster.replication").With("channel", conf.Channel),
 		Dialer:  dialer,
 		TLSCert: tlsCertAsDER.Bytes,
 		VerifyBlockSequence: func(blocks []*common.Block, channel string) error {

--- a/orderer/consensus/etcdraft/blockpuller.go
+++ b/orderer/consensus/etcdraft/blockpuller.go
@@ -90,7 +90,7 @@ func NewBlockPuller(support consensus.ConsenterSupport,
 
 	bp := &cluster.BlockPuller{
 		VerifyBlockSequence: verifyBlockSequence,
-		Logger:              flogging.MustGetLogger("orderer.common.cluster.puller"),
+		Logger:              flogging.MustGetLogger("orderer.common.cluster.puller").With("channel", support.ChannelID()),
 		RetryTimeout:        clusterConfig.ReplicationRetryTimeout,
 		MaxTotalBufferBytes: clusterConfig.ReplicationBufferSize,
 		FetchTimeout:        clusterConfig.ReplicationPullTimeout,


### PR DESCRIPTION
Signed-off-by: Jay Guo <guojiannan1101@gmail.com>

Simple change that adds channel name to the logger of blockpuller.