### PR TITLE
[FAB-17448] Fix couchDB startup inconsistence in package couchDB

### DIFF
--- a/core/ledger/util/couchdb/couchdb_test.go
+++ b/core/ledger/util/couchdb/couchdb_test.go
@@ -229,7 +229,7 @@ func TestBadCouchDBInstance(t *testing.T) {
 }
 
 func TestDBCreateSaveWithoutRevision(t *testing.T) {
-
+	startCouchDB()
 	database := "testdbcreatesavewithoutrevision"
 	err := cleanup(database)
 	assert.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
@@ -251,7 +251,7 @@ func TestDBCreateSaveWithoutRevision(t *testing.T) {
 }
 
 func TestDBCreateEnsureFullCommit(t *testing.T) {
-
+	startCouchDB()
 	database := "testdbensurefullcommit"
 	err := cleanup(database)
 	assert.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
@@ -276,6 +276,7 @@ func TestDBCreateEnsureFullCommit(t *testing.T) {
 }
 
 func TestIsEmpty(t *testing.T) {
+	startCouchDB()
 	couchInstance, err := CreateCouchInstance(testConfig(), &disabled.Provider{})
 	assert.NoError(t, err)
 
@@ -316,7 +317,7 @@ func TestIsEmpty(t *testing.T) {
 }
 
 func TestDBBadDatabaseName(t *testing.T) {
-
+	startCouchDB()
 	//create a new instance and database object using a valid database name mixed case
 	couchInstance, err := CreateCouchInstance(testConfig(), &disabled.Provider{})
 	assert.NoError(t, err, "Error when trying to create couch instance")
@@ -347,7 +348,7 @@ func TestDBBadDatabaseName(t *testing.T) {
 }
 
 func TestDBBadConnection(t *testing.T) {
-
+	startCouchDB()
 	//create a new instance and database object
 	//Limit the maxRetriesOnStartup to 3 in order to reduce time for the failure
 	config := testConfig()
@@ -358,7 +359,7 @@ func TestDBBadConnection(t *testing.T) {
 }
 
 func TestBadDBCredentials(t *testing.T) {
-
+	startCouchDB()
 	database := "testdbbadcredentials"
 	err := cleanup(database)
 	assert.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
@@ -374,6 +375,7 @@ func TestBadDBCredentials(t *testing.T) {
 }
 
 func TestDBCreateDatabaseAndPersist(t *testing.T) {
+	startCouchDB()
 
 	//Test create and persist with default configured maxRetries
 	testDBCreateDatabaseAndPersist(t, testConfig().MaxRetries)
@@ -604,7 +606,7 @@ func testDBCreateDatabaseAndPersist(t *testing.T, maxRetries int) {
 }
 
 func TestDBRequestTimeout(t *testing.T) {
-
+	startCouchDB()
 	database := "testdbrequesttimeout"
 	err := cleanup(database)
 	assert.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
@@ -631,7 +633,7 @@ func TestDBRequestTimeout(t *testing.T) {
 }
 
 func TestDBTimeoutConflictRetry(t *testing.T) {
-
+	startCouchDB()
 	database := "testdbtimeoutretry"
 	err := cleanup(database)
 	assert.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
@@ -672,7 +674,7 @@ func TestDBTimeoutConflictRetry(t *testing.T) {
 }
 
 func TestDBBadNumberOfRetries(t *testing.T) {
-
+	startCouchDB()
 	database := "testdbbadretries"
 	err := cleanup(database)
 	assert.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
@@ -688,7 +690,7 @@ func TestDBBadNumberOfRetries(t *testing.T) {
 }
 
 func TestDBBadJSON(t *testing.T) {
-
+	startCouchDB()
 	database := "testdbbadjson"
 	err := cleanup(database)
 	assert.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
@@ -717,7 +719,7 @@ func TestDBBadJSON(t *testing.T) {
 }
 
 func TestPrefixScan(t *testing.T) {
-
+	startCouchDB()
 	database := "testprefixscan"
 	err := cleanup(database)
 	assert.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
@@ -775,7 +777,7 @@ func TestPrefixScan(t *testing.T) {
 }
 
 func TestDBSaveAttachment(t *testing.T) {
-
+	startCouchDB()
 	database := "testdbsaveattachment"
 	err := cleanup(database)
 	assert.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
@@ -815,7 +817,7 @@ func TestDBSaveAttachment(t *testing.T) {
 }
 
 func TestDBDeleteDocument(t *testing.T) {
-
+	startCouchDB()
 	database := "testdbdeletedocument"
 	err := cleanup(database)
 	assert.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
@@ -849,7 +851,7 @@ func TestDBDeleteDocument(t *testing.T) {
 }
 
 func TestDBDeleteNonExistingDocument(t *testing.T) {
-
+	startCouchDB()
 	database := "testdbdeletenonexistingdocument"
 	err := cleanup(database)
 	assert.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
@@ -870,7 +872,7 @@ func TestDBDeleteNonExistingDocument(t *testing.T) {
 }
 
 func TestCouchDBVersion(t *testing.T) {
-
+	startCouchDB()
 	err := checkCouchDBVersion("2.0.0")
 	assert.NoError(t, err, "Error should not have been thrown for valid version")
 
@@ -886,7 +888,7 @@ func TestCouchDBVersion(t *testing.T) {
 }
 
 func TestIndexOperations(t *testing.T) {
-
+	startCouchDB()
 	database := "testindexoperations"
 	err := cleanup(database)
 	assert.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
@@ -1058,7 +1060,7 @@ func TestIndexOperations(t *testing.T) {
 }
 
 func TestRichQuery(t *testing.T) {
-
+	startCouchDB()
 	byteJSON01 := []byte(`{"asset_name":"marble01","color":"blue","size":1,"owner":"jerry"}`)
 	byteJSON02 := []byte(`{"asset_name":"marble02","color":"red","size":2,"owner":"tom"}`)
 	byteJSON03 := []byte(`{"asset_name":"marble03","color":"green","size":3,"owner":"jerry"}`)
@@ -1595,7 +1597,7 @@ func addRevisionAndDeleteStatus(revision string, value []byte, deleted bool) []b
 }
 
 func TestDatabaseSecuritySettings(t *testing.T) {
-
+	startCouchDB()
 	database := "testdbsecuritysettings"
 	err := cleanup(database)
 	assert.NoError(t, err, "Error when trying to cleanup  Error: %s", err)
@@ -1649,7 +1651,7 @@ func TestDatabaseSecuritySettings(t *testing.T) {
 }
 
 func TestURLWithSpecialCharacters(t *testing.T) {
-
+	startCouchDB()
 	database := "testdb+with+plus_sign"
 	err := cleanup(database)
 	assert.NoError(t, err, "Error when trying to cleanup  Error: %s", err)

--- a/core/ledger/util/couchdb/couchdbutil.go
+++ b/core/ledger/util/couchdb/couchdbutil.go
@@ -35,7 +35,6 @@ var namespaceNameAllowedLength = 50
 var collectionNameAllowedLength = 50
 
 func CreateCouchInstance(config *Config, metricsProvider metrics.Provider) (*CouchInstance, error) {
-
 	// make sure the address is valid
 	connectURL := &url.URL{
 		Host:   config.Address,

--- a/core/ledger/util/couchdb/couchdbutil_test.go
+++ b/core/ledger/util/couchdb/couchdbutil_test.go
@@ -17,7 +17,7 @@ import (
 
 //Unit test of couch db util functionality
 func TestCreateCouchDBConnectionAndDB(t *testing.T) {
-
+	startCouchDB()
 	database := "testcreatecouchdbconnectionanddb"
 	cleanup(database)
 	defer cleanup(database)
@@ -32,6 +32,7 @@ func TestCreateCouchDBConnectionAndDB(t *testing.T) {
 
 //Unit test of couch db util functionality
 func TestNotCreateCouchGlobalChangesDB(t *testing.T) {
+	startCouchDB()
 	config := testConfig()
 	config.CreateGlobalChangesDB = false
 	database := "_global_changes"
@@ -51,7 +52,7 @@ func TestNotCreateCouchGlobalChangesDB(t *testing.T) {
 
 //Unit test of couch db util functionality
 func TestCreateCouchDBSystemDBs(t *testing.T) {
-
+	startCouchDB()
 	database := "testcreatecouchdbsystemdb"
 	cleanup(database)
 	defer cleanup(database)


### PR DESCRIPTION
Signed-off-by: Chongxin Luo <Chongxin.Luo@ibm.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

<!--- Describe your changes in detail, including motivation. -->
- Fixed couchDB unit tests are not starting couchDB container correctly.
Multiple functions are missing startCouchDB function call.
#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->
[FAB-17448](https://jira.hyperledger.org/browse/FAB-17448)
<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
