### PR TITLE
Remove reference to BYFN in network concept doc

### DIFF
--- a/docs/source/network/network.md
+++ b/docs/source/network/network.md
@@ -6,9 +6,6 @@ you're an architect, administrator or developer, you can use this topic to get a
 solid understanding of the major structure and process components in a
 Hyperledger Fabric blockchain network. This topic will use a manageable worked
 example that introduces all of the major components in a blockchain network.
-After understanding this example you can read more detailed information about
-these components elsewhere in the documentation, or try
-[building a sample network](../build_network.html).
 
 After reading this topic and understanding the concept of policies, you will
 have a solid understanding of the decisions that organizations need to make to


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>

#### Type of change

- Documentation update

#### Description

Removing a reference to the first network in the blockchain network concept doc. We have gotten user feedback on the need for fewer links and references to other docs (intro docs and the table of contents can do that), so I am removing the entire sentence.