### PR TITLE
[FAB-17472] Clarify doc and samples for NodeOU Certificate

### DIFF
--- a/docs/source/msp.rst
+++ b/docs/source/msp.rst
@@ -189,17 +189,24 @@ below:
 
    NodeOUs:
      Enable: true
+     # For each identity classification that you would like to utilize, specify
+     # an OU identifier.
+     # You can optionally configure that the OU identifier must be issued by a specific CA
+     # or intermediate certificate from your organization. However, it is typical to NOT
+     # configure a specific Certificate. By not configuring a specific Certificate, you will be
+     # able to add other CA or intermediate certs later, without having to reissue all credentials.
+     # For this reason, the sample below comments out the Certificate field.
      ClientOUIdentifier:
-       Certificate: "cacerts/cacert.pem"
+       # Certificate: "cacerts/cacert.pem"
        OrganizationalUnitIdentifier: "client"
      AdminOUIdentifier:
-       Certificate: "cacerts/cacert.pem"
+       # Certificate: "cacerts/cacert.pem"
        OrganizationalUnitIdentifier: "admin"
      PeerOUIdentifier:
-       Certificate: "cacerts/cacert.pem"
+       # Certificate: "cacerts/cacert.pem"
        OrganizationalUnitIdentifier: "peer"
      OrdererOUIdentifier:
-       Certificate: "cacerts/cacert.pem"
+       # Certificate: "cacerts/cacert.pem"
        OrganizationalUnitIdentifier: "orderer"
 
 Identity classification is enabled when ``NodeOUs.Enable`` is set to ``true``. Then the client
@@ -210,10 +217,12 @@ the ``NodeOUs.ClientOUIdentifier`` (``NodeOUs.AdminOUIdentifier``, ``NodeOUs.Pee
 a. ``OrganizationalUnitIdentifier``: Is the OU value that the x509 certificate needs to contain
    to be considered a client (admin, peer, orderer respectively). If this field is empty, then the classification
    is not applied.
-b. ``Certificate``: Set this to the path of the CA or intermediate CA certificate under which client
-   (peer, admin or orderer) identities should be validated. The field is relative to the MSP root
-   folder. This field is optional. You can leave this field blank and allow the certificate to be
-   validated under any CA defined in the MSP configuration.
+b. ``Certificate``: (Optional) Set this to the path of the CA or intermediate CA certificate
+   under which client (peer, admin or orderer) identities should be validated.
+   The field is relative to the MSP root folder. Only a single Certificate can be specified.
+   If you do not set this field, then the identities are validated under any CA defined in
+   the organization's MSP configuration, which could be desirable in the future if you need
+   to add other CA or intermediate certificates.
 
 Notice that if the ``NodeOUs.ClientOUIdentifier`` section (``NodeOUs.AdminOUIdentifier``,
 ``NodeOUs.PeerOUIdentifier``, ``NodeOUs.OrdererOUIdentifier``) is missing, then the classification

--- a/msp/configbuilder.go
+++ b/msp/configbuilder.go
@@ -367,7 +367,7 @@ func loadCertificateAt(dir, certificatePath string, ouType string) []byte {
 	f := filepath.Join(dir, certificatePath)
 	raw, err := readFile(f)
 	if err != nil {
-		mspLogger.Infof("Failed loading %s certificate at [%s]: [%s]", ouType, f, err)
+		mspLogger.Warnf("Failed loading %s certificate at [%s]: [%s]", ouType, f, err)
 	} else {
 		return raw
 	}

--- a/sampleconfig/msp/config.yaml
+++ b/sampleconfig/msp/config.yaml
@@ -9,10 +9,22 @@ OrganizationalUnitIdentifiers:
 
 NodeOUs:
   Enable: false
+  # For each identity classification that you would like to utilize, specify
+  # an OU identifier.
+  # You can optionally configure that the OU identifier must be issued by a specific CA
+  # or intermediate certificate from your organization. However, it is typical to NOT
+  # configure a specific Certificate. By not configuring a specific Certificate, you will be
+  # able to add other CA or intermediate certs later, without having to reissue all credentials.
+  # For this reason, the sample below comments out the Certificate field.
   ClientOUIdentifier:
-    # if Certificate is empty, then the certifier identifier will not be enforced
-    Certificate: "cacerts/cacert.pem"
+    # Certificate: "cacerts/cacert.pem"
     OrganizationalUnitIdentifier: "OU_client"
   PeerOUIdentifier:
-    Certificate: "cacerts/cacert.pem"
+    # Certificate: "cacerts/cacert.pem"
     OrganizationalUnitIdentifier: "OU_peer"
+  AdminOUIdentifier:
+    # Certificate: "cacerts/cacert.pem"
+    OrganizationalUnitIdentifier: "OU_admin"
+  OrdererOUIdentifier:
+    # Certificate: "cacerts/cacert.pem"
+    OrganizationalUnitIdentifier: "OU_orderer"


### PR DESCRIPTION
#### Type of change

- Documentation and log message update

#### Description

Clarify in doc and samples that NodeOU classification
Certificate can be left unconfigured in scenarios
where any of the organization's CA's can issue NodeOU
classifications. This is the recommended configuration
so that it is possible to add CA or intermediate certs later,
without having to reissue existing credentials (only a single
Certificate can be configured for each NodeOU classification).

Also, change a Info message to Warning message, if the
configured Certificate cannot be found, for example when
running configtxgen.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
