### PR TITLE
Add Documentation Maintainers to CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,4 @@
 
 # Fabric Maintainers
 *       @hyperledger/fabric-core-maintainers
+/docs/  @hyperledger/fabric-core-doc-maintainers @hyperledger/fabric-core-maintainers


### PR DESCRIPTION
in release-1.4 branch

Signed-off-by: pama-ibm <pama@ibm.com>

Added `/docs/  @hyperledger/fabric-core-doc-maintainers @hyperledger/fabric-core-maintainers` to the CODEOWNERS file so that the mergify bot can run for merging documentation changes to Fabric docs.

#### Type of change

- Improvement (improvement to code, performance, etc)
- Documentation update

#### Description
This was already implemented in the /master and /release-2.0 branches, just porting it back to /release-1.4 since this is currently the LTS release.