### PR TITLE
Add Core Maintainers to /docs in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 
 # Fabric Maintainers
 *       @hyperledger/fabric-core-maintainers
-/docs/  @hyperledger/fabric-core-doc-maintainers
+/docs/  @hyperledger/fabric-core-doc-maintainers @hyperledger/fabric-core-maintainers


### PR DESCRIPTION
The `/docs/` entry in CODEOWNERS has precedence over `*` give to core maintainers, we need to explicitly add the maintainers group to docs so they retain the ability to approve doc changes

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
