### PR TITLE
[FAB-17400] Improve log message for approved definition

### DIFF
--- a/core/chaincode/lifecycle/lifecycle.go
+++ b/core/chaincode/lifecycle/lifecycle.go
@@ -447,7 +447,7 @@ func (ef *ExternalFunctions) ApproveChaincodeDefinitionForOrg(chname, ccname str
 		return errors.WithMessage(err, "could not serialize chaincode package info to state")
 	}
 
-	logger.Infof("Successfully approved definition %s, name '%s' on channel '%s'", cd, ccname, chname)
+	logger.Infof("Successfully approved definition %s, name '%s', package ID '%s', on channel '%s'", cd, ccname, packageID, chname)
 
 	return nil
 }


### PR DESCRIPTION
This patch adds information on the package ID for the approved chaincode definition in the peer logs. 

The log message will be useful for Fabric admins to confirm the applied package ID immediately or later.

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Current peer `lifecycle chaincode approveformyorg` does not seem to output any information of the specified package ID to both the standard output on the console and the peer logs, when the command is executed successfully.

As a Fabric admin, at least, I want to see the output of the specified package ID for approved definition in the peer logs.

The log message will be useful for the following scenarios:
- The message can help Fabric admins to confirm the applied package ID later without recording the command history with the parameters on their console
- The message can help Fabric admins to quickly notice operation mistakes on the applied package ID especially when environment variables are interpolated in package IDs (e.g., empty package ID)

#### Related issues

https://jira.hyperledger.org/projects/FAB/issues/FAB-17400
