### PR TITLE
[FAB-17462] Create signature for config update

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,56 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"crypto/rand"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-protos-go/common"
+)
+
+// SignConfigUpdate signs the given configuration update with a
+// specific signer.
+func SignConfigUpdate(configUpdate *common.ConfigUpdate, signer *Signer) (*common.ConfigSignature, error) {
+	signatureHeader, err := signer.CreateSignatureHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	configSignature := &common.ConfigSignature{
+		SignatureHeader: MarshalOrPanic(signatureHeader),
+	}
+	configUpdateBytes := MarshalOrPanic(configUpdate)
+	configSignature.Signature, err = signer.Sign(rand.Reader, concatenateBytes(configSignature.SignatureHeader, configUpdateBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	return configSignature, nil
+}
+
+// concatenateBytes combines multiple arrays of bytes, for signatures or digests
+// over multiple fields.
+func concatenateBytes(data ...[]byte) []byte {
+	bytes := []byte{}
+	for _, d := range data {
+		for _, b := range d {
+			bytes = append(bytes, b)
+		}
+	}
+	return bytes
+}
+
+// MarshalOrPanic serializes a protobuf message and panics if this
+// operation fails.
+func MarshalOrPanic(pb proto.Message) []byte {
+	data, err := proto.Marshal(pb)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-protos-go/common"
+	. "github.com/onsi/gomega"
+)
+
+func TestSignConfigUpdate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		gt := NewGomegaWithT(t)
+
+		signer, err := NewSigner([]byte(publicKey), []byte(privateKey), "test-msp")
+		gt.Expect(err).NotTo(HaveOccurred())
+		configSignature, err := SignConfigUpdate(&common.ConfigUpdate{}, signer)
+		gt.Expect(err).NotTo(HaveOccurred())
+
+		expectedCreator, err := signer.Serialize()
+		gt.Expect(err).NotTo(HaveOccurred())
+		signatureHeader := &common.SignatureHeader{}
+		err = proto.Unmarshal(configSignature.SignatureHeader, signatureHeader)
+		gt.Expect(err).NotTo(HaveOccurred())
+		gt.Expect(signatureHeader.Creator).To(Equal(expectedCreator))
+	})
+}

