### PR TITLE
[FAB-17440] Improve docs on peer lifecycle chaincode with JSON output

### DIFF
--- a/docs/source/commands/configtxgen.md
+++ b/docs/source/commands/configtxgen.md
@@ -25,7 +25,7 @@ Usage of configtxgen:
   -inspectChannelCreateTx string
     	Prints the configuration contained in the transaction at the specified path
   -outputAnchorPeersUpdate string
-    	Creates an config update to update an anchor peer (works only with the default channel creation, and only for the first update)
+    	[DEPRECATED] Creates a config update to update an anchor peer (works only with the default channel creation, and only for the first update)
   -outputBlock string
     	The path to write the genesis block to (if set)
   -outputCreateChannelTx string

--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -375,6 +375,36 @@ Get installed chaincodes on peer:
 Package ID: myccv1:a7ca45a7cc85f1d89c905b775920361ed089a364e12a9b6d55ba75c965ddd6a9, Label: myccv1
 ```
 
+  * You can also use the `--output` flag to have the CLI format the output as
+    JSON.
+
+    ```
+    peer lifecycle chaincode queryinstalled --peerAddresses peer0.org1.example.com:7051 --output json
+    ```
+
+    If successful, the command will return the chaincodes you have installed as JSON.
+
+    ```
+    {
+      "installed_chaincodes": [
+        {
+          "package_id": "mycc_1:aab9981fa5649cfe25369fce7bb5086a69672a631e4f95c4af1b5198fe9f845b",
+          "label": "mycc_1",
+          "references": {
+            "mychannel": {
+              "chaincodes": [
+                {
+                  "name": "mycc",
+                  "version": "1"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+    ```
+
 ### peer lifecycle chaincode getinstalledpackage example
 
 You can retrieve an installed chaincode package from a peer using the
@@ -531,5 +561,79 @@ chaincode.
     Name: mycc, Version: 1, Sequence: 1, Endorsement Plugin: escc, Validation Plugin: vscc
     Name: yourcc, Version: 2, Sequence: 3, Endorsement Plugin: escc, Validation Plugin: vscc
     ```
+
+  * You can also use the `--output` flag to have the CLI format the output as
+    JSON.
+
+    - For querying a specific chaincode definition
+
+      ```
+      export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
+
+      peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --name mycc --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051 --output json
+      ```
+
+      If successful, the command will return a JSON that has committed chaincode definition for chaincode 'mycc' on channel 'mychannel'.
+
+      ```
+      {
+        "sequence": 1,
+        "version": "1",
+        "endorsement_plugin": "escc",
+        "validation_plugin": "vscc",
+        "validation_parameter": "EiAvQ2hhbm5lbC9BcHBsaWNhdGlvbi9FbmRvcnNlbWVudA==",
+        "collections": {},
+        "init_required": true,
+        "approvals": {
+          "Org1MSP": true,
+          "Org2MSP": true
+        }
+      }
+      ```
+
+      The `validation_parameter` is base64 encoded. An example of the command to decode it is as follows.
+
+      ```
+      echo EiAvQ2hhbm5lbC9BcHBsaWNhdGlvbi9FbmRvcnNlbWVudA== | base64 -d
+
+       /Channel/Application/Endorsement
+      ```
+
+    - For querying all chaincode definitions on that channel
+
+      ```
+      export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
+
+      peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051 --output json
+      ```
+
+      If successful, the command will return a JSON that has committed chaincode definitions on channel 'mychannel'.
+
+      ```
+      {
+        "chaincode_definitions": [
+          {
+            "name": "mycc",
+            "sequence": 1,
+            "version": "1",
+            "endorsement_plugin": "escc",
+            "validation_plugin": "vscc",
+            "validation_parameter": "EiAvQ2hhbm5lbC9BcHBsaWNhdGlvbi9FbmRvcnNlbWVudA==",
+            "collections": {},
+            "init_required": true
+          },
+          {
+            "name": "yourcc",
+            "sequence": 3,
+            "version": "2",
+            "endorsement_plugin": "escc",
+            "validation_plugin": "vscc",
+            "validation_parameter": "EiAvQ2hhbm5lbC9BcHBsaWNhdGlvbi9FbmRvcnNlbWVudA==",
+            "collections": {}
+          }
+        ]
+      }
+      ```
+
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/docs/wrappers/peer_lifecycle_chaincode_postscript.md
+++ b/docs/wrappers/peer_lifecycle_chaincode_postscript.md
@@ -52,6 +52,36 @@ Get installed chaincodes on peer:
 Package ID: myccv1:a7ca45a7cc85f1d89c905b775920361ed089a364e12a9b6d55ba75c965ddd6a9, Label: myccv1
 ```
 
+  * You can also use the `--output` flag to have the CLI format the output as
+    JSON.
+
+    ```
+    peer lifecycle chaincode queryinstalled --peerAddresses peer0.org1.example.com:7051 --output json
+    ```
+
+    If successful, the command will return the chaincodes you have installed as JSON.
+
+    ```
+    {
+      "installed_chaincodes": [
+        {
+          "package_id": "mycc_1:aab9981fa5649cfe25369fce7bb5086a69672a631e4f95c4af1b5198fe9f845b",
+          "label": "mycc_1",
+          "references": {
+            "mychannel": {
+              "chaincodes": [
+                {
+                  "name": "mycc",
+                  "version": "1"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+    ```
+
 ### peer lifecycle chaincode getinstalledpackage example
 
 You can retrieve an installed chaincode package from a peer using the
@@ -208,5 +238,79 @@ chaincode.
     Name: mycc, Version: 1, Sequence: 1, Endorsement Plugin: escc, Validation Plugin: vscc
     Name: yourcc, Version: 2, Sequence: 3, Endorsement Plugin: escc, Validation Plugin: vscc
     ```
+
+  * You can also use the `--output` flag to have the CLI format the output as
+    JSON.
+
+    - For querying a specific chaincode definition
+
+      ```
+      export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
+
+      peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --name mycc --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051 --output json
+      ```
+
+      If successful, the command will return a JSON that has committed chaincode definition for chaincode 'mycc' on channel 'mychannel'.
+
+      ```
+      {
+        "sequence": 1,
+        "version": "1",
+        "endorsement_plugin": "escc",
+        "validation_plugin": "vscc",
+        "validation_parameter": "EiAvQ2hhbm5lbC9BcHBsaWNhdGlvbi9FbmRvcnNlbWVudA==",
+        "collections": {},
+        "init_required": true,
+        "approvals": {
+          "Org1MSP": true,
+          "Org2MSP": true
+        }
+      }
+      ```
+
+      The `validation_parameter` is base64 encoded. An example of the command to decode it is as follows.
+
+      ```
+      echo EiAvQ2hhbm5lbC9BcHBsaWNhdGlvbi9FbmRvcnNlbWVudA== | base64 -d
+
+       /Channel/Application/Endorsement
+      ```
+
+    - For querying all chaincode definitions on that channel
+
+      ```
+      export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
+
+      peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051 --output json
+      ```
+
+      If successful, the command will return a JSON that has committed chaincode definitions on channel 'mychannel'.
+
+      ```
+      {
+        "chaincode_definitions": [
+          {
+            "name": "mycc",
+            "sequence": 1,
+            "version": "1",
+            "endorsement_plugin": "escc",
+            "validation_plugin": "vscc",
+            "validation_parameter": "EiAvQ2hhbm5lbC9BcHBsaWNhdGlvbi9FbmRvcnNlbWVudA==",
+            "collections": {},
+            "init_required": true
+          },
+          {
+            "name": "yourcc",
+            "sequence": 3,
+            "version": "2",
+            "endorsement_plugin": "escc",
+            "validation_plugin": "vscc",
+            "validation_parameter": "EiAvQ2hhbm5lbC9BcHBsaWNhdGlvbi9FbmRvcnNlbWVudA==",
+            "collections": {}
+          }
+        ]
+      }
+      ```
+
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
This patch adds example usages with JSON output option to the commands
reference for peer lifecycle chaincode queryinstalled and querycommitted.

This patch also updates the syntax of configtxgen in the commands reference
that were not synchronized with the implementation.

Signed-off-by: Tatsuya Sato <Tatsuya.Sato@hal.hitachi.com>

#### Type of change

- Documentation update

#### Description

Some of the `peer lifecycle chaincode` subcommands support output format as JSON with `–output` option. 
Fabric admins need to use this JSON output to see the detailed information on chaincode definition
because default output shows only partial information.

On the other hand, the current command reference for `peer lifecycle chaincode` describe example usages withthe JSON output only for the `checkcommitreadiness` subcommand.

To let more Fabric admins know about the useful option, the reference should explicitly describe example usages of the output options for the remaining `queryinstalled` and ` querycommitted ` as well.

#### Related issues

https://jira.hyperledger.org/browse/FAB-17440


