### PR TITLE
Fix go routine leak in core/scc tests

### DIFF
--- a/core/scc/inprocstream_test.go
+++ b/core/scc/inprocstream_test.go
@@ -46,3 +46,15 @@ func TestRecvChannelClosedError(t *testing.T) {
 		assert.Contains(t, err.Error(), "channel is closed")
 	}
 }
+
+func TestCloseSend(t *testing.T) {
+	send := make(chan *pb.ChaincodeMessage)
+	recv := make(chan *pb.ChaincodeMessage)
+
+	stream := newInProcStream(recv, send)
+	stream.CloseSend()
+
+	_, ok := <-send
+	assert.False(t, ok, "send channel should be closed")
+	assert.NotPanics(t, func() { stream.CloseSend() }, "CloseSend should be idempotent")
+}

--- a/core/scc/scc_test.go
+++ b/core/scc/scc_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode/lifecycle"
 	"github.com/hyperledger/fabric/core/scc"
 	"github.com/hyperledger/fabric/core/scc/mock"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 //go:generate counterfeiter -o mock/chaincode_stream_handler.go --fake-name ChaincodeStreamHandler . chaincodeStreamHandler
@@ -21,14 +21,24 @@ type chaincodeStreamHandler interface {
 }
 
 func TestDeploy(t *testing.T) {
-	gt := gomega.NewGomegaWithT(t)
+	gt := NewGomegaWithT(t)
 
-	csh := &mock.ChaincodeStreamHandler{}
 	doneC := make(chan struct{})
-	close(doneC)
+	csh := &mock.ChaincodeStreamHandler{}
 	csh.LaunchInProcReturns(doneC)
-	scc.DeploySysCC(&lifecycle.SCC{}, csh)
-	gt.Expect(csh.LaunchInProcCallCount()).To(gomega.Equal(1))
-	gt.Expect(csh.LaunchInProcArgsForCall(0)).To(gomega.Equal("_lifecycle.syscc"))
-	gt.Eventually(csh.HandleChaincodeStreamCallCount).Should(gomega.Equal(1))
+
+	deployC := make(chan struct{})
+	go func() { scc.DeploySysCC(&lifecycle.SCC{}, csh); close(deployC) }()
+
+	// Consume the register message to enable cleanup
+	gt.Eventually(csh.HandleChaincodeStreamCallCount).Should(Equal(1))
+	stream := csh.HandleChaincodeStreamArgsForCall(0)
+	stream.Recv()
+
+	close(doneC)
+	gt.Eventually(deployC).Should(BeClosed())
+
+	gt.Expect(csh.LaunchInProcCallCount()).To(Equal(1))
+	gt.Expect(csh.LaunchInProcArgsForCall(0)).To(Equal("_lifecycle.syscc"))
+	gt.Eventually(csh.HandleChaincodeStreamCallCount).Should(Equal(1))
 }


### PR DESCRIPTION
- Implement CloseSend on the in-process stream
- Consume registration message from system chaincode in test
- Use dot import for gomega in `scc_test.go`

FAB-16112