### PR TITLE
[FAB-17467] Create signature for config update

### DIFF
--- a/pkg/config/signer.go
+++ b/pkg/config/signer.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package config
 
 import (
-	"crypto"
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/x509"
@@ -23,10 +22,9 @@ import (
 	"github.com/hyperledger/fabric-protos-go/msp"
 )
 
-// Signer holds the information necessary to sign a configuration update.
-// It implements the crypto.Signer interface for ECDSA keys.
-type Signer struct {
-	cert       *x509.Certificate
+// SigningIdentity is an MSP Identity that can be used to sign configuration updates and transaction.
+type SigningIdentity struct {
+	pemCert    []byte // pem encoded publicCert
 	mspID      string
 	privateKey *ecdsa.PrivateKey
 	publicKey  *ecdsa.PublicKey
@@ -36,11 +34,11 @@ type ecdsaSignature struct {
 	R, S *big.Int
 }
 
-// NewSigner creates a new signer for configuration updates. The publicCert
-// and privateKey should be pem encoded.
-func NewSigner(publicCert []byte, privateCert []byte, mspID string) (*Signer, error) {
+// NewSigningIdentity creates a new signing identity for configuration updates.
+// The publicCert and privateKey should be pem encoded.
+func NewSigningIdentity(publicCert []byte, privateKey []byte, mspID string) (*SigningIdentity, error) {
 	if mspID == "" {
-		return nil, errors.New("failed to create new signer, mspID can not be empty")
+		return nil, errors.New("failed to create new signingIdentity, mspID can not be empty")
 	}
 
 	cert, err := getCertFromPem(publicCert)
@@ -48,74 +46,66 @@ func NewSigner(publicCert []byte, privateCert []byte, mspID string) (*Signer, er
 		return nil, fmt.Errorf("failed to get cert from pem: %v", err)
 	}
 
-	publicKey, err := ecdsaPublicKeyImport(cert)
+	pubKey, err := ecdsaPublicKeyImport(cert)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ECDSA public key: %v", err)
 	}
 
-	pkBlock, _ := pem.Decode(privateCert)
-	if pkBlock == nil {
+	pkBlock, _ := pem.Decode(privateKey)
+	if pkBlock == nil || pkBlock.Type != "PRIVATE KEY" {
 		return nil, errors.New("failed to decode private key from pem")
 	}
 
-	privateKey, err := ecdsaPrivateKeyImport(pkBlock.Bytes)
+	privKey, err := ecdsaPrivateKeyImport(pkBlock.Bytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ECDSA private key: %v", err)
 	}
 
-	signer := &Signer{
-		cert:       cert,
+	signer := &SigningIdentity{
+		pemCert:    publicCert,
 		mspID:      mspID,
-		privateKey: privateKey,
-		publicKey:  publicKey,
+		privateKey: privKey,
+		publicKey:  pubKey,
 	}
 
 	return signer, nil
 }
 
 // Serialize returns a byte array representation of this identity.
-func (s *Signer) Serialize() ([]byte, error) {
-	pb := &pem.Block{Bytes: s.cert.Raw, Type: "CERTIFICATE"}
-	pemBytes := pem.EncodeToMemory(pb)
-	if pemBytes == nil {
-		return nil, errors.New("failed to encode pem block")
-	}
-
+func (s *SigningIdentity) Serialize() ([]byte, error) {
 	// serialize identities by prepending the MSPID and appending
 	// the ASN.1 DER content of the cert
-	sID := &msp.SerializedIdentity{Mspid: s.mspID, IdBytes: pemBytes}
-
+	sID := &msp.SerializedIdentity{Mspid: s.mspID, IdBytes: s.pemCert}
 	idBytes, err := proto.Marshal(sID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal serialized identity: %v", err)
+		return nil, fmt.Errorf("failed to marshal serialized indentity: %v", err)
 	}
 
 	return idBytes, nil
 }
 
-// Public returns the public key of the signer.
-func (s *Signer) Public() crypto.PublicKey {
-	return s.publicKey
-}
-
 // Cert returns the certificate of the signer.
-func (s *Signer) Cert() *x509.Certificate {
-	return s.cert
+func (s *SigningIdentity) Cert() (*x509.Certificate, error) {
+	cert, err := getCertFromPem(s.pemCert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cert from pem: %v", err)
+	}
+	return cert, nil
 }
 
 // MSPId returns the MSP ID of the signer.
-func (s *Signer) MSPId() string {
+func (s *SigningIdentity) MSPId() string {
 	return s.mspID
 }
 
-// Sign performs ECDSA sign with signer's private key on given digest. It
-// ensures signatures are created with Low S values since Fabric normalizes
+// Sign performs ECDSA sign with SigningIdentity's private key on given digest.
+// It ensures signatures are created with Low S values since Fabric normalizes
 // all signatures to Low S.
 // See https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki#low_s
 // for more detail.
-func (s *Signer) Sign(reader io.Reader, digest []byte) (signature []byte, err error) {
+func (s *SigningIdentity) Sign(reader io.Reader, digest []byte) (signature []byte, err error) {
 	if reader == nil {
-		return nil, errors.New("failed to sign, reader can not be nil")
+		return nil, errors.New("reader can not be nil")
 	}
 
 	rr, ss, err := ecdsa.Sign(reader, s.privateKey, digest)
@@ -135,9 +125,9 @@ func (s *Signer) Sign(reader io.Reader, digest []byte) (signature []byte, err er
 	return asn1.Marshal(sig)
 }
 
-// CreateSignatureHeader returns a new SignatureHeader. It contains a valid
-// nonce and a creator, which is a serialized representation of the signer.
-func (s *Signer) CreateSignatureHeader() (*common.SignatureHeader, error) {
+// CreateSignatureHeader returns a new SignatureHeader. It contains a valid nonce
+// and a creator, which is a serialized representation of the signing identity.
+func (s *SigningIdentity) CreateSignatureHeader() (*common.SignatureHeader, error) {
 	creator, err := s.Serialize()
 	if err != nil {
 		return nil, err
@@ -155,28 +145,22 @@ func (s *Signer) CreateSignatureHeader() (*common.SignatureHeader, error) {
 
 // createNonce generates a nonce using the crypto/rand package.
 func createNonce() ([]byte, error) {
-	nonce, err := getRandomNonce()
+	nonce := make([]byte, 24)
+
+	_, err := rand.Read(nonce)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate random nonce: %s", err)
+		return nil, fmt.Errorf("failed to get random bytes: %v", err)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate random nonce: %v", err)
 	}
 	return nonce, nil
 }
 
-func getRandomNonce() ([]byte, error) {
-	key := make([]byte, 24)
-
-	_, err := rand.Read(key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get random bytes: %s", err)
-	}
-	return key, nil
-}
-
-// When using ECDSA, both (r,s) and (r, -s mod n) are valid signatures.
-// In order to protect against signature malleability attacks, Fabric
-// normalizes all signatures to a canonical form where s is at most half
-// the order of the curve. In order to make signatures compliant with what
-// Fabric expects, toLowS creates signatures in this canonical form.
+// toLows normalizes all signatures to a canonical form where s is at most
+// half the order of the curve. By doing so, it compliant with what Fabric
+// expected as well as protect against signature malleability attacks.
 func toLowS(key ecdsa.PublicKey, sig ecdsaSignature) ecdsaSignature {
 	// calculate half order of the curve
 	halfOrder := new(big.Int).Div(key.Curve.Params().N, big.NewInt(2))
@@ -191,7 +175,7 @@ func toLowS(key ecdsa.PublicKey, sig ecdsaSignature) ecdsaSignature {
 // getCertFromPem decodes a pem encoded cert into an x509 certificate.
 func getCertFromPem(pemBytes []byte) (*x509.Certificate, error) {
 	pemCert, _ := pem.Decode(pemBytes)
-	if pemCert == nil {
+	if pemCert == nil || pemCert.Type != "CERTIFICATE" {
 		return nil, fmt.Errorf("failed to decode pem bytes: %v", pemBytes)
 	}
 


### PR DESCRIPTION
Signed-off-by: Chongxin Luo <Chongxin.Luo@ibm.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
- additional fixes that addresses this PR: https://github.com/hyperledger/fabric/pull/669

#### Additional details
- Changed the structure name from **_Signer_** to **_SigningIdentity_**.
- Added parallel execution for all unit tests.
- Removed **_MarshalOrPanic_** function.
- Removed **_Public_** method from **_SigningIdentity_** , as it does not implement [crypto.Signer](https://golang.org/pkg/crypto/#Signer) anymore.
- Removed package level state **_publicKey_**, **_privateKey_** in unit tests. 


#### Related issues
[FAB-17467](https://jira.hyperledger.org/browse/FAB-17467)

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