--- a/pkg/config/signer.go
+++ b/pkg/config/signer.go
@@ -1,0 +1,225 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric-protos-go/msp"
+)
+
+// Signer holds the information necessary to sign a configuration update.
+// It implements the crypto.Signer interface for ECDSA keys.
+type Signer struct {
+	cert       *x509.Certificate
+	mspID      string
+	privateKey *ecdsa.PrivateKey
+	publicKey  *ecdsa.PublicKey
+}
+
+type ecdsaSignature struct {
+	R, S *big.Int
+}
+
+// NewSigner creates a new signer for configuration updates. The publicCert
+// and privateKey should be pem encoded.
+func NewSigner(publicCert []byte, privateCert []byte, mspID string) (*Signer, error) {
+	if mspID == "" {
+		return nil, errors.New("failed to create new signer, mspID can not be empty")
+	}
+
+	cert, err := getCertFromPem(publicCert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cert from pem: %v", err)
+	}
+
+	publicKey, err := ecdsaPublicKeyImport(cert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ECDSA public key: %v", err)
+	}
+
+	pkBlock, _ := pem.Decode(privateCert)
+	if pkBlock == nil {
+		return nil, errors.New("failed to decode private key from pem")
+	}
+
+	privateKey, err := ecdsaPrivateKeyImport(pkBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ECDSA private key: %v", err)
+	}
+
+	signer := &Signer{
+		cert:       cert,
+		mspID:      mspID,
+		privateKey: privateKey,
+		publicKey:  publicKey,
+	}
+	return signer, nil
+}
+
+// Serialize returns a byte array representation of this identity.
+func (s *Signer) Serialize() ([]byte, error) {
+	pb := &pem.Block{Bytes: s.cert.Raw, Type: "CERTIFICATE"}
+	pemBytes := pem.EncodeToMemory(pb)
+	if pemBytes == nil {
+		return nil, errors.New("failed to encode pem block")
+	}
+
+	// serialize identities by prepending the MSPID and appending
+	// the ASN.1 DER content of the cert
+	sID := &msp.SerializedIdentity{Mspid: s.mspID, IdBytes: pemBytes}
+	idBytes := MarshalOrPanic(sID)
+
+	return idBytes, nil
+}
+
+// Public returns the public key of the signer.
+func (s *Signer) Public() crypto.PublicKey {
+	return s.publicKey
+}
+
+// Cert returns the certificate of the signer.
+func (s *Signer) Cert() *x509.Certificate {
+	return s.cert
+}
+
+// MSPId returns the MSP ID of the signer.
+func (s *Signer) MSPId() string {
+	return s.mspID
+}
+
+// Sign performs ECDSA sign with signer's private key on given digest. It
+// ensures signatures are created with Low S values since Fabric normalizes
+// all signatures to Low S.
+// See https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki#low_s
+// for more detail.
+func (s *Signer) Sign(reader io.Reader, digest []byte) (signature []byte, err error) {
+	if reader == nil {
+		return nil, errors.New("failed to sign, reader can not be nil")
+	}
+
+	rr, ss, err := ecdsa.Sign(reader, s.privateKey, digest)
+	if err != nil {
+		return nil, err
+	}
+
+	// ensure Low S signatures
+	sig := toLowS(
+		s.privateKey.PublicKey,
+		ecdsaSignature{
+			R: rr,
+			S: ss,
+		},
+	)
+
+	return asn1.Marshal(sig)
+}
+
+// CreateSignatureHeader returns a new SignatureHeader. It contains a valid
+// nonce and a creator, which is a serialized representation of the signer.
+func (s *Signer) CreateSignatureHeader() (*common.SignatureHeader, error) {
+	creator, err := s.Serialize()
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := createNonce()
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.SignatureHeader{
+		Creator: creator,
+		Nonce:   nonce,
+	}, nil
+}
+
+// createNonce generates a nonce using the crypto/rand package.
+func createNonce() ([]byte, error) {
+	nonce, err := getRandomNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate random nonce: %s", err)
+	}
+	return nonce, nil
+}
+
+func getRandomNonce() ([]byte, error) {
+	key := make([]byte, 24)
+
+	_, err := rand.Read(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get random bytes: %s", err)
+	}
+	return key, nil
+}
+
+// When using ECDSA, both (r,s) and (r, -s mod n) are valid signatures.
+// In order to protect against signature malleability attacks, Fabric
+// normalizes all signatures to a canonical form where s is at most half
+// the order of the curve. In order to make signatures compliant with what
+// Fabric expects, toLowS creates signatures in this canonical form.
+func toLowS(key ecdsa.PublicKey, sig ecdsaSignature) ecdsaSignature {
+	// calculate half order of the curve
+	halfOrder := new(big.Int).Div(key.Curve.Params().N, big.NewInt(2))
+	// check if s is greater than half order of curve
+	if sig.S.Cmp(halfOrder) == 1 {
+		// Set s to N - s so that s will be less than or equal to half order
+		sig.S.Sub(key.Params().N, sig.S)
+	}
+	return sig
+}
+
+// getCertFromPem decodes a pem encoded cert into an x509 certificate.
+func getCertFromPem(pemBytes []byte) (*x509.Certificate, error) {
+	pemCert, _ := pem.Decode(pemBytes)
+	if pemCert == nil {
+		return nil, fmt.Errorf("failed to decode pem bytes: %v", pemBytes)
+	}
+
+	cert, err := x509.ParseCertificate(pemCert.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse x509 cert: %v", err)
+	}
+
+	return cert, nil
+}
+
+// ecdsaPublicKeyImport imports the public key from an x509 certificate.
+func ecdsaPublicKeyImport(x509Cert *x509.Certificate) (*ecdsa.PublicKey, error) {
+	pk := x509Cert.PublicKey
+
+	lowLevelKey, ok := pk.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, errors.New("certificate does not contain valid ECDSA public key")
+	}
+
+	return lowLevelKey, nil
+}
+
+// ecdsaPrivateKeyImport imports the private key from the private key bytes.
+func ecdsaPrivateKeyImport(pkBytes []byte) (*ecdsa.PrivateKey, error) {
+	lowLevelKey, err := x509.ParsePKCS8PrivateKey(pkBytes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid key type. The DER must contain an ecdsa.PrivateKey: %v", err)
+	}
+
+	ecdsaSK, ok := lowLevelKey.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("failed to cast private key bytes to ECDSA private key")
+	}
+
+	return ecdsaSK, nil
+}

