### PR TITLE
Go SDK link should point to 1.4 release

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -25,7 +25,7 @@ Hyperledger Fabric smart contract (chaincode) SDKs
 Hyperledger Fabric offers a number of SDKs to support developing smart contracts (chaincode)
 in various programming languages. There are three smart contract SDKs available for Go, Node.js, and Java:
 
-  * `Go SDK <https://github.com/hyperledger/fabric-chaincode-go>`__ and `Go SDK documentation <https://godoc.org/github.com/hyperledger/fabric-chaincode-go/shim>`__.
+  * `Go SDK <https://github.com/hyperledger/fabric/tree/release-1.4/core/chaincode/shim>`__ and `Go SDK documentation <https://godoc.org/gopkg.in/hyperledger/fabric.v1/core/chaincode/shim>`__.
   * `Node.js SDK <https://github.com/hyperledger/fabric-chaincode-node>`__ and `Node.js SDK documentation <https://fabric-shim.github.io/>`__.
   * `Java SDK <https://github.com/hyperledger/fabric-chaincode-java>`__ and `Java SDK documentation <https://hyperledger.github.io/fabric-chaincode-java/>`__.
 


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

The links should point to the 1.4 release of the shim package and its documentation as discussed in #476.

#### Additional details

N/A

#### Related issues

#476