### PR TITLE
[FAB-17339] Refactor couchDB unit test

### DIFF
--- a/core/ledger/kvledger/tests/v1x_test.go
+++ b/core/ledger/kvledger/tests/v1x_test.go
@@ -72,7 +72,11 @@ func TestV13WithStateCouchdb(t *testing.T) {
 	testutil.CopyDir("testdata/v13_statecouchdb/couchdb_etc/local.d", localdHostDir, true)
 
 	// start couchdb using couchdbDataUnzipDir and localdHostDir as mount dirs
-	couchAddress, cleanup := couchdbtest.CouchDBSetup(couchdbDataUnzipDir, localdHostDir)
+	couchdbBinds := []string{
+		fmt.Sprintf("%s:%s", couchdbDataUnzipDir, "/opt/couchdb/data"),
+		fmt.Sprintf("%s:%s", localdHostDir, "/opt/couchdb/etc/local.d"),
+	}
+	couchAddress, cleanup := couchdbtest.CouchDBSetup(couchdbBinds)
 	defer cleanup()
 
 	// set required config data to use state couchdb

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/purge_mgr_test.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/purge_mgr_test.go
@@ -21,11 +21,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	levelDBtestEnvName = "levelDB_TestEnv"
+	couchDBtestEnvName = "couchDB_TestEnv"
+)
+
 // Tests will be run against each environment in this array
 // For example, to skip CouchDB tests, remove &couchDBLockBasedEnv{}
