### PR TITLE
fix wrong escaping in document

### DIFF
--- a/docs/source/pluggable_endorsement_and_validation.rst
+++ b/docs/source/pluggable_endorsement_and_validation.rst
@@ -304,8 +304,8 @@ Important notes
 
 - **Error handling for private metadata retrieval**: In case a plugin retrieves
   metadata for private data by making use of the ``StateFetcher`` interface,
-  it is important that errors are handled as follows: ``CollConfigNotDefinedError''
-  and ``InvalidCollNameError'', signalling that the specified collection does
+  it is important that errors are handled as follows: ``CollConfigNotDefinedError``
+  and ``InvalidCollNameError``, signalling that the specified collection does
   not exist, should be handled as deterministic errors and should not lead the
   plugin to return an ``ExecutionFailureError``.
 


### PR DESCRIPTION
The CollConfigNotDefinedError and InvalidCollNameError have
wrong escaping, which causes the entire line to be formatted
as a command.

Change-Id: Ib7e4d9203da1dc49d745c0d487540ce2dd69c549
Signed-off-by: yacovm <yacovm@il.ibm.com>