### PR TITLE
Fix Heading Size in Deployment Doc

### DIFF
--- a/docs/source/deployment_guide_overview.md
+++ b/docs/source/deployment_guide_overview.md
@@ -83,7 +83,7 @@ To install the Fabric CA client, which is used to register and enroll identities
 
 For an example of how to setup a CA and enroll its admin, check out [Setup Orderer Org CA](https://hyperledger-fabric-ca.readthedocs.io/en/latest/operations_guide.html#setup-orderer-org-ca). For an example of how to set up a TLS CA, check out [Setup TLS CA](https://hyperledger-fabric-ca.readthedocs.io/en/latest/operations_guide.html#setup-tls-ca). Note that bootstrapping the CA server means assigning a username and password that functions as "registering" the CA admin.
 
-### Step four: Use the CA to create identities and MSPs
+## Step four: Use the CA to create identities and MSPs
 
 After you have created your CAs, you can use them to create the certificates for the identities and components related to your organization (which is represented by an MSP). For each organization, you will need to, at a minimum:
 


### PR DESCRIPTION
Fixes the below error where the Step 4 section is a subheading of Step 3

![image](https://user-images.githubusercontent.com/9400927/75061816-807e6b00-54af-11ea-8ba4-ca8206b92fa0.png)

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
