### PR TITLE
[FAB-17469] Support updating orderer configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -251,19 +251,8 @@ func addValue(cg *cb.ConfigGroup, value *standardConfigValue, modPolicy string) 
 	return nil
 }
 
-// addOrdererPolicies adds *cb.ConfigPolicies to the passed Orderer *cb.ConfigGroup's Policies map.
-func addOrdererPolicies(cg *cb.ConfigGroup, policyMap map[string]*Policy, modPolicy string) error {
-	switch {
-	case policyMap == nil:
-		return errors.New("no policies defined")
-	case policyMap[BlockValidationPolicyKey] == nil:
-		return errors.New("no BlockValidation policy defined")
-	}
-
-	return addPolicies(cg, policyMap, modPolicy)
-}
-
 // addPolicies adds *cb.ConfigPolicies to the passed *cb.ConfigGroup's Policies map.
+// TODO: evaluate if modPolicy actually needs to be passed in if all callers pass AdminsPolicyKey.
 func addPolicies(cg *cb.ConfigGroup, policyMap map[string]*Policy, modPolicy string) error {
 	switch {
 	case policyMap == nil:

--- a/pkg/config/orderer_test.go
+++ b/pkg/config/orderer_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+
+	cb "github.com/hyperledger/fabric-protos-go/common"
 	mb "github.com/hyperledger/fabric-protos-go/msp"
 	ob "github.com/hyperledger/fabric-protos-go/orderer"
 	eb "github.com/hyperledger/fabric-protos-go/orderer/etcdraft"
@@ -131,7 +133,9 @@ func TestNewOrdererGroupFailure(t *testing.T) {
 					},
 				}
 			},
