### PR TITLE
Parallelize Unit Tests in CI

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -48,6 +48,8 @@ jobs:
     dependsOn: VerifyBuild
     pool:
       vmImage: ubuntu-18.04
+    strategy:
+      parallel: 3
     steps:
       - template: install_deps.yml
       - checkout: self

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -1,222 +1,94 @@
 #!/bin/bash
-
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-
-set -e
-set -o pipefail
-
-base_dir="$(cd "$(dirname "$0")/.." && pwd)"
+set -eo pipefail
 
 # regexes for packages to exclude from unit test
 excluded_packages=(
-    "/integration(/|$)"
-)
-
-# packages that must be run serially
-serial_packages=(
-    "github.com/hyperledger/fabric/gossip/..."
-)
-
-# packages which need to be tested with build tag pluginsenabled
-plugin_packages=()
-
-# packages which need to be tested with build tag pkcs11
-pkcs11_packages=(
-    "github.com/hyperledger/fabric/bccsp/..."
+  "/integration(/|$)"
 )
 
 # packages that are only tested when they (or their deps) change
 conditional_packages=(
-    "github.com/hyperledger/fabric/gossip/..."
+  "github.com/hyperledger/fabric/gossip"
 )
 
-# join array elements by the specified string
-join_by() {
-    local IFS="$1"; shift
-    [ "$#" -eq 0 ] && return 0
-    echo "$*"
-}
+# run everything when profiling
+if [[ "${JOB_TYPE}" = "PROFILE" ]]; then
+    conditional_packages=()
+fi
 
-contains_element() {
-    local key="$1"; shift
+# Retrieves the full directory path of all packages that have been changed
+changed=$(git diff --dirstat=files,0 "HEAD^..HEAD" | awk '{$1=$1};1' | cut -d' ' -f2)
 
-    for e in "$@"; do [ "$e" == "$key" ] && return 0; done
-    return 1
-}
+for dir in ${conditional_packages[@]}; do
+  # Retrieves the entire dependency tree of the conditional package
+  deps=($(
+    go list -f '{{ .Deps }}' -json "${dir}/..." |
+      grep -E "github.com/hyperledger" |
+      awk '{$1=$1};1' |
+      grep -v "\.\.\." |
+      grep -v vendor |
+      grep "^\"github" |
+      cut -d',' -f1
+  ))
 
-# create a grep regex from the provide package spec
-package_filter() {
-    local -a filter
-    if [ "${#@}" -ne 0 ]; then
-        while IFS= read -r pkg; do [ -n "$pkg" ] && filter+=("$pkg"); done < <(go list -f '^{{ .ImportPath }}$' "${@}")
-    fi
+  # Add the package itself
+  deps+=("${dir}")
 
-    join_by '|' "${filter[@]}"
-}
-
-# obtain packages changed since some git refspec
-packages_diff() {
-    git -C "${base_dir}" diff --no-commit-id --name-only -r "${1:-HEAD}" |
-        (grep '.go$' || true) | \
-        sed 's%/[^/]*$%%' | sort -u | \
-        awk '{print "github.com/hyperledger/fabric/"$1}'
-}
-
-# obtain list of changed packages for verification
-changed_packages() {
-    local -a changed
-
-    # first check for uncommitted changes
-    while IFS= read -r pkg; do changed+=("$pkg"); done < <(packages_diff HEAD | grep -Ev '/vendor(/|$)' || true)
-    if [ "${#changed[@]}" -eq 0 ]; then
-        # next check for changes in the latest commit
-        while IFS= read -r pkg; do changed+=("$pkg"); done < <(packages_diff HEAD^ | grep -Ev '/vendor(/|$)' || true)
-    fi
-
-    join_by $'\n' "${changed[@]}"
-}
-
-# "go list" packages and filter out excluded packages
-list_and_filter() {
-    local excluded conditional filter
-
-    excluded=("${excluded_packages[@]}")
-    conditional=$(package_filter "${conditional_packages[@]}")
-    if [ -n "$conditional" ]; then
-        excluded+=("$conditional")
-    fi
-
-    filter=$(join_by '|' "${excluded[@]}")
-    if [ -n "$filter" ]; then
-        go list "$@" 2>/dev/null | grep -Ev "${filter}" || true
-    else
-        go list "$@" 2>/dev/null
-    fi
-}
-
-# list conditional packages that have been changed
-list_changed_conditional() {
-    [ "${#conditional_packages[@]}" -eq 0 ] && return 0
-
-    local changed
-    changed=$(changed_packages)
-
-    local -a additional_packages
-    for pkg in $(go list "${conditional_packages[@]}"); do
-        local dep_regexp
-        dep_regexp=$(go list -f '{{ join .Deps "$|" }}' "$pkg")
-        echo "${changed}" | grep -qE "$dep_regexp" && additional_packages+=("$pkg")
-        echo "${changed}" | grep -qE "$pkg\$" && additional_packages+=("$pkg")
+  # Checks to see if each of the changed packages is a dependency of the
+  # conditional package
+  for change in ${changed[@]}; do
+    for dep in ${deps[@]}; do
+      regex="^${dep}"
+      # Checks to see if the dependency is a superset of the change
+      if [[ "github.com/hyperledger/fabric/${change}" =~ ${regex} ]]; then
+        # If the dependency was a superset of the change we remove
+        # the package from the conditional set. Later we will remove
+        # all packages that remain in the conditional set
+        if [[ ! "${conditional_packages[*]}" =~ ${dir} ]]; then
+          delete=("${dir}")
+          conditional_packages=(${conditional_packages[@]/$delete})
+        fi
+      fi
     done
+  done
+  unset deps
+done
 
-    join_by $'\n' "${additional_packages[@]}"
-}
+test_packages=($(go list ./...))
 
