### PR TITLE
Fix and chaincode label regexp and Backfill tests

### DIFF
--- a/core/chaincode/persistence/chaincode_package.go
+++ b/core/chaincode/persistence/chaincode_package.go
@@ -243,7 +243,7 @@ type ChaincodePackageParser struct {
 var (
 	// LabelRegexp is the regular expression controlling
 	// the allowed characters for the package label
-	LabelRegexp = regexp.MustCompile("^[a-zA-Z0-9]+([.+-_][a-zA-Z0-9]+)*$")
+	LabelRegexp = regexp.MustCompile(`^[[:alnum:]][[:alnum:]_.+-]*$`)
 )
 
 func validateLabel(label string) error {

--- a/core/chaincode/persistence/label_test.go
+++ b/core/chaincode/persistence/label_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package persistence
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLabels(t *testing.T) {
+	tests := []struct {
+		label   string
+		success bool
+	}{
+		{label: "", success: false},
+		{label: ".", success: false},
+		{label: "0", success: true},
+		{label: ":", success: false},
+		{label: "_", success: false},
+		{label: "a", success: true},
+		{label: "a#", success: false},
+		{label: "a$", success: false},
+		{label: "a%", success: false},
+		{label: "a-", success: true},
+		{label: "a++b", success: true},
+		{label: "a+b", success: true},
+		{label: "a+bb", success: true},
+		{label: "a--b", success: true},
+		{label: "a-b", success: true},
+		{label: "a-bb", success: true},
+		{label: "a::b", success: false},
+		{label: "a:b", success: false},
+		{label: "a__b", success: true},
+		{label: "a_b", success: true},
+		{label: "a_bb", success: true},
+		{label: "aa", success: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.label, func(t *testing.T) {
+			err := validateLabel(tt.label)
+			if tt.success {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.label)
+			}
+		})
+	}
+}


### PR DESCRIPTION
With the recent PR's around special characters in labels, I decided to look at the regexp we use. It was wrong. There were very few tests.  So...

Ensure that some of the special cases are properly evaluated.