### PR TITLE
Fix conditional_packages processing in UT script

### DIFF
--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -35,7 +35,8 @@ conditional_packages=(
 # join array elements by the specified string
 join_by() {
     local IFS="$1"; shift
-    [ "$#" -ne 0 ] && echo "$*"
+    [ "$#" -eq 0 ] && return 0
+    echo "$*"
 }
 
 contains_element() {


### PR DESCRIPTION
An empty conditional_packages list would result in an error in join_by
that resulted in an empty test list.

FAB-17454