-# remove packages that must be tested serially
-parallel_test_packages() {
-    local filter
-    filter=$(package_filter "${serial_packages[@]}")
-    if [ -n "$filter" ]; then
-        join_by $'\n' "$@" | grep -Ev "$filter" || true
-    else
-        join_by $'\n' "$@"
-    fi
-}
+# Remove conditional packages
+for excluded in ${conditional_packages[@]}; do
+  test_packages=($(echo ${test_packages[*]} | tr ' ' '\n' | grep -v "${excluded}" | sort | uniq))
+done
 
-# get packages that must be tested serially
-serial_test_packages() {
-    local filter
-    filter=$(package_filter "${serial_packages[@]}")
-    if [ -n "$filter" ]; then
-        join_by $'\n' "$@" | grep -E "$filter" || true
-    else
-        join_by $'\n' "$@"
-    fi
-}
+# Remove explicitly exclude packages via regex
+for excluded in ${excluded_packages[@]}; do
+  test_packages=($(echo ${test_packages[*]} | tr ' ' '\n' | grep -Ev ${excluded} | sort | uniq))
+done
 
-# "go test" the provided packages. Packages that are not present in the serial package list
-# will be tested in parallel
-run_tests() {
-    local -a flags=("-cover")
-    if [ -n "${VERBOSE}" ]; then
-        flags+=("-v")
-    fi
+totalAgents=${SYSTEM_TOTALJOBSINPHASE:-0}   # standard VSTS variables available using parallel execution; total number of parallel jobs running
+agentNumber=${SYSTEM_JOBPOSITIONINPHASE:-0} # current job position
+testCount=${#test_packages[@]}
 
-    local -a race_flags=()
-    if [ "$(uname -m)" == "x86_64" ]; then
-        export GORACE=atexit_sleep_ms=0 # reduce overhead of race
-        race_flags+=("-race")
-    fi
+# below conditions are used if parallel pipeline is not used. i.e. pipeline is running with single agent (no parallel configuration)
+if [[ "$totalAgents" -eq 0 ]]; then totalAgents=1; fi
+if [[ "$agentNumber" -eq 0 ]]; then agentNumber=1; fi
 
-    GO_TAGS=${GO_TAGS## }
-    [ -n "$GO_TAGS" ] && echo "Testing with $GO_TAGS..."
+declare -a tests
+for ((i = "$agentNumber"; i <= "$testCount"; )); do
+  tests+=("${test_packages[$i - 1]}")
+  i=$((${i} + ${totalAgents}))
+done
 
-    time {
-        local -a serial
-        while IFS= read -r pkg; do serial+=("$pkg"); done < <(serial_test_packages "$@")
-        if [ "${#serial[@]}" -ne 0 ]; then
-            go test "${flags[@]}" -tags "$GO_TAGS" "${serial[@]}" -short -p 1 -timeout=20m
-        fi
-
-        local -a parallel
-        while IFS= read -r pkg; do parallel+=("$pkg"); done < <(parallel_test_packages "$@")
-        if [ "${#parallel[@]}" -ne 0 ]; then
-            go test "${flags[@]}" "${race_flags[@]}" -tags "$GO_TAGS" "${parallel[@]}" -short -timeout=20m
-        fi
-    }
-}
-
-# "go test" the provided packages and generate code coverage reports.
-run_tests_with_coverage() {
-    # run the tests serially
-    time go test -p 1 -cover -coverprofile=profile_tmp.cov -tags "$GO_TAGS" "$@" -timeout=20m
+# run everything when profiling
+if [[ "${JOB_TYPE}" = "PROFILE" ]]; then
+    time go test -cover -coverprofile=profile_tmp.cov -timeout=20m ${tests[@]}
     tail -n +2 profile_tmp.cov >> profile.cov && rm profile_tmp.cov
-}
-
-main() {
-    # explicit exclusions for ppc and s390x
-    if [ "$(uname -m)" == "ppc64le" ] || [ "$(uname -m)" == "s390x" ]; then
-        excluded_packages+=("github.com/hyperledger/fabric/core/chaincode/platforms/java")
-    fi
-
-    # default behavior is to run all tests
-    local -a package_spec=("${TEST_PKGS:-github.com/hyperledger/fabric/...}")
-
-    # when running a "verify" job, only test packages that have changed
-    if [ "${JOB_TYPE}" = "VERIFY" ]; then
-        package_spec=()
-        while IFS= read -r pkg; do package_spec+=("$pkg"); done < <(changed_packages)
-    fi
-
-    # run everything when profiling
-    if [ "${JOB_TYPE}" = "PROFILE" ]; then
-        conditional_packages=()
-    fi
-
-    # expand the package specs into arrays of packages
-    local -a candidates packages packages_with_plugins packages_with_pkcs11
-    while IFS= read -r pkg; do candidates+=("$pkg"); done < <(go list "${package_spec[@]}")
-    while IFS= read -r pkg; do packages+=("$pkg"); done < <(list_and_filter "${package_spec[@]}")
-    while IFS= read -r pkg; do contains_element "$pkg" "${candidates[@]}" && packages+=("$pkg"); done < <(list_changed_conditional)
-    while IFS= read -r pkg; do contains_element "$pkg" "${packages[@]}" && packages_with_plugins+=("$pkg"); done < <(list_and_filter "${plugin_packages[@]}")
-    while IFS= read -r pkg; do contains_element "$pkg" "${packages[@]}" && packages_with_pkcs11+=("$pkg"); done < <(list_and_filter "${pkcs11_packages[@]}")
-
-    local all_packages=( "${packages[@]}" "${packages_with_pkcs11[@]}" "${packages_with_pkcs11[@]}" )
-    if [ "${#all_packages[@]}" -eq 0 ]; then
-        echo "Nothing to test!!!"
-    elif [ "${JOB_TYPE}" = "PROFILE" ]; then
-        echo "mode: set" > profile.cov
-        [ "${#packages}" -eq 0 ] || run_tests_with_coverage "${packages[@]}"
-        [ "${#packages_with_plugins}" -eq 0 ] || GO_TAGS="${GO_TAGS} pluginsenabled" run_tests_with_coverage "${packages_with_plugins[@]}"
-        [ "${#packages_with_pkcs11}" -eq 0 ] || GO_TAGS="${GO_TAGS} pkcs11" run_tests_with_coverage "${packages_with_pkcs11[@]}"
-        gocov convert profile.cov | gocov-xml > report.xml
-    else
-        [ "${#packages}" -eq 0 ] || run_tests "${packages[@]}"
-        [ "${#packages_with_plugins}" -eq 0 ] || GO_TAGS="${GO_TAGS} pluginsenabled" run_tests "${packages_with_plugins[@]}"
-        [ "${#packages_with_pkcs11}" -eq 0 ] || GO_TAGS="${GO_TAGS} pkcs11" run_tests "${packages_with_pkcs11[@]}"
-    fi
-}
-
-main
+    gocov convert profile.cov | gocov-xml > report.xml
+else
+    export GORACE=atexit_sleep_ms=0
+    time go test -cover -race -tags pkcs11 -short -timeout=20m ${tests[@]}
+fi


### PR DESCRIPTION
Parallelizes unit tests. Beyond making unit take less time to execute, this also means if you have a failure you don't have to wait 40 minutes for units to rerun as you only have to rerun the failed test.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
