### PR TITLE
Add cURL with retry logic

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -26,10 +26,6 @@ Hyperledger Fabric.
           documentation for `shared drives <https://docs.docker.com/docker-for-windows/#shared-drives>`__
           and use a location under one of the shared drives.
 
-.. note:: If you are running on **Mac**, you may need to install ``wget`` before proceeding.
-          The ``wget`` command is used to download binaries from GitHub releases.
-          To install wget, ``brew install wget``.
-
 Determine a location on your machine where you want to place the `fabric-samples`
 repository and enter that directory in a terminal window. The
 command that follows will perform the following steps:

--- a/docs/source/prereqs.rst
+++ b/docs/source/prereqs.rst
@@ -23,14 +23,6 @@ documentation.
 .. note:: If you're on Windows please see the specific note on `Windows
    extras`_ below.
 
-Install wget
-------------
-
-If you will be downloading Fabric binaries based on the :doc:`install` documentation,
-you will need ``wget`` installed.
-
-  - MacOSX does not include ``wget`` by default, you can install it using ``brew install wget``.
-
 Docker and Docker Compose
 -------------------------
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -71,9 +71,7 @@ download() {
     local BINARY_FILE=$1
     local URL=$2
     echo "===> Downloading: " "${URL}"
-    wget "${URL}" || rc=$?
-    tar xvzf "${BINARY_FILE}" || rc=$?
-    rm "${BINARY_FILE}"
+    curl -L --retry 5 --retry-delay 3 "${URL}" | tar xz || rc=$?
     if [ -n "$rc" ]; then
         echo "==> There was an error downloading the binary file."
         return 22


### PR DESCRIPTION
There were too many issues with the wget method related to how it handles failures, moving back to curl, but simplifying the custom `retry` logic we had with `retry` support that exists in curl now.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
