### PR TITLE
[FAB-17491] Do not disseminate pvtdata for other org's implicit collection

### DIFF
--- a/core/chaincode/lifecycle/deployedcc_infoprovider_test.go
+++ b/core/chaincode/lifecycle/deployedcc_infoprovider_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode/lifecycle"
 	"github.com/hyperledger/fabric/core/chaincode/lifecycle/mock"
 	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/peer"
 	"github.com/hyperledger/fabric/protoutil"
 
 	"github.com/golang/protobuf/proto"
@@ -67,6 +68,7 @@ var _ = Describe("ValidatorCommitter", func() {
 		}
 
 		vc = &lifecycle.ValidatorCommitter{
+			CoreConfig:                   &peer.Config{LocalMSPID: "first-mspid"},
 			Resources:                    resources,
 			LegacyDeployedCCInfoProvider: fakeLegacyProvider,
 		}
@@ -312,10 +314,12 @@ var _ = Describe("ValidatorCommitter", func() {
 			}
 			Expect(firstOrg).NotTo(BeNil())
 			Expect(firstOrg.RequiredPeerCount).To(Equal(int32(0)))
+			// implicit collection MaximumPeerCount is 1 when its mspid matches peer's local mspid
 			Expect(firstOrg.MaximumPeerCount).To(Equal(int32(1)))
 			Expect(secondOrg).NotTo(BeNil())
 			Expect(secondOrg.RequiredPeerCount).To(Equal(int32(0)))
-			Expect(secondOrg.MaximumPeerCount).To(Equal(int32(1)))
+			// implicit collection MaximumPeerCount is 0 when its mspid doesn't match peer's local mspid
+			Expect(secondOrg.MaximumPeerCount).To(Equal(int32(0)))
 		})
 
 		Context("when the chaincode does not exist", func() {

--- a/core/ledger/kvledger/tests/env.go
+++ b/core/ledger/kvledger/tests/env.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/ledger/kvledger"
 	"github.com/hyperledger/fabric/core/ledger/ledgermgmt"
+	corepeer "github.com/hyperledger/fabric/core/peer"
 	"github.com/hyperledger/fabric/core/scc/lscc"
 	"github.com/hyperledger/fabric/msp"
 	"github.com/hyperledger/fabric/msp/mgmt"
@@ -313,13 +314,14 @@ func (dc *deployedCCInfoProviderWrapper) AllCollectionsConfigPkg(channelName, ch
 func (dc *deployedCCInfoProviderWrapper) ImplicitCollections(channelName, chaincodeName string, qe ledger.SimpleQueryExecutor) ([]*peer.StaticCollectionConfig, error) {
 	collConfigs := make([]*peer.StaticCollectionConfig, 0, len(dc.orgMSPIDs))
 	for _, mspID := range dc.orgMSPIDs {
-		collConfigs = append(collConfigs, lifecycle.GenerateImplicitCollectionForOrg(mspID))
+		collConfigs = append(collConfigs, dc.ValidatorCommitter.GenerateImplicitCollectionForOrg(mspID))
 	}
 	return collConfigs, nil
 }
 
 func createDeployedCCInfoProvider(orgMSPIDs []string) ledger.DeployedChaincodeInfoProvider {
 	deployedCCInfoProvider := &lifecycle.ValidatorCommitter{
+		CoreConfig: &corepeer.Config{},
 		Resources: &lifecycle.Resources{
 			Serializer: &lifecycle.Serializer{},
 		},

--- a/integration/chaincode/kvexecutor/chaincode.go
+++ b/integration/chaincode/kvexecutor/chaincode.go
@@ -1,0 +1,117 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package kvexecutor
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hyperledger/fabric-chaincode-go/shim"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/pkg/errors"
+)
+
+// KVExcutor is a chaincode implementation that takes a KVData array as read parameter
+// and a a KVData array as write parameter, and then calls GetXXX/PutXXX methods to read and write
+// state/collection data. Both input params should be marshalled json data and then base64 encoded.
+type KVExcutor struct {
+}
+
+// KVData contains the data to read/write a key.
+// Key is required. Value is required for write and ignored for read.
+// When Collection is empty string "", it will read/write state data.
+// When Collection is not empty string "", it will read/write private data in the collection.
+type KVData struct {
+	Collection string `json:"collection"` // optional
+	Key        string `json:"key"`        // required
+	Value      string `json:"value"`      // required for read, ignored for write
+}
+
+// Init initializes chaincode
+// ===========================
+func (t *KVExcutor) Init(stub shim.ChaincodeStubInterface) pb.Response {
+	return shim.Success(nil)
+}
+
+// Invoke - Our entry point for Invocations
+// ========================================
+func (t *KVExcutor) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
+	function, args := stub.GetFunctionAndParameters()
+	fmt.Println("invoke is running " + function)
+
+	switch function {
+	case "readWriteKVs":
+		return t.readWriteKVs(stub, args)
+	default:
+		//error
+		fmt.Println("invoke did not find func: " + function)
+		return shim.Error("Received unknown function invocation")
+	}
+}
+
+// both params should be marshalled json data and base64 encoded
+func (t *KVExcutor) readWriteKVs(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	if len(args) != 2 {
+		return shim.Error("Incorrect number of arguments. Expecting 2 (readInputs and writeInputs)")
+	}
+	readInputs, err := parseArg(args[0])
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	writeInputs, err := parseArg(args[1])
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+
+	results := make([]*KVData, 0)
+	var val []byte
+	for _, input := range readInputs {
+		if input.Collection == "" {
+			val, err = stub.GetState(input.Key)
+		} else {
+			val, err = stub.GetPrivateData(input.Collection, input.Key)
+		}
+		if err != nil {
+			return shim.Error(fmt.Sprintf("failed to read data for %+v: %s", input, err))
+		}
+		result := KVData{Collection: input.Collection, Key: input.Key, Value: string(val)}
+		results = append(results, &result)
+	}
+
+	for _, input := range writeInputs {
+		if input.Collection == "" {
+			err = stub.PutState(input.Key, []byte(input.Value))
+		} else {
+			err = stub.PutPrivateData(input.Collection, input.Key, []byte(input.Value))
+		}
+		if err != nil {
+			return shim.Error(fmt.Sprintf("failed to write data for %+v: %s", input, err))
+		}
+	}
+
+	resultBytes, err := json.Marshal(results)
+	if err != nil {
+		return shim.Error(fmt.Sprintf("failed to marshal results %+v: %s", results, err))
+	}
+	return shim.Success(resultBytes)
+}
+
+func parseArg(inputParam string) ([]*KVData, error) {
+	kvdata := make([]*KVData, 0)
+	inputBytes, err := base64.StdEncoding.DecodeString(inputParam)
+	if inputParam == "" {
+		return kvdata, nil
+	}
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to base64 decode input %s", inputParam)
+	}
+	if err = json.Unmarshal(inputBytes, &kvdata); err != nil {
+		return nil, errors.WithMessagef(err, "failed to unmarshal kvdata %s", string(inputBytes))
+	}
+	return kvdata, nil
+}

--- a/integration/chaincode/kvexecutor/cmd/main.go
+++ b/integration/chaincode/kvexecutor/cmd/main.go
@@ -1,0 +1,23 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hyperledger/fabric-chaincode-go/shim"
+	"github.com/hyperledger/fabric/integration/chaincode/kvexecutor"
+)
+
+func main() {
+	err := shim.Start(&kvexecutor.KVExcutor{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Exiting Simple chaincode: %s", err)
+		os.Exit(2)
+	}
+}

--- a/integration/pvtdata/implicit_coll_test.go
+++ b/integration/pvtdata/implicit_coll_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pvtdata
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/hyperledger/fabric/integration/chaincode/kvexecutor"
+	"github.com/hyperledger/fabric/integration/nwo"
+	"github.com/hyperledger/fabric/integration/nwo/commands"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/tedsuo/ifrit"
+)
+
+var _ bool = Describe("PrivateData implicit collection", func() {
+	var (
+		network       *nwo.Network
+		process       ifrit.Process
+		orderer       *nwo.Orderer
+		testChaincode chaincode
+	)
+
+	BeforeEach(func() {
+		By("setting up the network")
+		network = initThreeOrgsSetup(false)
+
+		By("setting the pull retry threshold to 0 on all peers")
+		// set pull retry threshold to 0 to disable pulling
+		for _, p := range network.Peers {
+			core := network.ReadPeerConfig(p)
+			core.Peer.Gossip.PvtData.PullRetryThreshold = 0
+			network.WritePeerConfig(p, core)
+		}
+
+		By("starting the network")
+		process, orderer = startNetwork(network)
+
+		By("deploying new lifecycle chaincode")
+		testChaincode = chaincode{
+			Chaincode: nwo.Chaincode{
+				Name:        "kvexecutor",
+				Version:     "1.0",
+				Path:        components.Build("github.com/hyperledger/fabric/integration/chaincode/kvexecutor/cmd"),
+				Lang:        "binary",
+				PackageFile: filepath.Join(network.RootDir, "kvexcutor.tar.gz"),
+				Label:       "kvexcutor",
+				Sequence:    "1",
+			},
+			isLegacy: false,
+		}
+		nwo.EnableCapabilities(network, channelID, "Application", "V2_0", orderer, network.Peers...)
+		deployChaincode(network, orderer, testChaincode)
+	})
+
+	AfterEach(func() {
+		testCleanup(network, process)
+	})
+
+	It("disseminates implicit collection data owned by the peer's org ", func() {
+		peer1 := network.Peer("Org1", "peer0")
+		peer2 := network.Peer("Org2", "peer0")
+
+		By("writing private data to org1's and org2's implicit collections")
+		writeInput := []kvexecutor.KVData{
+			{Collection: "_implicit_org_Org1MSP", Key: "org1_key1", Value: "org1_value1"},
+			{Collection: "_implicit_org_Org2MSP", Key: "org2_key1", Value: "org2_value1"},
+		}
+		writeImplicitCollection(network, orderer, testChaincode.Name, writeInput, peer1, peer2)
+
+		By("querying org1.peer0 for _implicit_org_Org1MSP collection data, expecting pvtdata")
+		readInput1 := []kvexecutor.KVData{{Collection: "_implicit_org_Org1MSP", Key: "org1_key1"}}
+		expectedMsg1, err := json.Marshal(writeInput[:1])
+		Expect(err).NotTo(HaveOccurred())
+		readImplicitCollection(network, network.Peer("Org1", "peer0"), testChaincode.Name, readInput1, string(expectedMsg1), true)
+
+		By("querying org1.peer1 for _implicit_org_Org1MSP collection data, expecting pvtdata")
+		readImplicitCollection(network, network.Peer("Org1", "peer1"), testChaincode.Name, readInput1, string(expectedMsg1), true)
+
+		By("querying org2.peer0 for _implicit_org_Org1MSP collection data, expecting error")
+		readImplicitCollection(network, network.Peer("Org2", "peer0"), testChaincode.Name, readInput1,
+			"private data matching public hash version is not available", false)
+
+		By("querying org2.peer1 for _implicit_org_Org1MSP collection data, expecting error")
+		readImplicitCollection(network, network.Peer("Org2", "peer1"), testChaincode.Name, readInput1,
+			"private data matching public hash version is not available", false)
+
+		By("querying org2.peer0 for _implicit_org_Org2MSP collection data, expecting pvtdata")
+		readInput2 := []kvexecutor.KVData{{Collection: "_implicit_org_Org2MSP", Key: "org2_key1"}}
+		expectedMsg2, err := json.Marshal(writeInput[1:])
+		Expect(err).NotTo(HaveOccurred())
+		readImplicitCollection(network, network.Peer("Org2", "peer0"), testChaincode.Name, readInput2, string(expectedMsg2), true)
+
+		By("querying org2.peer1 for _implicit_org_Org2MSP collection data, expecting pvtdata")
+		readImplicitCollection(network, network.Peer("Org2", "peer1"), testChaincode.Name, readInput2, string(expectedMsg2), true)
+
+		By("querying org1.peer0 for _implicit_org_Org2MSP collection data, expecting error")
+		readImplicitCollection(network, network.Peer("Org1", "peer0"), testChaincode.Name, readInput2,
+			"private data matching public hash version is not available", false)
+
+		By("querying org1.peer1 for _implicit_org_Org2MSP collection data, expecting error")
+		readImplicitCollection(network, network.Peer("Org1", "peer1"), testChaincode.Name, readInput2,
+			"private data matching public hash version is not available", false)
+	})
+})
+
+func writeImplicitCollection(n *nwo.Network, orderer *nwo.Orderer, chaincodeName string, writeInput []kvexecutor.KVData, peers ...*nwo.Peer) {
+	writeInputBytes, err := json.Marshal(writeInput)
+	Expect(err).NotTo(HaveOccurred())
+	writeInputBase64 := base64.StdEncoding.EncodeToString(writeInputBytes)
+
+	peerAddresses := make([]string, 0)
+	for _, peer := range peers {
+		peerAddresses = append(peerAddresses, n.PeerAddress(peer, nwo.ListenPort))
+	}
+	command := commands.ChaincodeInvoke{
+		ChannelID:     channelID,
+		Orderer:       n.OrdererAddress(orderer, nwo.ListenPort),
+		Name:          chaincodeName,
+		Ctor:          fmt.Sprintf(`{"Args":["readWriteKVs","%s","%s"]}`, "", writeInputBase64),
+		PeerAddresses: peerAddresses,
+		WaitForEvent:  true,
+	}
+	invokeChaincode(n, peers[0], command)
+	nwo.WaitUntilEqualLedgerHeight(n, channelID, nwo.GetLedgerHeight(n, peers[0], channelID), n.Peers...)
+}
+
+func readImplicitCollection(n *nwo.Network, peer *nwo.Peer, chaincodeName string, readInput []kvexecutor.KVData, expectedMsg string, expectSuccess bool) {
+	readInputBytes, err := json.Marshal(readInput)
+	Expect(err).NotTo(HaveOccurred())
+	readInputBase64 := base64.StdEncoding.EncodeToString(readInputBytes)
+
+	command := commands.ChaincodeQuery{
+		ChannelID: channelID,
+		Name:      chaincodeName,
+		Ctor:      fmt.Sprintf(`{"Args":["readWriteKVs","%s","%s"]}`, readInputBase64, ""),
+	}
+	queryChaincode(n, peer, command, expectedMsg, expectSuccess)
+}

--- a/integration/pvtdata/pvtdata_test.go
+++ b/integration/pvtdata/pvtdata_test.go
@@ -66,7 +66,7 @@ var _ bool = Describe("PrivateData", func() {
 	Describe("Dissemination when pulling is disabled", func() {
 		BeforeEach(func() {
 			By("setting up the network")
-			network = initThreeOrgsSetup()
+			network = initThreeOrgsSetup(true)
 
 			By("setting the pull retry threshold to 0 on all peers")
 			// set pull retry threshold to 0
@@ -145,7 +145,7 @@ var _ bool = Describe("PrivateData", func() {
 
 		BeforeEach(func() {
 			By("setting up the network")
-			network = initThreeOrgsSetup()
+			network = initThreeOrgsSetup(true)
 			legacyChaincode = nwo.Chaincode{
 				Name:    "marblesp",
 				Version: "1.0",
@@ -723,7 +723,7 @@ var _ bool = Describe("PrivateData", func() {
 	})
 })
 
-func initThreeOrgsSetup() *nwo.Network {
+func initThreeOrgsSetup(removePeer1 bool) *nwo.Network {
 	var err error
 	testDir, err := ioutil.TempDir("", "e2e-pvtdata")
 	Expect(err).NotTo(HaveOccurred())
@@ -754,6 +754,11 @@ func initThreeOrgsSetup() *nwo.Network {
 
 	n := nwo.New(config, testDir, client, StartPort(), components)
 	n.GenerateConfigTree()
+
+	if !removePeer1 {
+		Expect(n.Peers).To(HaveLen(5))
+		return n
+	}
 
 	// remove peer1 from org1 and org2 so we can add it back later, we generate the config tree above
 	// with the two peers so the config files exist later when adding the peer back

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -350,6 +350,7 @@ func serve(args []string) error {
 	}
 
 	lifecycleValidatorCommitter := &lifecycle.ValidatorCommitter{
+		CoreConfig:                   coreConfig,
 		Resources:                    lifecycleResources,
 		LegacyDeployedCCInfoProvider: &lscc.DeployedCCInfoProvider{},
 	}


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Bug fix

#### Description
For implicit collection, a peer should only disseminate pvtdata for it own org's implicit collection. Update GenerateImplicitCollectionForOrg to set maxPeerCount to 0 if an implicit collection is for another org so that the peer will not disseminate pvtdata for other org's implicit collection.

#### Related issues
https://jira.hyperledger.org/browse/FAB-17491