### PR TITLE
[FAB-17509] Handle all os.Stat errors in InitCrypto

### DIFF
--- a/internal/peer/common/common.go
+++ b/internal/peer/common/common.go
@@ -121,9 +121,10 @@ func InitConfig(cmdRoot string) error {
 func InitCrypto(mspMgrConfigDir, localMSPID, localMSPType string) error {
 	// Check whether msp folder exists
 	fi, err := os.Stat(mspMgrConfigDir)
-	if os.IsNotExist(err) || !fi.IsDir() {
-		// No need to try to load MSP from folder which is not available
-		return errors.Errorf("cannot init crypto, folder \"%s\" does not exist", mspMgrConfigDir)
+	if err != nil {
+		return errors.Errorf("cannot init crypto, specified path \"%s\" does not exist or cannot be accessed: %v", mspMgrConfigDir, err)
+	} else if !fi.IsDir() {
+		return errors.Errorf("cannot init crypto, specified path \"%s\" is not a directory", mspMgrConfigDir)
 	}
 	// Check whether localMSPID exists
 	if localMSPID == "" {


### PR DESCRIPTION
<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

Stop a SIGSEGV occurring in InitCrypto under certain circumstances.

os.Stat can return errors other than an ENOENT, so ensure all errors are handled.
    
Also cleaned up the unit tests; removed a duplicate test for ENOENT, and added the missing test for "file" instead of directory".

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->
https://jira.hyperledger.org/browse/FAB-17509

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
