### PR TITLE
Reduce execution time of platforms/golang unit tests by disabling gzip compression

### DIFF
--- a/core/chaincode/platforms/golang/platform.go
+++ b/core/chaincode/platforms/golang/platform.go
@@ -108,6 +108,9 @@ func (p *Platform) ValidateCodePackage(code []byte) error {
 // Directory constant copied from tar package.
 const c_ISDIR = 040000
 
+// Default compression to use for production. Test packages disable compression.
+var gzipCompressionLevel = gzip.DefaultCompression
+
 // GetDeploymentPayload creates a gzip compressed tape archive that contains the
 // required assets to build and run go chaincode.
 //
@@ -145,7 +148,10 @@ func (p *Platform) GetDeploymentPayload(codepath string) ([]byte, error) {
 	}
 
 	payload := bytes.NewBuffer(nil)
-	gw := gzip.NewWriter(payload)
+	gw, err := gzip.NewWriterLevel(payload, gzipCompressionLevel)
+	if err != nil {
+		return nil, err
+	}
 	tw := tar.NewWriter(gw)
 
 	// Create directories so they get sane ownership and permissions


### PR DESCRIPTION
Packaging chaincode involves creating a compressed tar of the chaincode source and its transitive dependencies. In many cases, this is hundreds of files due to the dependency tree of grpc. It turns out that compressing hundreds of files takes a while and doing it multiple times
in tests results in very long test execution times.

By disabling gzip compression, the tests (running with race detection enabled) go from taking about 1m to about 10s.

This change creates an unexported package level var to hold the compression level to use that is initialized to gzip.DefaultCompression. An `init()` function was added to the test to explicitly set compression to gzip.NoCompression.