### PR TITLE
Add Alpine version to tools Dockerfile

### DIFF
--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -4,7 +4,7 @@
 
 ARG GO_VER
 ARG ALPINE_VER
-FROM golang:${GO_VER}-alpine as golang
+FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
 
 RUN apk add --no-cache \
 	bash \


### PR DESCRIPTION
We pass the Alpine version into the Dockerfile but fail to consume it. Once Alpine 3.11 is release tools will diverge on versions

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
