### PR TITLE
Cherry-pick #573 to release 2.0 [FAB-17421] Reword links to contract APIs and documentation

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -23,17 +23,15 @@ After you have downloaded the Fabric Samples and Docker images to your local
 machine, you can get started working with Fabric with the
 :doc:`test_network` tutorial.
 
-Hyperledger Fabric smart contract (chaincode) SDKs
+Hyperledger Fabric smart contract (chaincode) APIs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Hyperledger Fabric offers a number of SDKs to support developing smart contracts (chaincode)
-in various programming languages. Smart contract SDKs are available for Go, Node.js, and Java:
+Hyperledger Fabric offers a number of APIs to support developing smart contracts (chaincode)
+in various programming languages. Smart contract APIs are available for Go, Node.js, and Java:
 
-  * Go SDK documentation
-    * `Low-level <https://github.com/hyperledger/fabric-chaincode-go>`__.
-    * `High-level <https://github.com/hyperledger/fabric-contract-api-go>`__.
-  * `Node.js SDK <https://github.com/hyperledger/fabric-chaincode-node>`__ and `Node.js SDK documentation <https://fabric-shim.github.io/>`__.
-  * `Java SDK <https://github.com/hyperledger/fabric-chaincode-java>`__ and `Java SDK documentation <https://hyperledger.github.io/fabric-chaincode-java/>`__.
+  * `Go contract-api <https://github.com/hyperledger/fabric-contract-api-go>`__.
+  * `Node.js contract API <https://github.com/hyperledger/fabric-chaincode-node>`__ and `Node.js contract API documentation <https://fabric-shim.github.io/>`__.
+  * `Java contract API <https://github.com/hyperledger/fabric-chaincode-java>`__ and `Java contract API documentation <https://hyperledger.github.io/fabric-chaincode-java/>`__.
 
 Hyperledger Fabric application SDKs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Hursley has asked that for 2.0 we drive users towards the
high level apis, so we've renamed the links and removed the link
to the Go low-level docs. See Heather's comment in the jira
for rationale.

Signed-off-by: pama-ibm <pama@ibm.com>


#### Type of change

- Documentation update

#### Description

#### Related issues

FAB-17421

