### PR TITLE
Chaincode persistence uses period separator

### DIFF
--- a/core/chaincode/persistence/chaincode_package.go
+++ b/core/chaincode/persistence/chaincode_package.go
@@ -240,11 +240,9 @@ type ChaincodePackageParser struct {
 	MetadataProvider MetadataProvider
 }
 
-var (
-	// LabelRegexp is the regular expression controlling
-	// the allowed characters for the package label
-	LabelRegexp = regexp.MustCompile(`^[[:alnum:]][[:alnum:]_.+-]*$`)
-)
+// LabelRegexp is the regular expression controlling  the allowed characters
+// for the package label.
+var LabelRegexp = regexp.MustCompile(`^[[:alnum:]][[:alnum:]_.+-]*$`)
 
 func validateLabel(label string) error {
 	if !LabelRegexp.MatchString(label) {

--- a/core/chaincode/persistence/label_test.go
+++ b/core/chaincode/persistence/label_test.go
@@ -27,19 +27,21 @@ func TestLabels(t *testing.T) {
 		{label: "a#", success: false},
 		{label: "a$", success: false},
 		{label: "a%", success: false},
-		{label: "a-", success: true},
 		{label: "a++b", success: true},
 		{label: "a+b", success: true},
 		{label: "a+bb", success: true},
+		{label: "a-", success: true},
 		{label: "a--b", success: true},
 		{label: "a-b", success: true},
 		{label: "a-bb", success: true},
+		{label: "a.b", success: true},
 		{label: "a::b", success: false},
 		{label: "a:b", success: false},
 		{label: "a__b", success: true},
 		{label: "a_b", success: true},
 		{label: "a_bb", success: true},
 		{label: "aa", success: true},
+		{label: "v1.0.0", success: true},
 	}
 
 	for _, tt := range tests {

--- a/core/chaincode/persistence/persistence.go
+++ b/core/chaincode/persistence/persistence.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/hyperledger/fabric/common/chaincode"
 	"github.com/hyperledger/fabric/common/flogging"
@@ -230,14 +231,14 @@ func (s *Store) GetChaincodeInstallPath() string {
 }
 
 func packageID(label string, hash []byte) string {
-	return fmt.Sprintf("%s~%x", label, hash)
+	return fmt.Sprintf("%s:%x", label, hash)
 }
 
 func CCFileName(packageID string) string {
-	return packageID + ".tar.gz"
+	return strings.Replace(packageID, ":", ".", 1) + ".tar.gz"
 }
 
-var packageFileMatcher = regexp.MustCompile("^(.+)~([0-9abcdef]+)[.]tar[.]gz$")
+var packageFileMatcher = regexp.MustCompile("^(.+)[.]([0-9a-f]{64})[.]tar[.]gz$")
 
 func installedChaincodeFromFilename(fileName string) (chaincode.InstalledChaincode, bool) {
 	matches := packageFileMatcher.FindStringSubmatch(fileName)

--- a/integration/nwo/deploy.go
+++ b/integration/nwo/deploy.go
@@ -51,7 +51,7 @@ func (c *Chaincode) SetPackageIDFromPackageFile() {
 	fileBytes, err := ioutil.ReadFile(c.PackageFile)
 	Expect(err).NotTo(HaveOccurred())
 	hashStr := fmt.Sprintf("%x", util.ComputeSHA256(fileBytes))
-	c.PackageID = c.Label + "~" + hashStr
+	c.PackageID = c.Label + ":" + hashStr
 }
 
 // DeployChaincode is a helper that will install chaincode to all peers that


### PR DESCRIPTION
- Use a period separator between the chaincode label and hash
- Update chaincode store file matcher to explicitly look for files with
  a suffix of exactly 64 hex characters + ".tar.gz" to reduce depenency
  on special characters in the label.

#### Related Issue
[FAB-17315](https://jira.hyperledger.org/browse/FAB-17315)
