### PR TITLE
[FABCN-378] Update links to chaincode JSDoc

### DIFF
--- a/docs/source/build_network.rst
+++ b/docs/source/build_network.rst
@@ -156,7 +156,7 @@ Next, you can bring the network up with one of the following commands:
 
 The above command will compile Golang chaincode images and spin up the corresponding
 containers. Go is the default chaincode language, however there is also support
-for `Node.js <https://fabric-shim.github.io/>`_ and `Java <https://hyperledger.github.io/fabric-chaincode-java/>`_
+for `Node.js <https://hyperledger.github.io/fabric-chaincode-node/>`_ and `Java <https://hyperledger.github.io/fabric-chaincode-java/>`_
 chaincode. If you'd like to run through this tutorial with node chaincode, pass
 the following command instead:
 
@@ -168,10 +168,10 @@ the following command instead:
   ./byfn.sh up -l javascript
 
 .. note:: For more information on the Node.js shim, please refer to its
-          `documentation <https://fabric-shim.github.io/ChaincodeInterface.html>`_.
+          `documentation <https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeInterface.html>`_.
 
 .. note:: For more information on the Java shim, please refer to its
-          `documentation <https://hyperledger.github.io/fabric-chaincode-java/master/api/org/hyperledger/fabric/shim/Chaincode.html>`_.
+          `documentation <https://hyperledger.github.io/fabric-chaincode-java/release-2.0/api/org/hyperledger/fabric/shim/Chaincode.html>`_.
 
 Тo make the sample run with Java chaincode, you have to specify ``-l java`` as follows:
 

--- a/docs/source/chaincode4ade.rst
+++ b/docs/source/chaincode4ade.rst
@@ -30,8 +30,8 @@ are called in response to received transactions. You can find the reference
 documentation of the Chaincode Shim API for different languages below:
 
   - `Go <https://godoc.org/github.com/hyperledger/fabric-chaincode-go/shim#Chaincode>`__
-  - `node.js <https://fabric-shim.github.io/ChaincodeInterface.html>`__
-  - `Java <https://hyperledger.github.io/fabric-chaincode-java/master/api/org/hyperledger/fabric/shim/Chaincode.html>`_
+  - `node.js <https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeInterface.html>`__
+  - `Java <https://hyperledger.github.io/fabric-chaincode-java/release-2.0/api/org/hyperledger/fabric/shim/Chaincode.html>`_
 
 In each language, the ``Invoke`` method is called by clients to submit transaction
 proposals. This method allows you to use the chaincode to read and write data on
@@ -54,8 +54,8 @@ function by using the `peer chaincode invoke` command and passing the
 The other interface in the chaincode "shim" APIs is the ``ChaincodeStubInterface``:
 
   - `Go <https://godoc.org/github.com/hyperledger/fabric-chaincode-go/shim#ChaincodeStubInterface>`__
-  - `node.js <https://fabric-shim.github.io/ChaincodeStub.html>`__
-  - `Java <https://hyperledger.github.io/fabric-chaincode-java/master/api/org/hyperledger/fabric/shim/ChaincodeStub.html>`_
+  - `node.js <https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html>`__
+  - `Java <https://hyperledger.github.io/fabric-chaincode-java/release-2.0/api/org/hyperledger/fabric/shim/ChaincodeStub.html>`_
 
 which is used to access and modify the ledger, and to make invocations between
 chaincodes.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -205,6 +205,3 @@ linkcheck_anchors = False
 
 # Increase the linkcheck timeout to 5 seconds
 linkcheck_timeout = 5
-
-# Ignore redirects from fabric-shim.github.io
-linkcheck_ignore = [r'https://fabric-shim.github.io/*']

--- a/docs/source/developapps/chaincodenamespace.md
+++ b/docs/source/developapps/chaincodenamespace.md
@@ -261,7 +261,7 @@ Notice how:
   See interaction points **2a**, **2b**, **2c** and **2d**.
 
 Control is passed between chaincode using the `invokeChaincode()`
