### PR TITLE
[FABCN-378] Update links to chaincode JSDoc

### DIFF
--- a/docs/source/build_network.rst
+++ b/docs/source/build_network.rst
@@ -156,7 +156,7 @@ Next, you can bring the network up with one of the following commands:
 
 The above command will compile Golang chaincode images and spin up the corresponding
 containers. Go is the default chaincode language, however there is also support
-for `Node.js <https://fabric-shim.github.io/>`_ and `Java <https://hyperledger.github.io/fabric-chaincode-java/>`_
+for `Node.js <https://hyperledger.github.io/fabric-chaincode-node/>`_ and `Java <https://hyperledger.github.io/fabric-chaincode-java/>`_
 chaincode. If you'd like to run through this tutorial with node chaincode, pass
 the following command instead:
 
@@ -168,7 +168,7 @@ the following command instead:
   ./byfn.sh up -l node
 
 .. note:: For more information on the Node.js shim, please refer to its
-          `documentation <https://fabric-shim.github.io/ChaincodeInterface.html>`_.
+          `documentation <https://hyperledger.github.io/fabric-chaincode-node/release-1.4/api/fabric-shim.ChaincodeInterface.html>`_.
 
 .. note:: For more information on the Java shim, please refer to its
           `documentation <https://hyperledger.github.io/fabric-chaincode-java/release-1.4/api/org/hyperledger/fabric/shim/Chaincode.html>`_.

--- a/docs/source/chaincode4ade.rst
+++ b/docs/source/chaincode4ade.rst
@@ -28,7 +28,7 @@ Chaincode API
 Every chaincode program must implement the ``Chaincode`` interface:
 
   - `Go <https://godoc.org/github.com/hyperledger/fabric/core/chaincode/shim#Chaincode>`__
-  - `node.js <https://fabric-shim.github.io/ChaincodeInterface.html>`__
+  - `node.js <https://hyperledger.github.io/fabric-chaincode-node/release-1.4/api/fabric-shim.ChaincodeInterface.html>`__
   - `Java <https://hyperledger.github.io/fabric-chaincode-java/release-1.4/api/org/hyperledger/fabric/shim/Chaincode.html>`_
 
 whose methods are called in response to received transactions.
@@ -41,7 +41,7 @@ application state. The ``Invoke`` method is called in response to receiving an
 The other interface in the chaincode "shim" APIs is the ``ChaincodeStubInterface``:
 
   - `Go <https://godoc.org/github.com/hyperledger/fabric/core/chaincode/shim#ChaincodeStubInterface>`__
-  - `node.js <https://fabric-shim.github.io/ChaincodeStub.html>`__
+  - `node.js <https://hyperledger.github.io/fabric-chaincode-node/release-1.4/api/fabric-shim.ChaincodeStub.html>`__
   - `Java <https://hyperledger.github.io/fabric-chaincode-java/release-1.4/api/org/hyperledger/fabric/shim/ChaincodeStub.html>`_
 
 which is used to access and modify the ledger, and to make invocations between

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -205,6 +205,3 @@ linkcheck_anchors = False
 
 # Increase the linkcheck timeout to 5 seconds
 linkcheck_timeout = 5
-
-# Ignore redirects from fabric-shim.github.io
-linkcheck_ignore = [r'https://fabric-shim.github.io/*']

--- a/docs/source/developapps/chaincodenamespace.md
+++ b/docs/source/developapps/chaincodenamespace.md
@@ -261,7 +261,7 @@ Notice how:
   See interaction points **2a**, **2b**, **2c** and **2d**.
 
 Control is passed between chaincode using the `invokeChaincode()`
