### PR TITLE
Reduce the number of peers in test networks

### DIFF
--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -141,11 +141,11 @@ var _ = Describe("EndToEnd", func() {
 
 			CheckPeerStatsdStreamMetrics(datagramReader.String())
 			CheckPeerStatsdMetrics(datagramReader.String(), "org1_peer0")
-			CheckPeerStatsdMetrics(datagramReader.String(), "org2_peer1")
+			CheckPeerStatsdMetrics(datagramReader.String(), "org2_peer0")
 			CheckOrdererStatsdMetrics(datagramReader.String(), "ordererorg_orderer")
 
 			By("setting up a channel from a base profile")
-			additionalPeer := network.Peer("Org2", "peer1")
+			additionalPeer := network.Peer("Org2", "peer0")
 			network.CreateChannel("baseprofilechannel", orderer, peer, additionalPeer)
 		})
 	})
@@ -195,25 +195,24 @@ var _ = Describe("EndToEnd", func() {
 			}
 
 			orderer := network.Orderer("orderer")
-			peer := network.Peer("Org1", "peer1")
 
 			network.CreateAndJoinChannel(orderer, "testchannel")
 			nwo.EnableCapabilities(network, "testchannel", "Application", "V2_0", orderer, network.Peer("Org1", "peer0"), network.Peer("Org2", "peer0"))
 
 			// package, install, and approve by org1 - module chaincode
-			packageInstallApproveChaincode(network, "testchannel", orderer, chaincode, network.Peer("Org1", "peer0"), network.Peer("Org1", "peer1"))
+			packageInstallApproveChaincode(network, "testchannel", orderer, chaincode, network.Peer("Org1", "peer0"))
 
 			// package, install, and approve by org2 - gopath chaincode, same logic
-			packageInstallApproveChaincode(network, "testchannel", orderer, gopathChaincode, network.Peer("Org2", "peer0"), network.Peer("Org2", "peer1"))
+			packageInstallApproveChaincode(network, "testchannel", orderer, gopathChaincode, network.Peer("Org2", "peer0"))
 
 			testPeers := network.PeersWithChannel("testchannel")
 			nwo.CheckCommitReadinessUntilReady(network, "testchannel", chaincode, network.PeerOrgs(), testPeers...)
 			nwo.CommitChaincode(network, "testchannel", orderer, chaincode, testPeers[0], testPeers...)
 			nwo.InitChaincode(network, "testchannel", orderer, chaincode, testPeers...)
 
-			RunQueryInvokeQuery(network, orderer, peer, "testchannel")
+			RunQueryInvokeQuery(network, orderer, network.Peer("Org1", "peer0"), "testchannel")
 
-			CheckPeerOperationEndpoints(network, network.Peer("Org2", "peer1"))
+			CheckPeerOperationEndpoints(network, network.Peer("Org2", "peer0"))
 			CheckOrdererOperationEndpoints(network, orderer)
 		})
 	})
