### PR TITLE
[FAB-17428] Deprecate --outputAnchorPeersUpdate flag in configtxgen

### DIFF
--- a/cmd/configtxgen/main.go
+++ b/cmd/configtxgen/main.go
@@ -217,7 +217,7 @@ func main() {
 	flag.StringVar(&configPath, "configPath", "", "The path containing the configuration to use (if set)")
 	flag.StringVar(&inspectBlock, "inspectBlock", "", "Prints the configuration contained in the block at the specified path")
 	flag.StringVar(&inspectChannelCreateTx, "inspectChannelCreateTx", "", "Prints the configuration contained in the transaction at the specified path")
-	flag.StringVar(&outputAnchorPeersUpdate, "outputAnchorPeersUpdate", "", "Creates an config update to update an anchor peer (works only with the default channel creation, and only for the first update)")
+	flag.StringVar(&outputAnchorPeersUpdate, "outputAnchorPeersUpdate", "", "[DEPRECATED] Creates a config update to update an anchor peer (works only with the default channel creation, and only for the first update)")
 	flag.StringVar(&asOrg, "asOrg", "", "Performs the config generation as a particular organization (by name), only including values in the write set that org (likely) has privilege to set")
 	flag.StringVar(&printOrg, "printOrg", "", "Prints the definition of an organization as JSON. (useful for adding an org to a channel manually)")
 

--- a/release_notes/v2.0.0.txt
+++ b/release_notes/v2.0.0.txt
@@ -122,6 +122,12 @@ FAB-16477 and FAB-17116 The orderer config `general.genesismethod` and
 `general.genesisfile` will be replaced by the new `general.bootstrapmethod` and
 `general.bootstrapfile`.
 
+FAB-17428 - The configtxgen flag `--outputAnchorPeersUpdate` is officially deprecated.
+This flag was originally used for creating channel config updates to update an anchor peer
+and only worked for the first update of the default channel creation. The flag will be
+officially removed in FAB-17427 in favor of using the `configtx.yaml` for the default
+channel configuration.
+
 Known Vulnerabilities
 ---------------------
 FAB-8664 - Peer should detect and react when its org has been removed


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
- Documentation update

#### Description

We're deprecating this flag in 2.0 for removal

#### Related issues

[FAB-17428](https://jira.hyperledger.org/browse/FAB-17428)
[FAB-17427](https://jira.hyperledger.org/browse/FAB-17427)