### PR TITLE
Update link to Fabric research paper

### DIFF
--- a/docs/source/whatis.md
+++ b/docs/source/whatis.md
@@ -323,7 +323,7 @@ platforms.
 ## Acknowledgement
 
 The preceding is derived from the peer reviewed
-["Hyperledger Fabric: A Distributed Operating System for Permissioned Blockchains"](https://arxiv.org/abs/1801.10228v2) - Elli Androulaki, Artem
+["Hyperledger Fabric: A Distributed Operating System for Permissioned Blockchains"](https://dl.acm.org/doi/10.1145/3190508.3190538) - Elli Androulaki, Artem
 Barger, Vita Bortnikov, Christian Cachin, Konstantinos Christidis, Angelo De
 Caro, David Enyeart, Christopher Ferris, Gennady Laventman, Yacov Manevich,
 Srinivasan Muralidharan, Chet Murthy, Binh Nguyen, Manish Sethi, Gari Singh,


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Updated link to official Fabric paper location.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>


