### PR TITLE
[FAB-16957] Fix nil pointer panic flake in deliver_test

### DIFF
--- a/orderer/common/cluster/deliver_test.go
+++ b/orderer/common/cluster/deliver_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
@@ -271,8 +272,11 @@ func (ds *deliverServer) addExpectProbeAssert() {
 
 func (ds *deliverServer) addExpectPullAssert(seq uint64) {
 	ds.seekAssertions <- func(info *orderer.SeekInfo, _ string) {
-		assert.NotNil(ds.t, info.GetStart().GetSpecified())
-		assert.Equal(ds.t, seq, info.GetStart().GetSpecified().Number)
+		seekPosition := info.GetStart()
+		require.NotNil(ds.t, seekPosition)
+		seekSpecified := seekPosition.GetSpecified()
+		require.NotNil(ds.t, seekSpecified)
+		assert.Equal(ds.t, seq, seekSpecified.Number)
 		assert.Equal(ds.t, info.ErrorResponse, orderer.SeekInfo_BEST_EFFORT)
 	}
 }


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Seems like info.GetStart().GetSpecified() can somehow return nil on
subsequent calls. Let's just assign it before the first nil check and
use it for the rest of the assertion.

#### Related issues

[FAB-16957](https://jira.hyperledger.org/browse/FAB-16957)