### PR TITLE
[FAB-17299] Support collection level endorsement policies for discovery

### DIFF
--- a/common/chaincode/metadata.go
+++ b/common/chaincode/metadata.go
@@ -32,11 +32,15 @@ type InstalledChaincode struct {
 
 // Metadata defines channel-scoped metadata of a chaincode
 type Metadata struct {
-	Name              string
-	Version           string
-	Policy            []byte
-	Id                []byte
-	CollectionsConfig *peer.CollectionConfigPackage
+	Name    string
+	Version string
+	Policy  []byte
+	// CollectionPolicies will only be set for _lifecycle
+	// chaincodes and stores a map from collection name to
+	// that collection's endorsement policy if one exists.
+	CollectionPolicies map[string][]byte
+	Id                 []byte
+	CollectionsConfig  *peer.CollectionConfigPackage
 	// These two fields (Approved, Installed) are only set for
 	// _lifecycle chaincodes. They are used to ensure service
 	// discovery doesn't publish a stale chaincode definition

--- a/core/cclifecycle/lifecycle.go
+++ b/core/cclifecycle/lifecycle.go
@@ -105,7 +105,7 @@ func NewMetadataManager(installedChaincodes Enumerator) (*MetadataManager, error
 
 // Metadata returns the metadata of the chaincode on the given channel,
 // or nil if not found or an error occurred at retrieving it
-func (m *MetadataManager) Metadata(channel string, cc string, collections bool) *chaincode.Metadata {
+func (m *MetadataManager) Metadata(channel string, cc string, collections ...string) *chaincode.Metadata {
 	queryCreator := m.queryCreatorsByChannel[channel]
 	if queryCreator == nil {
 		Logger.Warning("Requested Metadata for non-existent channel", channel)
@@ -113,7 +113,7 @@ func (m *MetadataManager) Metadata(channel string, cc string, collections bool) 
 	}
 	// Search the metadata in our local cache, and if it exists - return it, but only if
 	// no collections were specified in the invocation.
-	if md, found := m.deployedCCsByChannel[channel].Lookup(cc); found && !collections {
+	if md, found := m.deployedCCsByChannel[channel].Lookup(cc); found && len(collections) == 0 {
 		Logger.Debug("Returning metadata for channel", channel, ", chaincode", cc, ":", md)
 		return &md
 	}
@@ -122,7 +122,7 @@ func (m *MetadataManager) Metadata(channel string, cc string, collections bool) 
 		Logger.Error("Failed obtaining new query for channel", channel, ":", err)
 		return nil
 	}
-	md, err := DeployedChaincodes(query, AcceptAll, collections, cc)
+	md, err := DeployedChaincodes(query, AcceptAll, len(collections) > 0, cc)
 	if err != nil {
 		Logger.Error("Failed querying LSCC for channel", channel, ":", err)
 		return nil

--- a/core/cclifecycle/lifecycle_test.go
+++ b/core/cclifecycle/lifecycle_test.go
@@ -386,7 +386,7 @@ func TestMetadata(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Scenario I: No subscription was invoked on the lifecycle
-	md := m.Metadata("mychannel", "cc1", false)
+	md := m.Metadata("mychannel", "cc1")
 	assert.Nil(t, md)
 	assertLogged(t, recorder, "Requested Metadata for non-existent channel mychannel")
 
@@ -398,7 +398,7 @@ func TestMetadata(t *testing.T) {
 	defer sub.ChaincodeDeployDone(true)
 	assert.NoError(t, err)
 	assert.NotNil(t, sub)
-	md = m.Metadata("mychannel", "cc1", false)
+	md = m.Metadata("mychannel", "cc1")
 	assert.Equal(t, &chaincode.Metadata{
 		Name:    "cc1",
 		Version: "1.0",
@@ -410,7 +410,7 @@ func TestMetadata(t *testing.T) {
 	// Scenario III: A metadata retrieval is made and the chaincode is not in memory yet,
 	// and when the query is attempted to be made - it fails.
 	queryCreator.On("NewQuery").Return(nil, errors.New("failed obtaining query executor")).Once()
-	md = m.Metadata("mychannel", "cc2", false)
+	md = m.Metadata("mychannel", "cc2")
 	assert.Nil(t, md)
 	assertLogged(t, recorder, "Failed obtaining new query for channel mychannel : failed obtaining query executor")
 
@@ -418,7 +418,7 @@ func TestMetadata(t *testing.T) {
 	// and when the query is attempted to be made - it succeeds, but GetState fails.
 	queryCreator.On("NewQuery").Return(query, nil).Once()
 	query.On("GetState", "lscc", "cc2").Return(nil, errors.New("GetState failed")).Once()
-	md = m.Metadata("mychannel", "cc2", false)
+	md = m.Metadata("mychannel", "cc2")
 	assert.Nil(t, md)
 	assertLogged(t, recorder, "Failed querying LSCC for channel mychannel : GetState failed")
 
@@ -426,7 +426,7 @@ func TestMetadata(t *testing.T) {
 	// and both the query and the GetState succeed, however - GetState returns nil
 	queryCreator.On("NewQuery").Return(query, nil).Once()
 	query.On("GetState", "lscc", "cc2").Return(nil, nil).Once()
-	md = m.Metadata("mychannel", "cc2", false)
+	md = m.Metadata("mychannel", "cc2")
 	assert.Nil(t, md)
 	assertLogged(t, recorder, "Chaincode cc2 isn't defined in channel mychannel")
 
@@ -434,7 +434,7 @@ func TestMetadata(t *testing.T) {
 	// and both the query and the GetState succeed, however - GetState returns a valid metadata
 	queryCreator.On("NewQuery").Return(query, nil).Once()
 	query.On("GetState", "lscc", "cc2").Return(cc2Bytes, nil).Once()
-	md = m.Metadata("mychannel", "cc2", false)
+	md = m.Metadata("mychannel", "cc2")
 	assert.Equal(t, &chaincode.Metadata{
 		Name:    "cc2",
 		Version: "1.0",
@@ -447,7 +447,7 @@ func TestMetadata(t *testing.T) {
 	queryCreator.On("NewQuery").Return(query, nil).Once()
 	query.On("GetState", "lscc", "cc1").Return(cc1Bytes, nil).Once()
 	query.On("GetState", "lscc", privdata.BuildCollectionKVSKey("cc1")).Return(protoutil.MarshalOrPanic(&peer.CollectionConfigPackage{}), nil).Once()
-	md = m.Metadata("mychannel", "cc1", true)
+	md = m.Metadata("mychannel", "cc1", "col1")
 	assert.Equal(t, &chaincode.Metadata{
 		Name:              "cc1",
 		Version:           "1.0",
@@ -463,7 +463,7 @@ func TestMetadata(t *testing.T) {
 	queryCreator.On("NewQuery").Return(query, nil).Once()
 	query.On("GetState", "lscc", "cc1").Return(cc1Bytes, nil).Once()
 	query.On("GetState", "lscc", privdata.BuildCollectionKVSKey("cc1")).Return(nil, errors.New("foo")).Once()
-	md = m.Metadata("mychannel", "cc1", true)
+	md = m.Metadata("mychannel", "cc1", "col1")
 	assert.Nil(t, md)
 	assertLogged(t, recorder, "Failed querying lscc namespace for cc1~collection: foo")
 }

--- a/core/chaincode/lifecycle/metadata_provider_test.go
+++ b/core/chaincode/lifecycle/metadata_provider_test.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package lifecycle_test
 
 import (
+	"github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric-protos-go/msp"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	lb "github.com/hyperledger/fabric-protos-go/peer/lifecycle"
 	"github.com/hyperledger/fabric/common/chaincode"
@@ -51,10 +53,11 @@ var _ = Describe("MetadataProvider", func() {
 		fakeChaincodeInfoProvider.ChaincodeInfoReturns(ccInfo, nil)
 
 		legacyCCMetadata := &chaincode.Metadata{
-			Name:              "legacy-cc",
-			Version:           "legacy-version",
-			Policy:            []byte("legacy-policy"),
-			CollectionsConfig: &pb.CollectionConfigPackage{},
+			Name:               "legacy-cc",
+			Version:            "legacy-version",
+			Policy:             []byte("legacy-policy"),
+			CollectionPolicies: nil,
+			CollectionsConfig:  &pb.CollectionConfigPackage{},
 		}
 		fakeLegacyMetadataProvider = &mock.LegacyMetadataProvider{}
 		fakeLegacyMetadataProvider.MetadataReturns(legacyCCMetadata)
@@ -63,13 +66,14 @@ var _ = Describe("MetadataProvider", func() {
 	})
 
 	It("returns metadata using the ChaincodeInfoProvider (SignaturePolicyEnvelope case)", func() {
-		metadata := metadataProvider.Metadata("testchannel", "cc-name", true)
+		metadata := metadataProvider.Metadata("testchannel", "cc-name", "col1")
 		Expect(metadata).To(Equal(
 			&chaincode.Metadata{
-				Name:              "cc-name",
-				Version:           "1",
-				Policy:            policydsl.MarshaledAcceptAllPolicy,
-				CollectionsConfig: &pb.CollectionConfigPackage{},
+				Name:               "cc-name",
+				Version:            "1",
+				Policy:             policydsl.MarshaledAcceptAllPolicy,
+				CollectionPolicies: map[string][]byte{},
+				CollectionsConfig:  &pb.CollectionConfigPackage{},
 			},
 		))
 	})
@@ -80,13 +84,14 @@ var _ = Describe("MetadataProvider", func() {
 		})
 
 		It("returns metadata using the LegacyMetadataProvider", func() {
-			metadata := metadataProvider.Metadata("testchannel", "legacy-cc", true)
+			metadata := metadataProvider.Metadata("testchannel", "legacy-cc", "col1")
 			Expect(metadata).To(Equal(
 				&chaincode.Metadata{
-					Name:              "legacy-cc",
-					Version:           "legacy-version",
-					Policy:            []byte("legacy-policy"),
-					CollectionsConfig: &pb.CollectionConfigPackage{},
+					Name:               "legacy-cc",
+					Version:            "legacy-version",
+					Policy:             []byte("legacy-policy"),
+					CollectionPolicies: nil,
+					CollectionsConfig:  &pb.CollectionConfigPackage{},
 				},
 			))
 		})
@@ -98,16 +103,9 @@ var _ = Describe("MetadataProvider", func() {
 			fakeChaincodeInfoProvider.ChaincodeInfoReturns(ccInfo, nil)
 		})
 
-		It("returns metadata after providing a reject-all policy", func() {
-			metadata := metadataProvider.Metadata("testchannel", "cc-name", true)
-			Expect(metadata).To(Equal(
-				&chaincode.Metadata{
-					Name:              "cc-name",
-					Version:           "1",
-					Policy:            policydsl.MarshaledRejectAllPolicy,
-					CollectionsConfig: &pb.CollectionConfigPackage{},
-				},
-			))
+		It("returns nil", func() {
+			metadata := metadataProvider.Metadata("testchannel", "cc-name", "col1")
+			Expect(metadata).To(BeNil())
 		})
 	})
 
@@ -130,13 +128,14 @@ var _ = Describe("MetadataProvider", func() {
 		})
 
 		It("returns metadata after translating the policy", func() {
-			metadata := metadataProvider.Metadata("testchannel", "cc-name", true)
+			metadata := metadataProvider.Metadata("testchannel", "cc-name", "col1")
 			Expect(metadata).To(Equal(
 				&chaincode.Metadata{
-					Name:              "cc-name",
-					Version:           "1",
-					Policy:            policydsl.MarshaledAcceptAllPolicy,
-					CollectionsConfig: &pb.CollectionConfigPackage{},
+					Name:               "cc-name",
+					Version:            "1",
+					Policy:             policydsl.MarshaledAcceptAllPolicy,
+					CollectionPolicies: map[string][]byte{},
+					CollectionsConfig:  &pb.CollectionConfigPackage{},
 				},
 			))
 		})
@@ -148,16 +147,9 @@ var _ = Describe("MetadataProvider", func() {
 				metadataProvider.ChannelPolicyReferenceProvider = fakeChannelPolicyReferenceProvider
 			})
 
-			It("returns metadata after providing a reject-all policy", func() {
-				metadata := metadataProvider.Metadata("testchannel", "cc-name", true)
-				Expect(metadata).To(Equal(
-					&chaincode.Metadata{
-						Name:              "cc-name",
-						Version:           "1",
-						Policy:            policydsl.MarshaledRejectAllPolicy,
-						CollectionsConfig: &pb.CollectionConfigPackage{},
-					},
-				))
+			It("returns nil", func() {
+				metadata := metadataProvider.Metadata("testchannel", "cc-name", "col1")
+				Expect(metadata).To(BeNil())
 			})
 		})
 
@@ -168,16 +160,9 @@ var _ = Describe("MetadataProvider", func() {
 				metadataProvider.ChannelPolicyReferenceProvider = fakeChannelPolicyReferenceProvider
 			})
 
-			It("returns metadata after providing a reject-all policy", func() {
-				metadata := metadataProvider.Metadata("testchannel", "cc-name", true)
-				Expect(metadata).To(Equal(
-					&chaincode.Metadata{
-						Name:              "cc-name",
-						Version:           "1",
-						Policy:            policydsl.MarshaledRejectAllPolicy,
-						CollectionsConfig: &pb.CollectionConfigPackage{},
-					},
-				))
+			It("returns nil", func() {
+				metadata := metadataProvider.Metadata("testchannel", "cc-name", "col1")
+				Expect(metadata).To(BeNil())
 			})
 		})
 
@@ -191,17 +176,99 @@ var _ = Describe("MetadataProvider", func() {
 				metadataProvider.ChannelPolicyReferenceProvider = fakeChannelPolicyReferenceProvider
 			})
 
-			It("returns metadata after providing a reject-all policy", func() {
-				metadata := metadataProvider.Metadata("testchannel", "cc-name", true)
-				Expect(metadata).To(Equal(
-					&chaincode.Metadata{
-						Name:              "cc-name",
-						Version:           "1",
-						Policy:            policydsl.MarshaledRejectAllPolicy,
-						CollectionsConfig: &pb.CollectionConfigPackage{},
-					},
-				))
+			It("returns nil", func() {
+				metadata := metadataProvider.Metadata("testchannel", "cc-name", "col1")
+				Expect(metadata).To(BeNil())
 			})
+		})
+	})
+
+	Context("when collection endorsement policies exist", func() {
+		var (
+			expectedSignaturePolicy         *common.SignaturePolicyEnvelope
+			expectedCollectionConfigPackage *pb.CollectionConfigPackage
+		)
+
+		BeforeEach(func() {
+			expectedSignaturePolicy = &common.SignaturePolicyEnvelope{
+				Identities: []*msp.MSPPrincipal{
+					{
+						Principal: []byte("test"),
+					},
+				},
+			}
+
+			expectedCollectionConfigPackage = &pb.CollectionConfigPackage{
+				Config: []*pb.CollectionConfig{
+					{
+						Payload: &pb.CollectionConfig_StaticCollectionConfig{
+							StaticCollectionConfig: &pb.StaticCollectionConfig{
+								Name: "col1",
+								EndorsementPolicy: &pb.ApplicationPolicy{
+									Type: &pb.ApplicationPolicy_SignaturePolicy{
+										SignaturePolicy: expectedSignaturePolicy,
+									},
+								},
+							},
+						},
+					},
+					{
+						Payload: &pb.CollectionConfig_StaticCollectionConfig{
+							StaticCollectionConfig: &pb.StaticCollectionConfig{
+								Name: "col2",
+								EndorsementPolicy: &pb.ApplicationPolicy{
+									Type: &pb.ApplicationPolicy_SignaturePolicy{
+										SignaturePolicy: expectedSignaturePolicy,
+									},
+								},
+							},
+						},
+					},
+					{
+						Payload: &pb.CollectionConfig_StaticCollectionConfig{
+							StaticCollectionConfig: &pb.StaticCollectionConfig{
+								Name: "col3",
+								// col3 has no endorsement policy
+								EndorsementPolicy: nil,
+							},
+						},
+					},
+				},
+			}
+			ccInfo = &lifecycle.LocalChaincodeInfo{
+				Definition: &lifecycle.ChaincodeDefinition{
+					Sequence: 1,
+					EndorsementInfo: &lb.ChaincodeEndorsementInfo{
+						Version: "cc-version",
+					},
+					ValidationInfo: &lb.ChaincodeValidationInfo{
+						ValidationParameter: protoutil.MarshalOrPanic(&pb.ApplicationPolicy{
+							Type: &pb.ApplicationPolicy_SignaturePolicy{
+								SignaturePolicy: policydsl.AcceptAllPolicy,
+							},
+						}),
+					},
+					Collections: expectedCollectionConfigPackage,
+				},
+			}
+			fakeChaincodeInfoProvider.ChaincodeInfoReturns(ccInfo, nil)
+		})
+
+		It("returns metadata that includes the collection policies", func() {
+			metadata := metadataProvider.Metadata("testchannel", "cc-name", "col1", "col2", "col3")
+			Expect(metadata).To(Equal(
+				&chaincode.Metadata{
+					Name:    "cc-name",
+					Version: "1",
+					Policy:  policydsl.MarshaledAcceptAllPolicy,
+					CollectionPolicies: map[string][]byte{
+						"col1": protoutil.MarshalOrPanic(expectedSignaturePolicy),
+						"col2": protoutil.MarshalOrPanic(expectedSignaturePolicy),
+						// col3 has no endorsement policy
+					},
+					CollectionsConfig: expectedCollectionConfigPackage,
+				},
+			))
 		})
 	})
 })

--- a/core/chaincode/lifecycle/mock/legacy_metadata_provider.go
+++ b/core/chaincode/lifecycle/mock/legacy_metadata_provider.go
@@ -8,12 +8,12 @@ import (
 )
 
 type LegacyMetadataProvider struct {
-	MetadataStub        func(string, string, bool) *chaincode.Metadata
+	MetadataStub        func(string, string, ...string) *chaincode.Metadata
 	metadataMutex       sync.RWMutex
 	metadataArgsForCall []struct {
 		arg1 string
 		arg2 string
-		arg3 bool
+		arg3 []string
 	}
 	metadataReturns struct {
 		result1 *chaincode.Metadata
@@ -25,18 +25,18 @@ type LegacyMetadataProvider struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *LegacyMetadataProvider) Metadata(arg1 string, arg2 string, arg3 bool) *chaincode.Metadata {
+func (fake *LegacyMetadataProvider) Metadata(arg1 string, arg2 string, arg3 ...string) *chaincode.Metadata {
 	fake.metadataMutex.Lock()
 	ret, specificReturn := fake.metadataReturnsOnCall[len(fake.metadataArgsForCall)]
 	fake.metadataArgsForCall = append(fake.metadataArgsForCall, struct {
 		arg1 string
 		arg2 string
-		arg3 bool
+		arg3 []string
 	}{arg1, arg2, arg3})
 	fake.recordInvocation("Metadata", []interface{}{arg1, arg2, arg3})
 	fake.metadataMutex.Unlock()
 	if fake.MetadataStub != nil {
-		return fake.MetadataStub(arg1, arg2, arg3)
+		return fake.MetadataStub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
@@ -51,13 +51,13 @@ func (fake *LegacyMetadataProvider) MetadataCallCount() int {
 	return len(fake.metadataArgsForCall)
 }
 
-func (fake *LegacyMetadataProvider) MetadataCalls(stub func(string, string, bool) *chaincode.Metadata) {
+func (fake *LegacyMetadataProvider) MetadataCalls(stub func(string, string, ...string) *chaincode.Metadata) {
 	fake.metadataMutex.Lock()
 	defer fake.metadataMutex.Unlock()
 	fake.MetadataStub = stub
 }
 
-func (fake *LegacyMetadataProvider) MetadataArgsForCall(i int) (string, string, bool) {
+func (fake *LegacyMetadataProvider) MetadataArgsForCall(i int) (string, string, []string) {
 	fake.metadataMutex.RLock()
 	defer fake.metadataMutex.RUnlock()
 	argsForCall := fake.metadataArgsForCall[i]

--- a/discovery/client/client_test.go
+++ b/discovery/client/client_test.go
@@ -798,7 +798,7 @@ type ccMetadataFetcher struct {
 	mock.Mock
 }
 
-func (mdf *ccMetadataFetcher) Metadata(channel string, cc string, _ bool) *chaincode.Metadata {
+func (mdf *ccMetadataFetcher) Metadata(channel string, cc string, _ ...string) *chaincode.Metadata {
 	return mdf.Called(cc).Get(0).(*chaincode.Metadata)
 }
 

--- a/discovery/endorsement/endorsement.go
+++ b/discovery/endorsement/endorsement.go
@@ -35,12 +35,12 @@ type principalEvaluator interface {
 type chaincodeMetadataFetcher interface {
 	// ChaincodeMetadata returns the metadata of the chaincode as appears in the ledger,
 	// or nil if the channel doesn't exist, or the chaincode isn't found in the ledger
-	Metadata(channel string, cc string, loadCollections bool) *chaincode.Metadata
+	Metadata(channel string, cc string, collections ...string) *chaincode.Metadata
 }
 
 type policyFetcher interface {
-	// PolicyByChaincode returns a policy that can be inquired which identities
-	// satisfy it
+	// PoliciesByChaincode returns the chaincode policy or existing collection level policies that can be
+	// inquired for which identities satisfy them
 	PoliciesByChaincode(channel string, cc string, collections ...string) []policies.InquireablePolicy
 }
 
@@ -227,7 +227,7 @@ func loadMetadataAndFilters(ctx metadataAndFilterContext) (*metadataAndColFilter
 	var filters []identityFilter
 
 	for _, chaincode := range ctx.interest.Chaincodes {
-		ccMD := ctx.fetch.Metadata(string(ctx.chainID), chaincode.Name, len(chaincode.CollectionNames) > 0)
+		ccMD := ctx.fetch.Metadata(string(ctx.chainID), chaincode.Name, chaincode.CollectionNames...)
 		if ccMD == nil {
 			return nil, errors.Errorf("No metadata was found for chaincode %s in channel %s", chaincode.Name, string(ctx.chainID))
 		}

--- a/discovery/endorsement/endorsement_test.go
+++ b/discovery/endorsement/endorsement_test.go
@@ -939,7 +939,7 @@ type metadataFetcher struct {
 	mock.Mock
 }
 
-func (mf *metadataFetcher) Metadata(channel string, cc string, _ bool) *chaincode.Metadata {
+func (mf *metadataFetcher) Metadata(channel string, cc string, _ ...string) *chaincode.Metadata {
 	arg := mf.Called().Get(0)
 	if arg == nil {
 		return nil

--- a/discovery/support/chaincode/support.go
+++ b/discovery/support/chaincode/support.go
@@ -18,7 +18,7 @@ import (
 var logger = flogging.MustGetLogger("discovery.DiscoverySupport")
 
 type MetadataRetriever interface {
-	Metadata(channel string, cc string, loadCollections bool) *chaincode.Metadata
+	Metadata(channel string, cc string, collections ...string) *chaincode.Metadata
 }
 
 // DiscoverySupport implements support that is used for service discovery
@@ -35,20 +35,61 @@ func NewDiscoverySupport(ci MetadataRetriever) *DiscoverySupport {
 	return s
 }
 
-func (s *DiscoverySupport) PoliciesByChaincode(channel string, cc string, _ ...string) []policies.InquireablePolicy {
-	chaincodeData := s.ci.Metadata(channel, cc, false)
+func (s *DiscoverySupport) PoliciesByChaincode(channel string, cc string, collections ...string) []policies.InquireablePolicy {
+	chaincodeData := s.ci.Metadata(channel, cc, collections...)
 	if chaincodeData == nil {
-		logger.Info("Chaincode", cc, "wasn't found")
+		logger.Infof("Chaincode %s wasn't found", cc)
 		return nil
 	}
+
+	// chaincode policy
 	pol := &common2.SignaturePolicyEnvelope{}
 	if err := proto.Unmarshal(chaincodeData.Policy, pol); err != nil {
-		logger.Warning("Failed unmarshaling policy for chaincode", cc, ":", err)
+		logger.Errorf("Failed unmarshaling policy for chaincode '%s': %s", cc, err)
 		return nil
 	}
 	if len(pol.Identities) == 0 || pol.Rule == nil {
-		logger.Warningf("Invalid policy, either Identities(%v) or Rule(%v) are empty:", pol.Identities, pol.Rule)
+		logger.Errorf("Invalid policy, either Identities(%v) or Rule(%v) are empty", pol.Identities, pol.Rule)
 		return nil
 	}
-	return []policies.InquireablePolicy{inquire.NewInquireableSignaturePolicy(pol)}
+	// chaincodeData.CollectionPolicies will be nil when using legacy lifecycle (lscc)
+	// because collection endorsement policies are not supported in lscc
+	chaincodePolicy := inquire.NewInquireableSignaturePolicy(pol)
+	if chaincodeData.CollectionPolicies == nil || len(collections) == 0 {
+		return []policies.InquireablePolicy{chaincodePolicy}
+	}
+
+	// process any collection policies
+	inquireablePolicies := make(map[string]struct{})
+	uniqueInquireablePolicies := []policies.InquireablePolicy{}
+
+	for _, collectionName := range collections {
+		// default to the chaincode policy if the collection policy doesn't exist
+		if _, collectionPolicyExists := chaincodeData.CollectionPolicies[collectionName]; !collectionPolicyExists {
+			if _, exists := inquireablePolicies[string(chaincodeData.Policy)]; !exists {
+				uniqueInquireablePolicies = append(uniqueInquireablePolicies, chaincodePolicy)
+				inquireablePolicies[string(chaincodeData.Policy)] = struct{}{}
+			}
+			continue
+		}
+
+		collectionPolicy := chaincodeData.CollectionPolicies[collectionName]
+		pol := &common2.SignaturePolicyEnvelope{}
+		if err := proto.Unmarshal(collectionPolicy, pol); err != nil {
+			logger.Errorf("Failed unmarshaling collection policy for chaincode '%s' collection '%s': %s", cc, collectionName, err)
+			return nil
+		}
+		if len(pol.Identities) == 0 || pol.Rule == nil {
+			logger.Errorf("Invalid collection policy, either Identities(%v) or Rule(%v) are empty", pol.Identities, pol.Rule)
+			return nil
+		}
+		// only add to uniqueInquireablePolicies if the policy doesn't already exist there
+		// this prevents duplicate inquireablePolicies from being returned
+		if _, exists := inquireablePolicies[string(collectionPolicy)]; !exists {
+			uniqueInquireablePolicies = append(uniqueInquireablePolicies, inquire.NewInquireableSignaturePolicy(pol))
+			inquireablePolicies[string(collectionPolicy)] = struct{}{}
+		}
+	}
+
+	return uniqueInquireablePolicies
 }

--- a/discovery/support/chaincode/support_test.go
+++ b/discovery/support/chaincode/support_test.go
@@ -9,10 +9,12 @@ package chaincode
 import (
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric/common/chaincode"
+	"github.com/hyperledger/fabric/common/policies"
+	"github.com/hyperledger/fabric/common/policies/inquire"
+	"github.com/hyperledger/fabric/protoutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,43 +22,60 @@ type mockMetadataRetriever struct {
 	res *chaincode.Metadata
 }
 
-func (r *mockMetadataRetriever) Metadata(channel string, cc string, loadCollections bool) *chaincode.Metadata {
+func (r *mockMetadataRetriever) Metadata(channel string, cc string, collections ...string) *chaincode.Metadata {
 	return r.res
 }
 
 func TestSupport(t *testing.T) {
-	emptySignaturePolicyEnvelope, _ := proto.Marshal(&common.SignaturePolicyEnvelope{})
-	ccmd1 := &chaincode.Metadata{Policy: emptySignaturePolicyEnvelope}
-	notEmptySignaturePolicyEnvelope, _ := proto.Marshal(&common.SignaturePolicyEnvelope{
+	emptySignaturePolicyEnvelope := &common.SignaturePolicyEnvelope{}
+	ccmd1 := &chaincode.Metadata{Policy: protoutil.MarshalOrPanic(emptySignaturePolicyEnvelope)}
+	notEmptySignaturePolicyEnvelope := &common.SignaturePolicyEnvelope{
 		Rule:       &common.SignaturePolicy{},
-		Identities: []*msp.MSPPrincipal{{}},
-	})
-	ccmd2 := &chaincode.Metadata{Policy: notEmptySignaturePolicyEnvelope}
+		Identities: []*msp.MSPPrincipal{{Principal: []byte("principal-1")}},
+	}
+	ccmd2 := &chaincode.Metadata{Policy: protoutil.MarshalOrPanic(notEmptySignaturePolicyEnvelope)}
+	notEmptySignaturePolicyEnvelope2 := &common.SignaturePolicyEnvelope{
+		Rule:       &common.SignaturePolicy{},
+		Identities: []*msp.MSPPrincipal{{Principal: []byte("principal-2")}},
+	}
+	ccmd3 := &chaincode.Metadata{Policy: protoutil.MarshalOrPanic(notEmptySignaturePolicyEnvelope),
+		CollectionPolicies: map[string][]byte{"col1": protoutil.MarshalOrPanic(notEmptySignaturePolicyEnvelope2)}}
 
 	tests := []struct {
-		name        string
-		input       *chaincode.Metadata
-		shouldBeNil bool
+		name           string
+		input          *chaincode.Metadata
+		collNames      []string
+		expectedReturn []policies.InquireablePolicy
 	}{
 		{
-			name:        "Nil instantiatedChaincode",
-			input:       nil,
-			shouldBeNil: true,
+			name:           "Nil instantiatedChaincode",
+			input:          nil,
+			collNames:      nil,
+			expectedReturn: nil,
 		},
 		{
-			name:        "Invalid policy bytes",
-			input:       &chaincode.Metadata{Policy: []byte{1, 2, 3}},
-			shouldBeNil: true,
+			name:           "Invalid policy bytes",
+			input:          &chaincode.Metadata{Policy: []byte{1, 2, 3}},
+			collNames:      nil,
+			expectedReturn: nil,
 		},
 		{
-			name:        "Empty signature policy envelope",
-			input:       ccmd1,
-			shouldBeNil: true,
+			name:           "Empty signature policy envelope",
+			input:          ccmd1,
+			collNames:      nil,
+			expectedReturn: nil,
 		},
 		{
-			name:        "Not Empty signature policy envelope",
-			input:       ccmd2,
-			shouldBeNil: false,
+			name:           "Not Empty signature policy envelope",
+			input:          ccmd2,
+			collNames:      nil,
+			expectedReturn: []policies.InquireablePolicy{inquire.NewInquireableSignaturePolicy(notEmptySignaturePolicyEnvelope)},
+		},
+		{
+			name:           "Not Empty signature policy envelopes with existing collection policy",
+			input:          ccmd3,
+			collNames:      []string{"col1"},
+			expectedReturn: []policies.InquireablePolicy{inquire.NewInquireableSignaturePolicy(notEmptySignaturePolicyEnvelope2)},
 		},
 	}
 
@@ -64,11 +83,10 @@ func TestSupport(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			sup := NewDiscoverySupport(&mockMetadataRetriever{res: test.input})
-			res := sup.PoliciesByChaincode("", "")
-			if test.shouldBeNil {
-				assert.Nil(t, res)
-			} else {
-				assert.NotNil(t, res)
+			res := sup.PoliciesByChaincode("", "", test.collNames...)
+			assert.Equal(t, len(res), len(test.expectedReturn))
+			for i := 0; i < len(test.expectedReturn); i++ {
+				assert.Equal(t, res[i].SatisfiedBy(), test.expectedReturn[i].SatisfiedBy())
 			}
 		})
 	}

--- a/integration/discovery/discovery_test.go
+++ b/integration/discovery/discovery_test.go
@@ -548,7 +548,7 @@ var _ = Describe("DiscoveryService", func() {
 		Expect(discovered[0].Layouts).To(HaveLen(1))
 		Expect(discovered[0].Layouts[0].QuantitiesByGroup).To(ConsistOf(uint32(1), uint32(1), uint32(1)))
 
-		By("discovering endorsers for collection available on all peers")
+		By("discovering endorsers for a collection without collection EP, using chaincode EP")
 		endorsers.Collection = "mycc:collectionMarbles"
 		de = discoverEndorsers(network, endorsers)
 		Eventually(endorsersByGroups(de), network.EventuallyTimeout).Should(ConsistOf(
@@ -556,6 +556,18 @@ var _ = Describe("DiscoveryService", func() {
 			ConsistOf(network.DiscoveredPeer(org2Peer0)),
 			ConsistOf(network.DiscoveredPeer(org3Peer0)),
 		))
+
+		By("discovering endorsers for a collection with collection EP, using collection EP")
+		endorsers.Collection = "mycc:collectionDetails"
+		de = discoverEndorsers(network, endorsers)
+		Eventually(endorsersByGroups(de), network.EventuallyTimeout).Should(ConsistOf(
+			ConsistOf(network.DiscoveredPeer(org1Peer0)),
+			ConsistOf(network.DiscoveredPeer(org2Peer0)),
+		))
+		discovered = de()
+		Expect(discovered).To(HaveLen(1))
+		Expect(discovered[0].Layouts).To(HaveLen(1))
+		Expect(discovered[0].Layouts[0].QuantitiesByGroup).To(ConsistOf(uint32(1), uint32(1)))
 
 		By("trying to discover endorsers as an org3 admin")
 		endorsers = commands.Endorsers{

--- a/integration/discovery/testdata/collections_config_org1_org2_org3.json
+++ b/integration/discovery/testdata/collections_config_org1_org2_org3.json
@@ -5,5 +5,15 @@
         "requiredPeerCount": 1,
         "maxPeerCount": 2,
         "blockToLive":1000000
+    },
+    {
+        "name": "collectionDetails",
+        "policy": "OR('Org1MSP.member', 'Org2MSP.member')",
+        "requiredPeerCount": 1,
+        "maxPeerCount": 2,
+        "blockToLive":1000000,
+        "endorsementPolicy": {
+            "signaturePolicy": "AND('Org1MSP.member', 'Org2MSP.member')"
+        }
     }
 ]


### PR DESCRIPTION
#### Type of change

- New feature

#### Description
* PoliciesByChaincode now returns one InquireablePolicy per collection,
either the collection's endorsement policy if one exists or the
chaincode policy by default
* chaincode.Metadata now stores CollectionPolicies for _lifecycle
namespace chaincodes that have collection endorsement policies

#### Related issues

[FAB-17299](https://jira.hyperledger.org/browse/FAB-17299)
This PR cannot be merged until [FAB-17308](https://jira.hyperledger.org/browse/FAB-17308) is complete; however, submitting PR now for review/feedback.

/cc @yacovm @denyeart 