### PR TITLE
[FAB-17453] 'peer lifecycle chaincode package' mandates does not need to init crypto

### DIFF
--- a/internal/peer/common/common.go
+++ b/internal/peer/common/common.go
@@ -305,6 +305,12 @@ func InitCmd(cmd *cobra.Command, args []string) {
 		LogSpec: loggingSpec,
 	})
 
+	// chaincode packaging does not require material from the local MSP
+	if cmd.CommandPath() == "peer lifecycle chaincode package" {
+		mainLogger.Debug("peer lifecycle chaincode package does not need to init crypto")
+		return
+	}
+
 	// Init the MSP
 	var mspMgrConfigDir = config.GetPath("peer.mspConfigPath")
 	var mspID = viper.GetString("peer.localMspId")


### PR DESCRIPTION
Description

A developer might never have any credentials if He is just developing and packaging,
so the MSP initialization process should be removed while packaging with
lifecycle.

Related issues

https://jira.hyperledger.org/browse/FAB-17453

Signed-off-by: xu wu <wuxu1103@163.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
