### PR TITLE
[FAB-17458] check LifecycleV20 capability before getting cc info (#608)

### DIFF
--- a/core/chaincode/lifecycle/endorsment_info.go
+++ b/core/chaincode/lifecycle/endorsment_info.go
@@ -109,6 +109,19 @@ func (cei *ChaincodeEndorsementInfoSource) ChaincodeEndorsementInfo(channelID, c
 		}, nil
 	}
 
+	// return legacy cc endorsement info if V20 is not enabled
+	channelConfig := cei.Resources.ChannelConfigSource.GetStableChannelConfig(channelID)
+	if channelConfig == nil {
+		return nil, errors.Errorf("could not get channel config for channel '%s'", channelID)
+	}
+	ac, ok := channelConfig.ApplicationConfig()
+	if !ok {
+		return nil, errors.Errorf("could not get application config for channel '%s'", channelID)
+	}
+	if !ac.Capabilities().LifecycleV20() {
+		return cei.LegacyImpl.ChaincodeEndorsementInfo(channelID, chaincodeName, qe)
+	}
+
 	chaincodeInfo, ok, err := cei.CachedChaincodeInfo(channelID, chaincodeName, qe)
 	if err != nil {
 		return nil, err

--- a/integration/lifecycle/interop_test.go
+++ b/integration/lifecycle/interop_test.go
@@ -209,9 +209,11 @@ var _ = Describe("Release interoperability", func() {
 			}
 			nwo.DeployChaincode(network, "testchannel", orderer, chaincode)
 
-			By("committing the old transaction, expecting to hit an MVCC conflict")
+			By("committing the old transaction")
+			// FAB-17458: because the endorsed tx doesn't have _lifecycle in read set,
+			// it has no read conflict with the cc upgrade via new lifecycle.
 			err = CommitTx(network, env, endorsers[0], deliveryClient, ordererClient, userSigner, txid)
-			Expect(err).To(MatchError(ContainSubstring("transaction invalidated with status (MVCC_READ_CONFLICT)")))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("deploys a chaincode with the new lifecycle, invokes it and the tx is committed only after the chaincode is upgraded via _lifecycle", func() {


### PR DESCRIPTION
Check LifecycleV20 capability before getting new lifecycle
chaincode info during endorsement and skip new lifecycle cc info
if LifecycleV20 is not enabled.

Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>