### PR TITLE
Stop _lifecycle chaincodes that are no longer referenced

### DIFF
--- a/core/chaincode/handler.go
+++ b/core/chaincode/handler.go
@@ -392,8 +392,8 @@ func (h *Handler) ProcessStream(stream ccintf.ChaincodeStream) error {
 				chaincodeLogger.Debugf("received EOF, ending chaincode support stream: %s", rmsg.err)
 				return rmsg.err
 			case rmsg.err != nil:
-				err := errors.Wrap(rmsg.err, "receive failed")
-				chaincodeLogger.Errorf("handling chaincode support stream: %+v", err)
+				err := errors.Wrap(rmsg.err, "receive from chaincode support stream failed")
+				chaincodeLogger.Debugf("%+v", err)
 				return err
 			case rmsg.msg == nil:
 				err := errors.New("received nil message, ending chaincode support stream")

--- a/core/chaincode/handler_test.go
+++ b/core/chaincode/handler_test.go
@@ -2767,7 +2767,7 @@ var _ = Describe("Handler", func() {
 
 			It("returns an error", func() {
 				err := handler.ProcessStream(fakeChatStream)
-				Expect(err).To(MatchError("receive failed: chocolate"))
+				Expect(err).To(MatchError("receive from chaincode support stream failed: chocolate"))
 			})
 		})
 

--- a/core/chaincode/lifecycle/custodian_test.go
+++ b/core/chaincode/lifecycle/custodian_test.go
@@ -99,4 +99,20 @@ var _ = Describe("Custodian", func() {
 
 		Expect(fakeBuilder.BuildCallCount()).To(Equal(0))
 	})
+
+	It("stops chaincodes", func() {
+		cc.NotifyStoppable("ccid1")
+		cc.NotifyStoppable("ccid2")
+		cc.NotifyStoppable("ccid3")
+		Eventually(fakeLauncher.StopCallCount).Should(Equal(3))
+		ccid := fakeLauncher.StopArgsForCall(0)
+		Expect(ccid).To(Equal("ccid1"))
+		ccid = fakeLauncher.StopArgsForCall(1)
+		Expect(ccid).To(Equal("ccid2"))
+		ccid = fakeLauncher.StopArgsForCall(2)
+		Expect(ccid).To(Equal("ccid3"))
+
+		Expect(fakeBuilder.BuildCallCount()).To(Equal(0))
+		Expect(fakeLauncher.LaunchCallCount()).To(Equal(0))
+	})
 })

