### PR TITLE
[FAB-17357] Add endorser metric for simulation failure

### DIFF
--- a/core/endorser/metrics.go
+++ b/core/endorser/metrics.go
@@ -66,6 +66,14 @@ var (
 		LabelNames:   []string{"channel", "chaincode"},
 		StatsdFormat: "%{#fqname}.%{channel}.%{chaincode}",
 	}
+
+	simulationFailureCounterOpts = metrics.CounterOpts{
+		Namespace:    "endorser",
+		Name:         "proposal_simulation_failures",
+		Help:         "The number of failed proposal simulations",
+		LabelNames:   []string{"channel", "chaincode"},
+		StatsdFormat: "%{#fqname}.%{channel}.%{chaincode}",
+	}
 )
 
 type Metrics struct {
@@ -77,6 +85,7 @@ type Metrics struct {
 	InitFailed               metrics.Counter
 	EndorsementsFailed       metrics.Counter
 	DuplicateTxsFailure      metrics.Counter
+	SimulationFailure        metrics.Counter
 }
 
 func NewMetrics(p metrics.Provider) *Metrics {
@@ -89,5 +98,6 @@ func NewMetrics(p metrics.Provider) *Metrics {
 		InitFailed:               p.NewCounter(initFailureCounterOpts),
 		EndorsementsFailed:       p.NewCounter(endorsementFailureCounterOpts),
 		DuplicateTxsFailure:      p.NewCounter(duplicateTxsFailureCounterOpts),
+		SimulationFailure:        p.NewCounter(simulationFailureCounterOpts),
 	}
 }

--- a/core/endorser/metrics_test.go
+++ b/core/endorser/metrics_test.go
@@ -30,6 +30,7 @@ func TestNewMetrics(t *testing.T) {
 		InitFailed:               &metricsfakes.Counter{},
 		EndorsementsFailed:       &metricsfakes.Counter{},
 		DuplicateTxsFailure:      &metricsfakes.Counter{},
+		SimulationFailure:        &metricsfakes.Counter{},
 	}))
 
 	gt.Expect(provider.NewHistogramCallCount()).To(Equal(1))
@@ -37,7 +38,7 @@ func TestNewMetrics(t *testing.T) {
 		{proposalDurationHistogramOpts},
 	}))
 
-	gt.Expect(provider.NewCounterCallCount()).To(Equal(7))
+	gt.Expect(provider.NewCounterCallCount()).To(Equal(8))
 	gt.Expect(provider.Invocations()["NewCounter"]).To(ConsistOf([][]interface{}{
 		{receivedProposalsCounterOpts},
 		{successfulProposalsCounterOpts},
@@ -46,5 +47,6 @@ func TestNewMetrics(t *testing.T) {
 		{initFailureCounterOpts},
 		{endorsementFailureCounterOpts},
 		{duplicateTxsFailureCounterOpts},
+		{simulationFailureCounterOpts},
 	}))
 }

--- a/docs/source/metrics_reference.rst
+++ b/docs/source/metrics_reference.rst
@@ -200,6 +200,10 @@ The following metrics are currently exported for consumption by Prometheus.
 |                                                     |           |                                                            +------------------+-------------------------------------------------------------+
 |                                                     |           |                                                            | success          |                                                             |
 +-----------------------------------------------------+-----------+------------------------------------------------------------+------------------+-------------------------------------------------------------+
+| endorser_proposal_simulation_failures               | counter   | The number of failed proposal simulations                  | channel          |                                                             |
+|                                                     |           |                                                            +------------------+-------------------------------------------------------------+
+|                                                     |           |                                                            | chaincode        |                                                             |
++-----------------------------------------------------+-----------+------------------------------------------------------------+------------------+-------------------------------------------------------------+
 | endorser_proposal_validation_failures               | counter   | The number of proposals that have failed initial           |                  |                                                             |
 |                                                     |           | validation.                                                |                  |                                                             |
 +-----------------------------------------------------+-----------+------------------------------------------------------------+------------------+-------------------------------------------------------------+
@@ -452,6 +456,8 @@ associated with the metric.
 | endorser.proposal_acl_failures.%{channel}.%{chaincode}                                  | counter   | The number of proposals that failed ACL checks.            |
 +-----------------------------------------------------------------------------------------+-----------+------------------------------------------------------------+
 | endorser.proposal_duration.%{channel}.%{chaincode}.%{success}                           | histogram | The time to complete a proposal.                           |
++-----------------------------------------------------------------------------------------+-----------+------------------------------------------------------------+
+| endorser.proposal_simulation_failures.%{channel}.%{chaincode}                           | counter   | The number of failed proposal simulations                  |
 +-----------------------------------------------------------------------------------------+-----------+------------------------------------------------------------+
 | endorser.proposal_validation_failures                                                   | counter   | The number of proposals that have failed initial           |
 |                                                                                         |           | validation.                                                |


### PR DESCRIPTION
Signed-off-by: Tiffany Harris <tiffany.harris@ibm.com>

#### Type of change

- Bug fix
- Documentation update

#### Description

- Add new endorser metric, _endorser_simulation_failures_
- Add unit test for endorser_simulation_failures metric

#### Related issues
[FAB-17357](https://jira.hyperledger.org/browse/FAB-17357)