### PR TITLE
Create a new Documentation Maintainers sub-group

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,4 @@
 
 # Fabric Maintainers
 *       @hyperledger/fabric-core-maintainers
+/docs/  @hyperledger/fabric-core-doc-maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,9 +17,18 @@ Maintainers
 | Kostas Christidis | kchristidis | kostas | <kostas@gmail.com>
 | Manish Sethi | manish-sethi | manish-sethi | <manish.sethi@gmail.com>
 | Matthew Sykes | sykesm | sykesm | <sykesmat@us.ibm.com>
-| Pam Andrejko | pamandrejko | pandrejko | <pama@ibm.com>
 | Srinivasan Muralidharan | muralisrini | muralisr | <srinivasan.muralidharan99@gmail.com>
 | Yacov Manevich | yacovm | yacovm | <yacovm@il.ibm.com>
+
+**Documentation Maintainers**
+
+| Name | GitHub | Chat | email
+|------|--------|------|----------------------
+| Anthony O'Dowd | odowdaibm  | odowdaibm | <a_o-dowd@uk.ibm.com>
+| Chris Gabriel  | denali49   | cmgabriel | <alaskadd@gmail.com>
+| Joe Alewine | joealewine | joe-alewine | <joe.alewine@ibm.com>
+| Nikhil Gupta | nikhil550 | nikhilgupta | <negupta@us.ibm.com>
+| Pam Andrejko | pamandrejko | pandrejko | <pama@ibm.com>
 
 **Release Managers**
 
@@ -40,4 +49,3 @@ Maintainers
 | Yaoguo Jiang | jiangyaoguo | jiangyaoguo | <jiangyaoguo@gmail.com>
 | Greg Haskins | ghaskins | ghaskins | <gregory.haskins@gmail.com>
 | Keith Smith | smithbk | smithbk | <bksmith@us.ibm.com>
-


### PR DESCRIPTION
Members of this Documentation Maintainer sub-team can merge documentation changes into the Fabric repo.

Signed-off-by: pama-ibm <pama@ibm.com>

Per the ML [proposal](https://lists.hyperledger.org/g/fabric/message/7549), this PR creates a Documentation Maintainers sub-group who would be authorized to merge documentation (only) PRs which they did not author.

The list of Documentation Maintainers includes: Anthony O'Dowd, Chris Gabriel, Joe Alewine, Nik Gupta, Pam Andrejko, all members who have a track record of sustained documentation leadership  in the form of GitHub reviews or contributions, or consistent documentation workgroup contributions, or translation contribution.

#### Type of change

- Documentation update

#### Description
Why do we want to modify the process?
- Encourage more community contribution by including more contributors in the process.
- Simplify the process to merge trivial changes to the documentation.
- Facilitate inclusion of translated content in ReadTheDocs.
 