### PR TITLE
[FAB-17442] Fix comments on private collection layout in lifecycle.go

### DIFF
--- a/core/chaincode/lifecycle/lifecycle.go
+++ b/core/chaincode/lifecycle/lifecycle.go
@@ -33,7 +33,7 @@ const (
 
 	// ChaincodeSourcesName is the namespace reserved for storing the information about where
 	// to find the chaincode (such as as a package on the local filesystem, or in the future,
-	// at some network resource).  This namespace is only populated in the org implicit collection.
+	// at some network resource). This namespace is only populated in the org implicit collection.
 	ChaincodeSourcesName = "chaincode-sources"
 
 	// ChaincodeDefinitionType is the name of the type used to store defined chaincodes
@@ -87,10 +87,10 @@ var (
 // namespaces/fields/mycc#2/ValidationInfo:      {ValidationPlugin: "builtin", ValidationParameter: <application-policy>}
 // namespaces/fields/mycc#2/Collections          {<collection info>}
 //
-// chaincode-source/metadata/mycc#1              "LocalPackage"
-// chaincode-source/fields/mycc#1/Hash           "hash1"
+// chaincode-sources/metadata/mycc#1              "ChaincodeLocalPackage"
+// chaincode-sources/fields/mycc#1/PackageID      "hash1"
 
-// ChaincodeLocalPackage is a type of chaincode-source which may be serialized
+// ChaincodeLocalPackage is a type of chaincode-sources which may be serialized
 // into the org's private data collection.
 // WARNING: This structure is serialized/deserialized from the DB, re-ordering
 // or adding fields will cause opaque checks to fail.
@@ -251,7 +251,7 @@ func (r *Resources) ChaincodeDefinitionIfDefined(chaincodeName string, state Rea
 // ExternalFunctions is intended primarily to support the SCC functions.
 // In general, its methods signatures produce writes (which must be commmitted
 // as part of an endorsement flow), or return human readable errors (for
-// instance indicating a chaincode is not found) rather than sentinals.
+// instance indicating a chaincode is not found) rather than sentinels.
 // Instead, use the utility functions attached to the lifecycle Resources
 // when needed.
 type ExternalFunctions struct {
@@ -435,7 +435,7 @@ func (ef *ExternalFunctions) ApproveChaincodeDefinitionForOrg(chname, ccname str
 
 	// set the package id - whether empty or not. Setting
 	// an empty package ID means that the chaincode won't
-	// be invokable. The package might be set empty after
+	// be invocable. The package might be set empty after
 	// the definition commits as a way of instructing the
 	// peers of an org no longer to endorse invocations
 	// for this chaincode
@@ -542,7 +542,7 @@ func (ef *ExternalFunctions) InstallChaincode(chaincodeInstallPackage []byte) (*
 	}, nil
 }
 
-// GetInstalledChaincodePakcage retreives the installed chaincode with the given package ID
+// GetInstalledChaincodePackage retrieves the installed chaincode with the given package ID
 // from the peer's chaincode store.
 func (ef *ExternalFunctions) GetInstalledChaincodePackage(packageID string) ([]byte, error) {
 	pkgBytes, err := ef.Resources.ChaincodeStore.Load(packageID)


### PR DESCRIPTION
This patch fixes comments on private implicit collection layout in `core/chaincode/lifecycle/lifecycle.go` according to the current implementation.

This patch also fixes some minor typos in comments in `lifecycle.go`.

Signed-off-by: Tatsuya Sato <Tatsuya.Sato@hal.hitachi.com>

#### Type of change

- Bug fix

#### Description

In `core/chaincode/lifecycle/ lifecycle.go`, private/org scope implcit collection layout is described as comments.

The information about chaincode source is different from the implementation.
This incorrect information may confuse Fabric platform developers.

So, according to the current implementation, it should be modified.

#### Related issues

https://jira.hyperledger.org/browse/FAB-17442
