### PR TITLE
Add repolint.json and NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Hyperledger Fabric
+Copyright [2016-2020] contributors to Hyperledger Fabric
+
+This product includes software developed at
+Hyperledger (http://www.hyperledger.org/).

--- a/repolint.json
+++ b/repolint.json
@@ -1,0 +1,87 @@
+{
+  "axioms": {
+    "linguist":"language",
+    "licensee":"license",
+    "packagers":"packager"
+  },
+  "rules": {
+    "all": {
+      "license-file-exists:file-existence": ["error", {"files": ["LICENSE*", "COPYING*"], "nocase": true}],
+      "readme-file-exists:file-existence": ["error", {"files": ["README*"], "nocase": true}],
+
+      "contributing-file-exists:file-existence": ["error", {"files": ["CONTRIB*", ".github/CONTRIB*"]}],
+      "code-of-conduct-file-exists:file-existence": ["error", {"files": [
+        "CODEOFCONDUCT*", "CODE-OF-CONDUCT*", "CODE_OF_CONDUCT*",
+        ".github/CODEOFCONDUCT*", ".github/CODE-OF-CONDUCT*", ".github/CODE_OF_CONDUCT*"
+        ]}],
+      "changelog-file-exists:file-existence": ["error", {"files": ["CHANGELOG*"], "nocase": true}],
+      "security-file-exists:file-existence": ["error", {"files": ["SECURITY.md"]}],
+      "support-file-exists:file-existence": ["warning", {"files": ["{docs/,.github/,}SUPPORT*"], "nocase": true}],
+      "readme-references-license:file-contents": ["error", {"files": ["README*"], "content": "license", "flags": "i"}],
+      "binaries-not-present:file-type-exclusion": ["error", {"type": ["**/*.exe", "**/*.dll", "!node_modules/**"]}],
+      "test-directory-exists:directory-existence": ["error", {"directories": ["**/test*", "**/specs"], "nocase": true}],
+      "integrates-with-ci:file-existence": [
+        "error",
+        {
+          "files": [
+            ".gitlab-ci.yml", 
+            ".travis.yml", 
+            "appveyor.yml", 
+            ".appveyor.yml", 
+            "circle.yml", 
+            ".circleci/config.yml", 
+            "Jenkinsfile", 
+            ".drone.yml",
+            ".github/workflows/*",
+            "ci/azure-pipelines.yml"
+          ]
+        }
+      ],
+      "code-of-conduct-file-contains-email:file-contents": [
+        "warning",
+        {
+          "files": [
+            "CODEOFCONDUCT*", "CODE-OF-CONDUCT*", "CODE_OF_CONDUCT*",
+            ".github/CODEOFCONDUCT*", ".github/CODE-OF-CONDUCT*", ".github/CODE_OF_CONDUCT*"
+          ],
+          "content": ".+@.+\\..+",
+          "flags": "i",
+          "human-readable-content": "email address"
+        }
+      ],
+      "source-license-headers-exist:file-starts-with": ["warning", {"files": ["**/*.js", "!node_modules/**"], "lineCount": 5, "patterns": ["Copyright", "License"], "flags": "i"}],
+      "github-issue-template-exists:file-existence": ["warning", {"files": ["ISSUE_TEMPLATE*", ".github/ISSUE_TEMPLATE*"]}],
+      "github-pull-request-template-exists:file-existence": ["warning", {"files": ["PULL_REQUEST_TEMPLATE*", ".github/PULL_REQUEST_TEMPLATE*"]}]
+    },
+    "language=javascript": {
+      "package-metadata-exists:file-existence": ["error", {"files": ["package.json"]}]
+    },
+    "language=ruby": {
+      "package-metadata-exists:file-existence": ["error", {"files": ["Gemfile"]}]
+    },
+    "language=java": {
+      "package-metadata-exists:file-existence": ["error", {"files": ["pom.xml", "build.xml", "build.gradle"]}]
+    },
+    "license=*": {
+      "license-detectable-by-licensee": ["error"]
+    },
+    "license=Apache-2.0": {
+      "notice-file-exists:apache-notice": ["error"]
+    },
+    "language=python": {
+      "package-metadata-exists:file-existence": ["error", {"files": ["setup.py", "requirements.txt"]}]
+    },
+    "language=objective-c": {
+      "package-metadata-exists:file-existence": ["error", {"files": ["Cartfile", "Podfile", "*.podspec"]}]
+    },
+    "language=swift": {
+      "package-metadata-exists:file-existence": ["error", {"files": ["Package.swift"]}]
+    },
+    "language=erlang": {
+      "package-metadata-exists:file-existence": ["error", {"files": ["rebar.config"]}]
+    },
+    "language=elixir": {
+      "package-metadata-exists:file-existence": ["error", {"files": ["mix.exs"]}]
+    }
+  }
+}


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Add repolint.json to enable use of repolinter tool from TODO group.
The TSC is considering adopting this tool as a means of ensuring
consistency of Hyperledger repositories by requiring that all project
repos adhere to a single policy. Adding the config file to Fabric to demo
its use.

A NOTICE file should be included per ASF policy. Content per ASF 
policy adapted to Hyperledger.

Signed-off-by: Christopher Ferris <chrisfer@us.ibm.com>

#### Additional details

tested by running repolinter locally against my local fork of the
fabric repo. https://github.com/todogroup/repolinter

#### Related issues

