### PR TITLE
Validate label when packaging _lifecycle chaincode

### DIFF
--- a/core/chaincode/persistence/chaincode_package.go
+++ b/core/chaincode/persistence/chaincode_package.go
@@ -240,11 +240,13 @@ type ChaincodePackageParser struct {
 	MetadataProvider MetadataProvider
 }
 
-// LabelRegexp is the regular expression controlling  the allowed characters
+// LabelRegexp is the regular expression controlling the allowed characters
 // for the package label.
 var LabelRegexp = regexp.MustCompile(`^[[:alnum:]][[:alnum:]_.+-]*$`)
 
-func validateLabel(label string) error {
+// ValidateLabel return an error if the provided label contains any invalid
+// characters, as determined by LabelRegexp.
+func ValidateLabel(label string) error {
 	if !LabelRegexp.MatchString(label) {
 		return errors.Errorf("invalid label '%s'. Label must be non-empty, can only consist of alphanumerics, symbols from '.+-_', and can only begin with alphanumerics", label)
 	}
@@ -307,7 +309,7 @@ func (ccpp ChaincodePackageParser) Parse(source []byte) (*ChaincodePackage, erro
 		return nil, errors.Errorf("did not find any package metadata (missing %s)", MetadataFile)
 	}
 
-	if err := validateLabel(ccPackageMetadata.Label); err != nil {
+	if err := ValidateLabel(ccPackageMetadata.Label); err != nil {
 		return nil, err
 	}
 

--- a/core/chaincode/persistence/label_test.go
+++ b/core/chaincode/persistence/label_test.go
@@ -39,6 +39,7 @@ func TestLabels(t *testing.T) {
 		{label: "a:b", success: false},
 		{label: "a__b", success: true},
 		{label: "a_b", success: true},
+		{label: "a a", success: false},
 		{label: "a_bb", success: true},
 		{label: "aa", success: true},
 		{label: "v1.0.0", success: true},
@@ -46,7 +47,7 @@ func TestLabels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.label, func(t *testing.T) {
-			err := validateLabel(tt.label)
+			err := ValidateLabel(tt.label)
 			if tt.success {
 				assert.NoError(t, err)
 			} else {

--- a/internal/peer/lifecycle/chaincode/package.go
+++ b/internal/peer/lifecycle/chaincode/package.go
@@ -59,6 +59,9 @@ func (p *PackageInput) Validate() error {
 	if p.Label == "" {
 		return errors.New("package label must be specified")
 	}
+	if err := persistence.ValidateLabel(p.Label); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/peer/lifecycle/chaincode/package_test.go
+++ b/internal/peer/lifecycle/chaincode/package_test.go
@@ -124,6 +124,17 @@ var _ = Describe("Package", func() {
 			})
 		})
 
+		Context("when the label is invalid", func() {
+			BeforeEach(func() {
+				input.Label = "label with spaces"
+			})
+
+			It("returns an error", func() {
+				err := packager.Package()
+				Expect(err).To(MatchError("invalid label 'label with spaces'. Label must be non-empty, can only consist of alphanumerics, symbols from '.+-_', and can only begin with alphanumerics"))
+			})
+		})
+
 		Context("when the platform registry fails to normalize the path", func() {
 			BeforeEach(func() {
 				mockPlatformRegistry.NormalizePathReturns("", errors.New("cortado"))


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Since the lifecycle package command is a local action (doesn't go to the peer), we should validate the label when packaging _lifecycle chaincodes from the CLI. 

#### Related issues

https://jira.hyperledger.org/browse/FAB-17126
