### PR TITLE
Improve chaincode lifecycle peer log messages

### DIFF
--- a/core/chaincode/lifecycle/lifecycle.go
+++ b/core/chaincode/lifecycle/lifecycle.go
@@ -284,7 +284,7 @@ func (ef *ExternalFunctions) CheckCommitReadiness(chname, ccname string, cd *Cha
 		return nil, err
 	}
 
-	logger.Infof("Successfully checked commit readiness of chaincode definition %s, name '%s' on channel '%s'", cd, ccname, chname)
+	logger.Infof("Successfully checked commit readiness of chaincode name '%s' on channel '%s' with definition {%s}", ccname, chname, cd)
 
 	return approvals, nil
 }
@@ -304,8 +304,6 @@ func (ef *ExternalFunctions) CommitChaincodeDefinition(chname, ccname string, cd
 	if err = ef.Resources.Serializer.Serialize(NamespacesName, ccname, cd, publicState); err != nil {
 		return nil, errors.WithMessage(err, "could not serialize chaincode definition")
 	}
-
-	logger.Infof("Successfully committed definition %s, name '%s' on channel '%s'", cd, ccname, chname)
 
 	return approvals, nil
 }
@@ -447,7 +445,7 @@ func (ef *ExternalFunctions) ApproveChaincodeDefinitionForOrg(chname, ccname str
 		return errors.WithMessage(err, "could not serialize chaincode package info to state")
 	}
 
-	logger.Infof("Successfully approved definition %s, name '%s', package ID '%s', on channel '%s'", cd, ccname, packageID, chname)
+	logger.Infof("Successfully endorsed chaincode approval with name '%s', package ID '%s', on channel '%s' with definition {%s}", ccname, packageID, chname, cd)
 
 	return nil
 }
@@ -479,7 +477,7 @@ func (ef *ExternalFunctions) QueryChaincodeDefinition(name string, publicState R
 		return nil, errors.WithMessagef(err, "could not deserialize namespace %s as chaincode", name)
 	}
 
-	logger.Infof("Successfully queried definition %s, name '%s'", definedChaincode, name)
+	logger.Infof("Successfully queried chaincode name '%s' with definition {%s},", name, definedChaincode)
 
 	return definedChaincode, nil
 }

--- a/core/chaincode/lifecycle/lifecycle_test.go
+++ b/core/chaincode/lifecycle/lifecycle_test.go
@@ -129,22 +129,28 @@ var _ = Describe("Resources", func() {
 		BeforeEach(func() {
 			fakePublicState = map[string][]byte{}
 			err := resources.Serializer.Serialize(lifecycle.NamespacesName, "cc-name", &lifecycle.ChaincodeDefinition{
+				Sequence: 5,
 				EndorsementInfo: &lb.ChaincodeEndorsementInfo{
-					Version: "version",
+					Version:           "version",
+					EndorsementPlugin: "my endorsement plugin",
 				},
-				ValidationInfo: &lb.ChaincodeValidationInfo{},
-				Collections:    &pb.CollectionConfigPackage{},
+				ValidationInfo: &lb.ChaincodeValidationInfo{
+					ValidationPlugin:    "my validation plugin",
+					ValidationParameter: []byte("some awesome policy"),
+				},
+				Collections: &pb.CollectionConfigPackage{},
 			}, fakePublicState)
 			Expect(err).NotTo(HaveOccurred())
 			fakeReadableState = &mock.ReadWritableState{}
 			fakeReadableState.GetStateStub = fakePublicState.GetState
 		})
 
-		It("returns that the chaincode is defined and the definition", func() {
+		It("returns that the chaincode is defined and that the chaincode definition can be converted to a string suitable for log messages", func() {
 			exists, definition, err := resources.ChaincodeDefinitionIfDefined("cc-name", fakeReadableState)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(exists).To(BeTrue())
 			Expect(definition.EndorsementInfo.Version).To(Equal("version"))
+			Expect(fmt.Sprintf("{%s}", definition)).To(Equal("{sequence: 5, endorsement info: (version: 'version', plugin: 'my endorsement plugin', init required: false), validation info: (plugin: 'my validation plugin', policy: '736f6d6520617765736f6d6520706f6c696379'), collections: ()}"))
 		})
 
 		Context("when the requested chaincode is _lifecycle", func() {

--- a/core/chaincode/lifecycle/scc.go
+++ b/core/chaincode/lifecycle/scc.go
@@ -514,6 +514,8 @@ func (i *Invocation) CommitChaincodeDefinition(input *lb.CommitChaincodeDefiniti
 		return nil, errors.Errorf("chaincode definition not agreed to by this org (%s)", i.SCC.OrgMSPID)
 	}
 
+	logger.Infof("Successfully endorsed commit for chaincode name '%s' on channel '%s' with definition {%s}", input.Name, i.Stub.GetChannelID(), cd)
+
 	return &lb.CommitChaincodeDefinitionResult{}, nil
 }
 


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement

#### Description

Suppressed commit endorsement success message when commit endorsement fails.
Clarified that approve and commit transaction are endorsements rather than actual commits.
Moved chaincode definition to end of messages and placed in brackets for readability.

Also, added a test to ensure that chaincode definition string is suitable for log messages.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
