### PR TITLE
Update Copyright for 2020

### DIFF
--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -18,7 +18,7 @@
       {%- if hasdoc('copyright') %}
         {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
       {%- else %}
-        {% trans copyright=copyright|e %}&copy; Copyright Hyperledger 2019.{% endtrans %}
+        {% trans copyright=copyright|e %}&copy; Copyright Hyperledger 2020.{% endtrans %}
       {%- endif %}
     {%- endif %}
     <br>

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -16,6 +16,7 @@ function filterExcludedAndGeneratedFiles {
         '(^|/)go.mod$'
         '(^|/)go.sum$'
         '(^|/)Gopkg\.lock$'
+        '\.html$'
         '\.json$'
         '\.key$'
         '(^|/)LICENSE$'


### PR DESCRIPTION
Update Hyperledger Copyright on Footer of every doc page

#### Type of change

- Documentation update

#### Description

Changed
Copyright Hyperledger 2019
to
Copyright Hyperledger 2020

#### Additional details

Issue was surfaced in RocketChat