--- a/pkg/config/signer_test.go
+++ b/pkg/config/signer_test.go
@@ -1,0 +1,289 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"log"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-protos-go/msp"
+	. "github.com/onsi/gomega"
+)
+
+var publicKey, privateKey []byte
+
+func TestMain(m *testing.M) {
+	publicKey, privateKey = generatePublicAndPrivateKey()
+
+	os.Exit(m.Run())
+}
+
+func TestNewSigner(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		gt := NewGomegaWithT(t)
+		signer, err := NewSigner([]byte(publicKey), []byte(privateKey), "test-msp")
+		gt.Expect(err).NotTo(HaveOccurred())
+		gt.Expect(signer.MSPId()).To(Equal("test-msp"))
+		gt.Expect(signer.Cert().Subject.CommonName).To(Equal("Wile E. Coyote"))
+	})
+
+	tests := []struct {
+		spec        string
+		publicKey   []byte
+		privateKey  []byte
+		mspID       string
+		expectedErr string
+		matchErr    bool
+	}{
+		{
+			spec:        "nil public key",
+			publicKey:   nil,
+			privateKey:  []byte(privateKey),
+			mspID:       "test-msp",
+			expectedErr: "failed to get cert from pem: failed to decode pem bytes: []",
+			matchErr:    true,
+		},
+		{
+			spec:        "invalid public key",
+			publicKey:   []byte("apple"),
+			privateKey:  []byte(privateKey),
+			mspID:       "test-msp",
+			expectedErr: "failed to get cert from pem: failed to decode pem bytes",
+			matchErr:    false,
+		},
+		{
+			spec:        "public key is not a certificate",
+			publicKey:   []byte(privateKey),
+			privateKey:  []byte(privateKey),
+			mspID:       "test-msp",
+			expectedErr: "failed to get cert from pem: failed to parse x509 cert",
+			matchErr:    false,
+		},
+		{
+			spec:        "nil private key",
+			publicKey:   []byte(publicKey),
+			privateKey:  nil,
+			mspID:       "test-msp",
+			expectedErr: "failed to decode private key from pem",
+			matchErr:    true,
+		},
+		{
+			spec:        "empty mspID",
+			publicKey:   []byte(publicKey),
+			privateKey:  []byte(privateKey),
+			expectedErr: "failed to create new signer, mspID can not be empty",
+			matchErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.spec, func(t *testing.T) {
+			gt := NewGomegaWithT(t)
+
+			_, err := NewSigner(tc.publicKey, tc.privateKey, tc.mspID)
+			if tc.matchErr {
+				gt.Expect(err).To(MatchError(tc.expectedErr))
+			} else {
+				gt.Expect(err.Error()).To(ContainSubstring(tc.expectedErr))
+			}
+		})
+	}
+}
+
+func TestECDSAPublicKeyImport(t *testing.T) {
+	t.Run("certificate does not contain valid ecdsa publicKey", func(t *testing.T) {
+		gt := NewGomegaWithT(t)
+		x509cert := &x509.Certificate{PublicKey: struct{}{}}
+		_, err := ecdsaPublicKeyImport(x509cert)
+		gt.Expect(err).To(MatchError("certificate does not contain valid ECDSA public key"))
+	})
+}
+
+func TestECDSAPrivateKeyImport(t *testing.T) {
+	t.Run("nil private key", func(t *testing.T) {
+		gt := NewGomegaWithT(t)
+		_, err := ecdsaPrivateKeyImport(nil)
+		gt.Expect(err.Error()).To(ContainSubstring("invalid key type. The DER must contain an ecdsa.PrivateKey"))
+	})
+}
+
+func TestSerialize(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		gt := NewGomegaWithT(t)
+		signer, err := NewSigner([]byte(publicKey), []byte(privateKey), "test-msp")
+		gt.Expect(err).NotTo(HaveOccurred())
+
+		sBytes, err := signer.Serialize()
+		gt.Expect(err).NotTo(HaveOccurred())
+		serializedIdentity := &msp.SerializedIdentity{}
+		err = proto.Unmarshal(sBytes, serializedIdentity)
+		gt.Expect(serializedIdentity.Mspid).To(Equal("test-msp"))
+	})
+}
+
+func TestPublic(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		gt := NewGomegaWithT(t)
+		signer, err := NewSigner([]byte(publicKey), []byte(privateKey), "test-msp")
+		gt.Expect(err).NotTo(HaveOccurred())
+
+		expectedCert, err := getCertFromPem([]byte(publicKey))
+		gt.Expect(err).NotTo(HaveOccurred())
+		expectedPublicKey, err := ecdsaPublicKeyImport(expectedCert)
+		gt.Expect(err).NotTo(HaveOccurred())
+		publicKey := signer.Public()
+		gt.Expect(publicKey).To(Equal(expectedPublicKey))
+	})
+}
+
+func TestSign(t *testing.T) {
+	tests := []struct {
+		spec        string
+		reader      io.Reader
+		digest      []byte
+		expectedErr string
+	}{
+		{
+			spec:        "success",
+			reader:      rand.Reader,
+			digest:      []byte("banana"),
+			expectedErr: "",
+		},
+		{
+			spec:        "nil reader",
+			reader:      nil,
+			expectedErr: "failed to sign, reader can not be nil",
+		},
+	}
+
+	gt := NewGomegaWithT(t)
+	signer, err := NewSigner([]byte(publicKey), []byte(privateKey), "test-msp")
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	for _, tc := range tests {
+		t.Run(tc.spec, func(t *testing.T) {
+			gt := NewGomegaWithT(t)
+			_, err = signer.Sign(tc.reader, tc.digest)
+			if tc.expectedErr == "" {
+				gt.Expect(err).NotTo(HaveOccurred())
+			} else {
+				gt.Expect(err).To(MatchError(tc.expectedErr))
+			}
+		})
+	}
+}
+
+func TestToLowS(t *testing.T) {
+	curve := elliptic.P256()
+	halfOrder := new(big.Int).Div(curve.Params().N, big.NewInt(2))
+
+	for _, test := range []struct {
+		name        string
+		sig         ecdsaSignature
+		expectedSig ecdsaSignature
+	}{
+		{
+			name: "HighS",
+			sig: ecdsaSignature{
+				R: big.NewInt(1),
+				// set S to halfOrder + 1
+				S: new(big.Int).Add(halfOrder, big.NewInt(1)),
+			},
+			// expected signature should be (sig.R, -sig.S mod N)
+			expectedSig: ecdsaSignature{
+				R: big.NewInt(1),
+				S: new(big.Int).Mod(new(big.Int).Neg(new(big.Int).Add(halfOrder, big.NewInt(1))), curve.Params().N),
+			},
+		},
+		{
+			name: "LowS",
+			sig: ecdsaSignature{
+				R: big.NewInt(1),
+				// set S to halfOrder - 1
+				S: new(big.Int).Sub(halfOrder, big.NewInt(1)),
+			},
+			// expected signature should be sig
+			expectedSig: ecdsaSignature{
+				R: big.NewInt(1),
+				S: new(big.Int).Sub(halfOrder, big.NewInt(1)),
+			},
+		},
+		{
+			name: "HalfOrder",
+			sig: ecdsaSignature{
+				R: big.NewInt(1),
+				// set S to halfOrder
+				S: halfOrder,
+			},
+			// expected signature should be sig
+			expectedSig: ecdsaSignature{
+				R: big.NewInt(1),
+				S: halfOrder,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			gt := NewGomegaWithT(t)
+			curve := elliptic.P256()
+			key := ecdsa.PublicKey{
+				Curve: curve,
+			}
+			gt.Expect(toLowS(key, test.sig), test.expectedSig)
+		})
+	}
+}
+
+func generatePublicAndPrivateKey() ([]byte, []byte) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		log.Fatalf("Failed to generate private key: %s", err)
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		log.Fatalf("Failed to generate serial number: %s", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   "Wile E. Coyote",
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		log.Fatalf("Failed to create certificate: %s", err)
+	}
+	publicKey := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		log.Fatalf("Unable to marshal private key: %v", err)
+	}
+	privateKey := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+
+	return publicKey, privateKey
+}


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

This PR is part of an effort to create an easier way to create and update the channel configuration for fabric networks. This specific PR creates a signature for the provided configuration update.

#### Related issues

[FAB-17467](https://jira.hyperledger.org/browse/FAB-17467)

