### PR TITLE
[FAB-17431] Use two digit version for chaincode images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,9 @@ BUILD_DIR ?= build
 EXTRA_VERSION ?= $(shell git rev-parse --short HEAD)
 PROJECT_VERSION=$(BASE_VERSION)-snapshot-$(EXTRA_VERSION)
 
+#TWO_DIGIT_VERSION is derived, e.g. "2.0", especially useful as a local tag for two digit references to most recent baseos and ccenv patch releases
+TWO_DIGIT_VERSION = $(shell echo $(BASE_VERSION) | cut -d'.' -f1,2)
+
 PKGNAME = github.com/hyperledger/fabric
 ARCH=$(shell go env GOARCH)
 MARCH=$(shell go env GOOS)-$(shell go env GOARCH)
@@ -226,6 +229,7 @@ $(BUILD_DIR)/images/%/$(DUMMY):
 		$(BUILD_ARGS) \
 		-t $(DOCKER_NS)/fabric-$* ./$(BUILD_CONTEXT)
 	docker tag $(DOCKER_NS)/fabric-$* $(DOCKER_NS)/fabric-$*:$(BASE_VERSION)
+	docker tag $(DOCKER_NS)/fabric-$* $(DOCKER_NS)/fabric-$*:$(TWO_DIGIT_VERSION)
 	docker tag $(DOCKER_NS)/fabric-$* $(DOCKER_NS)/fabric-$*:$(DOCKER_TAG)
 	@touch $@
 

--- a/core/chaincode/chaincodetest.yaml
+++ b/core/chaincode/chaincodetest.yaml
@@ -287,38 +287,38 @@ vm:
 chaincode:
 
     # The id is used by the Chaincode stub to register the executing Chaincode
-    # ID with the Peerand is generally supplied through ENV variables
-    # the Path form of ID is provided when deploying the chaincode. The name is
-    # used for all other requests. The name is really a hashcode
-    # returned by the system in response to the deploy transaction. In
-    # development mode where user runs the chaincode, the name can be any string
+    # ID with the Peer and is generally supplied through ENV variables
+    # the `path` form of ID is provided when installing the chaincode.
+    # The `name` is used for all other requests and can be any string.
     id:
         path:
         name:
 
     # Generic builder environment, suitable for most chaincode types
-    builder: $(DOCKER_NS)/fabric-ccenv:$(PROJECT_VERSION)
+    builder: $(DOCKER_NS)/fabric-ccenv:$(TWO_DIGIT_VERSION)
+
+    # Enables/disables force pulling of the base docker images (listed below)
+    # during user chaincode instantiation.
+    # Useful when using moving image tags (such as :latest)
+    pull: false
 
     golang:
         # golang will never need more than baseos
-        runtime: $(DOCKER_NS)/fabric-baseos:$(PROJECT_VERSION)
-        dynamicLink: true
+        runtime: $(DOCKER_NS)/fabric-baseos:$(TWO_DIGIT_VERSION)
 
-    car:
-        # car may need more facilities (JVM, etc) in the future as the catalog
-        # of platforms are expanded.  For now, we can just use baseos
-        runtime: $(DOCKER_NS)/fabric-baseos:$(PROJECT_VERSION)
+        # whether or not golang chaincode should be linked dynamically
+        dynamicLink: false
 
     java:
         # This is an image based on java:openjdk-8 with addition compiler
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime:  $(DOCKER_NS)/fabric-javaenv:latest
+        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
 
     node:
-        # This is an image based on node:${NODE_VER}-alpine
-        runtime: $(DOCKER_NS)/fabric-nodeenv:latest
+        # This is an image based on node:$(NODE_VER)-alpine
+        runtime: $(DOCKER_NS)/fabric-nodeenv:$(TWO_DIGIT_VERSION)
 
     # timeout in millisecs for starting up a container and waiting for Register
     # to come through. 1sec should be plenty for chaincode unit tests

--- a/core/chaincode/platforms/util/utils.go
+++ b/core/chaincode/platforms/util/utils.go
@@ -164,12 +164,23 @@ func DockerBuild(opts DockerBuildOptions, client *docker.Client) error {
 	return nil
 }
 
+// GetDockerImageFromConfig replaces variables in the config
 func GetDockerImageFromConfig(path string) string {
 	r := strings.NewReplacer(
 		"$(ARCH)", runtime.GOARCH,
 		"$(PROJECT_VERSION)", metadata.Version,
+		"$(TWO_DIGIT_VERSION)", twoDigitVersion(metadata.Version),
 		"$(DOCKER_NS)", metadata.DockerNamespace,
 		"$(BASE_DOCKER_NS)", metadata.BaseDockerNamespace)
 
 	return r.Replace(viper.GetString(path))
+}
+
+// twoDigitVersion truncates a 3 digit version (e.g. 2.0.0) to a 2 digit version (e.g. 2.0),
+// If version does not include dots (e.g. latest), just return the passed version
+func twoDigitVersion(version string) string {
+	if strings.LastIndex(version, ".") < 0 {
+		return version
+	}
+	return version[0:strings.LastIndex(version, ".")]
 }

