### PR TITLE
Enable service discovery to query _lifecycle endorsers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1087,6 +1087,7 @@
     "github.com/onsi/gomega/gbytes",
     "github.com/onsi/gomega/gexec",
     "github.com/onsi/gomega/gstruct",
+    "github.com/onsi/gomega/matchers",
     "github.com/onsi/gomega/types",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",

--- a/core/chaincode/lifecycle/cache.go
+++ b/core/chaincode/lifecycle/cache.go
@@ -330,6 +330,17 @@ func (c *Cache) StateCommitDone(channelName string) {
 // ChaincodeInfo returns the chaincode definition and its install info.
 // An error is returned only if either the channel or the chaincode do not exist.
 func (c *Cache) ChaincodeInfo(channelID, name string) (*LocalChaincodeInfo, error) {
+	if name == LifecycleNamespace {
+		ac, ok := c.Resources.ChannelConfigSource.GetStableChannelConfig(channelID).ApplicationConfig()
+		if !ok {
+			return nil, errors.Errorf("application config does not exist for channel '%s'", channelID)
+		}
+		if !ac.Capabilities().LifecycleV20() {
+			return nil, errors.Errorf("cannot use _lifecycle without V2_0 application capabilities enabled for channel '%s'", channelID)
+		}
+		return c.getLifecycleSCCChaincodeInfo(channelID)
+	}
+
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 	channelChaincodes, ok := c.definedChaincodes[channelID]
@@ -346,6 +357,24 @@ func (c *Cache) ChaincodeInfo(channelID, name string) (*LocalChaincodeInfo, erro
 		Definition:  cachedChaincode.Definition,
 		InstallInfo: cachedChaincode.InstallInfo,
 		Approved:    cachedChaincode.Approved,
+	}, nil
+}
+
+func (c *Cache) getLifecycleSCCChaincodeInfo(channelID string) (*LocalChaincodeInfo, error) {
+	policyBytes, err := c.Resources.LifecycleEndorsementPolicyAsBytes(channelID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LocalChaincodeInfo{
+		Definition: &ChaincodeDefinition{
+			ValidationInfo: &lb.ChaincodeValidationInfo{
+				ValidationParameter: policyBytes,
+			},
+			Sequence: 1,
+		},
+		Approved:    true,
+		InstallInfo: &ChaincodeInstallInfo{},
 	}, nil
 }
 
@@ -599,6 +628,24 @@ func (c *Cache) retrieveChaincodesMetadataSetWhileLocked(channelID string) (chai
 			},
 		)
 	}
+
+	// get the chaincode info for _lifecycle
+	lc, err := c.getLifecycleSCCChaincodeInfo(channelID)
+	if err != nil {
+		return nil, err
+	}
+
+	// add it to the metadataset so _lifecycle can also be queried
+	// via service discovery
+	metadataSet = append(metadataSet,
+		chaincode.Metadata{
+			Name:      LifecycleNamespace,
+			Version:   strconv.FormatInt(lc.Definition.Sequence, 10),
+			Policy:    lc.Definition.ValidationInfo.ValidationParameter,
+			Approved:  lc.Approved,
+			Installed: lc.InstallInfo != nil,
+		},
+	)
 
 	return metadataSet, nil
 }

--- a/core/chaincode/lifecycle/deployedcc_infoprovider.go
+++ b/core/chaincode/lifecycle/deployedcc_infoprovider.go
@@ -13,7 +13,6 @@ import (
 
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
-	"github.com/hyperledger/fabric-protos-go/msp"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/common/cauthdsl"
 	"github.com/hyperledger/fabric/common/util"
@@ -267,35 +266,6 @@ func (vc *ValidatorCommitter) ImplicitCollectionEndorsementPolicyAsBytes(channel
 	}), nil, nil
 }
 
-func (vc *ValidatorCommitter) LifecycleEndorsementPolicyAsBytes(channelID string) ([]byte, error) {
-	channelConfig := vc.Resources.ChannelConfigSource.GetStableChannelConfig(channelID)
-	if channelConfig == nil {
-		return nil, errors.Errorf("could not get channel config for channel '%s'", channelID)
-	}
-
-	if _, ok := channelConfig.PolicyManager().GetPolicy(LifecycleEndorsementPolicyRef); ok {
-		return LifecycleDefaultEndorsementPolicyBytes, nil
-	}
-
-	// This was a channel which was upgraded or did not define a lifecycle endorsement policy, use a default
-	// of "a majority of orgs must have a member sign".
-	ac, ok := channelConfig.ApplicationConfig()
-	if !ok {
-		return nil, errors.Errorf("could not get application config for channel '%s'", channelID)
-	}
-	orgs := ac.Organizations()
-	mspids := make([]string, 0, len(orgs))
-	for _, org := range orgs {
-		mspids = append(mspids, org.MSPID())
-	}
-
-	return protoutil.MarshalOrPanic(&cb.ApplicationPolicy{
-		Type: &cb.ApplicationPolicy_SignaturePolicy{
-			SignaturePolicy: cauthdsl.SignedByNOutOfGivenRole(int32(len(mspids)/2+1), msp.MSPRole_MEMBER, mspids),
-		},
-	}), nil
-}
-
 // ValidationInfo returns the name and arguments of the validation plugin for the supplied
 // chaincode. The function returns two types of errors, unexpected errors and validation
 // errors. The reason for this is that this function is called from the validation code,