--- a/core/chaincode/lifecycle/mock/chaincode_launcher.go
+++ b/core/chaincode/lifecycle/mock/chaincode_launcher.go
@@ -19,6 +19,17 @@ type ChaincodeLauncher struct {
 	launchReturnsOnCall map[int]struct {
 		result1 error
 	}
+	StopStub        func(string) error
+	stopMutex       sync.RWMutex
+	stopArgsForCall []struct {
+		arg1 string
+	}
+	stopReturns struct {
+		result1 error
+	}
+	stopReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -83,11 +94,73 @@ func (fake *ChaincodeLauncher) LaunchReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *ChaincodeLauncher) Stop(arg1 string) error {
+	fake.stopMutex.Lock()
+	ret, specificReturn := fake.stopReturnsOnCall[len(fake.stopArgsForCall)]
+	fake.stopArgsForCall = append(fake.stopArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("Stop", []interface{}{arg1})
+	fake.stopMutex.Unlock()
+	if fake.StopStub != nil {
+		return fake.StopStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.stopReturns
+	return fakeReturns.result1
+}
+
+func (fake *ChaincodeLauncher) StopCallCount() int {
+	fake.stopMutex.RLock()
+	defer fake.stopMutex.RUnlock()
+	return len(fake.stopArgsForCall)
+}
+
+func (fake *ChaincodeLauncher) StopCalls(stub func(string) error) {
+	fake.stopMutex.Lock()
+	defer fake.stopMutex.Unlock()
+	fake.StopStub = stub
+}
+
+func (fake *ChaincodeLauncher) StopArgsForCall(i int) string {
+	fake.stopMutex.RLock()
+	defer fake.stopMutex.RUnlock()
+	argsForCall := fake.stopArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *ChaincodeLauncher) StopReturns(result1 error) {
+	fake.stopMutex.Lock()
+	defer fake.stopMutex.Unlock()
+	fake.StopStub = nil
+	fake.stopReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ChaincodeLauncher) StopReturnsOnCall(i int, result1 error) {
+	fake.stopMutex.Lock()
+	defer fake.stopMutex.Unlock()
+	fake.StopStub = nil
+	if fake.stopReturnsOnCall == nil {
+		fake.stopReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.stopReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *ChaincodeLauncher) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.launchMutex.RLock()
 	defer fake.launchMutex.RUnlock()
+	fake.stopMutex.RLock()
+	defer fake.stopMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/core/chaincode/runtime_launcher.go
+++ b/core/chaincode/runtime_launcher.go
@@ -154,10 +154,5 @@ func (r *RuntimeLauncher) Stop(ccid string) error {
 		return errors.WithMessagef(err, "failed to stop chaincode %s", ccid)
 	}
 
-	err = r.Registry.Deregister(ccid)
-	if err != nil {
-		return errors.WithMessagef(err, "failed to deregister chaincode %s", ccid)
-	}
-
 	return nil
 }

--- a/core/chaincode/runtime_launcher_test.go
+++ b/core/chaincode/runtime_launcher_test.go
@@ -463,10 +463,6 @@ var _ = Describe("RuntimeLauncher", func() {
 		Expect(fakeRuntime.StopCallCount()).To(Equal(1))
 		ccidArg := fakeRuntime.StopArgsForCall(0)
 		Expect(ccidArg).To(Equal("chaincode-name:chaincode-version"))
-
-		Expect(fakeRegistry.DeregisterCallCount()).To(Equal(1))
-		ccidArg = fakeRegistry.DeregisterArgsForCall(0)
-		Expect(ccidArg).To(Equal("chaincode-name:chaincode-version"))
 	})
 
 	Context("when stopping the runtime fails while stopping", func() {
@@ -477,18 +473,6 @@ var _ = Describe("RuntimeLauncher", func() {
 		It("preserves the initial error", func() {
 			err := runtimeLauncher.Stop("chaincode-name:chaincode-version")
 			Expect(err).To(MatchError("failed to stop chaincode chaincode-name:chaincode-version: liver-mush"))
-			Expect(fakeRegistry.DeregisterCallCount()).To(Equal(0))
-		})
-	})
-
-	Context("when deregistering fails while stopping", func() {
-		BeforeEach(func() {
-			fakeRegistry.DeregisterReturns(errors.New("pickled-okra"))
-		})
-
-		It("preserves the initial error", func() {
-			err := runtimeLauncher.Stop("chaincode-name:chaincode-version")
-			Expect(err).To(MatchError("failed to deregister chaincode chaincode-name:chaincode-version: pickled-okra"))
 		})
 	})
 })

--- a/integration/chaincode/module/main.go
+++ b/integration/chaincode/module/main.go
@@ -8,8 +8,11 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 
 	"github.com/hyperledger/fabric-chaincode-go/shim"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
@@ -200,10 +203,60 @@ func (t *SimpleChaincode) respond(stub shim.ChaincodeStubInterface, args []strin
 	}
 }
 
-func main() {
-	err := shim.Start(&SimpleChaincode{})
+func handleSignals(handlers map[os.Signal]func()) {
+	var signals []os.Signal
+	for sig := range handlers {
+		signals = append(signals, sig)
+	}
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, signals...)
+
+	for sig := range signalChan {
+		fmt.Fprintf(os.Stderr, "Received signal: %d (%s)", sig, sig)
+		handlers[sig]()
+	}
+}
+
+func handleSigTerm() {
+	termFile := os.Getenv("ORG1_TERM_FILE")
+	if termFile == "" {
+		termFile = os.Getenv("ORG2_TERM_FILE")
+	}
+	if termFile == "" {
+		return
+	}
+
+	err := ioutil.WriteFile(termFile, []byte("term-file"), 0644)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Exiting Simple chaincode: %s", err)
-		os.Exit(2)
+		fmt.Fprintf(os.Stderr, "failed to write term file to %s: %s", termFile, err)
+	}
+}
+
+func main() {
+	startErrChan := make(chan error)
+	sigtermChan := make(chan error)
+
+	go handleSignals(map[os.Signal]func(){
+		syscall.SIGTERM: func() { sigtermChan <- nil },
+	})
+
+	go func() {
+		err := shim.Start(&SimpleChaincode{})
+		if err != nil {
+			startErrChan <- err
+		}
+	}()
+
+	var err error
+	select {
+	case err = <-startErrChan:
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Exiting Simple chaincode: %s", err)
+			os.Exit(2)
+		}
+		os.Exit(0)
+	case <-sigtermChan:
+		handleSigTerm()
 	}
 }

