### PR TITLE
Optimize inquire.IsSubset

### DIFF
--- a/common/policies/inquire/compare.go
+++ b/common/policies/inquire/compare.go
@@ -23,6 +23,12 @@ type ComparablePrincipal struct {
 	mspID     string
 }
 
+// Equal returns whether this ComparablePrincipal is equal to the given ComparablePrincipal.
+func (cp *ComparablePrincipal) Equal(cp2 *ComparablePrincipal) bool {
+	return cp.mspID == cp2.mspID &&
+		cp.equalPrincipals(cp2) && cp.equalRoles(cp2) && cp.equalOUs(cp2)
+}
+
 // NewComparablePrincipal creates a ComparablePrincipal out of the given MSPPrincipal.
 // Returns nil if a failure occurs.
 func NewComparablePrincipal(principal *msp.MSPPrincipal) *ComparablePrincipal {
@@ -179,4 +185,53 @@ func (cps ComparablePrincipalSet) Clone() ComparablePrincipalSet {
 		res[i] = cp
 	}
 	return res
+}
+
+func (cp *ComparablePrincipal) equalRoles(cp2 *ComparablePrincipal) bool {
+	if cp.role == nil && cp2.role == nil {
+		return true
+	}
+
+	if cp.role == nil || cp2.role == nil {
+		return false
+	}
+
+	return cp.role.MspIdentifier == cp2.role.MspIdentifier &&
+		cp.role.Role == cp2.role.Role
+}
+
+func (cp *ComparablePrincipal) equalOUs(cp2 *ComparablePrincipal) bool {
+	if cp.ou == nil && cp2.ou == nil {
+		return true
+	}
+
+	if cp.ou == nil || cp2.ou == nil {
+		return false
+	}
+
+	if cp.ou.OrganizationalUnitIdentifier != cp2.ou.OrganizationalUnitIdentifier {
+		return false
+	}
+
+	if cp.ou.MspIdentifier != cp2.ou.MspIdentifier {
+		return false
+	}
+
+	return bytes.Equal(cp.ou.CertifiersIdentifier, cp2.ou.CertifiersIdentifier)
+}
+
+func (cp *ComparablePrincipal) equalPrincipals(cp2 *ComparablePrincipal) bool {
+	if cp.principal == nil && cp2.principal == nil {
+		return true
+	}
+
+	if cp.principal == nil || cp2.principal == nil {
+		return false
+	}
+
+	if cp.principal.PrincipalClassification != cp2.principal.PrincipalClassification {
+		return false
+	}
+
+	return bytes.Equal(cp.principal.Principal, cp2.principal.Principal)
 }

--- a/common/policies/inquire/merge.go
+++ b/common/policies/inquire/merge.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package inquire
 
 import (
-	"reflect"
-
 	"github.com/hyperledger/fabric/common/policies"
 )
 
@@ -275,7 +273,7 @@ func (cps ComparablePrincipalSet) IsSubset(sets ComparablePrincipalSet) bool {
 	for _, p1 := range cps {
 		var found bool
 		for _, p2 := range sets {
-			if reflect.DeepEqual(p1, p2) {
+			if p1.Equal(p2) {
 				found = true
 			}
 		}

--- a/common/policies/inquire/merge_test.go
+++ b/common/policies/inquire/merge_test.go
@@ -139,6 +139,14 @@ func TestMergeSubsetPrincipalSets(t *testing.T) {
 	assert.True(t, expected.IsEqual(merged))
 }
 
+func TestEqual(t *testing.T) {
+	member1 := NewComparablePrincipal(member("Org1MSP"))
+	member2 := NewComparablePrincipal(member("Org2MSP"))
+	anotherMember1 := NewComparablePrincipal(member("Org1MSP"))
+	assert.False(t, member1.Equal(member2))
+	assert.True(t, member1.Equal(anotherMember1))
+}
+
 func TestIsSubset(t *testing.T) {
 	members12 := ComparablePrincipalSet{member1, member2, member2}
 	members321 := ComparablePrincipalSet{member3, member2, member1}


### PR DESCRIPTION
This change set makes IsSubset not use reflection
for faster processing.

FAB-17519 raised a concern that the peer's CPU spikes
during evaluation of lots of combinations, and the captured
CPU profile trace showed that reflection eats a lot of CPU cycles.

Change-Id: I5859d585ae76f1cab204daac7ea461a60fe8f33d
Signed-off-by: yacovm <yacovm@il.ibm.com>