@@ -320,7 +290,7 @@ func (vc *ValidatorCommitter) ValidationInfo(channelID, chaincodeName string, qe
 	}
 
 	if chaincodeName == LifecycleNamespace {
-		b, err := vc.LifecycleEndorsementPolicyAsBytes(channelID)
+		b, err := vc.Resources.LifecycleEndorsementPolicyAsBytes(channelID)
 		if err != nil {
 			return "", nil, errors.WithMessage(err, "unexpected failure to create lifecycle endorsement policy"), nil
 		}

--- a/core/chaincode/lifecycle/deployedcc_infoprovider_test.go
+++ b/core/chaincode/lifecycle/deployedcc_infoprovider_test.go
@@ -481,55 +481,6 @@ var _ = Describe("ValidatorCommitter", func() {
 		})
 	})
 
-	Describe("LifecycleEndorsementPolicyAsBytes", func() {
-		It("returns the endorsement policy for the lifecycle chaincode", func() {
-			b, err := vc.LifecycleEndorsementPolicyAsBytes("channel-id")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(b).NotTo(BeNil())
-			policy := &cb.ApplicationPolicy{}
-			err = proto.Unmarshal(b, policy)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(policy.GetChannelConfigPolicyReference()).To(Equal("/Channel/Application/LifecycleEndorsement"))
-		})
-
-		Context("when the endorsement policy reference is not found", func() {
-			BeforeEach(func() {
-				fakePolicyManager.GetPolicyReturns(nil, false)
-			})
-
-			It("returns an error", func() {
-				b, err := vc.LifecycleEndorsementPolicyAsBytes("channel-id")
-				Expect(err).NotTo(HaveOccurred())
-				policy := &cb.ApplicationPolicy{}
-				err = proto.Unmarshal(b, policy)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(policy.GetSignaturePolicy()).NotTo(BeNil())
-			})
-
-			Context("when the application config cannot be retrieved", func() {
-				BeforeEach(func() {
-					fakeChannelConfig.ApplicationConfigReturns(nil, false)
-				})
-
-				It("returns an error", func() {
-					_, err := vc.LifecycleEndorsementPolicyAsBytes("channel-id")
-					Expect(err).To(MatchError("could not get application config for channel 'channel-id'"))
-				})
-			})
-		})
-
-		Context("when the channel config cannot be retrieved", func() {
-			BeforeEach(func() {
-				fakeChannelConfigSource.GetStableChannelConfigReturns(nil)
-			})
-
-			It("returns an error", func() {
-				_, err := vc.LifecycleEndorsementPolicyAsBytes("channel-id")
-				Expect(err).To(MatchError("could not get channel config for channel 'channel-id'"))
-			})
-		})
-	})
-
 	Describe("ValidationInfo", func() {
 		It("returns the validation info as defined in the new lifecycle", func() {
 			vPlugin, vParm, uerr, verr := vc.ValidationInfo("channel-id", "cc-name", fakeQueryExecutor)

--- a/core/chaincode/lifecycle/lifecycle.go
+++ b/core/chaincode/lifecycle/lifecycle.go
@@ -10,8 +10,11 @@ import (
 	"bytes"
 	"fmt"
 
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric-protos-go/msp"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	lb "github.com/hyperledger/fabric-protos-go/peer/lifecycle"
+	"github.com/hyperledger/fabric/common/cauthdsl"
 	"github.com/hyperledger/fabric/common/chaincode"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/core/chaincode/persistence"
@@ -246,6 +249,35 @@ func (r *Resources) ChaincodeDefinitionIfDefined(chaincodeName string, state Rea
 	}
 
 	return true, definedChaincode, nil
+}
+
+func (r *Resources) LifecycleEndorsementPolicyAsBytes(channelID string) ([]byte, error) {
+	channelConfig := r.ChannelConfigSource.GetStableChannelConfig(channelID)
+	if channelConfig == nil {
+		return nil, errors.Errorf("could not get channel config for channel '%s'", channelID)
+	}
+
+	if _, ok := channelConfig.PolicyManager().GetPolicy(LifecycleEndorsementPolicyRef); ok {
+		return LifecycleDefaultEndorsementPolicyBytes, nil
+	}
+
+	// This was a channel which was upgraded or did not define a lifecycle endorsement policy, use a default
+	// of "a majority of orgs must have a member sign".
+	ac, ok := channelConfig.ApplicationConfig()
+	if !ok {
+		return nil, errors.Errorf("could not get application config for channel '%s'", channelID)
+	}
+	orgs := ac.Organizations()
+	mspids := make([]string, 0, len(orgs))
+	for _, org := range orgs {
+		mspids = append(mspids, org.MSPID())
+	}
+
+	return protoutil.MarshalOrPanic(&cb.ApplicationPolicy{
+		Type: &cb.ApplicationPolicy_SignaturePolicy{
+			SignaturePolicy: cauthdsl.SignedByNOutOfGivenRole(int32(len(mspids)/2+1), msp.MSPRole_MEMBER, mspids),
+		},
+	}), nil
 }
 
 // ExternalFunctions is intended primarily to support the SCC functions.


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Enable service discovery to query the necessary endorsers for committing a _lifecycle chaincode definition.

#### Related issues

https://jira.hyperledger.org/browse/FAB-17310