-[API](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#invokeChaincode__anchor).
+[API](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#invokeChaincode__anchor).
 This API passes control from one chaincode to another chaincode.
 
 Although we have only discussed query transactions in the example, it is

--- a/docs/source/developapps/smartcontract.md
+++ b/docs/source/developapps/smartcontract.md
@@ -88,7 +88,7 @@ and **redeem**. It's these transactions that bring commercial papers into
 existence and move them through their lifecycle. We'll examine these
 [transactions](#transaction-definition) soon, but for now notice for JavaScript, that the
 `CommericalPaperContract` extends the Hyperledger Fabric `Contract`
-[class](https://fabric-shim.github.io/release-1.4/fabric-contract-api.Contract.html).
+[class](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-contract-api.Contract.html).
 
 With Java, the class must be decorated with the `@Contract(...)` annotation. This provides the opportunity
 to supply additional information about the contract, such as license and author. The `@Default()` annotation
@@ -99,7 +99,7 @@ If you are using a TypeScript implementation, there are similar `@Contract(...)`
 
 For more information on the available annotations, consult the available API documentation:
 * [API documentation for Java smart contracts](https://hyperledger.github.io/fabric-chaincode-java/)
-* [API documentation for Node.js smart contracts](https://fabric-shim.github.io/)
+* [API documentation for Node.js smart contracts](https://hyperledger.github.io/fabric-chaincode-node/)
 
 These classes, annotations, and the `Context` class, were brought into scope earlier:
 

--- a/docs/source/developapps/transactioncontext.md
+++ b/docs/source/developapps/transactioncontext.md
@@ -117,9 +117,9 @@ The APIs in the stub fall into the following categories:
   smart contracts to get, put and delete state corresponding to individual
   objects from the world state, using their key:
 
-    * [getState()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getState__anchor)
-    * [putState()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#putState__anchor)
-    * [deleteState()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#deleteState__anchor)
+    * [getState()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getState__anchor)
+    * [putState()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#putState__anchor)
+    * [deleteState()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#deleteState__anchor)
 
   <br> These basic APIs are complemented by query APIs which enable contracts to
   retrieve a set of states, rather than an individual state. See interaction
@@ -128,12 +128,12 @@ The APIs in the stub fall into the following categories:
   [database](../ledger/ledger.html#world-state-database-options).  For large
   queries, the result sets can be paginated to reduce storage requirements:
 
-    * [getStateByRange()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getStateByRange__anchor)
-    * [getStateByRangeWithPagination()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getStateByRangeWithPagination__anchor)
-    * [getStateByPartialCompositeKey()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getStateByPartialCompositeKey__anchor)
-    * [getStateByPartialCompositeKeyWithPagination()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getStateByPartialCompositeKeyWithPagination__anchor)
-    * [getQueryResult()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getQueryResult__anchor)
-    * [getQueryResultWithPagination()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getQueryResultWithPagination__anchor)
+    * [getStateByRange()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getStateByRange__anchor)
+    * [getStateByRangeWithPagination()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getStateByRangeWithPagination__anchor)
+    * [getStateByPartialCompositeKey()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getStateByPartialCompositeKey__anchor)
+    * [getStateByPartialCompositeKeyWithPagination()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getStateByPartialCompositeKeyWithPagination__anchor)
+    * [getQueryResult()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getQueryResult__anchor)
+    * [getQueryResultWithPagination()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getQueryResultWithPagination__anchor)
 
 
 * **Private data APIs**. See interaction point **(3)**. These APIs enable smart
@@ -141,9 +141,9 @@ The APIs in the stub fall into the following categories:
   the APIs for world state interactions, but for private data. There are APIs to
   get, put and delete a private data state by its key:
 
-    * [getPrivateData()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getPrivateData__anchor)
-    * [putPrivateData()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#putPrivateData__anchor)
-    * [deletePrivateData()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#deletePrivateData__anchor)
+    * [getPrivateData()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getPrivateData__anchor)
+    * [putPrivateData()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#putPrivateData__anchor)
+    * [deletePrivateData()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#deletePrivateData__anchor)
 
   <br> This set is complemented by set of APIs to query private data **(4)**.
   These APIs allow smart contracts to retrieve a set of states from a private
@@ -152,9 +152,9 @@ The APIs in the stub fall into the following categories:
   [database](../ledger/ledger.html#world-state-database-options). There are
   currently no pagination APIs for private data collections.
 
-    * [getPrivateDataByRange()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getPrivateDataByRange__anchor)
-    * [getPrivateDataByPartialCompositeKey()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getPrivateDataByPartialCompositeKey__anchor)
-    * [getPrivateDataQueryResult()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getPrivateDataQueryResult__anchor)
+    * [getPrivateDataByRange()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getPrivateDataByRange__anchor)
+    * [getPrivateDataByPartialCompositeKey()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getPrivateDataByPartialCompositeKey__anchor)
+    * [getPrivateDataQueryResult()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getPrivateDataQueryResult__anchor)
 
 
 * **Transaction APIs**. See interaction point **(5)**. These APIs are used by a
@@ -162,25 +162,25 @@ The APIs in the stub fall into the following categories:
   being processed by the smart contract. This includes the transaction
   identifier and the time when the transaction proposal was created.
 
-    * [getTxID()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getTxID__anchor)
+    * [getTxID()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getTxID__anchor)
       returns the identifier of the current transaction proposal **(5)**.
-    * [getTxTimestamp()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getTxTimestamp__anchor)
+    * [getTxTimestamp()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getTxTimestamp__anchor)
       returns the timestamp when the current transaction proposal was created by
       the application **(5)**.
-    * [getCreator()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getCreator__anchor)
+    * [getCreator()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getCreator__anchor)
       returns the raw identity (X.509 or otherwise) of the creator of
       transaction proposal. If this is an X.509 certificate then it is often
       more appropriate to use [`ctx.ClientIdentity`](#clientidentity).
-    * [getSignedProposal()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getSignedProposal__anchor)
+    * [getSignedProposal()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getSignedProposal__anchor)
       returns a signed copy of the current transaction proposal being processed
       by the smart contract.
-    * [getBinding()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getBinding__anchor)
+    * [getBinding()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getBinding__anchor)
       is used to prevent transactions being maliciously or accidentally replayed
       using a nonce. (For practical purposes, a nonce is a random number
       generated by the client application and incorporated in a cryptographic
       hash.) For example, this API could be used by a smart contract at **(1)**
       to detect a replay of the transaction **(5)**.
-    * [getTransient()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getTransient__anchor)
+    * [getTransient()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getTransient__anchor)
       allows a smart contract to access the transient data an application passes
       to a smart contract. See interaction points **(9)** and **(10)**.
       Transient data is private to the application-smart contract interaction.
@@ -200,19 +200,19 @@ The APIs in the stub fall into the following categories:
   stored values, including the transaction identifiers that performed the state
   update, allowing the transactions to be read from the blockchain **(10)**.
 
-    * [createCompositeKey()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#createCompositeKey__anchor)
-    * [splitCompositeKey()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#splitCompositeKey__anchor)
-    * [setStateValidationParameter()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#setStateValidationParameter__anchor)
-    * [getStateValidationParameter()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getStateValidationParameter__anchor)
-    * [getPrivateDataValidationParameter()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getPrivateDataValidationParameter__anchor)
-    * [setPrivateDataValidationParameter()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#setPrivateDataValidationParameter__anchor)
-    * [getHistoryForKey()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getHistoryForKey__anchor)
+    * [createCompositeKey()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#createCompositeKey__anchor)
+    * [splitCompositeKey()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#splitCompositeKey__anchor)
+    * [setStateValidationParameter()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#setStateValidationParameter__anchor)
+    * [getStateValidationParameter()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getStateValidationParameter__anchor)
+    * [getPrivateDataValidationParameter()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getPrivateDataValidationParameter__anchor)
+    * [setPrivateDataValidationParameter()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#setPrivateDataValidationParameter__anchor)
+    * [getHistoryForKey()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getHistoryForKey__anchor)
 
   <br>
 
 * **Event APIs** are used manage event processing in a smart contract.
 
-    * [setEvent()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#setEvent__anchor)
+    * [setEvent()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#setEvent__anchor)
 
       Smart contracts use this API to add user events to a transaction response.
       See interaction point **(5)**. These events are ultimately recorded on the
@@ -226,12 +226,12 @@ The APIs in the stub fall into the following categories:
   the current channel name and passing control to a different chaincode on the
   same peer.
 
-    * [getChannelID()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getChannelID__anchor)
+    * [getChannelID()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getChannelID__anchor)
 
       See interaction point **(13)**.  A smart contract running on any peer can
       use this API to determined on which channel the application invoked the
       smart contract.
-    * [invokeChaincode()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#invokeChaincode__anchor)
+    * [invokeChaincode()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#invokeChaincode__anchor)
 
       See interaction point **(14)**.  Peer3 owned by MagnetoCorp has multiple
       smart contracts installed on it.  These smart contracts are able to call
@@ -243,9 +243,9 @@ The APIs in the stub fall into the following categories:
   detailed manipulation of chaincode input; the smart contract `Contract` class
   does all of this parameter marshalling automatically for developers.
 
-    * [getFunctionAndParameters()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getFunctionAndParameters__anchor)
-    * [getStringArgs()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getStringArgs__anchor)
-    * [getArgs()](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#getArgs__anchor)
+    * [getFunctionAndParameters()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getFunctionAndParameters__anchor)
+    * [getStringArgs()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getStringArgs__anchor)
+    * [getArgs()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getArgs__anchor)
 
 
 ## ClientIdentity
@@ -259,21 +259,21 @@ the proposal in transaction `t6` **(5)**.
 of X.509 utility APIs on top of it to make it easier to use for this common use
 case.
 
-* [getX509Certificate()](https://fabric-shim.github.io/master/fabric-shim.ClientIdentity.html#getX509Certificate__anchor)
+* [getX509Certificate()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ClientIdentity.html#getX509Certificate__anchor)
   returns the full X.509 certificate of the transaction submitter, including all
   its attributes and their values. See interaction point **(6)**.
-* [getAttributeValue()](https://fabric-shim.github.io/master/fabric-shim.ClientIdentity.html#getAttributeValue__anchor)
+* [getAttributeValue()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ClientIdentity.html#getAttributeValue__anchor)
   returns the value of a particular X.509 attribute, for example, the
   organizational unit `OU`, or distinguished name `DN`. See interaction point
   **(6)**.
-* [assertAttributeValue()](https://fabric-shim.github.io/master/fabric-shim.ClientIdentity.html#assertAttributeValue__anchor)
+* [assertAttributeValue()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ClientIdentity.html#assertAttributeValue__anchor)
   returns `TRUE` if the specified attribute of the X.509 attribute has a
   specified value. See interaction point **(6)**.
-* [getID()](https://fabric-shim.github.io/master/fabric-shim.ClientIdentity.html#getID__anchor)
+* [getID()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ClientIdentity.html#getID__anchor)
   returns the unique identity of the transaction submitter, according to their
   distinguished name and the issuing CA's distinguished name. The format is
   `x509::{subject DN}::{issuer DN}`. See interaction point **(6)**.
-* [getMSPID()](https://fabric-shim.github.io/master/fabric-shim.ClientIdentity.html#getMSPID__anchor)
+* [getMSPID()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ClientIdentity.html#getMSPID__anchor)
   returns the channel MSP of the transaction submitter. This allows a smart
   contract to make processing decisions based on the submitter's organizational
   identity. See interaction point **(15)** or **(16)**.

--- a/docs/source/developapps/transactionhandler.md
+++ b/docs/source/developapps/transactionhandler.md
@@ -78,7 +78,7 @@ CommercialPaperContract extends Contract {
 The form of a transaction handler definition is the similar for all handler
 types, but notice how the `afterTransaction(ctx, result)` also receives any
 result returned by the transaction. The [API
-documentation](https://fabric-shim.github.io/release-1.4/fabric-contract-api.Contract.html)
+documentation](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-contract-api.Contract.html)
 shows you the exact form of these handlers.
 
 ## Handler processing

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -30,7 +30,7 @@ Hyperledger Fabric offers a number of APIs to support developing smart contracts
 in various programming languages. Smart contract APIs are available for Go, Node.js, and Java:
 
   * `Go contract-api <https://github.com/hyperledger/fabric-contract-api-go>`__.
-  * `Node.js contract API <https://github.com/hyperledger/fabric-chaincode-node>`__ and `Node.js contract API documentation <https://fabric-shim.github.io/>`__.
+  * `Node.js contract API <https://github.com/hyperledger/fabric-chaincode-node>`__ and `Node.js contract API documentation <https://hyperledger.github.io/fabric-chaincode-node/>`__.
   * `Java contract API <https://github.com/hyperledger/fabric-chaincode-java>`__ and `Java contract API documentation <https://hyperledger.github.io/fabric-chaincode-java/>`__.
 
 Hyperledger Fabric application SDKs

--- a/docs/source/tutorial/commercial_paper.md
+++ b/docs/source/tutorial/commercial_paper.md
@@ -403,7 +403,7 @@ environment. Note the following key program lines:
   This statement brings into scope two key Hyperledger Fabric classes that will
   be used extensively by the smart contract  -- `Contract` and `Context`. You
   can learn more about these classes in the
-  [`fabric-shim` JSDOCS](https://fabric-shim.github.io/).
+  [`fabric-shim` JSDOCS](https://hyperledger.github.io/fabric-chaincode-node/).
 
 
 * `class CommercialPaperContract extends Contract {`
@@ -473,9 +473,9 @@ file system within the target peer's docker container. Once the smart contract
 is installed on the peer and instantiated on a channel,
 `papercontract` can be invoked by applications, and interact with the ledger
 database via the
-[putState()](https://fabric-shim.github.io/release-1.4/fabric-shim.ChaincodeStub.html#putState__anchor)
+[putState()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#putState__anchor)
 and
-[getState()](https://fabric-shim.github.io/release-1.4/fabric-shim.ChaincodeStub.html#getState__anchor)
+[getState()](https://hyperledger.github.io/fabric-chaincode-node/release-2.0/api/fabric-shim.ChaincodeStub.html#getState__anchor)
 Fabric APIs. Examine how these APIs are used by `StateList` class within
 `ledger-api\statelist.js`.
 

--- a/docs/source/write_first_app.rst
+++ b/docs/source/write_first_app.rst
@@ -359,7 +359,7 @@ Below is a representation of how an application would call different
 transactions in a smart contract. Each transaction uses a broad set of APIs such
 as ``getStateByRange`` to interact with the ledger. You can read more about
 these APIs in `detail
-<https://fabric-shim.github.io/master/index.html?redirect=true>`_.
+<https://hyperledger.github.io/fabric-chaincode-node/>`_.
 
 .. image:: images/RunningtheSample.png
 


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Update readTheDocs docs chaincode JSDoc links to match new location

https://hyperledger.github.io/fabric-chaincode-node/

#### Related issues

https://jira.hyperledger.org/browse/FABCN-378