--- a/core/chaincode/platforms/util/utils_test.go
+++ b/core/chaincode/platforms/util/utils_test.go
@@ -66,11 +66,19 @@ func TestDockerPull(t *testing.T) {
 }
 
 func TestUtil_GetDockerImageFromConfig(t *testing.T) {
-	expected := "FROM " + metadata.DockerNamespace + ":" + runtime.GOARCH + "-" + metadata.Version
+
 	path := "dt"
+
+	expected := "FROM " + metadata.DockerNamespace + ":" + runtime.GOARCH + "-" + metadata.Version
 	viper.Set(path, "FROM $(DOCKER_NS):$(ARCH)-$(PROJECT_VERSION)")
 	actual := GetDockerImageFromConfig(path)
 	assert.Equal(t, expected, actual, `Error parsing Dockerfile Template. Expected "%s", got "%s"`, expected, actual)
+
+	expected = "FROM " + metadata.DockerNamespace + ":" + runtime.GOARCH + "-" + twoDigitVersion(metadata.Version)
+	viper.Set(path, "FROM $(DOCKER_NS):$(ARCH)-$(TWO_DIGIT_VERSION)")
+	actual = GetDockerImageFromConfig(path)
+	assert.Equal(t, expected, actual, `Error parsing Dockerfile Template. Expected "%s", got "%s"`, expected, actual)
+
 }
 
 func TestMain(m *testing.M) {
@@ -84,4 +92,16 @@ func TestMain(m *testing.M) {
 		os.Exit(-1)
 	}
 	os.Exit(m.Run())
+}
+
+func TestTwoDigitVersion(t *testing.T) {
+	version := "2.0.0"
+	expected := "2.0"
+	actual := twoDigitVersion(version)
+	assert.Equal(t, expected, actual, `Error parsing two digit version. Expected "%s", got "%s"`, expected, actual)
+
+	version = "latest"
+	expected = "latest"
+	actual = twoDigitVersion(version)
+	assert.Equal(t, expected, actual, `Error parsing two digit version. Expected "%s", got "%s"`, expected, actual)
 }

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -493,7 +493,7 @@ chaincode:
         name:
 
     # Generic builder environment, suitable for most chaincode types
-    builder: $(DOCKER_NS)/fabric-ccenv:$(PROJECT_VERSION)
+    builder: $(DOCKER_NS)/fabric-ccenv:$(TWO_DIGIT_VERSION)
 
     # Enables/disables force pulling of the base docker images (listed below)
     # during user chaincode instantiation.
@@ -502,7 +502,7 @@ chaincode:
 
     golang:
         # golang will never need more than baseos
-        runtime: $(DOCKER_NS)/fabric-baseos:$(PROJECT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-baseos:$(TWO_DIGIT_VERSION)
 
         # whether or not golang chaincode should be linked dynamically
         dynamicLink: false
@@ -512,11 +512,11 @@ chaincode:
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:latest
+        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
 
     node:
         # This is an image based on node:$(NODE_VER)-alpine
-        runtime: $(DOCKER_NS)/fabric-nodeenv:latest
+        runtime: $(DOCKER_NS)/fabric-nodeenv:$(TWO_DIGIT_VERSION)
 
     # List of directories to treat as external builders and launchers for
     # chaincode. The external builder detection processing will iterate over the

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -32,14 +32,18 @@ printHelp() {
 # be skipped, since this script doesn't terminate upon errors.
 
 dockerPull() {
-    image_tag=$1
+    #three_digit_image_tag is passed in, e.g. "1.4.4"
+    three_digit_image_tag=$1
     shift
+    #two_digit_image_tag is derived, e.g. "1.4", especially useful as a local tag for two digit references to most recent baseos, ccenv, javaenv, nodeenv patch releases
+    two_digit_image_tag=$(echo $three_digit_image_tag | cut -d'.' -f1,2)
     while [[ $# -gt 0 ]]
     do
         image_name="$1"
-        echo "====> hyperledger/fabric-$image_name:$image_tag"
-        docker pull "hyperledger/fabric-$image_name:$image_tag"
-        docker tag "hyperledger/fabric-$image_name:$image_tag" "hyperledger/fabric-$image_name"
+        echo "====> hyperledger/fabric-$image_name:$three_digit_image_tag"
+        docker pull "hyperledger/fabric-$image_name:$three_digit_image_tag"
+        docker tag "hyperledger/fabric-$image_name:$three_digit_image_tag" "hyperledger/fabric-$image_name"
+        docker tag "hyperledger/fabric-$image_name:$three_digit_image_tag" "hyperledger/fabric-$image_name:$two_digit_image_tag"
         shift
     done
 }


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement

#### Description

Since 'latest' tag will be retired, when building chaincode
images, use the two digit version, e.g.:

hyperledger/fabric-baseos:2.0
hyperledger/fabric-ccenv:2.0
hyperledger/fabric-nodeenv:2.0
hyperledger/fabric-javaenv:2.0

This will allow the chaincode image version to be decoupled
from the Fabric version, so that peer can automatically use the latest
third digit version. This will also provide consistency across
the chaincode images, and show users how to set a specific version.

This commit updates core.yaml references, and creates the local
two digit image tags, when building images locally, or pulling from dockerhub.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>