### PR TITLE
Remove BYFN reference from private data architecture doc

### DIFF
--- a/docs/source/private-data-arch.rst
+++ b/docs/source/private-data-arch.rst
@@ -124,7 +124,7 @@ collection definitions:
   }
  ]
 
-This example uses the organizations from the BYFN sample network, ``Org1`` and
+This example uses the organizations from the Fabric test network, ``Org1`` and
 ``Org2`` . The policy in the  ``collectionMarbles`` definition authorizes both
 organizations to the private data. This is a typical configuration when the
 chaincode data needs to remain private from the ordering service nodes. However,


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>

#### Type of change

- Documentation update

#### Description

Private data architecture guide contains a brief reference to BYFN. I replaced it with a mention of the test network as part of ongoing efforts to remove BYFN.
