### PR TITLE
Add disclaimer for commercial paper tutorial

### DIFF
--- a/docs/source/tutorial/commercial_paper.md
+++ b/docs/source/tutorial/commercial_paper.md
@@ -1,5 +1,7 @@
 # Commercial paper tutorial
 
+*Note: This tutorial uses the [1.4.x and older lifecycle process](https://hyperledger-fabric.readthedocs.io/en/release-1.4/chaincode4noah.html) in which a chaincode is instantiated on a channel and does not yet work with the Fabric 2.0 release. The commercial paper tutorial will be updated soon to use a multi-organization network and the new chaincode lifecycle.*
+
 **Audience:** Architects, application and smart contract developers,
 administrators
 


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>

#### Type of change

- Documentation update

#### Description

Add disclaimer that commercial paper does not yet use the new chaincode lifecycle or work with Fabric 2.0.

Tutorial and sample will be updated shortly to use the new test network on 2.0:

#### Related issues

https://jira.hyperledger.org/browse/FAB-14679