--- a/integration/nwo/fabricconfig/core.go
+++ b/integration/nwo/fabricconfig/core.go
@@ -217,19 +217,19 @@ type Docker struct {
 }
 
 type Chaincode struct {
-	Builder          string            `yaml:"builder,omitempty"`
-	Pull             bool              `yaml:"pull"`
-	Golang           *Golang           `yaml:"golang,omitempty"`
-	Java             *Java             `yaml:"java,omitempty"`
-	Node             *Node             `yaml:"node,omitempty"`
-	InstallTimeout   time.Duration     `yaml:"installTimeout,omitempty"`
-	StartupTimeout   time.Duration     `yaml:"startupTimeout,omitempty"`
-	ExecuteTimeout   time.Duration     `yaml:"executeTimeout,omitempty"`
-	Mode             string            `yaml:"mode,omitempty"`
-	Keepalive        int               `yaml:"keepalive,omitempty"`
-	System           SystemFlags       `yaml:"system,omitempty"`
-	Logging          *Logging          `yaml:"logging,omitempty"`
-	ExternalBuilders []ExternalBuilder `yaml:"externalBuilders"`
+	Builder          string             `yaml:"builder,omitempty"`
+	Pull             bool               `yaml:"pull"`
+	Golang           *Golang            `yaml:"golang,omitempty"`
+	Java             *Java              `yaml:"java,omitempty"`
+	Node             *Node              `yaml:"node,omitempty"`
+	InstallTimeout   time.Duration      `yaml:"installTimeout,omitempty"`
+	StartupTimeout   time.Duration      `yaml:"startupTimeout,omitempty"`
+	ExecuteTimeout   time.Duration      `yaml:"executeTimeout,omitempty"`
+	Mode             string             `yaml:"mode,omitempty"`
+	Keepalive        int                `yaml:"keepalive,omitempty"`
+	System           SystemFlags        `yaml:"system,omitempty"`
+	Logging          *Logging           `yaml:"logging,omitempty"`
+	ExternalBuilders []*ExternalBuilder `yaml:"externalBuilders"`
 
 	ExtraProperties map[string]interface{} `yaml:",inline,omitempty"`
 }

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -169,8 +169,12 @@ type custodianLauncherAdapter struct {
 	streamHandler extcc.StreamHandler
 }
 
-func (e custodianLauncherAdapter) Launch(ccid string) error {
-	return e.launcher.Launch(ccid, e.streamHandler)
+func (c custodianLauncherAdapter) Launch(ccid string) error {
+	return c.launcher.Launch(ccid, c.streamHandler)
+}
+
+func (c custodianLauncherAdapter) Stop(ccid string) error {
+	return c.launcher.Stop(ccid)
 }
 
 func serve(args []string) error {


### PR DESCRIPTION
#### Type of change
- New feature

#### Description
When a chaincode installed with _lifecycle is no longer referenced by any chaincode definition in any channel, it should be stopped.

#### Related issues
FAB-17046