-[API](https://fabric-shim.github.io/master/fabric-shim.ChaincodeStub.html#invokeChaincode__anchor).
+[API](https://hyperledger.github.io/fabric-chaincode-node/release-1.4/api/fabric-shim.ChaincodeStub.html#invokeChaincode__anchor).
 This API passes control from one chaincode to another chaincode.
 
 Although we have only discussed query transactions in the example, it is

--- a/docs/source/developapps/smartcontract.md
+++ b/docs/source/developapps/smartcontract.md
@@ -88,7 +88,7 @@ and **redeem**. It's these transactions that bring commercial papers into
 existence and move them through their lifecycle. We'll examine these
 [transactions](#transaction-definition) soon, but for now notice for JavaScript, that the
 `CommericalPaperContract` extends the Hyperledger Fabric `Contract`
-[class](https://fabric-shim.github.io/release-1.4/fabric-contract-api.Contract.html).
+[class](https://hyperledger.github.io/fabric-chaincode-node/release-1.4/api/fabric-contract-api.Contract.html).
 
 With Java, the class must be decorated with the `@Contract(...)` annotation. This provides the opportunity
 to supply additional information about the contract, such as license and author. The `@Default()` annotation
@@ -99,7 +99,7 @@ If you are using a TypeScript implementation, there are similar `@Contract(...)`
 
 For more information on the available annotations, consult the available API documentation:
 * [API documentation for Java smart contracts](https://hyperledger.github.io/fabric-chaincode-java/)
-* [API documentation for Node.js smart contracts](https://fabric-shim.github.io/)
+* [API documentation for Node.js smart contracts](https://hyperledger.github.io/fabric-chaincode-node/)
 
 These classes, annotations, and the `Context` class, were brought into scope earlier:
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -26,7 +26,7 @@ Hyperledger Fabric offers a number of SDKs to support developing smart contracts
 in various programming languages. There are three smart contract SDKs available for Go, Node.js, and Java:
 
   * `Go SDK <https://github.com/hyperledger/fabric/tree/release-1.4/core/chaincode/shim>`__ and `Go SDK documentation <https://godoc.org/gopkg.in/hyperledger/fabric.v1/core/chaincode/shim>`__.
-  * `Node.js SDK <https://github.com/hyperledger/fabric-chaincode-node>`__ and `Node.js SDK documentation <https://fabric-shim.github.io/>`__.
+  * `Node.js SDK <https://github.com/hyperledger/fabric-chaincode-node>`__ and `Node.js SDK documentation <https://hyperledger.github.io/fabric-chaincode-node/>`__.
   * `Java SDK <https://github.com/hyperledger/fabric-chaincode-java>`__ and `Java SDK documentation <https://hyperledger.github.io/fabric-chaincode-java/>`__.
 
 Currently, Node.js and Java support the new smart contract programming model delivered in

--- a/docs/source/tutorial/commercial_paper.md
+++ b/docs/source/tutorial/commercial_paper.md
@@ -401,7 +401,7 @@ environment. Note the following key program lines:
   This statement brings into scope two key Hyperledger Fabric classes that will
   be used extensively by the smart contract  -- `Contract` and `Context`. You
   can learn more about these classes in the
-  [`fabric-shim` JSDOCS](https://fabric-shim.github.io/).
+  [`fabric-shim` JSDOCS](https://hyperledger.github.io/fabric-chaincode-node/).
 
 
 * `class CommercialPaperContract extends Contract {`
@@ -471,9 +471,9 @@ file system within the target peer's docker container. Once the smart contract
 is installed on the peer and instantiated on a channel,
 `papercontract` can be invoked by applications, and interact with the ledger
 database via the
-[putState()](https://fabric-shim.github.io/release-1.3/fabric-shim.ChaincodeStub.html#putState__anchor)
+[putState()](https://hyperledger.github.io/fabric-chaincode-node/release-1.4/api/fabric-shim.ChaincodeStub.html#putState__anchor)
 and
-[getState()](https://fabric-shim.github.io/release-1.3/fabric-shim.ChaincodeStub.html#getState__anchor)
+[getState()](https://hyperledger.github.io/fabric-chaincode-node/release-1.4/api/fabric-shim.ChaincodeStub.html#getState__anchor)
 Fabric APIs. Examine how these APIs are used by `StateList` class within
 `ledger-api\statelist.js`.
 

--- a/docs/source/write_first_app.rst
+++ b/docs/source/write_first_app.rst
@@ -360,7 +360,7 @@ Below is a representation of how an application would call different
 transactions in a smart contract. Each transaction uses a broad set of APIs such
 as ``getStateByRange`` to interact with the ledger. You can read more about
 these APIs in `detail
-<https://fabric-shim.github.io/master/index.html?redirect=true>`_.
+<https://hyperledger.github.io/fabric-chaincode-node/>`_.
 
 .. image:: images/RunningtheSample.png
 


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Update readTheDocs docs chaincode JSDoc links to match new location

https://hyperledger.github.io/fabric-chaincode-node/

#### Related issues

https://jira.hyperledger.org/browse/FABCN-378
