### PR TITLE
[FAB-17443] Implement Bot to Support Doc Maintainers

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+pull_request_rules:
+  - name: Auto-Merge on Approving Label and Changes Limited to docs/ Folder
+    conditions:
+      - files~=^docs/
+      - -files~=^(?!^docs).*
+      - label=doc-merge
+    actions:
+      merge:
+        method: rebase


### PR DESCRIPTION
Adds ability for doc maintainers to merge code once all usual conditions are met (+1 CODEOWNERS and CI success) by adding a `doc-merge` label to the PR. I've tested this in my own repo to confirm when a PR contains changes both in the `/docs` directory and outside it, the PR is not merged.

This repo contains code merged using the rule, and an open PR that validates the above mentioned scenario does not occur: https://github.com/btl5037/fabric-utilities/pulls

Negative lookahead RegEx verification: https://regexr.com/4stjt

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>

- New feature