@@ -231,7 +230,7 @@ var _ = Describe("EndToEnd", func() {
 
 		It("creates two channels with two orgs trying to reconfigure and update metadata", func() {
 			orderer := network.Orderer("orderer")
-			peer := network.Peer("Org1", "peer1")
+			peer := network.Peer("Org1", "peer0")
 
 			By("Create first channel and deploy the chaincode")
 			network.CreateAndJoinChannel(orderer, "testchannel")
@@ -361,7 +360,7 @@ var _ = Describe("EndToEnd", func() {
 
 	Describe("basic solo network with containers being interrupted", func() {
 		BeforeEach(func() {
-			network = nwo.New(nwo.BasicSolo(), testDir, client, StartPort(), components)
+			network = nwo.New(nwo.FullSolo(), testDir, client, StartPort(), components)
 
 			network.GenerateConfigTree()
 			network.Bootstrap()
@@ -392,7 +391,7 @@ var _ = Describe("EndToEnd", func() {
 			network.CreateAndJoinChannels(orderer)
 
 			By("enabling new lifecycle capabilities")
-			nwo.EnableCapabilities(network, "testchannel", "Application", "V2_0", orderer, network.Peer("Org1", "peer1"), network.Peer("Org2", "peer1"))
+			nwo.EnableCapabilities(network, "testchannel", "Application", "V2_0", orderer, network.Peer("Org1", "peer0"), network.Peer("Org2", "peer0"))
 			By("deploying the chaincode")
 			nwo.DeployChaincode(network, "testchannel", orderer, chaincode)
 
@@ -465,7 +464,7 @@ func RunQueryInvokeQuery(n *nwo.Network, orderer *nwo.Orderer, peer *nwo.Peer, c
 		Ctor:      `{"Args":["invoke","a","b","10"]}`,
 		PeerAddresses: []string{
 			n.PeerAddress(n.Peer("Org1", "peer0"), nwo.ListenPort),
-			n.PeerAddress(n.Peer("Org2", "peer1"), nwo.ListenPort),
+			n.PeerAddress(n.Peer("Org2", "peer0"), nwo.ListenPort),
 		},
 		WaitForEvent: true,
 	})
@@ -491,8 +490,8 @@ func RunRespondWith(n *nwo.Network, orderer *nwo.Orderer, peer *nwo.Peer, channe
 		Name:      "mycc",
 		Ctor:      `{"Args":["respond","300","response-message","response-payload"]}`,
 		PeerAddresses: []string{
-			n.PeerAddress(n.Peer("Org1", "peer1"), nwo.ListenPort),
-			n.PeerAddress(n.Peer("Org2", "peer1"), nwo.ListenPort),
+			n.PeerAddress(n.Peer("Org1", "peer0"), nwo.ListenPort),
+			n.PeerAddress(n.Peer("Org2", "peer0"), nwo.ListenPort),
 		},
 		WaitForEvent: true,
 	})
@@ -507,8 +506,8 @@ func RunRespondWith(n *nwo.Network, orderer *nwo.Orderer, peer *nwo.Peer, channe
 		Name:      "mycc",
 		Ctor:      `{"Args":["respond","400","response-message","response-payload"]}`,
 		PeerAddresses: []string{
-			n.PeerAddress(n.Peer("Org1", "peer1"), nwo.ListenPort),
-			n.PeerAddress(n.Peer("Org2", "peer1"), nwo.ListenPort),
+			n.PeerAddress(n.Peer("Org1", "peer0"), nwo.ListenPort),
+			n.PeerAddress(n.Peer("Org2", "peer0"), nwo.ListenPort),
 		},
 		WaitForEvent: true,
 	})

--- a/integration/gossip/gossip_test.go
+++ b/integration/gossip/gossip_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Gossip Test", func() {
 		)
 
 		BeforeEach(func() {
-			network = nwo.New(nwo.BasicSolo(), testDir, client, StartPort(), components)
+			network = nwo.New(nwo.FullSolo(), testDir, client, StartPort(), components)
 
 			network.GenerateConfigTree()
 			//  modify peer config

--- a/integration/idemix/idemix_test.go
+++ b/integration/idemix/idemix_test.go
@@ -87,7 +87,7 @@ var _ = Describe("EndToEnd", func() {
 			nwo.DeployChaincode(network, "testchannel", orderer, chaincode)
 
 			By("getting the client peer by name")
-			peer := network.Peer("Org1", "peer1")
+			peer := network.Peer("Org1", "peer0")
 
 			Query(network, peer, "testchannel", "100")
 			Invoke(network, orderer, peer, "testchannel")
@@ -136,7 +136,7 @@ func Invoke(n *nwo.Network, orderer *nwo.Orderer, peer *nwo.Peer, channel string
 		Ctor:      `{"Args":["invoke","a","b","10"]}`,
 		PeerAddresses: []string{
 			n.PeerAddress(n.Peer("Org1", "peer0"), nwo.ListenPort),
-			n.PeerAddress(n.Peer("Org2", "peer1"), nwo.ListenPort),
+			n.PeerAddress(n.Peer("Org2", "peer0"), nwo.ListenPort),
 		},
 		WaitForEvent: true,
 	})
@@ -153,7 +153,7 @@ func InvokeWithIdemix(n *nwo.Network, orderer *nwo.Orderer, peer *nwo.Peer, idem
 		Ctor:      `{"Args":["invoke","a","b","10"]}`,
 		PeerAddresses: []string{
 			n.PeerAddress(n.Peer("Org1", "peer0"), nwo.ListenPort),
-			n.PeerAddress(n.Peer("Org2", "peer1"), nwo.ListenPort),
+			n.PeerAddress(n.Peer("Org2", "peer0"), nwo.ListenPort),
 		},
 		WaitForEvent: true,
 	})

--- a/integration/ledger/couchdb_indexes_test.go
+++ b/integration/ledger/couchdb_indexes_test.go
@@ -65,7 +65,7 @@ var _ = Describe("CouchDB indexes", func() {
 		client, err = docker.NewClientFromEnv()
 		Expect(err).NotTo(HaveOccurred())
 
-		network = nwo.New(nwo.BasicSolo(), testDir, client, StartPort(), components)
+		network = nwo.New(nwo.FullSolo(), testDir, client, StartPort(), components)
 
 		cwd, err := os.Getwd()
 		Expect(err).NotTo(HaveOccurred())

--- a/integration/lifecycle/ccenv14_test.go
+++ b/integration/lifecycle/ccenv14_test.go
@@ -63,7 +63,7 @@ var _ = Describe("solo network using ccenv-1.4", func() {
 		orderer := network.Orderer("orderer")
 		endorsers := []*nwo.Peer{
 			network.Peer("Org1", "peer0"),
-			network.Peer("Org2", "peer1"),
+			network.Peer("Org2", "peer0"),
 		}
 
 		cwd, err := os.Getwd()

--- a/integration/lifecycle/interop_test.go
+++ b/integration/lifecycle/interop_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Release interoperability", func() {
 		orderer = network.Orderer("orderer")
 		endorsers = []*nwo.Peer{
 			network.Peer("Org1", "peer0"),
-			network.Peer("Org2", "peer1"),
+			network.Peer("Org2", "peer0"),
 		}
 	})
 

--- a/integration/lifecycle/lifecycle_test.go
+++ b/integration/lifecycle/lifecycle_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Lifecycle", func() {
 		Eventually(couchProcess.Ready(), runner.DefaultStartTimeout).Should(BeClosed())
 		Consistently(couchProcess.Wait()).ShouldNot(Receive())
 		couchAddr := couchDB.Address()
-		peer := network.Peer("Org1", "peer1")
+		peer := network.Peer("Org1", "peer0")
 		core := network.ReadPeerConfig(peer)
 		core.Ledger.State.StateDatabase = "CouchDB"
 		core.Ledger.State.CouchDBConfig.CouchDBAddress = couchAddr
@@ -118,7 +118,7 @@ var _ = Describe("Lifecycle", func() {
 		network.CreateAndJoinChannels(orderer)
 		network.UpdateChannelAnchors(orderer, "testchannel")
 		network.VerifyMembership(network.PeersWithChannel("testchannel"), "testchannel")
-		nwo.EnableCapabilities(network, "testchannel", "Application", "V2_0", orderer, network.Peer("Org1", "peer1"), network.Peer("Org2", "peer1"))
+		nwo.EnableCapabilities(network, "testchannel", "Application", "V2_0", orderer, network.Peer("Org1", "peer0"), network.Peer("Org2", "peer0"))
 
 		By("deploying the chaincode")
 		nwo.PackageChaincodeBinary(chaincode)
@@ -148,7 +148,7 @@ var _ = Describe("Lifecycle", func() {
 		By("ensuring the chaincode can be invoked and queried")
 		endorsers := []*nwo.Peer{
 			network.Peer("Org1", "peer0"),
-			network.Peer("Org2", "peer1"),
+			network.Peer("Org2", "peer0"),
 		}
 		RunQueryInvokeQuery(network, orderer, "My_1st-Chaincode", 100, endorsers...)
 
@@ -212,7 +212,7 @@ var _ = Describe("Lifecycle", func() {
 		})
 
 		By("listing the installed chaincodes and verifying the channel/chaincode definitions that are using the chaincode package")
-		nwo.QueryInstalledReferences(network, "testchannel", chaincode.Label, chaincode.PackageID, network.Peer("Org2", "peer1"), []string{"My_1st-Chaincode", "Version-0.0"}, []string{"Your_Chaincode", "Version+0_0"})
+		nwo.QueryInstalledReferences(network, "testchannel", chaincode.Label, chaincode.PackageID, network.Peer("Org2", "peer0"), []string{"My_1st-Chaincode", "Version-0.0"}, []string{"Your_Chaincode", "Version+0_0"})
 
 		By("adding a new org")
 		org3 := &nwo.Organization{
@@ -231,23 +231,15 @@ var _ = Describe("Lifecycle", func() {
 			Organization: "Org3",
 			Channels:     testPeers[0].Channels,
 		}
-		org3peer1 := &nwo.Peer{
-			Name:         "peer1",
-			Organization: "Org3",
-			Channels:     testPeers[0].Channels,
-		}
-		org3Peers := []*nwo.Peer{org3peer0, org3peer1}
 
-		network.AddOrg(org3, org3peer0, org3peer1)
-		GenerateOrgUpdateMaterials(network, org3peer0, org3peer1)
+		network.AddOrg(org3, org3peer0)
+		GenerateOrgUpdateMaterials(network, org3peer0)
 
-		By("starting the org3 peers")
-		for _, peer := range org3Peers {
-			pr := network.PeerRunner(peer)
-			p := ifrit.Invoke(pr)
-			processes[peer.ID()] = p
-			Eventually(p.Ready(), network.EventuallyTimeout).Should(BeClosed())
-		}
+		By("starting the org3 peer")
+		pr := network.PeerRunner(org3peer0)
+		org3Process := ifrit.Invoke(pr)
+		processes[org3peer0.ID()] = org3Process
+		Eventually(org3Process.Ready(), network.EventuallyTimeout).Should(BeClosed())
 
 		By("updating the channel config to include org3")
 		// get the current channel config
@@ -270,7 +262,7 @@ var _ = Describe("Lifecycle", func() {
 		nwo.UpdateConfig(network, orderer, "testchannel", currentConfig, updatedConfig, true, testPeers[0], testPeers...)
 
 		By("joining the org3 peers to the channel")
-		network.JoinChannel("testchannel", orderer, org3peer0, org3peer1)
+		network.JoinChannel("testchannel", orderer, org3peer0)
 
 		// update testPeers now that org3 has joined
 		testPeers = network.PeersWithChannel("testchannel")
@@ -281,14 +273,14 @@ var _ = Describe("Lifecycle", func() {
 		nwo.WaitUntilEqualLedgerHeight(network, "testchannel", maxLedgerHeight, testPeers...)
 
 		By("querying definitions by org3 before performing any chaincode actions")
-		sess, err = network.PeerAdminSession(network.Peer("Org2", "peer1"), commands.ChaincodeListCommitted{
+		sess, err = network.PeerAdminSession(network.Peer("Org2", "peer0"), commands.ChaincodeListCommitted{
 			ChannelID: "testchannel",
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(0))
 
 		By("installing the chaincode to the org3 peers")
-		nwo.InstallChaincode(network, chaincode, org3peer0, org3peer1)
+		nwo.InstallChaincode(network, chaincode, org3peer0)
 
 		By("ensuring org3 peers do not execute the chaincode before approving the definition")
 		org3AndOrg1PeerAddresses := []string{
@@ -315,7 +307,7 @@ var _ = Describe("Lifecycle", func() {
 		By("ensuring chaincode can be invoked and queried by org3")
 		org3andOrg1Endorsers := []*nwo.Peer{
 			network.Peer("Org3", "peer0"),
-			network.Peer("Org1", "peer1"),
+			network.Peer("Org1", "peer0"),
 		}
 		RunQueryInvokeQuery(network, orderer, "My_1st-Chaincode", 80, org3andOrg1Endorsers...)
 

--- a/integration/msp/msp_test.go
+++ b/integration/msp/msp_test.go
@@ -79,7 +79,7 @@ var _ = Describe("MSP identity test on a network with mutual TLS required", func
 		By("creating and joining channels")
 		network.CreateAndJoinChannels(orderer)
 		By("enabling new lifecycle capabilities")
-		nwo.EnableCapabilities(network, "testchannel", "Application", "V2_0", orderer, network.Peer("Org1", "peer1"), network.Peer("Org2", "peer1"))
+		nwo.EnableCapabilities(network, "testchannel", "Application", "V2_0", orderer, network.Peer("Org1", "peer0"), network.Peer("Org2", "peer0"))
 
 		chaincode := nwo.Chaincode{
 			Name:            "mycc",
@@ -119,7 +119,7 @@ var _ = Describe("MSP identity test on a network with mutual TLS required", func
 			Name:      "mycc",
 			Ctor:      `{"Args":["invoke","a","b","10"]}`,
 			PeerAddresses: []string{
-				network.PeerAddress(network.Peer("Org2", "peer1"), nwo.ListenPort),
+				network.PeerAddress(network.Peer("Org2", "peer0"), nwo.ListenPort),
 			},
 			WaitForEvent: true,
 			ClientAuth:   network.ClientAuthRequired,
@@ -203,8 +203,8 @@ func RunQueryInvokeQuery(n *nwo.Network, orderer *nwo.Orderer, peer *nwo.Peer, i
 		Name:      "mycc",
 		Ctor:      `{"Args":["invoke","a","b","10"]}`,
 		PeerAddresses: []string{
-			n.PeerAddress(n.Peer("Org1", "peer1"), nwo.ListenPort),
-			n.PeerAddress(n.Peer("Org2", "peer1"), nwo.ListenPort),
+			n.PeerAddress(n.Peer("Org1", "peer0"), nwo.ListenPort),
+			n.PeerAddress(n.Peer("Org2", "peer0"), nwo.ListenPort),
 		},
 		WaitForEvent: true,
 		ClientAuth:   n.ClientAuthRequired,

--- a/integration/nwo/standard_networks.go
+++ b/integration/nwo/standard_networks.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 package nwo
 
+// BasicSolo is a configuration wtih two organizations and one peer per org.
 func BasicSolo() *Config {
 	return &Config{
 		Organizations: []*Organization{{
@@ -57,22 +58,10 @@ func BasicSolo() *Config {
 				{Name: "testchannel", Anchor: true},
 			},
 		}, {
-			Name:         "peer1",
-			Organization: "Org1",
-			Channels: []*PeerChannel{
-				{Name: "testchannel", Anchor: false},
-			},
-		}, {
 			Name:         "peer0",
 			Organization: "Org2",
 			Channels: []*PeerChannel{
 				{Name: "testchannel", Anchor: true},
-			},
-		}, {
-			Name:         "peer1",
-			Organization: "Org2",
-			Channels: []*PeerChannel{
-				{Name: "testchannel", Anchor: false},
 			},
 		}},
 		Profiles: []*Profile{{
@@ -84,6 +73,31 @@ func BasicSolo() *Config {
 			Organizations: []string{"Org1", "Org2"},
 		}},
 	}
+}
+
+// FullSolo is a configuration wtih two organizations and two peers per org.
+func FullSolo() *Config {
+	config := BasicSolo()
+
+	config.Peers = append(
+		config.Peers,
+		&Peer{
+			Name:         "peer1",
+			Organization: "Org1",
+			Channels: []*PeerChannel{
+				{Name: "testchannel", Anchor: false},
+			},
+		},
+		&Peer{
+			Name:         "peer1",
+			Organization: "Org2",
+			Channels: []*PeerChannel{
+				{Name: "testchannel", Anchor: false},
+			},
+		},
+	)
+
+	return config
 }
 
 func BasicSoloWithIdemix() *Config {
@@ -111,7 +125,8 @@ func MultiChannelBasicSolo() *Config {
 
 	config.Channels = []*Channel{
 		{Name: "testchannel", Profile: "TwoOrgsChannel"},
-		{Name: "testchannel2", Profile: "TwoOrgsChannel"}}
+		{Name: "testchannel2", Profile: "TwoOrgsChannel"},
+	}
 
 	for _, peer := range config.Peers {
 		peer.Channels = []*PeerChannel{
@@ -125,14 +140,17 @@ func MultiChannelBasicSolo() *Config {
 
 func BasicKafka() *Config {
 	config := BasicSolo()
+
 	config.Consensus.Type = "kafka"
 	config.Consensus.ZooKeepers = 1
 	config.Consensus.Brokers = 1
+
 	return config
 }
 
 func BasicEtcdRaft() *Config {
 	config := BasicSolo()
+
 	config.Consensus.Type = "etcdraft"
 	config.Profiles = []*Profile{{
 		Name:     "SampleDevModeEtcdRaft",
@@ -143,15 +161,26 @@ func BasicEtcdRaft() *Config {
 		Organizations: []string{"Org1", "Org2"},
 	}}
 	config.SystemChannel.Profile = "SampleDevModeEtcdRaft"
+
 	return config
 }
 
 func MinimalRaft() *Config {
 	config := BasicEtcdRaft()
+
 	config.Peers[1].Channels = nil
-	config.Peers[2].Channels = nil
-	config.Peers[3].Channels = nil
-	config.Profiles[1].Organizations = []string{"Org1"}
+	config.Channels = []*Channel{
+		{Name: "testchannel", Profile: "OneOrgChannel"},
+	}
+	config.Profiles = []*Profile{{
+		Name:     "SampleDevModeEtcdRaft",
+		Orderers: []string{"orderer"},
+	}, {
+		Name:          "OneOrgChannel",
+		Consortium:    "SampleConsortium",
+		Organizations: []string{"Org1"},
+	}}
+
 	return config
 }
 

--- a/integration/pvtdata/pvtdata_test.go
+++ b/integration/pvtdata/pvtdata_test.go
@@ -701,7 +701,7 @@ func initThreeOrgsSetup() *nwo.Network {
 	client, err := docker.NewClientFromEnv()
 	Expect(err).NotTo(HaveOccurred())
 
-	config := nwo.BasicSolo()
+	config := nwo.FullSolo()
 
 	// add org3 with one peer
 	config.Organizations = append(config.Organizations, &nwo.Organization{

--- a/integration/raft/cft_test.go
+++ b/integration/raft/cft_test.go
@@ -83,7 +83,7 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			network = nwo.New(nwo.MultiNodeEtcdRaft(), testDir, client, StartPort(), components)
 
 			o1, o2, o3 := network.Orderer("orderer1"), network.Orderer("orderer2"), network.Orderer("orderer3")
-			peer = network.Peer("Org1", "peer1")
+			peer = network.Peer("Org1", "peer0")
 
 			network.GenerateConfigTree()
 			network.Bootstrap()
@@ -151,7 +151,7 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			// - assert that o1 can catch up with o2 using snapshot
 			network = nwo.New(nwo.MultiNodeEtcdRaft(), testDir, client, StartPort(), components)
 			o1, o2, o3 := network.Orderer("orderer1"), network.Orderer("orderer2"), network.Orderer("orderer3")
-			peer = network.Peer("Org1", "peer1")
+			peer = network.Peer("Org1", "peer0")
 
 			network.GenerateConfigTree()
 			network.Bootstrap()
@@ -281,7 +281,7 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 
 			o1, o2, o3 := network.Orderer("orderer1"), network.Orderer("orderer2"), network.Orderer("orderer3")
 			orderers := []*nwo.Orderer{o1, o2, o3}
-			peer = network.Peer("Org1", "peer1")
+			peer = network.Peer("Org1", "peer0")
 			network.GenerateConfigTree()
 			network.Bootstrap()
 
@@ -345,7 +345,7 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			network = nwo.New(nwo.MultiNodeEtcdRaft(), testDir, client, StartPort(), components)
 
 			o1, o2, o3 := network.Orderer("orderer1"), network.Orderer("orderer2"), network.Orderer("orderer3")
-			peer = network.Peer("Org1", "peer1")
+			peer = network.Peer("Org1", "peer0")
 
 			network.GenerateConfigTree()
 			network.Bootstrap()
@@ -450,7 +450,7 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			network.GenerateConfigTree()
 			network.Bootstrap()
 
-			peer = network.Peer("Org1", "peer1")
+			peer = network.Peer("Org1", "peer0")
 			orderer := network.Orderer("orderer")
 
 			ordererDomain := network.Organization(orderer.Organization).Domain

--- a/integration/raft/migration_test.go
+++ b/integration/raft/migration_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Kafka2RaftMigration", func() {
 			Eventually(process.Ready(), network.EventuallyTimeout).Should(BeClosed())
 
 			orderer = network.Orderer("orderer")
-			peer = network.Peer("Org1", "peer1")
+			peer = network.Peer("Org1", "peer0")
 
 			syschannel = network.SystemChannel.Name
 			channel1 = "testchannel1"
@@ -498,7 +498,7 @@ var _ = Describe("Kafka2RaftMigration", func() {
 			network.Bootstrap()
 
 			o1, o2, o3 = network.Orderer("orderer1"), network.Orderer("orderer2"), network.Orderer("orderer3")
-			peer = network.Peer("Org1", "peer1")
+			peer = network.Peer("Org1", "peer0")
 
 			brokerGroup := network.BrokerGroupRunner()
 			brokerProc = ifrit.Invoke(brokerGroup)
@@ -684,7 +684,7 @@ var _ = Describe("Kafka2RaftMigration", func() {
 			network.Bootstrap()
 
 			orderer = network.Orderer("orderer")
-			peer = network.Peer("Org1", "peer1")
+			peer = network.Peer("Org1", "peer0")
 
 			brokerGroup := network.BrokerGroupRunner()
 			brokerProc = ifrit.Invoke(brokerGroup)

--- a/integration/raft/raft_suite_test.go
+++ b/integration/raft/raft_suite_test.go
@@ -62,7 +62,7 @@ func RunInvoke(n *nwo.Network, orderer *nwo.Orderer, peer *nwo.Peer, channel str
 		Ctor:      `{"Args":["invoke","a","b","10"]}`,
 		PeerAddresses: []string{
 			n.PeerAddress(n.Peer("Org1", "peer0"), nwo.ListenPort),
-			n.PeerAddress(n.Peer("Org2", "peer1"), nwo.ListenPort),
+			n.PeerAddress(n.Peer("Org2", "peer0"), nwo.ListenPort),
 		},
 		WaitForEvent: true,
 	})


### PR DESCRIPTION
Try to slightly reduce the resource requirements of our tests by reducing the number of server processes we launch by default by removing the second peer in each org in our "basic" networks.
