### PR TITLE
Implement stop for chaincode runtime launcher

### DIFF
--- a/core/chaincode/chaincode_support.go
+++ b/core/chaincode/chaincode_support.go
@@ -44,6 +44,7 @@ type Runtime interface {
 // Launcher is used to launch chaincode runtimes.
 type Launcher interface {
 	Launch(ccid string, streamHandler extcc.StreamHandler) error
+	Stop(ccid string) error
 }
 
 // Lifecycle provides a way to retrieve chaincode definitions and the packages necessary to run them

--- a/core/chaincode/runtime_launcher.go
+++ b/core/chaincode/runtime_launcher.go
@@ -147,3 +147,17 @@ func (r *RuntimeLauncher) Launch(ccid string, streamHandler extcc.StreamHandler)
 	chaincodeLogger.Debug("launch complete")
 	return err
 }
+
+func (r *RuntimeLauncher) Stop(ccid string) error {
+	err := r.Runtime.Stop(ccid)
+	if err != nil {
+		return errors.WithMessagef(err, "failed to stop chaincode %s", ccid)
+	}
+
+	err = r.Registry.Deregister(ccid)
+	if err != nil {
+		return errors.WithMessagef(err, "failed to deregister chaincode %s", ccid)
+	}
+
+	return nil
+}

--- a/core/chaincode/runtime_launcher_test.go
+++ b/core/chaincode/runtime_launcher_test.go
@@ -159,7 +159,6 @@ var _ = Describe("RuntimeLauncher", func() {
 		})
 
 		It("starts the runtime for the chaincode with no TLS", func() {
-
 			err := runtimeLauncher.Launch("chaincode-name:chaincode-version", fakeStreamHandler)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -445,7 +444,7 @@ var _ = Describe("RuntimeLauncher", func() {
 		})
 	})
 
-	Context("when stopping the runtime fails", func() {
+	Context("when stopping the runtime fails while launching", func() {
 		BeforeEach(func() {
 			fakeRuntime.StartReturns(errors.New("whirled-peas"))
 			fakeRuntime.StopReturns(errors.New("applesauce"))
@@ -454,6 +453,42 @@ var _ = Describe("RuntimeLauncher", func() {
 		It("preserves the initial error", func() {
 			err := runtimeLauncher.Launch("chaincode-name:chaincode-version", fakeStreamHandler)
 			Expect(err).To(MatchError("error starting container: whirled-peas"))
+		})
+	})
+
+	It("stops the runtime for the chaincode", func() {
+		err := runtimeLauncher.Stop("chaincode-name:chaincode-version")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(fakeRuntime.StopCallCount()).To(Equal(1))
+		ccidArg := fakeRuntime.StopArgsForCall(0)
+		Expect(ccidArg).To(Equal("chaincode-name:chaincode-version"))
+
+		Expect(fakeRegistry.DeregisterCallCount()).To(Equal(1))
+		ccidArg = fakeRegistry.DeregisterArgsForCall(0)
+		Expect(ccidArg).To(Equal("chaincode-name:chaincode-version"))
+	})
+
+	Context("when stopping the runtime fails while stopping", func() {
+		BeforeEach(func() {
+			fakeRuntime.StopReturns(errors.New("liver-mush"))
+		})
+
+		It("preserves the initial error", func() {
+			err := runtimeLauncher.Stop("chaincode-name:chaincode-version")
+			Expect(err).To(MatchError("failed to stop chaincode chaincode-name:chaincode-version: liver-mush"))
+			Expect(fakeRegistry.DeregisterCallCount()).To(Equal(0))
+		})
+	})
+
+	Context("when deregistering fails while stopping", func() {
+		BeforeEach(func() {
+			fakeRegistry.DeregisterReturns(errors.New("pickled-okra"))
+		})
+
+		It("preserves the initial error", func() {
+			err := runtimeLauncher.Stop("chaincode-name:chaincode-version")
+			Expect(err).To(MatchError("failed to deregister chaincode chaincode-name:chaincode-version: pickled-okra"))
 		})
 	})
 })


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Extend the chaincode runtime launcher to support stopping externally built/launched chaincodes and
docker chaincodes.

#### Related issues

FAB-17047