### PR TITLE
Remove 1.x video from 2.0 docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,12 +12,6 @@ A Blockchain Platform for the Enterprise
 Enterprise grade permissioned distributed ledger platform that offers
 modularity and versatility for a broad set of industry use cases.
 
-.. raw:: html
-
-   <br/><br/>
-   <iframe width="560" height="315" src="https://www.youtube.com/embed/EKa5Gh9whgU" frameborder="0" allowfullscreen></iframe>
-   <br/><br/>
-
 .. toctree::
    :maxdepth: 1
 


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>

#### Type of change

- Documentation update

#### Description

Remove 1.x vintage video promoting channels from 2.0 landing page.