### PR TITLE
FAB-16374: Update MAINTAINERS.md with Jonathan's personal Github ID

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,7 +13,7 @@ Maintainers
 | Gari Singh | mastersingh24 | mastersingh24 | <gari.r.singh@gmail.com>
 | Jason Yellick | jyellick | jyellick | <jyellick@us.ibm.com>
 | Jay Guo | guoger | guoger | <guojiannan1101@gmail.com>
-| Jonathan Levi | hacera | JonathanLevi | <jonathan@hacera.com>
+| Jonathan Levi | hacera-jonathan | JonathanLevi | <jonathan@hacera.com>
 | Kostas Christidis | kchristidis | kostas | <kostas@gmail.com>
 | Manish Sethi | manish-sethi | manish-sethi | <manish.sethi@gmail.com>
 | Matthew Sykes | sykesm | sykesm | <sykesmat@us.ibm.com>


### PR DESCRIPTION
To use my personal Github account and not the organization's

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description

Github ID for Jonathan Levi (HACERA) is now invalid.  Used to use the company's/organization's Github ID,  but it's probably better to use my personal one.

#### Related issues
https://jira.hyperledger.org/browse/FAB-16374

Signed-off-by Jonathan Levi (HACERA) <jonathan@hacera.com>
