### PR TITLE
[FAB-17299] Support collection level endorsement policies for discovery

### DIFF
--- a/common/chaincode/metadata.go
+++ b/common/chaincode/metadata.go
@@ -32,11 +32,15 @@ type InstalledChaincode struct {
 
 // Metadata defines channel-scoped metadata of a chaincode
 type Metadata struct {
-	Name              string
-	Version           string
-	Policy            []byte
-	Id                []byte
-	CollectionsConfig *peer.CollectionConfigPackage
+	Name    string
+	Version string
+	Policy  []byte
+	// CollectionPolicies will only be set for _lifecycle
+	// chaincodes and stores a map from collection name to
+	// that collection's endorsement policy if one exists.
+	CollectionPolicies map[string][]byte
+	Id                 []byte
+	CollectionsConfig  *peer.CollectionConfigPackage
 	// These two fields (Approved, Installed) are only set for
 	// _lifecycle chaincodes. They are used to ensure service
 	// discovery doesn't publish a stale chaincode definition

--- a/core/cclifecycle/lifecycle.go
+++ b/core/cclifecycle/lifecycle.go
@@ -105,7 +105,7 @@ func NewMetadataManager(installedChaincodes Enumerator) (*MetadataManager, error
 
 // Metadata returns the metadata of the chaincode on the given channel,
 // or nil if not found or an error occurred at retrieving it
-func (m *MetadataManager) Metadata(channel string, cc string, collections bool) *chaincode.Metadata {
+func (m *MetadataManager) Metadata(channel string, cc string, collections ...string) *chaincode.Metadata {
 	queryCreator := m.queryCreatorsByChannel[channel]
 	if queryCreator == nil {
 		Logger.Warning("Requested Metadata for non-existent channel", channel)
@@ -113,7 +113,7 @@ func (m *MetadataManager) Metadata(channel string, cc string, collections bool) 
 	}
 	// Search the metadata in our local cache, and if it exists - return it, but only if
 	// no collections were specified in the invocation.
-	if md, found := m.deployedCCsByChannel[channel].Lookup(cc); found && !collections {
+	if md, found := m.deployedCCsByChannel[channel].Lookup(cc); found && len(collections) == 0 {
 		Logger.Debug("Returning metadata for channel", channel, ", chaincode", cc, ":", md)
 		return &md
 	}
@@ -122,7 +122,7 @@ func (m *MetadataManager) Metadata(channel string, cc string, collections bool) 
 		Logger.Error("Failed obtaining new query for channel", channel, ":", err)
 		return nil
 	}
-	md, err := DeployedChaincodes(query, AcceptAll, collections, cc)
+	md, err := DeployedChaincodes(query, AcceptAll, len(collections) > 0, cc)
 	if err != nil {
 		Logger.Error("Failed querying LSCC for channel", channel, ":", err)
 		return nil

--- a/core/cclifecycle/lifecycle_test.go
+++ b/core/cclifecycle/lifecycle_test.go
@@ -386,7 +386,7 @@ func TestMetadata(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Scenario I: No subscription was invoked on the lifecycle
-	md := m.Metadata("mychannel", "cc1", false)
+	md := m.Metadata("mychannel", "cc1")
 	assert.Nil(t, md)
 	assertLogged(t, recorder, "Requested Metadata for non-existent channel mychannel")
 
@@ -398,7 +398,7 @@ func TestMetadata(t *testing.T) {
 	defer sub.ChaincodeDeployDone(true)
 	assert.NoError(t, err)
 	assert.NotNil(t, sub)
-	md = m.Metadata("mychannel", "cc1", false)
+	md = m.Metadata("mychannel", "cc1")
 	assert.Equal(t, &chaincode.Metadata{
 		Name:    "cc1",
 		Version: "1.0",
@@ -410,7 +410,7 @@ func TestMetadata(t *testing.T) {
 	// Scenario III: A metadata retrieval is made and the chaincode is not in memory yet,
 	// and when the query is attempted to be made - it fails.
 	queryCreator.On("NewQuery").Return(nil, errors.New("failed obtaining query executor")).Once()
-	md = m.Metadata("mychannel", "cc2", false)
+	md = m.Metadata("mychannel", "cc2")
 	assert.Nil(t, md)
 	assertLogged(t, recorder, "Failed obtaining new query for channel mychannel : failed obtaining query executor")
 
@@ -418,7 +418,7 @@ func TestMetadata(t *testing.T) {
 	// and when the query is attempted to be made - it succeeds, but GetState fails.
 	queryCreator.On("NewQuery").Return(query, nil).Once()
 	query.On("GetState", "lscc", "cc2").Return(nil, errors.New("GetState failed")).Once()
-	md = m.Metadata("mychannel", "cc2", false)
+	md = m.Metadata("mychannel", "cc2")
 	assert.Nil(t, md)
 	assertLogged(t, recorder, "Failed querying LSCC for channel mychannel : GetState failed")
 
@@ -426,7 +426,7 @@ func TestMetadata(t *testing.T) {
 	// and both the query and the GetState succeed, however - GetState returns nil
 	queryCreator.On("NewQuery").Return(query, nil).Once()
 	query.On("GetState", "lscc", "cc2").Return(nil, nil).Once()
-	md = m.Metadata("mychannel", "cc2", false)
+	md = m.Metadata("mychannel", "cc2")
 	assert.Nil(t, md)
 	assertLogged(t, recorder, "Chaincode cc2 isn't defined in channel mychannel")
 
@@ -434,7 +434,7 @@ func TestMetadata(t *testing.T) {
 	// and both the query and the GetState succeed, however - GetState returns a valid metadata
 	queryCreator.On("NewQuery").Return(query, nil).Once()
 	query.On("GetState", "lscc", "cc2").Return(cc2Bytes, nil).Once()
-	md = m.Metadata("mychannel", "cc2", false)
+	md = m.Metadata("mychannel", "cc2")
 	assert.Equal(t, &chaincode.Metadata{
 		Name:    "cc2",
 		Version: "1.0",
@@ -447,7 +447,7 @@ func TestMetadata(t *testing.T) {
 	queryCreator.On("NewQuery").Return(query, nil).Once()
 	query.On("GetState", "lscc", "cc1").Return(cc1Bytes, nil).Once()
 	query.On("GetState", "lscc", privdata.BuildCollectionKVSKey("cc1")).Return(protoutil.MarshalOrPanic(&peer.CollectionConfigPackage{}), nil).Once()
-	md = m.Metadata("mychannel", "cc1", true)
+	md = m.Metadata("mychannel", "cc1", "col1")
 	assert.Equal(t, &chaincode.Metadata{
 		Name:              "cc1",
 		Version:           "1.0",
@@ -463,7 +463,7 @@ func TestMetadata(t *testing.T) {
 	queryCreator.On("NewQuery").Return(query, nil).Once()
 	query.On("GetState", "lscc", "cc1").Return(cc1Bytes, nil).Once()
 	query.On("GetState", "lscc", privdata.BuildCollectionKVSKey("cc1")).Return(nil, errors.New("foo")).Once()
-	md = m.Metadata("mychannel", "cc1", true)
+	md = m.Metadata("mychannel", "cc1", "col1")
 	assert.Nil(t, md)
 	assertLogged(t, recorder, "Failed querying lscc namespace for cc1~collection: foo")
 }

--- a/core/chaincode/lifecycle/metadata_provider.go
+++ b/core/chaincode/lifecycle/metadata_provider.go
@@ -21,7 +21,7 @@ import (
 // LegacyMetadataProvider provides metadata for a lscc-defined chaincode
 // on a specific channel.
 type LegacyMetadataProvider interface {
-	Metadata(channel string, cc string, includeCollections bool) *chaincode.Metadata
+	Metadata(channel string, cc string, collections ...string) *chaincode.Metadata
 }
 
 // ChaincodeInfoProvider provides metadata for a _lifecycle-defined
@@ -105,12 +105,12 @@ func (mp *MetadataProvider) toSignaturePolicyEnvelope(channelID string, policyBy
 }
 
 // Metadata implements the metadata retriever support interface for service discovery
-func (mp *MetadataProvider) Metadata(channel string, ccName string, includeCollections bool) *chaincode.Metadata {
+func (mp *MetadataProvider) Metadata(channel string, ccName string, collections ...string) *chaincode.Metadata {
 	ccInfo, err := mp.ChaincodeInfoProvider.ChaincodeInfo(channel, ccName)
 	if err != nil {
 		logger.Debugf("chaincode '%s' on channel '%s' not defined in _lifecycle. requesting metadata from lscc", ccName, channel)
 		// fallback to legacy metadata via cclifecycle
-		return mp.LegacyMetadataProvider.Metadata(channel, ccName, includeCollections)
+		return mp.LegacyMetadataProvider.Metadata(channel, ccName, collections...)
 	}
 
 	spe, err := mp.toSignaturePolicyEnvelope(channel, ccInfo.Definition.ValidationInfo.ValidationParameter)
@@ -119,14 +119,36 @@ func (mp *MetadataProvider) Metadata(channel string, ccName string, includeColle
 		spe = cauthdsl.MarshaledRejectAllPolicy
 	}
 
+	// process any existing collection endorsement policies
+	collectionPolicies := map[string][]byte{}
+	if ccInfo.Definition.Collections != nil {
+		for _, collectionName := range collections {
+			for _, conf := range ccInfo.Definition.Collections.Config {
+				staticCollConfig := conf.GetStaticCollectionConfig()
+				if staticCollConfig != nil && staticCollConfig.Name == collectionName {
+					if staticCollConfig.EndorsementPolicy != nil {
+						ep := protoutil.MarshalOrPanic(staticCollConfig.EndorsementPolicy)
+						cspe, err := mp.toSignaturePolicyEnvelope(channel, ep)
+						if err != nil {
+							logger.Errorf("could not convert collection policy for chaincode '%s' collection '%s' on channel '%s', err '%s'", ccName, collectionName, channel, err)
+							cspe = cauthdsl.MarshaledRejectAllPolicy
+						}
+						collectionPolicies[collectionName] = cspe
+					}
+				}
+			}
+		}
+	}
+
 	// report the sequence as the version to service discovery since
 	// the version is no longer required to change when updating any
 	// part of the chaincode definition
 	ccMetadata := &chaincode.Metadata{
-		Name:              ccName,
-		Version:           strconv.FormatInt(ccInfo.Definition.Sequence, 10),
-		Policy:            spe,
-		CollectionsConfig: ccInfo.Definition.Collections,
+		Name:               ccName,
+		Version:            strconv.FormatInt(ccInfo.Definition.Sequence, 10),
+		Policy:             spe,
+		CollectionPolicies: collectionPolicies,
+		CollectionsConfig:  ccInfo.Definition.Collections,
 	}
 
 	return ccMetadata

--- a/core/chaincode/lifecycle/mock/legacy_metadata_provider.go
+++ b/core/chaincode/lifecycle/mock/legacy_metadata_provider.go
@@ -8,12 +8,12 @@ import (
 )
 
 type LegacyMetadataProvider struct {
-	MetadataStub        func(string, string, bool) *chaincode.Metadata
+	MetadataStub        func(string, string, ...string) *chaincode.Metadata
 	metadataMutex       sync.RWMutex
 	metadataArgsForCall []struct {
 		arg1 string
 		arg2 string
-		arg3 bool
+		arg3 []string
 	}
 	metadataReturns struct {
 		result1 *chaincode.Metadata
@@ -25,18 +25,18 @@ type LegacyMetadataProvider struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *LegacyMetadataProvider) Metadata(arg1 string, arg2 string, arg3 bool) *chaincode.Metadata {
+func (fake *LegacyMetadataProvider) Metadata(arg1 string, arg2 string, arg3 ...string) *chaincode.Metadata {
 	fake.metadataMutex.Lock()
 	ret, specificReturn := fake.metadataReturnsOnCall[len(fake.metadataArgsForCall)]
 	fake.metadataArgsForCall = append(fake.metadataArgsForCall, struct {
 		arg1 string
 		arg2 string
-		arg3 bool
+		arg3 []string
 	}{arg1, arg2, arg3})
 	fake.recordInvocation("Metadata", []interface{}{arg1, arg2, arg3})
 	fake.metadataMutex.Unlock()
 	if fake.MetadataStub != nil {
-		return fake.MetadataStub(arg1, arg2, arg3)
+		return fake.MetadataStub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
@@ -51,13 +51,13 @@ func (fake *LegacyMetadataProvider) MetadataCallCount() int {
 	return len(fake.metadataArgsForCall)
 }
 
-func (fake *LegacyMetadataProvider) MetadataCalls(stub func(string, string, bool) *chaincode.Metadata) {
+func (fake *LegacyMetadataProvider) MetadataCalls(stub func(string, string, ...string) *chaincode.Metadata) {
 	fake.metadataMutex.Lock()
 	defer fake.metadataMutex.Unlock()
 	fake.MetadataStub = stub
 }
 
-func (fake *LegacyMetadataProvider) MetadataArgsForCall(i int) (string, string, bool) {
+func (fake *LegacyMetadataProvider) MetadataArgsForCall(i int) (string, string, []string) {
 	fake.metadataMutex.RLock()
 	defer fake.metadataMutex.RUnlock()
 	argsForCall := fake.metadataArgsForCall[i]

--- a/discovery/client/client_test.go
+++ b/discovery/client/client_test.go
@@ -798,7 +798,7 @@ type ccMetadataFetcher struct {
 	mock.Mock
 }
 
-func (mdf *ccMetadataFetcher) Metadata(channel string, cc string, _ bool) *chaincode.Metadata {
+func (mdf *ccMetadataFetcher) Metadata(channel string, cc string, _ ...string) *chaincode.Metadata {
 	return mdf.Called(cc).Get(0).(*chaincode.Metadata)
 }
 

--- a/discovery/endorsement/endorsement.go
+++ b/discovery/endorsement/endorsement.go
@@ -35,12 +35,12 @@ type principalEvaluator interface {
 type chaincodeMetadataFetcher interface {
 	// ChaincodeMetadata returns the metadata of the chaincode as appears in the ledger,
 	// or nil if the channel doesn't exist, or the chaincode isn't found in the ledger
-	Metadata(channel string, cc string, loadCollections bool) *chaincode.Metadata
+	Metadata(channel string, cc string, collections ...string) *chaincode.Metadata
 }
 
 type policyFetcher interface {
-	// PolicyByChaincode returns a policy that can be inquired which identities
-	// satisfy it
+	// PoliciesByChaincode returns the chaincode policy or existing collection level policies that can be
+	// inquired for which identities satisfy them
 	PoliciesByChaincode(channel string, cc string, collections ...string) []policies.InquireablePolicy
 }
 
@@ -225,7 +225,7 @@ func loadMetadataAndFilters(ctx metadataAndFilterContext) (*metadataAndColFilter
 	var filters []identityFilter
 
 	for _, chaincode := range ctx.interest.Chaincodes {
-		ccMD := ctx.fetch.Metadata(string(ctx.chainID), chaincode.Name, len(chaincode.CollectionNames) > 0)
+		ccMD := ctx.fetch.Metadata(string(ctx.chainID), chaincode.Name, chaincode.CollectionNames...)
 		if ccMD == nil {
 			return nil, errors.Errorf("No metadata was found for chaincode %s in channel %s", chaincode.Name, string(ctx.chainID))
 		}

--- a/discovery/endorsement/endorsement_test.go
+++ b/discovery/endorsement/endorsement_test.go
@@ -886,7 +886,7 @@ type metadataFetcher struct {
 	mock.Mock
 }
 
-func (mf *metadataFetcher) Metadata(channel string, cc string, _ bool) *chaincode.Metadata {
+func (mf *metadataFetcher) Metadata(channel string, cc string, _ ...string) *chaincode.Metadata {
 	arg := mf.Called().Get(0)
 	if arg == nil {
 		return nil

--- a/discovery/support/chaincode/support.go
+++ b/discovery/support/chaincode/support.go
@@ -18,7 +18,7 @@ import (
 var logger = flogging.MustGetLogger("discovery.DiscoverySupport")
 
 type MetadataRetriever interface {
-	Metadata(channel string, cc string, loadCollections bool) *chaincode.Metadata
+	Metadata(channel string, cc string, collections ...string) *chaincode.Metadata
 }
 
 // DiscoverySupport implements support that is used for service discovery
@@ -35,20 +35,58 @@ func NewDiscoverySupport(ci MetadataRetriever) *DiscoverySupport {
 	return s
 }
 
-func (s *DiscoverySupport) PoliciesByChaincode(channel string, cc string, _ ...string) []policies.InquireablePolicy {
-	chaincodeData := s.ci.Metadata(channel, cc, false)
+func (s *DiscoverySupport) PoliciesByChaincode(channel string, cc string, collections ...string) []policies.InquireablePolicy {
+	chaincodeData := s.ci.Metadata(channel, cc, collections...)
 	if chaincodeData == nil {
-		logger.Info("Chaincode", cc, "wasn't found")
+		logger.Infof("Chaincode %s wasn't found", cc)
 		return nil
 	}
+
+	// chaincode policy
 	pol := &common2.SignaturePolicyEnvelope{}
 	if err := proto.Unmarshal(chaincodeData.Policy, pol); err != nil {
-		logger.Warning("Failed unmarshaling policy for chaincode", cc, ":", err)
+		logger.Warningf("Failed unmarshaling policy for chaincode '%s': %s", cc, err)
 		return nil
 	}
 	if len(pol.Identities) == 0 || pol.Rule == nil {
-		logger.Warningf("Invalid policy, either Identities(%v) or Rule(%v) are empty:", pol.Identities, pol.Rule)
+		logger.Warningf("Invalid policy, either Identities(%v) or Rule(%v) are empty", pol.Identities, pol.Rule)
 		return nil
 	}
-	return []policies.InquireablePolicy{inquire.NewInquireableSignaturePolicy(pol)}
+	chaincodePolicy := inquire.NewInquireableSignaturePolicy(pol)
+
+	inquireablePolicies := map[policies.InquireablePolicy]bool{}
+	uniqueInquireablePolicies := []policies.InquireablePolicy{}
+
+	// chaincodeData.CollectionPolicies will be nil when using legacy lifecycle (lscc)
+	// because collection endorsement policies are not supported in lscc
+	if chaincodeData.CollectionPolicies == nil || len(collections) == 0 {
+		return []policies.InquireablePolicy{chaincodePolicy}
+	}
+	// process any collection policies
+	for _, collectionName := range collections {
+		// add the collection policy if it exists otherwise default to the chaincode policy
+		if policy, collectionPolicyExists := chaincodeData.CollectionPolicies[collectionName]; collectionPolicyExists {
+			pol := &common2.SignaturePolicyEnvelope{}
+			if err := proto.Unmarshal(policy, pol); err != nil {
+				logger.Warningf("Failed unmarshaling collection policy for chaincode '%s' collection '%s': %s", cc, collectionName, err)
+				return nil
+			}
+			if len(pol.Identities) == 0 || pol.Rule == nil {
+				logger.Warningf("Invalid collection policy, either Identities(%v) or Rule(%v) are empty", pol.Identities, pol.Rule)
+				return nil
+			}
+			inquireablePolicy := inquire.NewInquireableSignaturePolicy(pol)
+			// only add to uniqueInquireablePolicies if the inquireablePolicy doesn't already exist there
+			// this prevents duplicate inquireablePolicies from being returned
+			if _, exists := inquireablePolicies[inquireablePolicy]; !exists {
+				uniqueInquireablePolicies = append(uniqueInquireablePolicies, inquireablePolicy)
+				inquireablePolicies[inquireablePolicy] = true
+			}
+		} else if _, exists := inquireablePolicies[chaincodePolicy]; !exists {
+			uniqueInquireablePolicies = append(uniqueInquireablePolicies, chaincodePolicy)
+			inquireablePolicies[chaincodePolicy] = true
+		}
+	}
+
+	return uniqueInquireablePolicies
 }

--- a/discovery/support/chaincode/support_test.go
+++ b/discovery/support/chaincode/support_test.go
@@ -9,10 +9,12 @@ package chaincode
 import (
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric/common/chaincode"
+	"github.com/hyperledger/fabric/common/policies"
+	"github.com/hyperledger/fabric/common/policies/inquire"
+	"github.com/hyperledger/fabric/protoutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,43 +22,54 @@ type mockMetadataRetriever struct {
 	res *chaincode.Metadata
 }
 
-func (r *mockMetadataRetriever) Metadata(channel string, cc string, loadCollections bool) *chaincode.Metadata {
+func (r *mockMetadataRetriever) Metadata(channel string, cc string, collections ...string) *chaincode.Metadata {
 	return r.res
 }
 
 func TestSupport(t *testing.T) {
-	emptySignaturePolicyEnvelope, _ := proto.Marshal(&common.SignaturePolicyEnvelope{})
-	ccmd1 := &chaincode.Metadata{Policy: emptySignaturePolicyEnvelope}
-	notEmptySignaturePolicyEnvelope, _ := proto.Marshal(&common.SignaturePolicyEnvelope{
+	emptySignaturePolicyEnvelope := &common.SignaturePolicyEnvelope{}
+	ccmd1 := &chaincode.Metadata{Policy: protoutil.MarshalOrPanic(emptySignaturePolicyEnvelope)}
+	notEmptySignaturePolicyEnvelope := &common.SignaturePolicyEnvelope{
 		Rule:       &common.SignaturePolicy{},
-		Identities: []*msp.MSPPrincipal{{}},
-	})
-	ccmd2 := &chaincode.Metadata{Policy: notEmptySignaturePolicyEnvelope}
+		Identities: []*msp.MSPPrincipal{{Principal: []byte("principal-1")}},
+	}
+	ccmd2 := &chaincode.Metadata{Policy: protoutil.MarshalOrPanic(notEmptySignaturePolicyEnvelope)}
+	notEmptySignaturePolicyEnvelope2 := &common.SignaturePolicyEnvelope{
+		Rule:       &common.SignaturePolicy{},
+		Identities: []*msp.MSPPrincipal{{Principal: []byte("principal-2")}},
+	}
+	ccmd3 := &chaincode.Metadata{Policy: protoutil.MarshalOrPanic(notEmptySignaturePolicyEnvelope),
+		CollectionPolicies: map[string][]byte{"col1": protoutil.MarshalOrPanic(notEmptySignaturePolicyEnvelope2)}}
 
 	tests := []struct {
-		name        string
-		input       *chaincode.Metadata
-		shouldBeNil bool
+		name           string
+		input          *chaincode.Metadata
+		expectedReturn []policies.InquireablePolicy
 	}{
 		{
-			name:        "Nil instantiatedChaincode",
-			input:       nil,
-			shouldBeNil: true,
+			name:           "Nil instantiatedChaincode",
+			input:          nil,
+			expectedReturn: nil,
 		},
 		{
-			name:        "Invalid policy bytes",
-			input:       &chaincode.Metadata{Policy: []byte{1, 2, 3}},
-			shouldBeNil: true,
+			name:           "Invalid policy bytes",
+			input:          &chaincode.Metadata{Policy: []byte{1, 2, 3}},
+			expectedReturn: nil,
 		},
 		{
-			name:        "Empty signature policy envelope",
-			input:       ccmd1,
-			shouldBeNil: true,
+			name:           "Empty signature policy envelope",
+			input:          ccmd1,
+			expectedReturn: nil,
 		},
 		{
-			name:        "Not Empty signature policy envelope",
-			input:       ccmd2,
-			shouldBeNil: false,
+			name:           "Not Empty signature policy envelope",
+			input:          ccmd2,
+			expectedReturn: []policies.InquireablePolicy{inquire.NewInquireableSignaturePolicy(notEmptySignaturePolicyEnvelope)},
+		},
+		{
+			name:           "Not Empty signature policy envelopes with existing collection policy",
+			input:          ccmd3,
+			expectedReturn: []policies.InquireablePolicy{inquire.NewInquireableSignaturePolicy(notEmptySignaturePolicyEnvelope2)},
 		},
 	}
 
@@ -64,11 +77,17 @@ func TestSupport(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			sup := NewDiscoverySupport(&mockMetadataRetriever{res: test.input})
-			res := sup.PoliciesByChaincode("", "")
-			if test.shouldBeNil {
+			var res []policies.InquireablePolicy
+			if test.input == ccmd3 {
+				res = sup.PoliciesByChaincode("", "", "col1")
+			} else {
+				res = sup.PoliciesByChaincode("", "")
+			}
+			if test.expectedReturn == nil {
 				assert.Nil(t, res)
 			} else {
-				assert.NotNil(t, res)
+				assert.Equal(t, len(res), 1)
+				assert.Equal(t, res[0].SatisfiedBy(), test.expectedReturn[0].SatisfiedBy())
 			}
 		})
 	}


### PR DESCRIPTION
#### Type of change

- New feature

#### Description
* PoliciesByChaincode now returns one InquireablePolicy per collection,
either the collection's endorsement policy if one exists or the
chaincode policy by default
* chaincode.Metadata now stores CollectionPolicies for _lifecycle
namespace chaincodes that have collection endorsement policies

#### Related issues

[FAB-17299](https://jira.hyperledger.org/browse/FAB-17299)
This PR cannot be merged until [FAB-17308](https://jira.hyperledger.org/browse/FAB-17308) is complete; however, submitting PR now for review/feedback.

/cc @yacovm @denyeart 