### PR TITLE
[FAB-15578] Fix typos on the endorser metric name

### DIFF
--- a/core/endorser/metrics.go
+++ b/core/endorser/metrics.go
@@ -11,7 +11,7 @@ import "github.com/hyperledger/fabric/common/metrics"
 var (
 	proposalDurationHistogramOpts = metrics.HistogramOpts{
 		Namespace:    "endorser",
-		Name:         "propsal_duration",
+		Name:         "proposal_duration",
 		Help:         "The time to complete a proposal.",
 		LabelNames:   []string{"channel", "chaincode", "success"},
 		StatsdFormat: "%{#fqname}.%{channel}.%{chaincode}.%{success}",

--- a/docs/source/metrics_reference.rst
+++ b/docs/source/metrics_reference.rst
@@ -153,14 +153,14 @@ The following metrics are currently exported for consumption by Prometheus.
 | endorser_proposal_acl_failures                      | counter   | The number of proposals that failed ACL checks.            | channel            |
 |                                                     |           |                                                            | chaincode          |
 +-----------------------------------------------------+-----------+------------------------------------------------------------+--------------------+
+| endorser_proposal_duration                          | histogram | The time to complete a proposal.                           | channel            |
+|                                                     |           |                                                            | chaincode          |
+|                                                     |           |                                                            | success            |
++-----------------------------------------------------+-----------+------------------------------------------------------------+--------------------+
 | endorser_proposal_validation_failures               | counter   | The number of proposals that have failed initial           |                    |
 |                                                     |           | validation.                                                |                    |
 +-----------------------------------------------------+-----------+------------------------------------------------------------+--------------------+
 | endorser_proposals_received                         | counter   | The number of proposals received.                          |                    |
-+-----------------------------------------------------+-----------+------------------------------------------------------------+--------------------+
-| endorser_propsal_duration                           | histogram | The time to complete a proposal.                           | channel            |
-|                                                     |           |                                                            | chaincode          |
-|                                                     |           |                                                            | success            |
 +-----------------------------------------------------+-----------+------------------------------------------------------------+--------------------+
 | endorser_successful_proposals                       | counter   | The number of successful proposals.                        |                    |
 +-----------------------------------------------------+-----------+------------------------------------------------------------+--------------------+
@@ -391,12 +391,12 @@ associated with the metric.
 +-----------------------------------------------------------------------------------------+-----------+------------------------------------------------------------+
 | endorser.proposal_acl_failures.%{channel}.%{chaincode}                                  | counter   | The number of proposals that failed ACL checks.            |
 +-----------------------------------------------------------------------------------------+-----------+------------------------------------------------------------+
+| endorser.proposal_duration.%{channel}.%{chaincode}.%{success}                           | histogram | The time to complete a proposal.                           |
++-----------------------------------------------------------------------------------------+-----------+------------------------------------------------------------+
 | endorser.proposal_validation_failures                                                   | counter   | The number of proposals that have failed initial           |
 |                                                                                         |           | validation.                                                |
 +-----------------------------------------------------------------------------------------+-----------+------------------------------------------------------------+
 | endorser.proposals_received                                                             | counter   | The number of proposals received.                          |
-+-----------------------------------------------------------------------------------------+-----------+------------------------------------------------------------+
-| endorser.propsal_duration.%{channel}.%{chaincode}.%{success}                            | histogram | The time to complete a proposal.                           |
 +-----------------------------------------------------------------------------------------+-----------+------------------------------------------------------------+
 | endorser.successful_proposals                                                           | counter   | The number of successful proposals.                        |
 +-----------------------------------------------------------------------------------------+-----------+------------------------------------------------------------+


### PR DESCRIPTION
This patch fixes typos on the endorser metric name from
"endorser_propsal_duration" to "endorser_proposal_duration"

Signed-off-by: Tatsuya Sato <Tatsuya.Sato@hal.hitachi.com>
Change-Id: I1bcb45baf43d398e1ec91885146c198e539d6f59

#### Type of change
- Bug fix
- Documentation update

#### Description

Fix spelling of endorser metric

#### Related issues
[FAB-17357](https://jira.hyperledger.org/browse/FAB-17357)

#### Release Note
Fix typo in endorser metric name from "endorser_propsal_duration" to "endorser_proposal_duration".