-var testEnvs = []privacyenabledstate.TestEnv{
-	&privacyenabledstate.LevelDBCommonStorageTestEnv{},
-	&privacyenabledstate.CouchDBCommonStorageTestEnv{},
+var testEnvs = map[string]privacyenabledstate.TestEnv{
+	levelDBtestEnvName: &privacyenabledstate.LevelDBCommonStorageTestEnv{},
+	couchDBtestEnvName: &privacyenabledstate.CouchDBCommonStorageTestEnv{},
 }
 
 func TestMain(m *testing.M) {
@@ -106,11 +111,7 @@ func testPurgeMgr(t *testing.T, dbEnv privacyenabledstate.TestEnv) {
 }
 
 func TestPurgeMgrForCommittingPvtDataOfOldBlocks(t *testing.T) {
-	dbEnvs := []privacyenabledstate.TestEnv{
-		&privacyenabledstate.LevelDBCommonStorageTestEnv{},
-		&privacyenabledstate.CouchDBCommonStorageTestEnv{},
-	}
-	for _, dbEnv := range dbEnvs {
+	for _, dbEnv := range testEnvs {
 		t.Run(dbEnv.GetName(), func(t *testing.T) { testPurgeMgrForCommittingPvtDataOfOldBlocks(t, dbEnv) })
 	}
 }
@@ -163,7 +164,7 @@ func testPurgeMgrForCommittingPvtDataOfOldBlocks(t *testing.T, dbEnv privacyenab
 }
 
 func TestKeyUpdateBeforeExpiryBlock(t *testing.T) {
-	dbEnv := &privacyenabledstate.LevelDBCommonStorageTestEnv{}
+	dbEnv := testEnvs[levelDBtestEnvName]
 	ledgerid := "testledger-perge-mgr"
 	btlPolicy := btltestutil.SampleBTLPolicy(
 		map[[2]string]uint64{
@@ -203,7 +204,7 @@ func TestKeyUpdateBeforeExpiryBlock(t *testing.T) {
 }
 
 func TestOnlyHashUpdateInExpiryBlock(t *testing.T) {
-	dbEnv := &privacyenabledstate.LevelDBCommonStorageTestEnv{}
+	dbEnv := testEnvs[levelDBtestEnvName]
 	ledgerid := "testledger-perge-mgr"
 	btlPolicy := btltestutil.SampleBTLPolicy(
 		map[[2]string]uint64{
@@ -250,7 +251,7 @@ func TestOnlyHashUpdateInExpiryBlock(t *testing.T) {
 }
 
 func TestOnlyHashDeleteBeforeExpiryBlock(t *testing.T) {
-	dbEnv := &privacyenabledstate.LevelDBCommonStorageTestEnv{}
+	dbEnv := testEnvs[levelDBtestEnvName]
 	ledgerid := "testledger-perge-mgr"
 	btlPolicy := btltestutil.SampleBTLPolicy(
 		map[[2]string]uint64{

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/redolog_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/redolog_test.go
@@ -62,8 +62,8 @@ func TestRedoLogger(t *testing.T) {
 }
 
 func TestCouchdbRedoLogger(t *testing.T) {
-	testEnv := NewTestVDBEnv(t)
-	defer testEnv.Cleanup()
+	testEnv.init(t, &statedb.Cache{})
+	defer testEnv.cleanup()
 
 	// commitToRedologAndRestart - a helper function that commits directly to redologs and restart the statedb
 	commitToRedologAndRestart := func(newVal string, version *version.Height) {
@@ -80,7 +80,7 @@ func TestCouchdbRedoLogger(t *testing.T) {
 				},
 			),
 		)
-		testEnv.CloseAndReopen()
+		testEnv.closeAndReopen()
 	}
 	// verifyExpectedVal - a helper function that verifies the statedb contents
 	verifyExpectedVal := func(expectedVal string, expectedSavepoint *version.Height) {

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
@@ -23,25 +23,26 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/commontests"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/version"
 	"github.com/hyperledger/fabric/core/ledger/util/couchdb"
-	"github.com/hyperledger/fabric/core/ledger/util/couchdbtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// couchDB backed versioned DB test environment.
+var testEnv = &testVDBEnv{}
+
 func TestMain(m *testing.M) {
 	flogging.ActivateSpec("statecouchdb=debug")
 
-	address, cleanup := couchdbtest.CouchDBSetup("", "")
-	couchAddress = address
-
 	rc := m.Run()
-	cleanup()
+	testEnv.stopExternalResource()
 	os.Exit(rc)
 }
 
 func TestBasicRW(t *testing.T) {
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+
+	defer env.cleanup()
 	commontests.TestBasicRW(t, env.DBProvider)
 
 }
@@ -50,9 +51,10 @@ func TestBasicRW(t *testing.T) {
 // updates during GetState call.
 func TestGetStateFromCache(t *testing.T) {
 	cache := statedb.NewCache(32, []string{"lscc"})
+	env := testEnv
+	env.init(t, cache)
+	defer env.cleanup()
 
-	env := newTestVDBEnvWithCache(t, cache)
-	defer env.Cleanup()
 	chainID := "testgetstatefromcache"
 	db, err := env.DBProvider.GetDBHandle(chainID)
 	require.NoError(t, err)
@@ -113,9 +115,10 @@ func TestGetStateFromCache(t *testing.T) {
 // updates during GetVersion call.
 func TestGetVersionFromCache(t *testing.T) {
 	cache := statedb.NewCache(32, []string{"lscc"})
+	env := testEnv
+	env.init(t, cache)
+	defer env.cleanup()
 
-	env := newTestVDBEnvWithCache(t, cache)
-	defer env.Cleanup()
 	chainID := "testgetstatefromcache"
 	db, err := env.DBProvider.GetDBHandle(chainID)
 	require.NoError(t, err)
@@ -176,9 +179,10 @@ func TestGetVersionFromCache(t *testing.T) {
 // and updates during GetStateMultipleKeys call.
 func TestGetMultipleStatesFromCache(t *testing.T) {
 	cache := statedb.NewCache(32, []string{"lscc"})
+	env := testEnv
+	env.init(t, cache)
+	defer env.cleanup()
 
-	env := newTestVDBEnvWithCache(t, cache)
-	defer env.Cleanup()
 	chainID := "testgetmultiplestatesfromcache"
 	db, err := env.DBProvider.GetDBHandle(chainID)
 	require.NoError(t, err)
@@ -237,9 +241,10 @@ func TestGetMultipleStatesFromCache(t *testing.T) {
 // after a commit of a update batch.
 func TestCacheUpdatesAfterCommit(t *testing.T) {
 	cache := statedb.NewCache(32, []string{"lscc"})
+	env := testEnv
+	env.init(t, cache)
+	defer env.cleanup()
 
-	env := newTestVDBEnvWithCache(t, cache)
-	defer env.Cleanup()
 	chainID := "testcacheupdatesaftercommit"
 	db, err := env.DBProvider.GetDBHandle(chainID)
 	require.NoError(t, err)
@@ -326,80 +331,101 @@ func TestCacheUpdatesAfterCommit(t *testing.T) {
 }
 
 func TestMultiDBBasicRW(t *testing.T) {
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
+
 	commontests.TestMultiDBBasicRW(t, env.DBProvider)
 
 }
 
 func TestDeletes(t *testing.T) {
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
+
 	commontests.TestDeletes(t, env.DBProvider)
 }
 
 func TestIterator(t *testing.T) {
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
+
 	commontests.TestIterator(t, env.DBProvider)
 }
 
 // The following tests are unique to couchdb, they are not used in leveldb
 //  query test
 func TestQuery(t *testing.T) {
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
+
 	commontests.TestQuery(t, env.DBProvider)
 }
 
 func TestGetStateMultipleKeys(t *testing.T) {
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
 
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
 	commontests.TestGetStateMultipleKeys(t, env.DBProvider)
 }
 
 func TestGetVersion(t *testing.T) {
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
+
 	commontests.TestGetVersion(t, env.DBProvider)
 }
 
 func TestSmallBatchSize(t *testing.T) {
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
+
 	commontests.TestSmallBatchSize(t, env.DBProvider)
 }
 
 func TestBatchRetry(t *testing.T) {
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
+
 	commontests.TestBatchWithIndividualRetry(t, env.DBProvider)
 }
 
 func TestValueAndMetadataWrites(t *testing.T) {
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
+
 	commontests.TestValueAndMetadataWrites(t, env.DBProvider)
 }
 
 func TestPaginatedRangeQuery(t *testing.T) {
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
+
 	commontests.TestPaginatedRangeQuery(t, env.DBProvider)
 }
 
 func TestRangeQuerySpecialCharacters(t *testing.T) {
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
+
 	commontests.TestRangeQuerySpecialCharacters(t, env.DBProvider)
 }
 
 // TestUtilityFunctions tests utility functions
 func TestUtilityFunctions(t *testing.T) {
-
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
 
 	db, err := env.DBProvider.GetDBHandle("testutilityfunctions")
 	assert.NoError(t, err)
@@ -448,9 +474,9 @@ func TestUtilityFunctions(t *testing.T) {
 
 // TestInvalidJSONFields tests for invalid JSON fields
 func TestInvalidJSONFields(t *testing.T) {
-
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
 
 	db, err := env.DBProvider.GetDBHandle("testinvalidfields")
 	assert.NoError(t, err)
@@ -506,9 +532,9 @@ func TestDebugFunctions(t *testing.T) {
 }
 
 func TestHandleChaincodeDeploy(t *testing.T) {
-
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
 
 	db, err := env.DBProvider.GetDBHandle("testinit")
 	assert.NoError(t, err)
@@ -615,8 +641,9 @@ func TestTryCastingToJSON(t *testing.T) {
 
 func TestHandleChaincodeDeployErroneousIndexFile(t *testing.T) {
 	channelName := "ch1"
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
 	db, err := env.DBProvider.GetDBHandle(channelName)
 	assert.NoError(t, err)
 	db.Open()
@@ -671,9 +698,9 @@ func printCompositeKeys(keys []*statedb.CompositeKey) string {
 
 // TestPaginatedQuery tests queries with pagination
 func TestPaginatedQuery(t *testing.T) {
-
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
 
 	db, err := env.DBProvider.GetDBHandle("testpaginatedquery")
 	assert.NoError(t, err)
@@ -931,14 +958,16 @@ func TestPaginatedQueryValidation(t *testing.T) {
 }
 
 func TestApplyUpdatesWithNilHeight(t *testing.T) {
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
 	commontests.TestApplyUpdatesWithNilHeight(t, env.DBProvider)
 }
 
 func TestRangeScanWithCouchInternalDocsPresent(t *testing.T) {
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
 	db, err := env.DBProvider.GetDBHandle("testrangescanfiltercouchinternaldocs")
 	assert.NoError(t, err)
 	couchDatabse, err := db.(*VersionedDB).getNamespaceDBHandle("ns")
@@ -1058,16 +1087,17 @@ func TestFormatCheck(t *testing.T) {
 		},
 	}
 
+	testEnv.init(t, &statedb.Cache{})
 	for i, testCase := range testCases {
 		t.Run(
 			fmt.Sprintf("testCase %d", i),
 			func(t *testing.T) {
-				testFormatCheck(t, testCase.dataFormat, testCase.dataExists, testCase.expectedErr, testCase.expectedFormat)
+				testFormatCheck(t, testCase.dataFormat, testCase.dataExists, testCase.expectedErr, testCase.expectedFormat, testEnv.couchAddress)
 			})
 	}
 }
 
-func testFormatCheck(t *testing.T, dataFormat string, dataExists bool, expectedErr *dataformat.ErrVersionMismatch, expectedFormat string) {
+func testFormatCheck(t *testing.T, dataFormat string, dataExists bool, expectedErr *dataformat.ErrVersionMismatch, expectedFormat, couchAddress string) {
 	redoPath, err := ioutil.TempDir("", "redoPath")
 	require.NoError(t, err)
 	defer os.RemoveAll(redoPath)
@@ -1133,9 +1163,10 @@ func testExistInCache(t *testing.T, db *couchdb.CouchDatabase, cache *statedb.Ca
 
 func TestLoadCommittedVersion(t *testing.T) {
 	cache := statedb.NewCache(32, []string{"lscc"})
+	env := testEnv
+	env.init(t, cache)
+	defer env.cleanup()
 
-	env := newTestVDBEnvWithCache(t, cache)
-	defer env.Cleanup()
 	chainID := "testloadcommittedversion"
 	db, err := env.DBProvider.GetDBHandle(chainID)
 	require.NoError(t, err)
@@ -1229,8 +1260,9 @@ func TestLoadCommittedVersion(t *testing.T) {
 }
 
 func TestMissingRevisionRetrievalFromDB(t *testing.T) {
-	env := NewTestVDBEnv(t)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, &statedb.Cache{})
+	defer env.cleanup()
 	chainID := "testmissingrevisionfromdb"
 	db, err := env.DBProvider.GetDBHandle(chainID)
 	require.NoError(t, err)
@@ -1271,8 +1303,10 @@ func TestMissingRevisionRetrievalFromDB(t *testing.T) {
 
 func TestMissingRevisionRetrievalFromCache(t *testing.T) {
 	cache := statedb.NewCache(32, []string{"lscc"})
-	env := newTestVDBEnvWithCache(t, cache)
-	defer env.Cleanup()
+	env := testEnv
+	env.init(t, cache)
+	defer env.cleanup()
+
 	chainID := "testmissingrevisionfromcache"
 	db, err := env.DBProvider.GetDBHandle(chainID)
 	require.NoError(t, err)

--- a/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/collection_val_test.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/collection_val_test.go
@@ -53,7 +53,7 @@ func TestCollectionValidation(t *testing.T) {
 }
 
 func TestPvtGetNoCollection(t *testing.T) {
-	testEnv := testEnvs[0]
+	testEnv := testEnvsMap[levelDBtestEnvName]
 	testEnv.init(t, "test-pvtdata-get-no-collection", nil)
 	defer testEnv.cleanup()
 	txMgr := testEnv.getTxMgr().(*LockBasedTxMgr)
@@ -67,7 +67,7 @@ func TestPvtGetNoCollection(t *testing.T) {
 	assert.IsType(t, &ledger.CollConfigNotDefinedError{}, err)
 }
 func TestPvtPutNoCollection(t *testing.T) {
-	testEnv := testEnvs[0]
+	testEnv := testEnvsMap[levelDBtestEnvName]
 	testEnv.init(t, "test-pvtdata-put-no-collection", nil)
 	defer testEnv.cleanup()
 	txMgr := testEnv.getTxMgr().(*LockBasedTxMgr)
@@ -79,7 +79,7 @@ func TestPvtPutNoCollection(t *testing.T) {
 }
 
 func TestNoCollectionValidationCheck(t *testing.T) {
-	testEnv := testEnvs[0]
+	testEnv := testEnvsMap[levelDBtestEnvName]
 	testEnv.init(t, "test-no-collection-validation-check", nil)
 	defer testEnv.cleanup()
 	txMgr := testEnv.getTxMgr().(*LockBasedTxMgr)

--- a/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/helper_test.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/helper_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestPvtdataResultsItr(t *testing.T) {
-	testEnv := testEnvs[0]
+	testEnv := testEnvsMap[levelDBtestEnvName]
 	btlPolicy := btltestutil.SampleBTLPolicy(
 		map[[2]string]uint64{
 			{"ns1", "coll1"}: 0,

--- a/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/txmgr_test.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/txmgr_test.go
@@ -839,7 +839,7 @@ func TestValidateKey(t *testing.T) {
 // TestTxSimulatorUnsupportedTx verifies that a simulation must throw an error when an unsupported transaction
 // is perfromed - queries on private data are supported in a read-only tran
 func TestTxSimulatorUnsupportedTx(t *testing.T) {
-	testEnv := testEnvs[0]
+	testEnv := testEnvsMap[levelDBtestEnvName]
 	testEnv.init(t, "testtxsimulatorunsupportedtx", nil)
 	defer testEnv.cleanup()
 	txMgr := testEnv.getTxMgr()
@@ -995,7 +995,7 @@ func TestConstructUniquePvtData(t *testing.T) {
 
 func TestFindAndRemoveStalePvtData(t *testing.T) {
 	ledgerid := "TestFindAndRemoveStalePvtData"
-	testEnv := testEnvs[0]
+	testEnv := testEnvsMap[levelDBtestEnvName]
 	testEnv.init(t, ledgerid, nil)
 	defer testEnv.cleanup()
 	db := testEnv.getVDB()
@@ -1178,7 +1178,7 @@ func testValidationAndCommitOfOldPvtData(t *testing.T, env testEnv) {
 }
 
 func TestTxSimulatorMissingPvtdata(t *testing.T) {
-	testEnv := testEnvs[0]
+	testEnv := testEnvsMap[levelDBtestEnvName]
 	testEnv.init(t, "TestTxSimulatorUnsupportedTxQueries", nil)
 	defer testEnv.cleanup()
 
@@ -1224,7 +1224,7 @@ func TestRemoveStaleAndCommitPvtDataOfOldBlocksWithExpiry(t *testing.T) {
 			{"ns", "coll"}: 1,
 		},
 	)
-	testEnv := testEnvs[0]
+	testEnv := testEnvsMap[levelDBtestEnvName]
 	testEnv.init(t, ledgerid, btlPolicy)
 	defer testEnv.cleanup()
 
@@ -1332,7 +1332,7 @@ func testPvtValueEqual(t *testing.T, txMgr txmgr.TxMgr, ns, coll, key string, va
 
 func TestDeleteOnCursor(t *testing.T) {
 	cID := "cid"
-	env := testEnvs[0]
+	env := testEnvsMap[levelDBtestEnvName]
 	env.init(t, "TestDeleteOnCursor", nil)
 	defer env.cleanup()
 
@@ -1380,7 +1380,7 @@ func TestDeleteOnCursor(t *testing.T) {
 
 func TestTxSimulatorMissingPvtdataExpiry(t *testing.T) {
 	ledgerid := "TestTxSimulatorMissingPvtdataExpiry"
-	testEnv := testEnvs[0]
+	testEnv := testEnvsMap[levelDBtestEnvName]
 	btlPolicy := btltestutil.SampleBTLPolicy(
 		map[[2]string]uint64{
 			{"ns", "coll"}: 1,

--- a/core/ledger/kvledger/txmgmt/validator/statebasedval/state_based_validator_test.go
+++ b/core/ledger/kvledger/txmgmt/validator/statebasedval/state_based_validator_test.go
@@ -43,11 +43,16 @@ type keyValue struct {
 	version    *version.Height
 }
 
+const (
+	levelDBtestEnvName = "levelDB_LockBasedTxMgr"
+	couchDBtestEnvName = "couchDB_LockBasedTxMgr"
+)
+
 // Tests will be run against each environment in this array
 // For example, to skip CouchDB tests, remove &couchDBLockBasedEnv{}
-var testEnvs = []privacyenabledstate.TestEnv{
-	&privacyenabledstate.LevelDBCommonStorageTestEnv{},
-	&privacyenabledstate.CouchDBCommonStorageTestEnv{},
+var testEnvs = map[string]privacyenabledstate.TestEnv{
+	levelDBtestEnvName: &privacyenabledstate.LevelDBCommonStorageTestEnv{},
+	couchDBtestEnvName: &privacyenabledstate.CouchDBCommonStorageTestEnv{},
 }
 
 func TestMain(m *testing.M) {
@@ -60,7 +65,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestValidatorBulkLoadingOfCache(t *testing.T) {
-	testDBEnv := testEnvs[1] // couchDB common storage test environment
+	testDBEnv := testEnvs[couchDBtestEnvName]
 	testDBEnv.Init(t)
 	defer testDBEnv.Cleanup()
 	db := testDBEnv.GetDBHandle("testdb")
@@ -190,7 +195,7 @@ func TestValidatorBulkLoadingOfCache(t *testing.T) {
 }
 
 func TestValidator(t *testing.T) {
-	testDBEnv := testEnvs[0] // LevelDB common storage test environment
+	testDBEnv := testEnvs[levelDBtestEnvName]
 	testDBEnv.Init(t)
 	defer testDBEnv.Cleanup()
 	db := testDBEnv.GetDBHandle("TestDB")
@@ -235,7 +240,7 @@ func TestValidator(t *testing.T) {
 }
 
 func TestPhantomValidation(t *testing.T) {
-	testDBEnv := testEnvs[0] // LevelDB common storage test environment
+	testDBEnv := testEnvs[levelDBtestEnvName]
 	testDBEnv.Init(t)
 	defer testDBEnv.Cleanup()
 	db := testDBEnv.GetDBHandle("TestDB")
@@ -308,7 +313,7 @@ func TestPhantomValidation(t *testing.T) {
 }
 
 func TestPhantomHashBasedValidation(t *testing.T) {
-	testDBEnv := testEnvs[0] // LevelDB common storage test environment
+	testDBEnv := testEnvs[levelDBtestEnvName]
 	testDBEnv.Init(t)
 	defer testDBEnv.Cleanup()
 	db := testDBEnv.GetDBHandle("TestDB")


### PR DESCRIPTION
Signed-off-by: Chongxin Luo <Chongxin.Luo@ibm.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (improvement to code, performance, etc)
- Test update

#### Description

<!--- Describe your changes in detail, including motivation. -->
- Fixed couchDB stopExternalResource in ./core/ledger/kvledger/txmgmt/privacyenabledstate. Only stop external couchDB container in this function. Move all DB cleanups in cleanup function.
- For package statecouchdb, un-export **testVDBEnv** and attach __couchDBAddress__ and __cleanupCouchDB__ function to the struct. Which during test, a single global instance of the testVDBEnv is being used, and couchDB external containers will only start once for this package.
- Replaced original array based test environments with map based test environments.

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->
https://jira.hyperledger.org/browse/FAB-17339
<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
/cc @manish-sethi 