### PR TITLE
lifecycle cache should remove stale chaincode definition references

### DIFF
--- a/integration/nwo/deploy.go
+++ b/integration/nwo/deploy.go
@@ -393,7 +393,7 @@ func UpgradeChaincodeLegacy(n *Network, channel string, orderer *Orderer, chainc
 
 func EnsureInstalled(n *Network, label, packageID string, peers ...*Peer) {
 	for _, p := range peers {
-		Eventually(queryInstalled(n, p), n.EventuallyTimeout).Should(
+		Eventually(QueryInstalled(n, p), n.EventuallyTimeout).Should(
 			ContainElement(MatchFields(IgnoreExtras,
 				Fields{
 					"Label":     Equal(label),
@@ -413,7 +413,7 @@ func QueryInstalledReferences(n *Network, channel, label, packageID string, chec
 		}
 	}
 
-	Expect(queryInstalled(n, checkPeer)()).To(
+	Expect(QueryInstalled(n, checkPeer)()).To(
 		ContainElement(MatchFields(IgnoreExtras,
 			Fields{
 				"Label":     Equal(label),
@@ -428,11 +428,14 @@ func QueryInstalledReferences(n *Network, channel, label, packageID string, chec
 	)
 }
 
+func QueryInstalledNoReferences(n *Network, channel, label, packageID string, checkPeer *Peer) {
+}
+
 type queryInstalledOutput struct {
 	InstalledChaincodes []lifecycle.QueryInstalledChaincodesResult_InstalledChaincode `json:"installed_chaincodes"`
 }
 
-func queryInstalled(n *Network, peer *Peer) func() []lifecycle.QueryInstalledChaincodesResult_InstalledChaincode {
+func QueryInstalled(n *Network, peer *Peer) func() []lifecycle.QueryInstalledChaincodesResult_InstalledChaincode {
 	return func() []lifecycle.QueryInstalledChaincodesResult_InstalledChaincode {
 		sess, err := n.PeerAdminSession(peer, commands.ChaincodeQueryInstalled{
 			ClientAuth: n.ClientAuthRequired,


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description

When a new chaincode package is installed and subsequently referenced by a committed chaincode definition that takes the place of a previous chaincode definition (aka they have the same name), the previous (stale) chaincode definition should no longer be listed as referenced by the previous
chaincode package in the lifecycle cache.

#### Related issues

FAB-17372