-			err: errors.New("failed to marshal etcdraft metadata for orderer type etcdraft: cannot load client cert for consenter " +
+			err: errors.New("failed to add orderer values: " +
+				"failed to marshal etcdraft metadata for orderer type etcdraft: " +
+				"cannot load client cert for consenter " +
 				"node-1.example.com:7050: open testdata/tls-client-1.pem: no such file or directory"),
 		},
 		{
@@ -139,7 +143,8 @@ func TestNewOrdererGroupFailure(t *testing.T) {
 			ordererMod: func(o *Orderer) {
 				o.OrdererType = "ConsensusTypeGreen"
 			},
-			err: errors.New("unknown orderer type ConsensusTypeGreen"),
+			err: errors.New("failed to add orderer values: " +
+				"unknown orderer type ConsensusTypeGreen"),
 		},
 		{
 			testName: "When EtcdRaft config is not set for consensus type etcdraft",
@@ -147,7 +152,8 @@ func TestNewOrdererGroupFailure(t *testing.T) {
 				o.OrdererType = ConsensusTypeEtcdRaft
 				o.EtcdRaft = nil
 			},
-			err: errors.New("missing etcdraft metadata for orderer type etcdraft"),
+			err: errors.New("failed to add orderer values: " +
+				"missing etcdraft metadata for orderer type etcdraft"),
 		},
 		{
 			testName: "When adding policies to orderer org group",
@@ -177,6 +183,112 @@ func TestNewOrdererGroupFailure(t *testing.T) {
 	}
 }
 
+func TestUpdateOrdererConfiguration(t *testing.T) {
+	t.Parallel()
+
+	gt := NewGomegaWithT(t)
+
+	baseOrdererConf := baseOrderer()
+
+	mspConfig := &mb.MSPConfig{}
+
+	ordererGroup, err := NewOrdererGroup(baseOrdererConf, mspConfig)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	originalOrdererAddresses, err := proto.Marshal(&cb.OrdererAddresses{
+		Addresses: baseOrdererConf.Addresses,
+	})
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	imp, err := implicitMetaFromString(baseOrdererConf.Policies[AdminsPolicyKey].Rule)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	originalAdminsPolicy, err := proto.Marshal(imp)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	config := &cb.Config{
+		ChannelGroup: &cb.ConfigGroup{
+			Groups: map[string]*cb.ConfigGroup{
+				"Orderer": ordererGroup,
+			},
+			Values: map[string]*cb.ConfigValue{
+				OrdererAddressesKey: {
+					Value:     originalOrdererAddresses,
+					ModPolicy: AdminsPolicyKey,
+				},
+			},
+			Policies: map[string]*cb.ConfigPolicy{
+				AdminsPolicyKey: {
+					Policy: &cb.Policy{
+						Type:  int32(cb.Policy_IMPLICIT_META),
+						Value: originalAdminsPolicy,
+					},
+					ModPolicy: AdminsPolicyKey,
+				},
+			},
+		},
+	}
+
+	updatedOrdererConf := baseOrdererConf
+
+	// Modify MaxMessageCount, Addresses, and ConesnsusType to etcdraft
+	updatedOrdererConf.BatchSize.MaxMessageCount = 10000
+	updatedOrdererConf.Addresses = []string{"newhost:345"}
+	updatedOrdererConf.OrdererType = ConsensusTypeEtcdRaft
+	updatedOrdererConf.EtcdRaft = &eb.ConfigMetadata{}
+
+	err = UpdateOrdererConfiguration(config, updatedOrdererConf)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	// Expected OrdererValues
+	expectedCapabilities, err := proto.Marshal(&cb.Capabilities{
+		Capabilities: map[string]*cb.Capability{
+			"V1_3": {},
+		},
+	})
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	expectedConsensusType, err := proto.Marshal(&ob.ConsensusType{
+		Type:     ConsensusTypeEtcdRaft,
+		Metadata: []byte{},
+	})
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	expectedBatchSize, err := proto.Marshal(&ob.BatchSize{
+		MaxMessageCount:   10000,
+		AbsoluteMaxBytes:  100,
+		PreferredMaxBytes: 100,
+	})
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	expectedBatchTimeout, err := proto.Marshal(&ob.BatchTimeout{
+		Timeout: "0s",
+	})
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	expectedChannelRestrictions, err := proto.Marshal(&ob.ChannelRestrictions{
+		MaxCount: 0,
+	})
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	expectedOrdererValues := map[string]*cb.ConfigValue{
+		CapabilitiesKey:        {Value: expectedCapabilities, ModPolicy: AdminsPolicyKey},
+		ConsensusTypeKey:       {Value: expectedConsensusType, ModPolicy: AdminsPolicyKey},
+		BatchSizeKey:           {Value: expectedBatchSize, ModPolicy: AdminsPolicyKey},
+		BatchTimeoutKey:        {Value: expectedBatchTimeout, ModPolicy: AdminsPolicyKey},
+		ChannelRestrictionsKey: {Value: expectedChannelRestrictions, ModPolicy: AdminsPolicyKey},
+	}
+
+	// Expected OrdererAddresses
+	expectedOrdererAddresses, err := proto.Marshal(&cb.OrdererAddresses{
+		Addresses: []string{"newhost:345"},
+	})
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	gt.Expect(config.ChannelGroup.Groups["Orderer"].Values).To(Equal(expectedOrdererValues))
+	gt.Expect(config.ChannelGroup.Values[OrdererAddressesKey].Value).To(Equal(expectedOrdererAddresses))
+}
+
 func baseOrderer() *Orderer {
 	return &Orderer{
 		Policies:    createOrdererStandardPolicies(),
@@ -202,5 +314,11 @@ func baseOrderer() *Orderer {
 		Capabilities: map[string]bool{
 			"V1_3": true,
 		},
+		BatchSize: BatchSize{
+			MaxMessageCount:   100,
+			AbsoluteMaxBytes:  100,
+			PreferredMaxBytes: 100,
+		},
+		Addresses: []string{"localhost:123"},
 	}
 }


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Support updating orderer configuration in new config package. Does not support updating orderer orgs or policies yet, that will likely be a follow up story.

#### Related issues

[FAB-17469](https://jira.hyperledger.org/browse/FAB-17469)