### PR TITLE
Limit concurrent requests to endorser/deliver services

### DIFF
--- a/common/semaphore/semaphore.go
+++ b/common/semaphore/semaphore.go
@@ -7,7 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 // Package semaphore provides an implementation of a counting semaphore.
 package semaphore
 
-import "context"
+import (
+	"context"
+)
 
 // Semaphore is a buffered channel based implementation of a counting
 // semaphore.
@@ -32,6 +34,18 @@ func (s Semaphore) Acquire(ctx context.Context) error {
 		return ctx.Err()
 	case s <- struct{}{}:
 		return nil
+	}
+}
+
+// TryAcquire acquires the semaphore without blocking.
+// Returns true if the semaphore is acquired.
+// Otherwise, returns false and leaves the semaphore unchanged.
+func (s Semaphore) TryAcquire() bool {
+	select {
+	case s <- struct{}{}:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/common/semaphore/semaphore_test.go
+++ b/common/semaphore/semaphore_test.go
@@ -19,7 +19,7 @@ func TestNewSemaphorePanic(t *testing.T) {
 	assert.PanicsWithValue(t, "permits must be greater than 0", func() { semaphore.New(0) })
 }
 
-func TestSemaphoreBlocking(t *testing.T) {
+func TestSemaphoreAcquireBlocking(t *testing.T) {
 	gt := NewGomegaWithT(t)
 
 	sema := semaphore.New(5)
@@ -42,7 +42,7 @@ func TestSemaphoreBlocking(t *testing.T) {
 	gt.Eventually(done).Should(BeClosed())
 }
 
-func TestSemaphoreContextError(t *testing.T) {
+func TestSemaphoreAcquireContextError(t *testing.T) {
 	gt := NewGomegaWithT(t)
 
 	sema := semaphore.New(1)
@@ -55,6 +55,17 @@ func TestSemaphoreContextError(t *testing.T) {
 	go func() { errCh <- sema.Acquire(ctx) }()
 
 	gt.Eventually(errCh).Should(Receive(Equal(context.Canceled)))
+}
+
+func TestSemaphoreTryAcquireBufferFull(t *testing.T) {
+	gt := NewGomegaWithT(t)
+
+	sema := semaphore.New(5)
+	for i := 0; i < 5; i++ {
+		gt.Expect(t, true, sema.TryAcquire())
+	}
+
+	gt.Expect(t, false, sema.TryAcquire())
 }
 
 func TestSemaphoreReleaseTooMany(t *testing.T) {

--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -114,6 +114,15 @@ type Config struct {
 	// qscc system chaincode requests.
 	LimitsConcurrencyQSCC int
 
+	// LimitsConcurrencyEndorserService sets the limits for concurrent requests sent to
+	// endorser service that handles chaincode deployment, query and invocation,
+	// including both user chaincodes and system chaincodes.
+	LimitsConcurrencyEndorserService int
+
+	// LimitsConcurrencyDeliverService sets the limits for concurrent event listeners
+	// registered to deliver service for blocks and transaction events.
+	LimitsConcurrencyDeliverService int
+
 	// ----- TLS -----
 	// Require server-side TLS.
 	// TODO: create separate sub-struct for PeerTLS config.
@@ -232,6 +241,8 @@ func (c *Config) load() error {
 	c.PeerTLSEnabled = viper.GetBool("peer.tls.enabled")
 	c.NetworkID = viper.GetString("peer.networkId")
 	c.LimitsConcurrencyQSCC = viper.GetInt("peer.limits.concurrency.qscc")
+	c.LimitsConcurrencyEndorserService = viper.GetInt("peer.limits.concurrency.endorserService")
+	c.LimitsConcurrencyDeliverService = viper.GetInt("peer.limits.concurrency.deliverService")
 	c.DiscoveryEnabled = viper.GetBool("peer.discovery.enabled")
 	c.ProfileEnabled = viper.GetBool("peer.profile.enabled")
 	c.ProfileListenAddress = viper.GetString("peer.profile.listenAddress")

--- a/core/peer/config_test.go
+++ b/core/peer/config_test.go
@@ -246,6 +246,8 @@ func TestGlobalConfig(t *testing.T) {
 	viper.Set("peer.tls.enabled", "false")
 	viper.Set("peer.networkId", "testNetwork")
 	viper.Set("peer.limits.concurrency.qscc", 5000)
+	viper.Set("peer.limits.concurrency.endorserService", 2500)
+	viper.Set("peer.limits.concurrency.deliverService", 2500)
 	viper.Set("peer.discovery.enabled", true)
 	viper.Set("peer.profile.enabled", false)
 	viper.Set("peer.profile.listenAddress", "peer.authentication.timewindow")
@@ -302,6 +304,8 @@ func TestGlobalConfig(t *testing.T) {
 		PeerID:                                "testPeerID",
 		NetworkID:                             "testNetwork",
 		LimitsConcurrencyQSCC:                 5000,
+		LimitsConcurrencyEndorserService:      2500,
+		LimitsConcurrencyDeliverService:       2500,
 		DiscoveryEnabled:                      true,
 		ProfileEnabled:                        false,
 		ProfileListenAddress:                  "peer.authentication.timewindow",

--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -136,7 +136,8 @@ peer:
     orgMembersAllowedAccess: false
   limits:
     concurrency:
-      qscc: 500
+      endorserService: 100
+      deliverService: 1
 
 vm:
   endpoint: unix:///var/run/docker.sock

--- a/internal/peer/node/grpc_limiters.go
+++ b/internal/peer/node/grpc_limiters.go
@@ -1,0 +1,74 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package node
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hyperledger/fabric/common/semaphore"
+	"github.com/hyperledger/fabric/core/peer"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+)
+
+func initGrpcSemaphores(config *peer.Config) map[string]semaphore.Semaphore {
+	semaphores := make(map[string]semaphore.Semaphore)
+	endorserConcurrency := config.LimitsConcurrencyEndorserService
+	deliverConcurrency := config.LimitsConcurrencyDeliverService
+
+	// Currently concurrency limit is applied to endorser service and deliver service.
+	// These services are defined in fabric-protos and fabric-protos-go (generated from fabric-protos).
+	// Below service names must match their definitions.
+	if endorserConcurrency != 0 {
+		logger.Infof("concurrency limit for endorser service is %d", endorserConcurrency)
+		semaphores["/protos.Endorser"] = semaphore.New(endorserConcurrency)
+	}
+	if deliverConcurrency != 0 {
+		logger.Infof("concurrency limit for deliver service is %d", deliverConcurrency)
+		semaphores["/protos.Deliver"] = semaphore.New(deliverConcurrency)
+	}
+
+	return semaphores
+}
+
+func unaryGrpcLimiter(semaphores map[string]semaphore.Semaphore) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		serviceName := getServiceName(info.FullMethod)
+		sema, ok := semaphores[serviceName]
+		if !ok {
+			return handler(ctx, req)
+		}
+		if !sema.TryAcquire() {
+			logger.Errorf("Too many requests for %s, exceeding concurrency limit (%d)", serviceName, cap(sema))
+			return nil, errors.Errorf("too many requests for %s, exceeding concurrency limit (%d)", serviceName, cap(sema))
+		}
+		defer sema.Release()
+		return handler(ctx, req)
+	}
+}
+
+func streamGrpcLimiter(semaphores map[string]semaphore.Semaphore) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		serviceName := getServiceName(info.FullMethod)
+		sema, ok := semaphores[serviceName]
+		if !ok {
+			return handler(srv, ss)
+		}
+		if !sema.TryAcquire() {
+			logger.Errorf("Too many requests for %s, exceeding concurrency limit (%d)", serviceName, cap(sema))
+			return errors.Errorf("too many requests for %s, exceeding concurrency limit (%d)", serviceName, cap(sema))
+		}
+		defer sema.Release()
+		return handler(srv, ss)
+	}
+}
+
+func getServiceName(methodName string) string {
+	index := strings.LastIndex(methodName, "/")
+	return methodName[:index]
+}

--- a/internal/peer/node/grpc_limiters_test.go
+++ b/internal/peer/node/grpc_limiters_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright Hitachi America, Ltd.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/hyperledger/fabric/core/peer"
+)
+
+func TestInitGrpcSemaphores(t *testing.T) {
+	config := peer.Config{
+		LimitsConcurrencyEndorserService: 5,
+		LimitsConcurrencyDeliverService:  5,
+	}
+	semaphores := initGrpcSemaphores(&config)
+	require.Equal(t, 2, len(semaphores))
+}
+
+func TestInitGrpcNoSemaphores(t *testing.T) {
+	config := peer.Config{
+		LimitsConcurrencyEndorserService: 0,
+		LimitsConcurrencyDeliverService:  0,
+	}
+	semaphores := initGrpcSemaphores(&config)
+	require.Equal(t, 0, len(semaphores))
+}
+
+func TestInitGrpcSemaphoresPanic(t *testing.T) {
+	config := peer.Config{
+		LimitsConcurrencyEndorserService: -1,
+	}
+	require.PanicsWithValue(t, "permits must be greater than 0", func() { initGrpcSemaphores(&config) })
+}
+
+func TestUnaryGrpcLimiterExceedLimit(t *testing.T) {
+	limit := 10
+	fullMethod := "/protos.Endorser/ProcessProposal"
+	semaphores := initGrpcSemaphores(&peer.Config{LimitsConcurrencyEndorserService: limit})
+	// acquire all permits so that semaphore buffer is full, expect error when calling interceptor
+	for i := 0; i < limit; i++ {
+		semaphores["/protos.Endorser"].TryAcquire()
+	}
+	interceptor := unaryGrpcLimiter(semaphores)
+	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: fullMethod}, nil)
+	require.EqualError(t, err, fmt.Sprintf("too many requests for %s, exceeding concurrency limit (%d)", getServiceName(fullMethod), limit))
+}
+
+func TestStreamGrpcLimiterExceedLimit(t *testing.T) {
+	limit := 5
+	fullMethods := []string{"/protos.Deliver/Deliver", "/protos.Deliver/DeliverFiltered", "/protos.Deliver/DeliverWithPrivateData"}
+	semaphores := initGrpcSemaphores(&peer.Config{LimitsConcurrencyDeliverService: limit})
+	// acquire all permits so that semaphore buffer is full, expect error when calling interceptor
+	for i := 0; i < limit; i++ {
+		semaphores["/protos.Deliver"].TryAcquire()
+	}
+	interceptor := streamGrpcLimiter(semaphores)
+	for _, method := range fullMethods {
+		err := interceptor(nil, nil, &grpc.StreamServerInfo{FullMethod: method}, nil)
+		require.EqualError(t, err, fmt.Sprintf("too many requests for %s, exceeding concurrency limit (%d)", getServiceName(method), limit))
+	}
+}
+
+func TestGetServiceName(t *testing.T) {
+	require.Equal(t, "/protos.Endorser", getServiceName("/protos.Endorser/ProcessProposal"))
+	require.Equal(t, "/protos.Deliver", getServiceName("/protos.Deliver/Deliver"))
+	require.Equal(t, "/protos.Deliver", getServiceName("/protos.Deliver/DeliverFiltered"))
+	require.Equal(t, "/protos.Deliver", getServiceName("/protos.Deliver/DeliverWithPrivateData"))
+}

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -253,6 +253,12 @@ func serve(args []string) error {
 		grpclogging.StreamServerInterceptor(flogging.MustGetLogger("comm.grpc.server").Zap()),
 	)
 
+	semaphores := initGrpcSemaphores(coreConfig)
+	if len(semaphores) != 0 {
+		serverConfig.UnaryInterceptors = append(serverConfig.UnaryInterceptors, unaryGrpcLimiter(semaphores))
+		serverConfig.StreamInterceptors = append(serverConfig.StreamInterceptors, streamGrpcLimiter(semaphores))
+	}
+
 	cs := comm.NewCredentialSupport()
 	if serverConfig.SecOpts.UseTLS {
 		logger.Info("Starting peer with TLS enabled")

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -422,10 +422,15 @@ peer:
 
     # Limits is used to configure some internal resource limits.
     limits:
-      # Concurrency limits the number of concurrently running system chaincode requests.
-      # This option is only supported for qscc at this time.
-      concurrency:
-        qscc: 5000
+        # Concurrency limits the number of concurrently running requests to a service on each peer.
+        # Currently this option is only applied to endorser service and deliver service.
+        # When the property is missing or the value is 0, the concurrency limit is disabled for the service.
+        concurrency:
+            # endorserService limits concurrent requests to endorser service that handles chaincode deployment, query and invocation,
+            # including both user chaincodes and system chaincodes.
+            endorserService: 2500
+            # deliverService limits concurrent event listeners registered to deliver service for blocks and transaction events.
+            deliverService: 2500
 
 ###############################################################################
 #


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description

Add new config data to set limits for concurrent requests to endorser
and deliver services. Create semaphores using the configurable limits.
Implement grpc interceptors (for unary and stream) to acquire
a semaphore and return an error when the semaphore limit is exceeded.

#### Related issues
https://jira.hyperledger.org/browse/FAB-14761

#### Release Note
TBD
