### PR TITLE
[FAB-17370] Delete old info about shim’s Logger

### DIFF
--- a/docs/source/logging-control.rst
+++ b/docs/source/logging-control.rst
@@ -5,9 +5,7 @@ Overview
 --------
 
 Logging in the ``peer`` and ``orderer`` is provided by the
-``common/flogging`` package. Chaincodes written in Go also use this
-package if they use the logging methods provided by the ``shim``.
-This package supports
+``common/flogging`` package. This package supports
 
 -  Logging control based on the severity of the message
 -  Logging control based on the software *logger* generating the message

--- a/docs/source/upgrade_to_newest_version.md
+++ b/docs/source/upgrade_to_newest_version.md
@@ -26,7 +26,7 @@ At this point, you have two options:
 
 ## Chaincode logger (Go chaincode only)
 
-Support for user chaincodes to utilize the chaincode shim's logger via `NewLogger()` has been deprecated. Chaincodes that used the shim's `NewLogger()` must now shift to their own preferred logging mechanism.
+Support for user chaincodes to utilize the chaincode shim's logger via `NewLogger()` has been removed. Chaincodes that used the shim's `NewLogger()` must now shift to their own preferred logging mechanism.
 
 For more information, check out [Logging control](./logging-control.html#chaincode).
 


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Logger has been removed from Go chaincode shim by FAB-15366 updates.
This patch deletes old information about the shim’s Logger remaining in some documents.

#### Related issues

https://jira.hyperledger.org/browse/FAB-17370