### PR TITLE
define couchDB connection pool size

### DIFF
--- a/core/ledger/util/couchdb/couchdbutil.go
+++ b/core/ledger/util/couchdb/couchdbutil.go
@@ -8,6 +8,7 @@ package couchdb
 import (
 	"bytes"
 	"encoding/hex"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -48,8 +49,20 @@ func CreateCouchInstance(couchDBConnectURL, id, pw string, maxRetries,
 	// and for efficiency should only be created once and re-used.
 	client := &http.Client{Timeout: couchConf.RequestTimeout}
 
-	transport := &http.Transport{Proxy: http.ProxyFromEnvironment}
-	transport.DisableCompression = false
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          2000,
+		MaxIdleConnsPerHost:   2000,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
 	client.Transport = transport
 
 	//Create the CouchDB instance


### PR DESCRIPTION
#### Type of change

- Bug fix
- Improvement (improvement to code, performance, etc)

#### Description

When the CouchDB is used as the StateDB, we observe too many TCP connections at the `time_wait` state. 

```
$ netstat -n | grep -i 5984 | grep -i time_wait | wc -l
34000
```

As the `/proc/sys/net/ipv4/tcp_fin_timeout` (i.e., keep-alive timeout) is usually set to 60 seconds in the Linux server, we quickly get into the following error when the peer tries to access the CouchDB: 

`connect: cannot assign requested address`

**Reason for the above behavior.** The peer creates a large number of TCP connections to CouchDB because the default reusable connection pool size is 2 per host while the max pool size is 100 (combining all hosts) -- refer to [transport.go](https://github.com/golang/go/blob/master/src/net/http/transport.go ) and [golang http doc](https://golang.org/pkg/net/http/). Thus only 2 TCP connections can be reused by the peer when it accesses CouchDB. When more than two goroutines in the peer try to simultaneously access the CouchDB, it results in new non-reusable connections (i.e., creation of new TCP connection outside the pool). Hence, when the peer runs for around 30 seconds at a high load, it results in too many TCP connections at the `time_wait` state.  

**Fix:** We set `MaxIdleConns` and `MaxIdleConnsPerHost` to 2000. This would create 2000 TCP connections in the pool and it would be reused whenever the peer accesses the CouchDB. As the peer is the only host for the CouchDB, we set the same value for both parameters. 

#### Additional details

We tested it using a load generator by generating 700 tps. Now, there is no TCP connection at the `time_wait` state. This PR is cherry-picked from the master -- https://github.com/hyperledger/fabric/pull/429

#### Related issues

[FAB-17277](https://jira.hyperledger.org/browse/FAB-17277)
