### PR TITLE
[FAB-17515] Support configuring BlockValidation policy for orderer group

### DIFF
--- a/common/tools/configtxgen/encoder/encoder_test.go
+++ b/common/tools/configtxgen/encoder/encoder_test.go
@@ -190,9 +190,15 @@ var _ = Describe("Encoder", func() {
 		It("translates the config into a config group", func() {
 			cg, err := encoder.NewOrdererGroup(conf)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(cg.Policies)).To(Equal(2)) // BlockValidation automatically added
+			Expect(len(cg.Policies)).To(Equal(1))
 			Expect(cg.Policies["SamplePolicy"]).NotTo(BeNil())
-			Expect(cg.Policies["BlockValidation"]).NotTo(BeNil())
+			Expect(cg.Policies["SamplePolicy"].Policy).To(Equal(&cb.Policy{
+				Type: int32(cb.Policy_IMPLICIT_META),
+				Value: utils.MarshalOrPanic(&cb.ImplicitMetaPolicy{
+					SubPolicy: "Admins",
+					Rule:      cb.ImplicitMetaPolicy_ANY,
+				}),
+			}))
 			Expect(len(cg.Groups)).To(Equal(1))
 			Expect(cg.Groups["SampleOrg"]).NotTo(BeNil())
 			Expect(len(cg.Values)).To(Equal(5))


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Before we used to hardcode the BlockValidation policy to an ImplicitMetaAnyPolicy and we also did not enforce that the BlockValidation policy existed.

#### Related issues

[FAB-17515](https://jira.hyperledger.org/browse/FAB-17515)