### PR TITLE
[FAB-17441] approveformyorg should allow update of only package ID

### DIFF
--- a/core/chaincode/lifecycle/lifecycle.go
+++ b/core/chaincode/lifecycle/lifecycle.go
@@ -424,7 +424,23 @@ func (ef *ExternalFunctions) ApproveChaincodeDefinitionForOrg(chname, ccname str
 			}
 
 			if err := uncommittedParameters.Equal(cd.Parameters()); err == nil {
-				return errors.Errorf("attempted to redefine uncommitted sequence (%d) for namespace %s with unchanged content", requestedSequence, ccname)
+				// also check package ID updates
+				uncommittedPackageID := ""
+				metadata, ok, err := ef.Resources.Serializer.DeserializeMetadata(ChaincodeSourcesName, privateName, orgState)
+				if err != nil {
+					return errors.WithMessagef(err, "could not deserialize chaincode-source metadata for %s", privateName)
+				}
+				if ok {
+					ccLocalPackage := &ChaincodeLocalPackage{}
+					if err := ef.Resources.Serializer.Deserialize(ChaincodeSourcesName, privateName, metadata, ccLocalPackage, orgState); err != nil {
+						return errors.WithMessagef(err, "could not deserialize chaincode package for %s", privateName)
+					}
+					uncommittedPackageID = ccLocalPackage.PackageID
+				}
+
+				if uncommittedPackageID == packageID {
+					return errors.Errorf("attempted to redefine uncommitted sequence (%d) for namespace %s with unchanged content", requestedSequence, ccname)
+				}
 			}
 		}
 	}

--- a/core/chaincode/lifecycle/lifecycle_test.go
+++ b/core/chaincode/lifecycle/lifecycle_test.go
@@ -769,6 +769,35 @@ var _ = Describe("ExternalFunctions", func() {
 					Expect(err).To(MatchError("attempted to redefine uncommitted sequence (5) for namespace cc-name with unchanged content"))
 				})
 			})
+
+			Context("when uncommitted definition has update of only package ID", func() {
+				It("succeeds", func() {
+					err := ef.ApproveChaincodeDefinitionForOrg("my-channel", "cc-name", testDefinition, "hash2", fakePublicState, fakeOrgState)
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+
+			Context("when deserializing chaincode-source metadata fails", func() {
+				BeforeEach(func() {
+					fakeOrgKVStore["chaincode-sources/metadata/cc-name#5"] = []byte("garbage")
+				})
+
+				It("wraps and returns the error", func() {
+					err := ef.ApproveChaincodeDefinitionForOrg("my-channel", "cc-name", testDefinition, "hash", fakePublicState, fakeOrgState)
+					Expect(err).To(MatchError("could not deserialize chaincode-source metadata for cc-name#5: could not unmarshal metadata for namespace chaincode-sources/cc-name#5: proto: can't skip unknown wire type 7"))
+				})
+			})
+
+			Context("when deserializing chaincode package fails", func() {
+				BeforeEach(func() {
+					fakeOrgKVStore["chaincode-sources/fields/cc-name#5/PackageID"] = []byte("garbage")
+				})
+
+				It("wraps and returns the error", func() {
+					err := ef.ApproveChaincodeDefinitionForOrg("my-channel", "cc-name", testDefinition, "hash", fakePublicState, fakeOrgState)
+					Expect(err).To(MatchError("could not deserialize chaincode package for cc-name#5: could not unmarshal state for key chaincode-sources/fields/cc-name#5/PackageID: proto: can't skip unknown wire type 7"))
+				})
+			})
 		})
 
 		Context("when the definition is for an expired sequence number", func() {


### PR DESCRIPTION
Originally, `ApproveChaincodeDefinitionForOrg` cannot redefine a uncommitted definition when attempting to update only the package ID and occurs 'unchanged content' error.

This patch improves the validation logic for uncommitted definition to allow update of only package ID.

Signed-off-by: Tatsuya Sato <Tatsuya.Sato@hal.hitachi.com>

#### Type of change

- Bug fix

#### Description

Currently, `ApproveChaincodeDefinitionForOrg` cannot redefine a uncommitted definition when attempting to update only the package ID and occurs the error as bellow.
```bash
# Define a uncommitted definition
$ peer lifecycle chaincode approveformyorg -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls true --cafile /home/ubuntu/workspace/src/github.com/hyperledger/fabric-samples/test-network/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem --channelID mychannel --name fabcar --version 1 --init-required --package-id fabcar_1:a6b61184ef66929c1b6e6ad657c248e9ba6283080eb59250a93e1706eeffe981 --sequence 2

2020-01-24 01:00:18.095 UTC [chaincodeCmd] ClientWait -> INFO 001 txid [b5d63afa55bf13070b60e77c3a3ca95323d6dbd5a53205fedaffdc8f13e15f34] committed with status (VALID) at 

# Attempt to update only the package ID
$ peer lifecycle chaincode approveformyorg -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls true --cafile /home/ubuntu/workspace/src/github.com/hyperledger/fabric-samples/test-network/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem --channelID mychannel --name fabcar --version 1 --init-required --package-id test --sequence 2

Error: proposal failed with status: 500 - failed to invoke backing implementation of 'ApproveChaincodeDefinitionForMyOrg': attempted to redefine uncommitted sequence (2) for namespace fabcar with unchanged content
```

The above is caused by the following validation logic in `ApproveChaincodeDefinitionForOrg` function in `core/chaincode/lifecycle/lifecycle.go`:
```golang
if err := uncommittedParameters.Equal(cd.Parameters()); err == nil {
    return errors.Errorf("attempted to redefine uncommitted sequence (%d) for namespace %s with unchanged content", requestedSequence, ccname)
 }
```
A check for package ID updates should be added in the above validation logic.

#### Related issues

https://jira.hyperledger.org/browse/FAB-17441
