### PR TITLE
Update bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -165,7 +165,7 @@ else
 fi
 
 BINARY_FILE=hyperledger-fabric-${ARCH}-${VERSION}.tar.gz
-CA_BINARY_FILE=hyperledger-fabric-ca-${ARCH}-${CA_VERSION}.tar.gz
+CA_BINARY_FILE=hyperledger-fabric-ca-${ARCH}.${CA_VERSION}.tar.gz
 
 # then parse opts
 while getopts "h?dsb" opt; do


### PR DESCRIPTION
Wrong CA_BINARY_FILE, ${ARCH} and ${CA_VERSION} must be separated by dot intead of dash if CA version is 1.4.4



#### Type of change

- Bug fix

#### Description

The binary CA file is not downloaded because there is probably a typo in a file name.
To overcome this problem it is necessary to change the separator  between the architecture and version from dash to dot

#### Additional details


#### Related issues

