### PR TITLE
[FAB-17059]: Change collection membership eligibility checks to only compare mspID

### DIFF
--- a/core/common/privdata/membershipinfo.go
+++ b/core/common/privdata/membershipinfo.go
@@ -16,27 +16,47 @@ var logger = flogging.MustGetLogger("common.privdata")
 
 // MembershipProvider can be used to check whether a peer is eligible to a collection or not
 type MembershipProvider struct {
+	mspID                       string
 	selfSignedData              common.SignedData
 	IdentityDeserializerFactory func(chainID string) msp.IdentityDeserializer
 }
 
 // NewMembershipInfoProvider returns MembershipProvider
-func NewMembershipInfoProvider(selfSignedData common.SignedData, identityDeserializerFunc func(chainID string) msp.IdentityDeserializer) *MembershipProvider {
-	return &MembershipProvider{selfSignedData: selfSignedData, IdentityDeserializerFactory: identityDeserializerFunc}
+func NewMembershipInfoProvider(mspID string, selfSignedData common.SignedData,
+	identityDeserializerFunc func(chainID string) msp.IdentityDeserializer) *MembershipProvider {
+	return &MembershipProvider{mspID: mspID, selfSignedData: selfSignedData, IdentityDeserializerFactory: identityDeserializerFunc}
 }
 
 // AmMemberOf checks whether the current peer is a member of the given collection config.
 // If getPolicy returns an error, it will drop the error and return false - same as a RejectAll policy.
-func (m *MembershipProvider) AmMemberOf(channelName string, collectionPolicyConfig *common.CollectionPolicyConfig) (bool, error) {
+// It is used when a chaincode is upgraded to see if the peer's org has become eligible after	a collection
+// change.
+func (m *MembershipProvider) AmMemberOf(channelName string,
+	collectionPolicyConfig *common.CollectionPolicyConfig) (bool, error) {
 	deserializer := m.IdentityDeserializerFactory(channelName)
+
+	// Do a simple check to see if the mspid matches any principal identities in the SignaturePolicy - FAB-17059
+	if collectionPolicyConfig.GetSignaturePolicy() != nil {
+		memberOrgs := getMemberOrgs(collectionPolicyConfig.GetSignaturePolicy().GetIdentities(), deserializer)
+
+		for _, org := range memberOrgs {
+			if m.mspID == org {
+				return true, nil
+			}
+		}
+	}
+
+	// Fall back to default access policy evaluation otherwise
 	accessPolicy, err := getPolicy(collectionPolicyConfig, deserializer)
 	if err != nil {
 		// drop the error and return false - same as reject all policy
 		logger.Errorf("Reject all due to error getting policy: %s", err)
 		return false, nil
 	}
+
 	if err := accessPolicy.Evaluate([]*common.SignedData{&m.selfSignedData}); err != nil {
 		return false, nil
 	}
+
 	return true, nil
 }

--- a/core/common/privdata/membershipinfo_test.go
+++ b/core/common/privdata/membershipinfo_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestMembershipInfoProvider(t *testing.T) {
+	mspID := "peer0"
 	peerSelfSignedData := common.SignedData{
 		Identity:  []byte("peer0"),
 		Signature: []byte{1, 2, 3},
@@ -27,7 +28,7 @@ func TestMembershipInfoProvider(t *testing.T) {
 	}
 
 	// verify membership provider returns true
-	membershipProvider := NewMembershipInfoProvider(peerSelfSignedData, identityDeserializer)
+	membershipProvider := NewMembershipInfoProvider(mspID, peerSelfSignedData, identityDeserializer)
 	res, err := membershipProvider.AmMemberOf("test1", getAccessPolicy([]string{"peer0", "peer1"}))
 	assert.True(t, res)
 	assert.Nil(t, err)

--- a/core/common/privdata/simplecollection.go
+++ b/core/common/privdata/simplecollection.go
@@ -7,13 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package privdata
 
 import (
-	"fmt"
-
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/common/policies"
 	"github.com/hyperledger/fabric/msp"
 	"github.com/hyperledger/fabric/protos/common"
-	m "github.com/hyperledger/fabric/protos/msp"
 	"github.com/pkg/errors"
 )
 
@@ -89,34 +85,8 @@ func (sc *SimpleCollection) Setup(collectionConfig *common.StaticCollectionConfi
 		return err
 	}
 
-	// get member org MSP IDs from the envelope
-	for _, principal := range accessPolicyEnvelope.Identities {
-		switch principal.PrincipalClassification {
-		case m.MSPPrincipal_ROLE:
-			// Principal contains the msp role
-			mspRole := &m.MSPRole{}
-			err := proto.Unmarshal(principal.Principal, mspRole)
-			if err != nil {
-				return errors.Wrap(err, "Could not unmarshal MSPRole from principal")
-			}
-			sc.memberOrgs = append(sc.memberOrgs, mspRole.MspIdentifier)
-		case m.MSPPrincipal_IDENTITY:
-			principalId, err := deserializer.DeserializeIdentity(principal.Principal)
-			if err != nil {
-				return errors.Wrap(err, "Invalid identity principal, not a certificate")
-			}
-			sc.memberOrgs = append(sc.memberOrgs, principalId.GetMSPIdentifier())
-		case m.MSPPrincipal_ORGANIZATION_UNIT:
-			OU := &m.OrganizationUnit{}
-			err := proto.Unmarshal(principal.Principal, OU)
-			if err != nil {
-				return errors.Wrap(err, "Could not unmarshal OrganizationUnit from principal")
-			}
-			sc.memberOrgs = append(sc.memberOrgs, OU.MspIdentifier)
-		default:
-			return errors.New(fmt.Sprintf("Invalid principal type %d", int32(principal.PrincipalClassification)))
-		}
-	}
+	// get member org MSP IDs from the envelope, identities that fail to deserialize will not be returned
+	sc.memberOrgs = getMemberOrgs(accessPolicyEnvelope.Identities, deserializer)
 
 	return nil
 }

--- a/core/common/privdata/simplecollection_test.go
+++ b/core/common/privdata/simplecollection_test.go
@@ -130,8 +130,8 @@ func TestSetupGoodConfigCollection(t *testing.T) {
 
 	// check members
 	members := sc.MemberOrgs()
-	assert.True(t, members[0] == "signer0")
-	assert.True(t, members[1] == "signer1")
+	assert.Contains(t, members, "signer0")
+	assert.Contains(t, members, "signer1")
 
 	// check required peer count
 	assert.True(t, sc.RequiredPeerCount() == 1)

--- a/core/ledger/kvledger/tests/env.go
+++ b/core/ledger/kvledger/tests/env.go
@@ -166,7 +166,8 @@ func initLedgerMgmt() {
 	identityDeserializerFactory := func(chainID string) msp.IdentityDeserializer {
 		return mgmt.GetManagerForChain(chainID)
 	}
-	membershipInfoProvider := privdata.NewMembershipInfoProvider(createSelfSignedData(), identityDeserializerFactory)
+	mspID := viper.GetString("peer.localMspId")
+	membershipInfoProvider := privdata.NewMembershipInfoProvider(mspID, createSelfSignedData(), identityDeserializerFactory)
 
 	ledgermgmt.InitializeExistingTestEnvWithInitializer(
 		&ledgermgmt.Initializer{

--- a/gossip/privdata/coordinator_test.go
+++ b/gossip/privdata/coordinator_test.go
@@ -635,6 +635,7 @@ var expectedCommittedPrivateData3 = map[uint64]*ledger.TxPvtData{}
 func TestCoordinatorStoreInvalidBlock(t *testing.T) {
 	metrics := metrics.NewGossipMetrics(&disabled.Provider{}).PrivdataMetrics
 
+	mspID := "Org1MSP"
 	peerSelfSignedData := common.SignedData{
 		Identity:  []byte{0, 1, 2},
 		Signature: []byte{3, 4, 5},
@@ -675,7 +676,7 @@ func TestCoordinatorStoreInvalidBlock(t *testing.T) {
 	appCapability := &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(true)
-	coordinator := NewCoordinator(Support{
+	coordinator := NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -690,7 +691,7 @@ func TestCoordinatorStoreInvalidBlock(t *testing.T) {
 	// Scenario II: Validator has an error while validating the block
 	block = bf.create()
 	pvtData = pdFactory.create()
-	coordinator = NewCoordinator(Support{
+	coordinator = NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -705,7 +706,7 @@ func TestCoordinatorStoreInvalidBlock(t *testing.T) {
 	// Scenario III: Block we got contains an inadequate length of Tx filter in the metadata
 	block = bf.withMetadataSize(100).create()
 	pvtData = pdFactory.create()
-	coordinator = NewCoordinator(Support{
+	coordinator = NewCoordinator(mspID, Support{
 		CollectionStore: cs,
 		Committer:       committer,
 		Fetcher:         fetcher,
@@ -747,7 +748,7 @@ func TestCoordinatorStoreInvalidBlock(t *testing.T) {
 	appCapability = &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(false)
-	coordinator = NewCoordinator(Support{
+	coordinator = NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -806,7 +807,7 @@ func TestCoordinatorStoreInvalidBlock(t *testing.T) {
 	appCapability = &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(true)
-	coordinator = NewCoordinator(Support{
+	coordinator = NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -878,7 +879,7 @@ func TestCoordinatorStoreInvalidBlock(t *testing.T) {
 		AddTxnWithEndorsement("tx2", "ns2", hash, "org2", true, "c1").create()
 	pvtData = pdFactory.addRWSet().addNSRWSet("ns1", "c1", "c2").create()
 	committer.On("DoesPvtDataInfoExistInLedger", mock.Anything).Return(false, nil)
-	coordinator = NewCoordinator(Support{
+	coordinator = NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -910,6 +911,7 @@ func TestCoordinatorToFilterOutPvtRWSetsWithWrongHash(t *testing.T) {
 		it has ns1:c1 in transient store, while it has wrong
 		hash, hence it will fetch ns1:c1 from other peers
 	*/
+	mspID := "Org1MSP"
 	peerSelfSignedData := common.SignedData{
 		Identity:  []byte{0, 1, 2},
 		Signature: []byte{3, 4, 5},
@@ -967,7 +969,7 @@ func TestCoordinatorToFilterOutPvtRWSetsWithWrongHash(t *testing.T) {
 	appCapability := &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(true)
-	coordinator := NewCoordinator(Support{
+	coordinator := NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -1013,6 +1015,7 @@ func TestCoordinatorToFilterOutPvtRWSetsWithWrongHash(t *testing.T) {
 }
 
 func TestCoordinatorStoreBlock(t *testing.T) {
+	mspID := "Org1MSP"
 	peerSelfSignedData := common.SignedData{
 		Identity:  []byte{0, 1, 2},
 		Signature: []byte{3, 4, 5},
@@ -1077,7 +1080,7 @@ func TestCoordinatorStoreBlock(t *testing.T) {
 	appCapability := &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(true)
-	coordinator := NewCoordinator(Support{
+	coordinator := NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -1167,7 +1170,7 @@ func TestCoordinatorStoreBlock(t *testing.T) {
 	// we verify that the error propagates properly.
 	mockCs := &mocks.CollectionStore{}
 	mockCs.On("RetrieveCollectionAccessPolicy", mock.Anything).Return(nil, errors.New("test error"))
-	coordinator = NewCoordinator(Support{
+	coordinator = NewCoordinator(mspID, Support{
 		CollectionStore:    mockCs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -1222,7 +1225,7 @@ func TestCoordinatorStoreBlock(t *testing.T) {
 		assert.Equal(t, expectedCommitOpts, commitOpts)
 	}).Return(nil)
 	committer.On("DoesPvtDataInfoExistInLedger", mock.Anything).Return(false, nil)
-	coordinator = NewCoordinator(Support{
+	coordinator = NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -1266,7 +1269,7 @@ func TestCoordinatorStoreBlock(t *testing.T) {
 		assert.Equal(t, expectedCommitOpts, commitOpts)
 	}).Return(nil)
 	committer.On("DoesPvtDataInfoExistInLedger", mock.Anything).Return(false, nil)
-	coordinator = NewCoordinator(Support{
+	coordinator = NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -1284,6 +1287,7 @@ func TestCoordinatorStoreBlock(t *testing.T) {
 }
 
 func TestCoordinatorStoreBlockWhenPvtDataExistInLedger(t *testing.T) {
+	mspID := "Org1MSP"
 	peerSelfSignedData := common.SignedData{
 		Identity:  []byte{0, 1, 2},
 		Signature: []byte{3, 4, 5},
@@ -1328,7 +1332,7 @@ func TestCoordinatorStoreBlockWhenPvtDataExistInLedger(t *testing.T) {
 	appCapability := &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(true)
-	coordinator := NewCoordinator(Support{
+	coordinator := NewCoordinator(mspID, Support{
 		CollectionStore:    nil,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -1344,6 +1348,7 @@ func TestCoordinatorStoreBlockWhenPvtDataExistInLedger(t *testing.T) {
 func TestProceedWithoutPrivateData(t *testing.T) {
 	// Scenario: we are missing private data (c2 in ns3) and it cannot be obtained from any peer.
 	// Block needs to be committed with missing private data.
+	mspID := "Org1MSP"
 	peerSelfSignedData := common.SignedData{
 		Identity:  []byte{0, 1, 2},
 		Signature: []byte{3, 4, 5},
@@ -1424,7 +1429,7 @@ func TestProceedWithoutPrivateData(t *testing.T) {
 	appCapability := &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(true)
-	coordinator := NewCoordinator(Support{
+	coordinator := NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -1441,6 +1446,7 @@ func TestProceedWithoutPrivateData(t *testing.T) {
 func TestProceedWithInEligiblePrivateData(t *testing.T) {
 	// Scenario: we are missing private data (c2 in ns3) and it cannot be obtained from any peer.
 	// Block needs to be committed with missing private data.
+	mspID := "Org1MSP"
 	peerSelfSignedData := common.SignedData{
 		Identity:  []byte{0, 1, 2},
 		Signature: []byte{3, 4, 5},
@@ -1485,7 +1491,7 @@ func TestProceedWithInEligiblePrivateData(t *testing.T) {
 	appCapability := &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(true)
-	coordinator := NewCoordinator(Support{
+	coordinator := NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            nil,
@@ -1500,6 +1506,7 @@ func TestProceedWithInEligiblePrivateData(t *testing.T) {
 
 func TestCoordinatorGetBlocks(t *testing.T) {
 	metrics := metrics.NewGossipMetrics(&disabled.Provider{}).PrivdataMetrics
+	mspID := "Org1MSP"
 	sd := common.SignedData{
 		Identity:  []byte{0, 1, 2},
 		Signature: []byte{3, 4, 5},
@@ -1515,7 +1522,7 @@ func TestCoordinatorGetBlocks(t *testing.T) {
 	appCapability := &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(true)
-	coordinator := NewCoordinator(Support{
+	coordinator := NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -1544,7 +1551,7 @@ func TestCoordinatorGetBlocks(t *testing.T) {
 		PvtData: expectedCommittedPrivateData1,
 	}, nil)
 	committer.On("DoesPvtDataInfoExistInLedger", mock.Anything).Return(false, nil)
-	coordinator = NewCoordinator(Support{
+	coordinator = NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -1570,6 +1577,7 @@ func TestCoordinatorGetBlocks(t *testing.T) {
 func TestPurgeByHeight(t *testing.T) {
 	// Scenario: commit 3000 blocks and ensure that PurgeByHeight is called
 	// at commit of blocks 2000 and 3000 with values of max block to retain of 1000 and 2000
+	mspID := "Org1MSP"
 	peerSelfSignedData := common.SignedData{}
 	cs := createcollectionStore(peerSelfSignedData).thatAcceptsAll()
 
@@ -1601,7 +1609,7 @@ func TestPurgeByHeight(t *testing.T) {
 	appCapability := &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(true)
-	coordinator := NewCoordinator(Support{
+	coordinator := NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -1624,6 +1632,7 @@ func TestPurgeByHeight(t *testing.T) {
 }
 
 func TestCoordinatorStorePvtData(t *testing.T) {
+	mspID := "Org1MSP"
 	metrics := metrics.NewGossipMetrics(&disabled.Provider{}).PrivdataMetrics
 	cs := createcollectionStore(common.SignedData{}).thatAcceptsAll()
 	committer := &mocks.Committer{}
@@ -1637,7 +1646,7 @@ func TestCoordinatorStorePvtData(t *testing.T) {
 	appCapability := &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(true)
-	coordinator := NewCoordinator(Support{
+	coordinator := NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -1679,6 +1688,7 @@ func TestIgnoreReadOnlyColRWSets(t *testing.T) {
 	// transient store or other peers, the test would fail.
 	// Also - we check that at commit time - the coordinator concluded that
 	// no missing private data was found.
+	mspID := "Org1MSP"
 	peerSelfSignedData := common.SignedData{
 		Identity:  []byte{0, 1, 2},
 		Signature: []byte{3, 4, 5},
@@ -1719,7 +1729,7 @@ func TestIgnoreReadOnlyColRWSets(t *testing.T) {
 	appCapability := &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(true)
-	coordinator := NewCoordinator(Support{
+	coordinator := NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            fetcher,
@@ -1735,6 +1745,7 @@ func TestIgnoreReadOnlyColRWSets(t *testing.T) {
 }
 
 func TestCoordinatorMetrics(t *testing.T) {
+	mspID := "Org1MSP"
 	peerSelfSignedData := common.SignedData{
 		Identity:  []byte{0, 1, 2},
 		Signature: []byte{3, 4, 5},
@@ -1768,7 +1779,7 @@ func TestCoordinatorMetrics(t *testing.T) {
 	appCapability := &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(true)
-	coordinator := NewCoordinator(Support{
+	coordinator := NewCoordinator(mspID, Support{
 		CollectionStore:    cs,
 		Committer:          committer,
 		Fetcher:            &fetcherMock{t: t},

--- a/gossip/service/gossip_service.go
+++ b/gossip/service/gossip_service.go
@@ -294,7 +294,9 @@ func (g *gossipServiceImpl) InitializeChannel(chainID string, oac OrdererAddress
 		SkipPullingInvalidTransactions: viper.GetBool("peer.gossip.pvtData.skipPullingInvalidTransactionsDuringCommit"),
 	}
 
-	coordinator := privdata2.NewCoordinator(privdata2.Support{
+	selfSignedData := g.createSelfSignedData()
+	mspID := string(g.secAdv.OrgByPeerIdentity(selfSignedData.Identity))
+	coordinator := privdata2.NewCoordinator(mspID, privdata2.Support{
 		ChainID:            chainID,
 		CollectionStore:    support.Cs,
 		Validator:          support.Validator,
@@ -302,7 +304,7 @@ func (g *gossipServiceImpl) InitializeChannel(chainID string, oac OrdererAddress
 		Committer:          support.Committer,
 		Fetcher:            fetcher,
 		CapabilityProvider: support.CapabilityProvider,
-	}, g.createSelfSignedData(), g.metrics.PrivdataMetrics, coordinatorConfig)
+	}, selfSignedData, g.metrics.PrivdataMetrics, coordinatorConfig)
 
 	reconcilerConfig := privdata2.GetReconcilerConfig()
 	var reconciler privdata2.PvtDataReconciler

--- a/gossip/service/gossip_service_test.go
+++ b/gossip/service/gossip_service_test.go
@@ -723,6 +723,7 @@ func newGossipInstance(port int, id int, gRPCServer *comm.GRPCServer, certs *gos
 		gRPCServer.Start()
 	}()
 
+	secAdv := peergossip.NewSecurityAdvisor(mgmt.NewDeserializersManager())
 	gossipService := &gossipServiceImpl{
 		mcs:             cryptoService,
 		gossipSvc:       gossip,
@@ -732,6 +733,7 @@ func newGossipInstance(port int, id int, gRPCServer *comm.GRPCServer, certs *gos
 		deliveryService: make(map[string]deliverclient.DeliverService),
 		deliveryFactory: &deliveryFactoryImpl{},
 		peerIdentity:    api.PeerIdentityType(conf.InternalEndpoint),
+		secAdv:          secAdv,
 		metrics:         metrics,
 	}
 

--- a/gossip/state/state_test.go
+++ b/gossip/state/state_test.go
@@ -423,11 +423,12 @@ func newPeerNodeWithGossipWithValidatorWithMetrics(id int, committer committer.C
 		SkipPullingInvalidTransactions: false,
 	}
 
+	mspID := "Org1MSP"
 	capabilityProvider := &capabilitymock.CapabilityProvider{}
 	appCapability := &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(true)
-	coord := privdata.NewCoordinator(privdata.Support{
+	coord := privdata.NewCoordinator(mspID, privdata.Support{
 		Validator:          v,
 		TransientStore:     &mockTransientStore{},
 		Committer:          committer,

--- a/integration/pvtdata/testdata/network.yaml
+++ b/integration/pvtdata/testdata/network.yaml
@@ -4,7 +4,7 @@
 ---
 organizations:
 - name: orderer-org
-  msp_id: OrdererOrgMSP
+  msp_id: OrdererMSP
   domain: orderer.example.com
   enable_node_organizational_units: false
   users: 0

--- a/peer/node/start.go
+++ b/peer/node/start.go
@@ -139,6 +139,8 @@ func serve(args []string) error {
 		panic("Unsupported msp type " + msp.ProviderTypeToString(mspType))
 	}
 
+	mspID := viper.GetString("peer.localMspId")
+
 	// Trace RPCs with the golang.org/x/net/trace package. This was moved out of
 	// the deliver service connection factory as it has process wide implications
 	// and was racy with respect to initialization of gRPC clients and servers.
@@ -176,7 +178,7 @@ func serve(args []string) error {
 	logObserver := floggingmetrics.NewObserver(metricsProvider)
 	flogging.Global.SetObserver(logObserver)
 
-	membershipInfoProvider := privdata.NewMembershipInfoProvider(createSelfSignedData(), identityDeserializerFactory)
+	membershipInfoProvider := privdata.NewMembershipInfoProvider(mspID, createSelfSignedData(), identityDeserializerFactory)
 	//initialize resource management exit
 	ledgermgmt.Initialize(
 		&ledgermgmt.Initializer{


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

This attempts to fix a bug where eligibility evaluation was failing when ca certs were rolled

#### Additional details

See [FAB-17059](https://jira.hyperledger.org/browse/FAB-17059)

/cc @ale-linux 