### PR TITLE
Cherry-pick release 1.4 fix for FAB-17059 to master

### DIFF
--- a/core/common/privdata/collection.go
+++ b/core/common/privdata/collection.go
@@ -30,7 +30,7 @@ type Collection interface {
 
 	// MemberOrgs returns the collection's members as MSP IDs. This serves as
 	// a human-readable way of quickly identifying who is part of a collection.
-	MemberOrgs() []string
+	MemberOrgs() map[string]struct{}
 }
 
 // CollectionAccessPolicy encapsulates functions for the access policy of a collection
@@ -49,7 +49,7 @@ type CollectionAccessPolicy interface {
 
 	// MemberOrgs returns the collection's members as MSP IDs. This serves as
 	// a human-readable way of quickly identifying who is part of a collection.
-	MemberOrgs() []string
+	MemberOrgs() map[string]struct{}
 
 	// IsMemberOnlyRead returns a true if only collection members can read
 	// the private data

--- a/core/common/privdata/membershipinfo.go
+++ b/core/common/privdata/membershipinfo.go
@@ -17,19 +17,33 @@ var logger = flogging.MustGetLogger("common.privdata")
 
 // MembershipProvider can be used to check whether a peer is eligible to a collection or not
 type MembershipProvider struct {
+	mspID                       string
 	selfSignedData              protoutil.SignedData
 	IdentityDeserializerFactory func(chainID string) msp.IdentityDeserializer
 }
 
 // NewMembershipInfoProvider returns MembershipProvider
-func NewMembershipInfoProvider(selfSignedData protoutil.SignedData, identityDeserializerFunc func(chainID string) msp.IdentityDeserializer) *MembershipProvider {
+func NewMembershipInfoProvider(mspID string, selfSignedData protoutil.SignedData, identityDeserializerFunc func(chainID string) msp.IdentityDeserializer) *MembershipProvider {
 	return &MembershipProvider{selfSignedData: selfSignedData, IdentityDeserializerFactory: identityDeserializerFunc}
 }
 
 // AmMemberOf checks whether the current peer is a member of the given collection config.
 // If getPolicy returns an error, it will drop the error and return false - same as a RejectAll policy.
+// It is used when a chaincode is upgraded to see if the peer's org has become eligible after	a collection
+// change.
 func (m *MembershipProvider) AmMemberOf(channelName string, collectionPolicyConfig *peer.CollectionPolicyConfig) (bool, error) {
 	deserializer := m.IdentityDeserializerFactory(channelName)
+
+	// Do a simple check to see if the mspid matches any principal identities in the SignaturePolicy - FAB-17059
+	if collectionPolicyConfig.GetSignaturePolicy() != nil {
+		memberOrgs := getMemberOrgs(collectionPolicyConfig.GetSignaturePolicy().GetIdentities(), deserializer)
+
+		if _, ok := memberOrgs[m.mspID]; ok {
+			return true, nil
+		}
+	}
+
+	// Fall back to default access policy evaluation otherwise
 	accessPolicy, err := getPolicy(collectionPolicyConfig, deserializer)
 	if err != nil {
 		// drop the error and return false - same as reject all policy
@@ -39,5 +53,6 @@ func (m *MembershipProvider) AmMemberOf(channelName string, collectionPolicyConf
 	if err := accessPolicy.EvaluateSignedData([]*protoutil.SignedData{&m.selfSignedData}); err != nil {
 		return false, nil
 	}
+
 	return true, nil
 }

--- a/core/common/privdata/membershipinfo_test.go
+++ b/core/common/privdata/membershipinfo_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestMembershipInfoProvider(t *testing.T) {
+	mspID := "peer0"
 	peerSelfSignedData := protoutil.SignedData{
 		Identity:  []byte("peer0"),
 		Signature: []byte{1, 2, 3},
@@ -28,7 +29,7 @@ func TestMembershipInfoProvider(t *testing.T) {
 	}
 
 	// verify membership provider returns true
-	membershipProvider := NewMembershipInfoProvider(peerSelfSignedData, identityDeserializer)
+	membershipProvider := NewMembershipInfoProvider(mspID, peerSelfSignedData, identityDeserializer)
 	res, err := membershipProvider.AmMemberOf("test1", getAccessPolicy([]string{"peer0", "peer1"}))
 	assert.True(t, res)
 	assert.Nil(t, err)

--- a/core/common/privdata/simplecollection_test.go
+++ b/core/common/privdata/simplecollection_test.go
@@ -130,8 +130,8 @@ func TestNewSimpleCollectionWithGoodConfig(t *testing.T) {
 
 	// check members
 	members := sc.MemberOrgs()
-	assert.True(t, members[0] == "signer0")
-	assert.True(t, members[1] == "signer1")
+	assert.Contains(t, members, "signer0")
+	assert.Contains(t, members, "signer1")
 
 	// check required peer count
 	assert.True(t, sc.RequiredPeerCount() == 1)
@@ -177,8 +177,8 @@ func TestSetupGoodConfigCollection(t *testing.T) {
 
 	// check members
 	members := sc.MemberOrgs()
-	assert.True(t, members[0] == "signer0")
-	assert.True(t, members[1] == "signer1")
+	assert.Contains(t, members, "signer0")
+	assert.Contains(t, members, "signer1")
 
 	// check required peer count
 	assert.True(t, sc.RequiredPeerCount() == 1)

--- a/core/common/privdata/util.go
+++ b/core/common/privdata/util.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package privdata
 
 import (
+	"github.com/gogo/protobuf/proto"
+	mspp "github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/common/cauthdsl"
 	"github.com/hyperledger/fabric/common/policies"
@@ -34,4 +36,35 @@ func getPolicy(collectionPolicyConfig *peer.CollectionPolicyConfig, deserializer
 	}
 
 	return accessPolicy, nil
+}
+
+// getMemberOrgs returns a map containing member orgs from a list of MSPPrincipals,
+// it will skip identities it fails to process
+func getMemberOrgs(identities []*mspp.MSPPrincipal, deserializer msp.IdentityDeserializer) map[string]struct{} {
+	memberOrgs := map[string]struct{}{}
+
+	// get member org MSP IDs from the envelope
+	for _, principal := range identities {
+		switch principal.PrincipalClassification {
+		case mspp.MSPPrincipal_ROLE:
+			// Principal contains the msp role
+			mspRole := &mspp.MSPRole{}
+			err := proto.Unmarshal(principal.Principal, mspRole)
+			if err == nil {
+				memberOrgs[mspRole.MspIdentifier] = struct{}{}
+			}
+		case mspp.MSPPrincipal_IDENTITY:
+			principalId, err := deserializer.DeserializeIdentity(principal.Principal)
+			if err == nil {
+				memberOrgs[principalId.GetMSPIdentifier()] = struct{}{}
+			}
+		case mspp.MSPPrincipal_ORGANIZATION_UNIT:
+			OU := &mspp.OrganizationUnit{}
+			err := proto.Unmarshal(principal.Principal, OU)
+			if err == nil {
+				memberOrgs[OU.MspIdentifier] = struct{}{}
+			}
+		}
+	}
+	return memberOrgs
 }

--- a/core/ledger/kvledger/tests/env.go
+++ b/core/ledger/kvledger/tests/env.go
@@ -217,7 +217,8 @@ func populateMissingsWithTestDefaults(t *testing.T, initializer *ledgermgmt.Init
 		}
 		cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 		assert.NoError(t, err)
-		membershipInfoProvider := privdata.NewMembershipInfoProvider(createSelfSignedData(cryptoProvider), identityDeserializerFactory)
+		mspID := "test-mspid"
+		membershipInfoProvider := privdata.NewMembershipInfoProvider(mspID, createSelfSignedData(cryptoProvider), identityDeserializerFactory)
 		initializer.MembershipInfoProvider = membershipInfoProvider
 	}
 

--- a/gossip/privdata/coordinator.go
+++ b/gossip/privdata/coordinator.go
@@ -119,6 +119,7 @@ type CoordinatorConfig struct {
 }
 
 type coordinator struct {
+	mspID          string
 	selfSignedData protoutil.SignedData
 	Support
 	store                          *transientstore.Store
@@ -130,9 +131,10 @@ type coordinator struct {
 }
 
 // NewCoordinator creates a new instance of coordinator
-func NewCoordinator(support Support, store *transientstore.Store, selfSignedData protoutil.SignedData, metrics *metrics.PrivdataMetrics,
+func NewCoordinator(mspID string, support Support, store *transientstore.Store, selfSignedData protoutil.SignedData, metrics *metrics.PrivdataMetrics,
 	config CoordinatorConfig, idDeserializerFactory IdentityDeserializerFactory) Coordinator {
 	return &coordinator{Support: support,
+		mspID:                          mspID,
 		store:                          store,
 		selfSignedData:                 selfSignedData,
 		transientBlockRetention:        config.TransientBlockRetention,
@@ -183,6 +185,7 @@ func (c *coordinator) StoreBlock(block *common.Block, privateDataSets util.PvtDa
 	fetchDurationHistogram := c.metrics.FetchDuration.With("channel", c.ChainID)
 	purgeDurationHistogram := c.metrics.PurgeDuration.With("channel", c.ChainID)
 	pdp := &PvtdataProvider{
+		mspID:                                   c.mspID,
 		selfSignedData:                          c.selfSignedData,
 		logger:                                  logger.With("channel", c.ChainID),
 		listMissingPrivateDataDurationHistogram: listMissingPrivateDataDurationHistogram,

--- a/gossip/privdata/distributor.go
+++ b/gossip/privdata/distributor.go
@@ -334,10 +334,8 @@ func (d *distributorImpl) disseminationPlanForMsg(colAP privdata.CollectionAcces
 func (d *distributorImpl) identitiesOfEligiblePeers(eligiblePeers []discovery.NetworkMember, colAP privdata.CollectionAccessPolicy) map[string]api.PeerIdentitySet {
 	return d.gossipAdapter.IdentityInfo().
 		Filter(func(info api.PeerIdentityInfo) bool {
-			for _, orgID := range colAP.MemberOrgs() {
-				if bytes.Equal(info.Organization, []byte(orgID)) {
-					return true
-				}
+			if _, ok := colAP.MemberOrgs()[string(info.Organization)]; ok {
+				return true
 			}
 			// peer not in the org
 			return false

--- a/gossip/privdata/distributor_test.go
+++ b/gossip/privdata/distributor_test.go
@@ -56,9 +56,9 @@ func (mock *collectionAccessPolicyMock) MaximumPeerCount() int {
 	return args.Int(0)
 }
 
-func (mock *collectionAccessPolicyMock) MemberOrgs() []string {
+func (mock *collectionAccessPolicyMock) MemberOrgs() map[string]struct{} {
 	args := mock.Called()
-	return args.Get(0).([]string)
+	return args.Get(0).(map[string]struct{})
 }
 
 func (mock *collectionAccessPolicyMock) IsMemberOnlyRead() bool {
@@ -72,7 +72,7 @@ func (mock *collectionAccessPolicyMock) IsMemberOnlyWrite() bool {
 }
 
 func (mock *collectionAccessPolicyMock) Setup(requiredPeerCount int, maxPeerCount int,
-	accessFilter privdata.Filter, orgs []string, memberOnlyRead bool) {
+	accessFilter privdata.Filter, orgs map[string]struct{}, memberOnlyRead bool) {
 	mock.On("AccessFilter").Return(accessFilter)
 	mock.On("RequiredPeerCount").Return(requiredPeerCount)
 	mock.On("MaximumPeerCount").Return(maxPeerCount)
@@ -178,7 +178,10 @@ func TestDistributor(t *testing.T) {
 	policyMock := &collectionAccessPolicyMock{}
 	policyMock.Setup(1, 2, func(_ protoutil.SignedData) bool {
 		return true
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{
+		"org1": {},
+		"org2": {},
+	}, false)
 
 	accessFactoryMock.On("AccessPolicy", c1ColConfig, channelID).Return(policyMock, nil)
 	accessFactoryMock.On("AccessPolicy", c2ColConfig, channelID).Return(policyMock, nil)

--- a/gossip/privdata/pull_test.go
+++ b/gossip/privdata/pull_test.go
@@ -141,7 +141,7 @@ func (mc *mockCollectionAccess) thatMapsTo(peers ...string) *mockCollectionStore
 	return mc.cs
 }
 
-func (mc *mockCollectionAccess) MemberOrgs() []string {
+func (mc *mockCollectionAccess) MemberOrgs() map[string]struct{} {
 	return nil
 }
 
@@ -321,7 +321,7 @@ func TestPullerFromOnly1Peer(t *testing.T) {
 	policyMock1 := &collectionAccessPolicyMock{}
 	policyMock1.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p2"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock1.On("AccessPolicy", mock.Anything, mock.Anything).Return(policyMock1, nil)
 	p1 := gn.newPuller("p1", policyStore, factoryMock1, membership(peerData{"p2", uint64(1)}, peerData{"p3", uint64(1)})...)
 
@@ -340,7 +340,7 @@ func TestPullerFromOnly1Peer(t *testing.T) {
 	policyMock2 := &collectionAccessPolicyMock{}
 	policyMock2.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p1"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock2.On("AccessPolicy", mock.Anything, mock.Anything).Return(policyMock2, nil)
 
 	p2 := gn.newPuller("p2", policyStore, factoryMock2)
@@ -364,7 +364,7 @@ func TestPullerFromOnly1Peer(t *testing.T) {
 	policyMock3 := &collectionAccessPolicyMock{}
 	policyMock3.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return false
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock3.On("AccessPolicy", mock.Anything, mock.Anything).Return(policyMock3, nil)
 
 	p3 := gn.newPuller("p3", newCollectionStore(), factoryMock3)
@@ -469,7 +469,7 @@ func TestPullerPeerNotEligible(t *testing.T) {
 	accessPolicyMock1 := &collectionAccessPolicyMock{}
 	accessPolicyMock1.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p2")) || bytes.Equal(data.Identity, []byte("p3"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock1.On("AccessPolicy", mock.Anything, mock.Anything).Return(accessPolicyMock1, nil)
 
 	p1 := gn.newPuller("p1", policyStore, factoryMock1, membership(peerData{"p2", uint64(1)}, peerData{"p3", uint64(1)})...)
@@ -479,7 +479,7 @@ func TestPullerPeerNotEligible(t *testing.T) {
 	accessPolicyMock2 := &collectionAccessPolicyMock{}
 	accessPolicyMock2.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p2"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock2.On("AccessPolicy", mock.Anything, mock.Anything).Return(accessPolicyMock2, nil)
 
 	p2 := gn.newPuller("p2", policyStore, factoryMock2)
@@ -514,7 +514,7 @@ func TestPullerPeerNotEligible(t *testing.T) {
 	accessPolicyMock3 := &collectionAccessPolicyMock{}
 	accessPolicyMock3.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p3"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock3.On("AccessPolicy", mock.Anything, mock.Anything).Return(accessPolicyMock1, nil)
 
 	p3 := gn.newPuller("p3", policyStore, factoryMock3)
@@ -535,7 +535,7 @@ func TestPullerDifferentPeersDifferentCollections(t *testing.T) {
 	accessPolicyMock1 := &collectionAccessPolicyMock{}
 	accessPolicyMock1.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p2")) || bytes.Equal(data.Identity, []byte("p3"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock1.On("AccessPolicy", mock.Anything, mock.Anything).Return(accessPolicyMock1, nil)
 
 	policyStore := newCollectionStore().withPolicy("col2", uint64(100)).thatMapsTo("p2").withPolicy("col3", uint64(100)).thatMapsTo("p3")
@@ -557,7 +557,7 @@ func TestPullerDifferentPeersDifferentCollections(t *testing.T) {
 	accessPolicyMock2 := &collectionAccessPolicyMock{}
 	accessPolicyMock2.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p1"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock2.On("AccessPolicy", mock.Anything, mock.Anything).Return(accessPolicyMock2, nil)
 
 	p2 := gn.newPuller("p2", policyStore, factoryMock2)
@@ -600,7 +600,7 @@ func TestPullerDifferentPeersDifferentCollections(t *testing.T) {
 	accessPolicyMock3 := &collectionAccessPolicyMock{}
 	accessPolicyMock3.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p1"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock3.On("AccessPolicy", mock.Anything, mock.Anything).Return(accessPolicyMock3, nil)
 
 	p3 := gn.newPuller("p3", policyStore, factoryMock3)
@@ -638,7 +638,7 @@ func TestPullerRetries(t *testing.T) {
 		return bytes.Equal(data.Identity, []byte("p2")) || bytes.Equal(data.Identity, []byte("p3")) ||
 			bytes.Equal(data.Identity, []byte("p4")) ||
 			bytes.Equal(data.Identity, []byte("p5"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock1.On("AccessPolicy", mock.Anything, mock.Anything).Return(accessPolicyMock1, nil)
 
 	// p1
@@ -678,7 +678,7 @@ func TestPullerRetries(t *testing.T) {
 	accessPolicyMock2 := &collectionAccessPolicyMock{}
 	accessPolicyMock2.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p2"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock2.On("AccessPolicy", mock.Anything, mock.Anything).Return(accessPolicyMock2, nil)
 
 	p2 := gn.newPuller("p2", policyStore, factoryMock2)
@@ -690,7 +690,7 @@ func TestPullerRetries(t *testing.T) {
 	accessPolicyMock3 := &collectionAccessPolicyMock{}
 	accessPolicyMock3.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p1"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock3.On("AccessPolicy", mock.Anything, mock.Anything).Return(accessPolicyMock3, nil)
 
 	p3 := gn.newPuller("p3", policyStore, factoryMock3)
@@ -702,7 +702,7 @@ func TestPullerRetries(t *testing.T) {
 	accessPolicyMock4 := &collectionAccessPolicyMock{}
 	accessPolicyMock4.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p4"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock4.On("AccessPolicy", mock.Anything, mock.Anything).Return(accessPolicyMock4, nil)
 
 	p4 := gn.newPuller("p4", policyStore, factoryMock4)
@@ -714,7 +714,7 @@ func TestPullerRetries(t *testing.T) {
 	accessPolicyMock5 := &collectionAccessPolicyMock{}
 	accessPolicyMock5.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p5"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock5.On("AccessPolicy", mock.Anything, mock.Anything).Return(accessPolicyMock5, nil)
 
 	p5 := gn.newPuller("p5", policyStore, factoryMock5)
@@ -742,7 +742,7 @@ func TestPullerPreferEndorsers(t *testing.T) {
 	accessPolicyMock2 := &collectionAccessPolicyMock{}
 	accessPolicyMock2.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p2")) || bytes.Equal(data.Identity, []byte("p1"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock.On("AccessPolicy", mock.Anything, mock.Anything).Return(accessPolicyMock2, nil)
 
 	policyStore := newCollectionStore().
@@ -840,7 +840,7 @@ func TestPullerFetchReconciledItemsPreferPeersFromOriginalConfig(t *testing.T) {
 	accessPolicyMock2 := &collectionAccessPolicyMock{}
 	accessPolicyMock2.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p2")) || bytes.Equal(data.Identity, []byte("p1"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock.On("AccessPolicy", mock.Anything, mock.Anything).Return(accessPolicyMock2, nil)
 
 	policyStore := newCollectionStore().
@@ -957,7 +957,7 @@ func TestPullerAvoidPullingPurgedData(t *testing.T) {
 	accessPolicyMock2 := &collectionAccessPolicyMock{}
 	accessPolicyMock2.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p1"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock.On("AccessPolicy", mock.Anything, mock.Anything).Return(accessPolicyMock2, nil)
 
 	policyStore := newCollectionStore().withPolicy("col1", uint64(100)).thatMapsTo("p1", "p2", "p3").
@@ -1069,7 +1069,7 @@ func TestPullerIntegratedWithDataRetreiver(t *testing.T) {
 	ap := &collectionAccessPolicyMock{}
 	ap.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p1"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 
 	factoryMock := &collectionAccessFactoryMock{}
 	factoryMock.On("AccessPolicy", mock.Anything, mock.Anything).Return(ap, nil)
@@ -1176,7 +1176,7 @@ func TestPullerMetrics(t *testing.T) {
 	policyMock1 := &collectionAccessPolicyMock{}
 	policyMock1.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p2"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock1.On("AccessPolicy", mock.Anything, mock.Anything).Return(policyMock1, nil)
 
 	testMetricProvider := gmetricsmocks.TestUtilConstructMetricProvider()
@@ -1199,7 +1199,7 @@ func TestPullerMetrics(t *testing.T) {
 	policyMock2 := &collectionAccessPolicyMock{}
 	policyMock2.Setup(1, 2, func(data protoutil.SignedData) bool {
 		return bytes.Equal(data.Identity, []byte("p1"))
-	}, []string{"org1", "org2"}, false)
+	}, map[string]struct{}{"org1": {}, "org2": {}}, false)
 	factoryMock2.On("AccessPolicy", mock.Anything, mock.Anything).Return(policyMock2, nil)
 
 	p2 := gn.newPullerWithMetrics(metrics, "p2", policyStore, factoryMock2)

--- a/gossip/privdata/pvtdataprovider_test.go
+++ b/gossip/privdata/pvtdataprovider_test.go
@@ -1331,6 +1331,7 @@ func setupPrivateDataProvider(t *testing.T,
 	storePvtdataInPeer(rwSetsInPeer, expectedDigKeys, fetcher, ts, skipPullingInvalidTransactions)
 
 	pdp := &PvtdataProvider{
+		mspID:                                   "Org1MSP",
 		selfSignedData:                          ts.peerSelfSignedData,
 		logger:                                  logger,
 		listMissingPrivateDataDurationHistogram: metrics.ListMissingPrivateDataDuration.With("channel", ts.channelID),

--- a/gossip/service/gossip_service.go
+++ b/gossip/service/gossip_service.go
@@ -307,14 +307,16 @@ func (g *GossipService) InitializeChannel(channelID string, ordererSource *order
 		PullRetryThreshold:             g.serviceConfig.PvtDataPullRetryThreshold,
 		SkipPullingInvalidTransactions: g.serviceConfig.SkipPullingInvalidTransactionsDuringCommit,
 	}
-	coordinator := gossipprivdata.NewCoordinator(gossipprivdata.Support{
+	selfSignedData := g.createSelfSignedData()
+	mspID := string(g.secAdv.OrgByPeerIdentity(selfSignedData.Identity))
+	coordinator := gossipprivdata.NewCoordinator(mspID, gossipprivdata.Support{
 		ChainID:            channelID,
 		CollectionStore:    support.CollectionStore,
 		Validator:          support.Validator,
 		Committer:          support.Committer,
 		Fetcher:            fetcher,
 		CapabilityProvider: support.CapabilityProvider,
-	}, store, g.createSelfSignedData(), g.metrics.PrivdataMetrics, coordinatorConfig,
+	}, store, selfSignedData, g.metrics.PrivdataMetrics, coordinatorConfig,
 		support.IdDeserializeFactory)
 
 	privdataConfig := gossipprivdata.GlobalConfig()

--- a/gossip/service/gossip_service_test.go
+++ b/gossip/service/gossip_service_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	transientstore2 "github.com/hyperledger/fabric-protos-go/transientstore"
+	"github.com/hyperledger/fabric/bccsp/factory"
 	"github.com/hyperledger/fabric/bccsp/sw"
 	"github.com/hyperledger/fabric/common/channelconfig"
 	"github.com/hyperledger/fabric/common/flogging"
@@ -797,6 +798,7 @@ func newGossipInstance(serviceConfig *ServiceConfig, port int, id int, gRPCServe
 	)
 	go gRPCServer.Start()
 
+	secAdv := peergossip.NewSecurityAdvisor(mgmt.NewDeserializersManager(factory.GetDefault()))
 	gossipService := &GossipService{
 		mcs:             cryptoService,
 		gossipSvc:       gossip,
@@ -808,6 +810,7 @@ func newGossipInstance(serviceConfig *ServiceConfig, port int, id int, gRPCServe
 			credentialSupport: comm.NewCredentialSupport(),
 		},
 		peerIdentity:  api.PeerIdentityType(conf.InternalEndpoint),
+		secAdv:        secAdv,
 		metrics:       metrics,
 		serviceConfig: serviceConfig,
 	}

--- a/gossip/state/state_test.go
+++ b/gossip/state/state_test.go
@@ -395,11 +395,13 @@ func newPeerNodeWithGossipWithValidatorWithMetrics(id int, committer committer.C
 		TransientBlockRetention:        1000,
 		SkipPullingInvalidTransactions: false,
 	}
+
+	mspID := "Org1MSP"
 	capabilityProvider := &capabilitymock.CapabilityProvider{}
 	appCapability := &capabilitymock.AppCapabilities{}
 	capabilityProvider.On("Capabilities").Return(appCapability)
 	appCapability.On("StorePvtDataOfInvalidTx").Return(true)
-	coord := privdata.NewCoordinator(privdata.Support{
+	coord := privdata.NewCoordinator(mspID, privdata.Support{
 		Validator:          v,
 		Committer:          committer,
 		CapabilityProvider: capabilityProvider,

--- a/integration/pvtdata/pvtdata_test.go
+++ b/integration/pvtdata/pvtdata_test.go
@@ -10,11 +10,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -29,6 +32,7 @@ import (
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
+	mspp "github.com/hyperledger/fabric-protos-go/msp"
 	ab "github.com/hyperledger/fabric-protos-go/orderer"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/bccsp/sw"
@@ -42,6 +46,7 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"github.com/tedsuo/ifrit"
+	"github.com/tedsuo/ifrit/grouper"
 )
 
 // The chaincode used in these tests has two collections defined:
@@ -131,6 +136,228 @@ var _ bool = Describe("PrivateData", func() {
 
 				assertPvtdataPresencePerCollectionConfig7(network, testChaincode.Name, "marble1", peer)
 			})
+		})
+	})
+
+	Describe("Pvtdata behavior when a peer with new certs joins the network", func() {
+		var (
+			peerProcesses map[string]ifrit.Process
+		)
+
+		BeforeEach(func() {
+			By("setting up the network")
+			network = initThreeOrgsSetup()
+
+			By("starting the network")
+			peerProcesses = make(map[string]ifrit.Process)
+			network.Bootstrap()
+
+			members := grouper.Members{
+				{Name: "brokers", Runner: network.BrokerGroupRunner()},
+				{Name: "orderers", Runner: network.OrdererGroupRunner()},
+			}
+			networkRunner := grouper.NewOrdered(syscall.SIGTERM, members)
+			process = ifrit.Invoke(networkRunner)
+			Eventually(process.Ready()).Should(BeClosed())
+
+			org1peer0 := network.Peer("Org1", "peer0")
+			org2peer0 := network.Peer("Org2", "peer0")
+			org3peer0 := network.Peer("Org3", "peer0")
+
+			testPeers := []*nwo.Peer{org1peer0, org2peer0, org3peer0}
+			for _, peer := range testPeers {
+				pr := network.PeerRunner(peer)
+				p := ifrit.Invoke(pr)
+				peerProcesses[peer.ID()] = p
+				Eventually(p.Ready(), network.EventuallyTimeout).Should(BeClosed())
+			}
+
+			orderer = network.Orderer("orderer")
+			network.CreateAndJoinChannel(orderer, channelID)
+			network.UpdateChannelAnchors(orderer, channelID)
+
+			By("verifying membership")
+			network.VerifyMembership(network.Peers, channelID)
+
+			By("installing and instantiating chaincode on all peers")
+			testChaincode := chaincode{
+				Chaincode: nwo.Chaincode{
+					Name:              "marblesp",
+					Version:           "1.0",
+					Path:              "github.com/hyperledger/fabric/integration/chaincode/marbles_private/cmd",
+					Ctor:              `{"Args":["init"]}`,
+					Policy:            `OR ('Org1MSP.member','Org2MSP.member', 'Org3MSP.member')`,
+					CollectionsConfig: filepath.Join("testdata", "collection_configs", "collections_config1.json"),
+				},
+				isLegacy: true,
+			}
+			deployChaincode(network, orderer, testChaincode)
+
+			By("adding marble1 with an org 1 peer as endorser")
+			peer := network.Peer("Org1", "peer0")
+			marbleDetails := `{"name":"marble1", "color":"blue", "size":35, "owner":"tom", "price":99}`
+			addMarble(network, orderer, testChaincode.Name, marbleDetails, peer)
+
+			By("waiting for block to propagate")
+			nwo.WaitUntilEqualLedgerHeight(network, channelID, nwo.GetLedgerHeight(network, network.Peers[0], channelID), network.Peers...)
+
+			org2Peer1 := &nwo.Peer{
+				Name:         "peer1",
+				Organization: "Org2",
+				Channels:     []*nwo.PeerChannel{}, // Don't set channels here so the UpdateConfig call doesn't try to fetch blocks for org2Peer1 with the default Admin user
+			}
+			network.Peers = append(network.Peers, org2Peer1)
+		})
+
+		AfterEach(func() {
+			for _, peerProcess := range peerProcesses {
+				if peerProcess != nil {
+					peerProcess.Signal(syscall.SIGTERM)
+					Eventually(peerProcess.Wait(), network.EventuallyTimeout).Should(Receive())
+				}
+			}
+		})
+
+		It("verifies private data is pulled when joining a new peer with new certs", func() {
+			By("generating new certs for org2Peer1")
+			org2Peer1 := network.Peer("Org2", "peer1")
+			tempCryptoDir, err := ioutil.TempDir("", "crypto")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(tempCryptoDir)
+			generateNewCertsForPeer(network, tempCryptoDir, org2Peer1)
+
+			By("updating the channel config with the new certs")
+			updateConfigWithNewCertsForPeer(network, tempCryptoDir, orderer, org2Peer1)
+
+			By("starting the peer1.org2 process")
+			pr := network.PeerRunner(org2Peer1)
+			p := ifrit.Invoke(pr)
+			peerProcesses[org2Peer1.ID()] = p
+			Eventually(p.Ready(), network.EventuallyTimeout).Should(BeClosed())
+
+			By("joining peer1.org2 to the channel with its Admin2 user")
+			tempFile, err := ioutil.TempFile("", "genesis-block")
+			Expect(err).NotTo(HaveOccurred())
+			tempFile.Close()
+			defer os.Remove(tempFile.Name())
+
+			sess, err := network.PeerUserSession(org2Peer1, "Admin2", commands.ChannelFetch{
+				Block:      "0",
+				ChannelID:  channelID,
+				Orderer:    network.OrdererAddress(orderer, nwo.ListenPort),
+				OutputFile: tempFile.Name(),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(0))
+
+			sess, err = network.PeerUserSession(org2Peer1, "Admin2", commands.ChannelJoin{
+				BlockPath: tempFile.Name(),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(0))
+
+			org2Peer1.Channels = append(org2Peer1.Channels, &nwo.PeerChannel{Name: channelID, Anchor: false})
+
+			ledgerHeight := nwo.GetLedgerHeight(network, network.Peers[0], channelID)
+
+			By("fetching latest blocks to peer1.org2")
+			// Retry channel fetch until peer1.org2 retrieves latest block
+			// Channel Fetch will repeatedly fail until org2Peer1 commits the config update adding its new cert
+			Eventually(fetchBlocksForPeer(network, org2Peer1, "Admin2"), network.EventuallyTimeout).Should(gbytes.Say(fmt.Sprintf("Received block: %d", ledgerHeight-1)))
+
+			By("installing chaincode on peer1.org2 to be able to query it")
+			chaincode := nwo.Chaincode{
+				Name:              "marblesp",
+				Version:           "1.0",
+				Path:              "github.com/hyperledger/fabric/integration/chaincode/marbles_private/cmd",
+				Ctor:              `{"Args":["init"]}`,
+				Policy:            `OR ('Org1MSP.member','Org2MSP.member', 'Org3MSP.member')`,
+				CollectionsConfig: filepath.Join("testdata", "collection_configs", "collections_config1.json")}
+
+			sess, err = network.PeerUserSession(org2Peer1, "Admin2", commands.ChaincodeInstallLegacy{
+				Name:        chaincode.Name,
+				Version:     chaincode.Version,
+				Path:        chaincode.Path,
+				Lang:        chaincode.Lang,
+				PackageFile: chaincode.PackageFile,
+				ClientAuth:  network.ClientAuthRequired,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(0))
+
+			sess, err = network.PeerUserSession(org2Peer1, "Admin2", commands.ChaincodeListInstalledLegacy{
+				ClientAuth: network.ClientAuthRequired,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(0))
+			Expect(sess).To(gbytes.Say(fmt.Sprintf("Name: %s, Version: %s,", chaincode.Name, chaincode.Version)))
+
+			expectedPeers := []*nwo.Peer{
+				network.Peer("Org1", "peer0"),
+				network.Peer("Org2", "peer0"),
+				network.Peer("Org2", "peer1"),
+				network.Peer("Org3", "peer0"),
+			}
+
+			By("making sure all peers have the same ledger height")
+			for _, peer := range expectedPeers {
+				Eventually(func() int {
+					var (
+						sess *gexec.Session
+						err  error
+					)
+					if peer.ID() == "Org2.peer1" {
+						// use Admin2 user for peer1.org2
+						sess, err = network.PeerUserSession(peer, "Admin2", commands.ChannelInfo{
+							ChannelID: channelID,
+						})
+						Expect(err).NotTo(HaveOccurred())
+						Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(0))
+						channelInfoStr := strings.TrimPrefix(string(sess.Buffer().Contents()[:]), "Blockchain info:")
+						var channelInfo = cb.BlockchainInfo{}
+						err = json.Unmarshal([]byte(channelInfoStr), &channelInfo)
+						Expect(err).NotTo(HaveOccurred())
+						return int(channelInfo.Height)
+					}
+
+					// If not Org2.peer1, just use regular getLedgerHeight call with User1
+					return nwo.GetLedgerHeight(network, peer, channelID)
+				}(), network.EventuallyTimeout).Should(Equal(ledgerHeight))
+			}
+
+			By("verifying membership")
+			expectedDiscoveredPeers := make([]nwo.DiscoveredPeer, 0, len(expectedPeers))
+			for _, peer := range expectedPeers {
+				expectedDiscoveredPeers = append(expectedDiscoveredPeers, network.DiscoveredPeer(peer, "_lifecycle", "marblesp"))
+			}
+			for _, peer := range expectedPeers {
+				By(fmt.Sprintf("checking expected peers for peer: %s", peer.ID()))
+				if peer.ID() == "Org2.peer1" {
+					// use Admin2 user for peer1.org2
+					Eventually(nwo.DiscoverPeers(network, peer, "Admin2", channelID), network.EventuallyTimeout).Should(ConsistOf(expectedDiscoveredPeers))
+				} else {
+					Eventually(nwo.DiscoverPeers(network, peer, "User1", channelID), network.EventuallyTimeout).Should(ConsistOf(expectedDiscoveredPeers))
+				}
+			}
+
+			By("verifying peer1.org2 got the private data that was created historically")
+			sess, err = network.PeerUserSession(org2Peer1, "Admin2", commands.ChaincodeQuery{
+				ChannelID: channelID,
+				Name:      "marblesp",
+				Ctor:      `{"Args":["readMarble","marble1"]}`,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(0))
+			Expect(sess).To(gbytes.Say(`{"docType":"marble","name":"marble1","color":"blue","size":35,"owner":"tom"}`))
+
+			sess, err = network.PeerUserSession(org2Peer1, "Admin2", commands.ChaincodeQuery{
+				ChannelID: channelID,
+				Name:      "marblesp",
+				Ctor:      `{"Args":["readMarblePrivateDetails","marble1"]}`,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(0))
+			Expect(sess).To(gbytes.Say(`{"docType":"marblePrivateDetails","name":"marble1","price":99}`))
 		})
 	})
 
@@ -1432,4 +1659,120 @@ func getValueForCollectionMarbles(marbleName, color, owner string, size int) []b
 func getValueForCollectionMarblePrivateDetails(marbleName string, price int) []byte {
 	marbleJSONasString := `{"docType":"marblePrivateDetails","name":"` + marbleName + `","price":` + strconv.Itoa(price) + `}`
 	return []byte(marbleJSONasString)
+}
+
+// fetchBlocksForPeer attempts to fetch the newest block on the given peer.
+// It skips the orderer and returns the session's Err buffer for parsing.
+func fetchBlocksForPeer(n *nwo.Network, peer *nwo.Peer, user string) func() *gbytes.Buffer {
+	return func() *gbytes.Buffer {
+		sess, err := n.PeerUserSession(peer, user, commands.ChannelFetch{
+			Block:      "newest",
+			ChannelID:  channelID,
+			OutputFile: filepath.Join(n.RootDir, "newest_block.pb"),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit())
+		return sess.Err
+	}
+}
+
+// updateConfigWithNewCertsForPeer updates the channel config with new certs for the designated peer
+func updateConfigWithNewCertsForPeer(network *nwo.Network, tempCryptoDir string, orderer *nwo.Orderer, peer *nwo.Peer) {
+	org := network.Organization(peer.Organization)
+
+	By("fetching the channel policy")
+	currentConfig := nwo.GetConfig(network, network.Peers[0], orderer, channelID)
+	updatedConfig := proto.Clone(currentConfig).(*cb.Config)
+
+	By("parsing the old and new MSP configs")
+	oldConfig := &mspp.MSPConfig{}
+	err := proto.Unmarshal(
+		updatedConfig.ChannelGroup.Groups["Application"].Groups[org.Name].Values["MSP"].Value,
+		oldConfig)
+	Expect(err).NotTo(HaveOccurred())
+
+	tempOrgMSPPath := filepath.Join(tempCryptoDir, "peerOrganizations", org.Domain, "msp")
+	newConfig, err := msp.GetVerifyingMspConfig(tempOrgMSPPath, org.MSPID, "bccsp")
+	Expect(err).NotTo(HaveOccurred())
+	oldMspConfig := &mspp.FabricMSPConfig{}
+	newMspConfig := &mspp.FabricMSPConfig{}
+	err = proto.Unmarshal(oldConfig.Config, oldMspConfig)
+	Expect(err).NotTo(HaveOccurred())
+	err = proto.Unmarshal(newConfig.Config, newMspConfig)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("merging the two MSP configs")
+	updateOldMspConfigWithNewMspConfig(oldMspConfig, newMspConfig)
+
+	By("updating the channel config")
+	updatedConfig.ChannelGroup.Groups["Application"].Groups[org.Name].Values["MSP"].Value = protoutil.MarshalOrPanic(
+		&mspp.MSPConfig{
+			Type:   oldConfig.Type,
+			Config: protoutil.MarshalOrPanic(oldMspConfig),
+		})
+	nwo.UpdateConfig(network, orderer, channelID, currentConfig, updatedConfig, false, network.Peer(org.Name, "peer0"))
+}
+
+// updateOldMspConfigWithNewMspConfig updates the oldMspConfig with certs from the newMspConfig
+func updateOldMspConfigWithNewMspConfig(oldMspConfig, newMspConfig *mspp.FabricMSPConfig) {
+	oldMspConfig.RootCerts = append(oldMspConfig.RootCerts, newMspConfig.RootCerts...)
+	oldMspConfig.TlsRootCerts = append(oldMspConfig.TlsRootCerts, newMspConfig.TlsRootCerts...)
+	oldMspConfig.FabricNodeOus.PeerOuIdentifier.Certificate = nil
+	oldMspConfig.FabricNodeOus.ClientOuIdentifier.Certificate = nil
+	oldMspConfig.FabricNodeOus.AdminOuIdentifier.Certificate = nil
+}
+
+// generateNewCertsForPeer generates new certs with cryptogen for the designated peer and copies
+// the necessary certs to the original crypto dir as well as creating an Admin2 user to use for
+// any peer operations involving the peer
+func generateNewCertsForPeer(network *nwo.Network, tempCryptoDir string, peer *nwo.Peer) {
+	sess, err := network.Cryptogen(commands.Generate{
+		Config: network.CryptoConfigPath(),
+		Output: tempCryptoDir,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(0))
+
+	By("copying the new msp certs for the peer to the original crypto dir")
+	oldPeerMSPPath := network.PeerLocalMSPDir(peer)
+	org := network.Organization(peer.Organization)
+	tempPeerMSPPath := filepath.Join(
+		tempCryptoDir,
+		"peerOrganizations",
+		org.Domain,
+		"peers",
+		fmt.Sprintf("%s.%s", peer.Name, org.Domain),
+		"msp",
+	)
+	os.RemoveAll(oldPeerMSPPath)
+	err = exec.Command("cp", "-r", tempPeerMSPPath, oldPeerMSPPath).Run()
+	Expect(err).NotTo(HaveOccurred())
+
+	// This lets us keep the old user certs for the org for any peers still remaining in the org
+	// using the old certs
+	By("copying the new Admin user cert to the original user certs dir as Admin2")
+	oldAdminUserPath := filepath.Join(
+		network.RootDir,
+		"crypto",
+		"peerOrganizations",
+		org.Domain,
+		"users",
+		fmt.Sprintf("Admin2@%s", org.Domain),
+	)
+	tempAdminUserPath := filepath.Join(
+		tempCryptoDir,
+		"peerOrganizations",
+		org.Domain,
+		"users",
+		fmt.Sprintf("Admin@%s", org.Domain),
+	)
+	os.RemoveAll(oldAdminUserPath)
+	err = exec.Command("cp", "-r", tempAdminUserPath, oldAdminUserPath).Run()
+	Expect(err).NotTo(HaveOccurred())
+	// We need to rename the signcert from Admin to Admin2 as well
+	err = os.Rename(
+		filepath.Join(oldAdminUserPath, "msp", "signcerts", fmt.Sprintf("Admin@%s-cert.pem", org.Domain)),
+		filepath.Join(oldAdminUserPath, "msp", "signcerts", fmt.Sprintf("Admin2@%s-cert.pem", org.Domain)),
+	)
+	Expect(err).NotTo(HaveOccurred())
 }

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -219,9 +219,9 @@ func serve(args []string) error {
 	logObserver := floggingmetrics.NewObserver(metricsProvider)
 	flogging.SetObserver(logObserver)
 
-	membershipInfoProvider := privdata.NewMembershipInfoProvider(createSelfSignedData(), identityDeserializerFactory)
-
 	mspID := coreConfig.LocalMSPID
+
+	membershipInfoProvider := privdata.NewMembershipInfoProvider(mspID, createSelfSignedData(), identityDeserializerFactory)
 
 	chaincodeInstallPath := filepath.Join(coreconfig.GetPath("peer.fileSystemPath"), "lifecycle", "chaincodes")
 	ccStore := persistence.NewStore(chaincodeInstallPath)


### PR DESCRIPTION
Cherry-pick of #626 with updates to work with master

* Also includes change to `getMemberOrgs` to return a `map[string]struct{}` instead of string slice for more efficient membership checks

/cc @ale-linux @denyeart 