### PR TITLE
[FAB-17317] Add code to stop init_public container

### DIFF
--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -935,6 +935,8 @@ func TestChaincodeInit(t *testing.T) {
 		Version: "0",
 	}
 
+	defer chaincodeSupport.Runtime.Stop(cID.Name + ":" + cID.Version)
+
 	resp, err := deploy(channelID, ccContext, spec, nextBlockNumber, chaincodeSupport)
 	assert.NoError(t, err)
 	// why response status is defined as int32 when the status codes are


### PR DESCRIPTION
This patch adds code to stop and cleanup `init_public_data` container to `TestChaincodeInit` func in `core/chaincode/exectransaction_test`.

#### Type of change

- Bug fix

#### Description

In `core/chaincode/exectransaction_test`, `TestChaincodeInit` func creates `init_public_data` container but does not stop and cleanup it.

This patch adds code to stop and cleanup the container to the func.

#### Related issues

https://jira.hyperledger.org/browse/FAB-17317
