### PR TITLE
Fail fast if 'jq' is missing

### DIFF
--- a/integration/nwo/deploy.go
+++ b/integration/nwo/deploy.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 
@@ -20,10 +21,10 @@ import (
 	"github.com/hyperledger/fabric/common/util"
 	"github.com/hyperledger/fabric/integration/nwo/commands"
 	"github.com/hyperledger/fabric/protoutil"
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
-
-	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 )
 
@@ -170,6 +171,11 @@ func PackageChaincodeLegacy(n *Network, chaincode Chaincode, peer *Peer) {
 }
 
 func InstallChaincode(n *Network, chaincode Chaincode, peers ...*Peer) {
+	// Ensure 'jq' exists in path, because we need it to build chaincode
+	if _, err := exec.LookPath("jq"); err != nil {
+		ginkgo.Fail("'jq' is needed to build chaincode but it wasn't found in the PATH")
+	}
+
 	if chaincode.PackageID == "" {
 		chaincode.SetPackageIDFromPackageFile()
 	}
@@ -187,6 +193,11 @@ func InstallChaincode(n *Network, chaincode Chaincode, peers ...*Peer) {
 }
 
 func InstallChaincodeLegacy(n *Network, chaincode Chaincode, peers ...*Peer) {
+	// Ensure 'jq' exists in path, because we need it to build chaincode
+	if _, err := exec.LookPath("jq"); err != nil {
+		ginkgo.Fail("'jq' is needed to build chaincode but it wasn't found in the PATH")
+	}
+
 	for _, p := range peers {
 		sess, err := n.PeerAdminSession(p, commands.ChaincodeInstallLegacy{
 			Name:        chaincode.Name,


### PR DESCRIPTION
If 'jq' is missing from the PATH then the chaincode installation fails and it
is not crystal clear why it failed unless you inspect the logs with care.

This change set makes the integration tests fail fast when attempting to install
chaincode and 'jq' doesn't exist in the path.

It prints:

'jq' is needed to build chaincode but it wasn't find in the PATH

and terminates the test.

Change-Id: Ic730ec6b90343c1da06818b16fb291963cbc20ac
Signed-off-by: yacovm <yacovm@il.ibm.com>
