### PR TITLE
[FAB-17379] Fix print format for querycommitted

### DIFF
--- a/internal/peer/lifecycle/chaincode/querycommitted.go
+++ b/internal/peer/lifecycle/chaincode/querycommitted.go
@@ -175,6 +175,7 @@ func (c *CommittedQuerier) printResponse(proposalResponse *pb.ProposalResponse) 
 	for _, cd := range result.ChaincodeDefinitions {
 		fmt.Fprintf(c.Writer, "Name: %s, ", cd.Name)
 		c.printSingleChaincodeDefinition(cd)
+		fmt.Fprintf(c.Writer, "\n")
 	}
 	return nil
 }

--- a/internal/peer/lifecycle/chaincode/querycommitted_test.go
+++ b/internal/peer/lifecycle/chaincode/querycommitted_test.go
@@ -85,9 +85,9 @@ var _ = Describe("QueryCommitted", func() {
 		It("queries committed chaincodes and writes the output as human readable plain-text", func() {
 			err := committedQuerier.Query()
 			Expect(err).NotTo(HaveOccurred())
-			Eventually(committedQuerier.Writer).Should(gbytes.Say("Committed chaincode definitions on channel 'test-channel'"))
-			Eventually(committedQuerier.Writer).Should(gbytes.Say("Name: woohoo, Version: a-version, Sequence: 93, Endorsement Plugin: e-plugin, Validation Plugin: v-plugin"))
-			Eventually(committedQuerier.Writer).Should(gbytes.Say("Name: yahoo, Version: another-version, Sequence: 20, Endorsement Plugin: e-plugin, Validation Plugin: v-plugin"))
+			Eventually(committedQuerier.Writer).Should(gbytes.Say("Committed chaincode definitions on channel 'test-channel':\n"))
+			Eventually(committedQuerier.Writer).Should(gbytes.Say("Name: woohoo, Version: a-version, Sequence: 93, Endorsement Plugin: e-plugin, Validation Plugin: v-plugin\n"))
+			Eventually(committedQuerier.Writer).Should(gbytes.Say("Name: yahoo, Version: another-version, Sequence: 20, Endorsement Plugin: e-plugin, Validation Plugin: v-plugin\n"))
 		})
 
 		Context("when JSON-formatted output is requested", func() {


### PR DESCRIPTION
This patch fixes the print format for `querycommitted` command to improve the readability.

#### Type of change

- Bug fix

#### Description

When running `peer lifecycle chaincode querycommitted` command with only a channel name (specified), the command displays multiple chaincode definitions without line breaks.

To improve readability, this patch adds line breaks to the print format.

#### Related issues

https://jira.hyperledger.org/browse/FAB-17379
