### PR TITLE
[FAB-16297] Remove pvtdataStore initiation with non-zero block height

### DIFF
--- a/core/ledger/ledgerstorage/store.go
+++ b/core/ledger/ledgerstorage/store.go
@@ -83,9 +83,6 @@ func (p *Provider) Open(ledgerid string) (*Store, error) {
 		BlockStore:   blockStore,
 		pvtdataStore: pvtdataStore,
 	}
-	if err := store.init(); err != nil {
-		return nil, err
-	}
 
 	info, err := blockStore.GetBlockchainInfo()
 	if err != nil {
@@ -274,54 +271,6 @@ func (s *Store) ResetLastUpdatedOldBlocksList() error {
 // greater than the blockstore height. Otherwise, it returns false.
 func (s *Store) IsPvtStoreAheadOfBlockStore() bool {
 	return s.isPvtstoreAheadOfBlockstore.Load().(bool)
-}
-
-// TODO: FAB-16297 -- Remove init() as it is no longer needed. The private data feature
-// became stable from v1.2 onwards. To allow the initiation of pvtdata store with non-zero
-// block height (mainly during a rolling upgrade from an existing v1.1 network to v1.2),
-// we introduced pvtdata init() function which would take the height of block store and
-// set it as a height of pvtdataStore. From v2.0 onwards, it is no longer needed as we do
-// not support a rolling upgrade from v1.1 to v2.0
-
-// init first invokes function `initFromExistingBlockchain`
-// in order to check whether the pvtdata store is present because of an upgrade
-// of peer from 1.0 and need to be updated with the existing blockchain. If, this is
-// not the case then this init will invoke function `syncPvtdataStoreWithBlockStore`
-// to follow the normal course
-func (s *Store) init() error {
-	var initialized bool
-	var err error
-	if initialized, err = s.initPvtdataStoreFromExistingBlockchain(); err != nil || initialized {
-		return err
-	}
-	return nil
-}
-
-// initPvtdataStoreFromExistingBlockchain updates the initial state of the pvtdata store
-// if an existing block store has a blockchain and the pvtdata store is empty.
-// This situation is expected to happen when a peer is upgrated from version 1.0
-// and an existing blockchain is present that was generated with version 1.0.
-// Under this scenario, the pvtdata store is brought upto the point as if it has
-// processed existing blocks with no pvt data. This function returns true if the
-// above mentioned condition is found to be true and pvtdata store is successfully updated
-func (s *Store) initPvtdataStoreFromExistingBlockchain() (bool, error) {
-	var bcInfo *common.BlockchainInfo
-	var pvtdataStoreEmpty bool
-	var err error
-
-	if bcInfo, err = s.BlockStore.GetBlockchainInfo(); err != nil {
-		return false, err
-	}
-	if pvtdataStoreEmpty, err = s.pvtdataStore.IsEmpty(); err != nil {
-		return false, err
-	}
-	if pvtdataStoreEmpty && bcInfo.Height > 0 {
-		if err = s.pvtdataStore.InitLastCommittedBlock(bcInfo.Height - 1); err != nil {
-			return false, err
-		}
-		return true, nil
-	}
-	return false, nil
 }
 
 func constructPvtdataMap(pvtdata []*ledger.TxPvtData) ledger.TxPvtDataMap {

--- a/core/ledger/pvtdatastorage/store.go
+++ b/core/ledger/pvtdatastorage/store.go
@@ -31,14 +31,6 @@ type Provider interface {
 type Store interface {
 	// Init initializes the store. This function is expected to be invoked before using the store
 	Init(btlPolicy pvtdatapolicy.BTLPolicy)
-	// InitLastCommittedBlockHeight sets the last committed block height into the pvt data store
-	// This function is used in a special case where the peer is started up with the blockchain
-	// from an earlier version of a peer when the pvt data feature (and hence this store) was not
-	// available. This function is expected to be called only this situation and hence is
-	// expected to throw an error if the store is not empty. On a successful return from this
-	// function the state of the store is expected to be same as of calling the prepare/commit
-	// function for block `0` through `blockNum` with no pvt data
-	InitLastCommittedBlock(blockNum uint64) error
 	// GetPvtDataByBlockNum returns only the pvt data  corresponding to the given block number
 	// The pvt data is filtered by the list of 'ns/collections' supplied in the filter
 	// A nil filter does not filter any results
@@ -67,8 +59,6 @@ type Store interface {
 	GetLastUpdatedOldBlocksPvtData() (map[uint64][]*ledger.TxPvtData, error)
 	// ResetLastUpdatedOldBlocksList removes the `lastUpdatedOldBlocksList` entry from the store
 	ResetLastUpdatedOldBlocksList() error
-	// IsEmpty returns true if the store does not have any block committed yet
-	IsEmpty() (bool, error)
 	// LastCommittedBlockHeight returns the height of the last committed block
 	LastCommittedBlockHeight() (uint64, error)
 	// Shutdown stops the store


### PR DESCRIPTION
#### Type of change

- Remove unneeded code

#### Description

This PR removes functions that set the initial state for the pvtdata store when an existing block store has a blockchain but the pvtdata store is empty. This situation is expected to happen when a peer is upgraded directly from version 1.0 to a future version (i.e., 1.0+), and an existing blockchain is present (which was created with version 1.0). Under this scenario, the pvtdata store is brought up to the point as if it has processed existing blocks with no pvtdata.

As we don't expect/support a direct upgrade from version 1.0 to version 2.1, we can remove code that takes care of the above-mentioned scenario.

#### Additional details

Note that pvtdata feature is available since version 1.1 (experimental) and became stable in version 1.2. 

#### Related issues

[FAB-16297](https://jira.hyperledger.org/browse/FAB-16297)

#### Release Note

Do we need to mention in the release note of v2.1 that the user cannot directly upgrade from version 1.0 to version 2.1?