### PR TITLE
[FAB-15920] Fix peer not respond when couchDB building indexes

### DIFF
--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -110,7 +110,7 @@ func (p *Peer) updateTrustedRoots(cm channelconfig.Resources) {
 	trustedRoots = append(trustedRoots, p.ServerConfig.SecOpts.ServerRootCAs...)
 
 	// now update the client roots for the peerServer
-	err := p.Server.SetClientRootCAs(trustedRoots)
+	err := p.server.SetClientRootCAs(trustedRoots)
 	if err != nil {
 		msg := "Failed to update trusted roots from latest config block. " +
 			"This peer may not be able to communicate with members of channel %s (%s)"
@@ -174,7 +174,6 @@ func (c *configSupport) GetChannelConfig(cid string) cc.Config {
 
 // A Peer holds references to subsystems and channels associated with a Fabric peer.
 type Peer struct {
-	Server                   *comm.GRPCServer
 	ServerConfig             comm.ServerConfig
 	CredentialSupport        *comm.CredentialSupport
 	StoreProvider            transientstore.StoreProvider
@@ -187,6 +186,7 @@ type Peer struct {
 	// go routines.
 	validationWorkersSemaphore semaphore.Semaphore
 
+	server             *comm.GRPCServer
 	pluginMapper       plugin.Mapper
 	channelInitializer func(cid string)
 
@@ -485,6 +485,7 @@ func (p *Peer) GetApplicationConfig(cid string) (channelconfig.Application, bool
 // ready
 func (p *Peer) Initialize(
 	init func(string),
+	server *comm.GRPCServer,
 	pm plugin.Mapper,
 	deployedCCInfoProvider ledger.DeployedChaincodeInfoProvider,
 	legacyLifecycleValidation plugindispatcher.LifecycleResources,
@@ -492,6 +493,7 @@ func (p *Peer) Initialize(
 	nWorkers int,
 ) {
 	// TODO: exported dep fields or constructor
+	p.server = server
 	p.validationWorkersSemaphore = semaphore.New(nWorkers)
 	p.pluginMapper = pm
 	p.channelInitializer = init

--- a/core/peer/pkg_test.go
+++ b/core/peer/pkg_test.go
@@ -282,7 +282,7 @@ func TestUpdateRootsFromConfigBlock(t *testing.T) {
 				return
 			}
 
-			peerInstance.Server = server
+			peerInstance.SetServer(server)
 			peerInstance.ServerConfig = test.serverConfig
 
 			assert.NoError(t, err, "NewGRPCServer should not have returned an error")


### PR DESCRIPTION
Signed-off-by: Chongxin Luo <Chongxin.Luo@ibm.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

<!--- Describe your changes in detail, including motivation. -->

- Fixing peer not respond when couchDB building indexes. Moved initialization of
peer gRPC server and gossip service to post ledger manager initialization. Which
all ledger initialization will be compelte before peer gRPC starts.
- Un-exported Server from Peer struct, and moved the assigning of peer gPRC server 
into peer initialization function. 
#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->
[FAB-15920](https://jira.hyperledger.org/browse/FAB-15920)
<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
