### PR TITLE
Static leader should not give up retrieving blocks

### DIFF
--- a/core/deliverservice/deliveryclient.go
+++ b/core/deliverservice/deliveryclient.go
@@ -88,6 +88,7 @@ type deliverClient struct {
 // how it verifies messages received from it,
 // and how it disseminates the messages to other peers
 type Config struct {
+	IsStaticLeader bool
 	// ConnFactory returns a function that creates a connection to an endpoint
 	ConnFactory func(channelID string, endpointOverrides map[string]*comm.OrdererEndpoint) func(endpointCriteria comm.EndpointCriteria) (*grpc.ClientConn, error)
 	// ABCFactory creates an AtomicBroadcastClient out of a connection
@@ -292,7 +293,10 @@ func (d *deliverServiceImpl) newClient(chainID string, ledgerInfoProvider blocks
 	}
 	backoffPolicy := func(attemptNum int, elapsedTime time.Duration) (time.Duration, bool) {
 		if elapsedTime >= reconnectTotalTimeThreshold {
-			return 0, false
+			if !d.conf.IsStaticLeader {
+				return 0, false
+			}
+			logger.Warning("peer is a static leader, ignoring peer.deliveryclient.reconnectTotalTimeThreshold")
 		}
 		sleepIncrement := float64(time.Millisecond * 500)
 		attempt := float64(attemptNum)

--- a/gossip/service/gossip_service_test.go
+++ b/gossip/service/gossip_service_test.go
@@ -92,7 +92,7 @@ func TestInitGossipService(t *testing.T) {
 			messageCryptoService := peergossip.NewMCS(&mocks.ChannelPolicyManagerGetter{}, localmsp.NewSigner(), mgmt.NewDeserializersManager())
 			secAdv := peergossip.NewSecurityAdvisor(mgmt.NewDeserializersManager())
 			err := InitGossipService(identity, &disabled.Provider{}, endpoint, grpcServer, nil,
-				messageCryptoService, secAdv, nil)
+				messageCryptoService, secAdv, nil, false)
 			assert.NoError(t, err)
 		}()
 	}
@@ -832,7 +832,7 @@ func TestInvalidInitialization(t *testing.T) {
 
 	secAdv := peergossip.NewSecurityAdvisor(mgmt.NewDeserializersManager())
 	err := InitGossipService(api.PeerIdentityType("IDENTITY"), &disabled.Provider{}, endpoint, grpcServer, nil,
-		&naiveCryptoService{}, secAdv, nil)
+		&naiveCryptoService{}, secAdv, nil, false)
 	assert.NoError(t, err)
 	gService := GetGossipService().(*gossipServiceImpl)
 	defer gService.Stop()
@@ -859,7 +859,7 @@ func TestChannelConfig(t *testing.T) {
 
 	secAdv := peergossip.NewSecurityAdvisor(mgmt.NewDeserializersManager())
 	error := InitGossipService(api.PeerIdentityType("IDENTITY"), &disabled.Provider{}, endpoint, grpcServer, nil,
-		&naiveCryptoService{}, secAdv, nil)
+		&naiveCryptoService{}, secAdv, nil, false)
 	assert.NoError(t, error)
 	gService := GetGossipService().(*gossipServiceImpl)
 	defer gService.Stop()

--- a/peer/node/start.go
+++ b/peer/node/start.go
@@ -892,6 +892,7 @@ func initGossipService(policyMgr policies.ChannelPolicyManagerGetter, metricsPro
 	)
 	secAdv := peergossip.NewSecurityAdvisor(mgmt.NewDeserializersManager())
 	bootstrap := viper.GetStringSlice("peer.gossip.bootstrap")
+	orgLeader := viper.GetBool("peer.gossip.orgLeader")
 
 	return service.InitGossipService(
 		serializedIdentity,
@@ -902,6 +903,7 @@ func initGossipService(policyMgr policies.ChannelPolicyManagerGetter, metricsPro
 		messageCryptoService,
 		secAdv,
 		secureDialOpts,
+		orgLeader,
 		bootstrap...,
 	)
 }


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description
When a peer is configured as a static org leader for gossip, it should
not give up on retrieving blocks in the event that the orderering
service goes down for an extended period of time (i.e. longer than the
peer.deliveryclient.reconnectTotalTimeThreshold). Otherwise, the peer
must be restarted before it will act as the leader again.

#### Related issues

FAB-17327
