### PR TITLE
Ensure we capture final line of chaincode output

### DIFF
--- a/core/container/dockercontroller/dockercontroller.go
+++ b/core/container/dockercontroller/dockercontroller.go
@@ -419,9 +419,11 @@ func streamOutput(logger *flogging.FabricLogger, client dockerClient, containerN
 			// Loop forever dumping lines of text into the containerLogger
 			// until the pipe is closed
 			line, err := is.ReadString('\n')
+			if len(line) > 0 {
+				containerLogger.Info(line)
+			}
 			switch err {
 			case nil:
-				containerLogger.Info(line)
 			case io.EOF:
 				logger.Infof("Container %s has closed its IO channel", containerName)
 				return

--- a/core/container/dockercontroller/dockercontroller_test.go
+++ b/core/container/dockercontroller/dockercontroller_test.go
@@ -223,14 +223,16 @@ func Test_streamOutput(t *testing.T) {
 	gt.Eventually(opts.Success).Should(BeClosed())
 
 	fmt.Fprintf(opts.OutputStream, "message-one\n")
-	fmt.Fprintf(opts.OutputStream, "message-two") // does not get written
+	fmt.Fprintf(opts.OutputStream, "message-two") // does not get written until after stream closed
 	gt.Eventually(containerRecorder).Should(gbytes.Say("message-one"))
 	gt.Consistently(containerRecorder.Entries).Should(HaveLen(1))
 
 	close(errCh)
+
 	gt.Eventually(recorder).Should(gbytes.Say("Container container-name has closed its IO channel"))
 	gt.Consistently(recorder.Entries).Should(HaveLen(1))
-	gt.Consistently(containerRecorder.Entries).Should(HaveLen(1))
+	gt.Eventually(containerRecorder).Should(gbytes.Say("message-two"))
+	gt.Consistently(containerRecorder.Entries).Should(HaveLen(2))
 }
 
 func Test_BuildMetric(t *testing.T) {


### PR DESCRIPTION
If the last line of text from the chaincode container does not end with a newline, we would not write the log message. This change ensures we write the final line.