### PR TITLE
Fix fixed-width rendering in metrics doc

### DIFF
--- a/docs/source/metrics_reference.rst
+++ b/docs/source/metrics_reference.rst
@@ -204,10 +204,10 @@ StatsD
 ~~~~~~
 
 The following orderer metrics are emitted for consumption by StatsD. The
-%{variable_name} nomenclature represents segments that vary based on
+``%{variable_name}`` nomenclature represents segments that vary based on
 context.
 
-For example, %{channel} will be replaced with the name of the channel
+For example, ``%{channel}`` will be replaced with the name of the channel
 associated with the metric.
 
 +---------------------------------------------------------------------------+-----------+------------------------------------------------------------+
@@ -569,10 +569,10 @@ StatsD
 ~~~~~~
 
 The following peer metrics are emitted for consumption by StatsD. The
-%{variable_name} nomenclature represents segments that vary based on
+``%{variable_name}`` nomenclature represents segments that vary based on
 context.
 
-For example, %{channel} will be replaced with the name of the channel
+For example, ``%{channel}`` will be replaced with the name of the channel
 associated with the metric.
 
 +-----------------------------------------------------------------------------------------+-----------+------------------------------------------------------------+

--- a/scripts/metrics_doc.sh
+++ b/scripts/metrics_doc.sh
@@ -42,10 +42,10 @@ StatsD
 ~~~~~~
 
 The following orderer metrics are emitted for consumption by StatsD. The
-``%{variable_name}`` nomenclature represents segments that vary based on
+\`\`%{variable_name}\`\` nomenclature represents segments that vary based on
 context.
 
-For example, ``%{channel}`` will be replaced with the name of the channel
+For example, \`\`%{channel}\`\` will be replaced with the name of the channel
 associated with the metric.
 
 ${orderer_statsd}
@@ -64,10 +64,10 @@ StatsD
 ~~~~~~
 
 The following peer metrics are emitted for consumption by StatsD. The
-``%{variable_name}`` nomenclature represents segments that vary based on
+\`\`%{variable_name}\`\` nomenclature represents segments that vary based on
 context.
 
-For example, ``%{channel}`` will be replaced with the name of the channel
+For example, \`\`%{channel}\`\` will be replaced with the name of the channel
 associated with the metric.
 
 ${peer_statsd}


### PR DESCRIPTION
The backticks in the template heredoc were evaluated by the shell and
lost. This change escapes them to prevent evaluation.

FAB-17422