### PR TITLE
[FAB-17431] Decouple javaenv from Fabric version

### DIFF
--- a/core/chaincode/chaincodetest.yaml
+++ b/core/chaincode/chaincodetest.yaml
@@ -315,7 +315,7 @@ chaincode:
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime:  $(DOCKER_NS)/fabric-javaenv:$(ARCH)-$(PROJECT_VERSION)
+        runtime:  $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
 
     # timeout in millisecs for starting up a container and waiting for Register
     # to come through. 1sec should be plenty for chaincode unit tests

--- a/core/container/util/dockerutil.go
+++ b/core/container/util/dockerutil.go
@@ -35,11 +35,21 @@ func ParseDockerfileTemplate(template string) string {
 	r := strings.NewReplacer(
 		"$(ARCH)", runtime.GOARCH,
 		"$(PROJECT_VERSION)", metadata.Version,
+		"$(TWO_DIGIT_VERSION)", twoDigitVersion(metadata.Version),
 		"$(BASE_VERSION)", metadata.BaseVersion,
 		"$(DOCKER_NS)", metadata.DockerNamespace,
 		"$(BASE_DOCKER_NS)", metadata.BaseDockerNamespace)
 
 	return r.Replace(template)
+}
+
+// twoDigitVersion truncates a 3 digit version (e.g. 2.0.0) to a 2 digit version (e.g. 2.0),
+// If version does not include dots (e.g. latest), just return the passed version
+func twoDigitVersion(version string) string {
+	if strings.LastIndex(version, ".") < 0 {
+		return version
+	}
+	return version[0:strings.LastIndex(version, ".")]
 }
 
 func GetDockerfileFromConfig(path string) string {

--- a/core/container/util/dockerutil_test.go
+++ b/core/container/util/dockerutil_test.go
@@ -23,10 +23,16 @@ func TestUtil_DockerfileTemplateParser(t *testing.T) {
 }
 
 func TestUtil_GetDockerfileFromConfig(t *testing.T) {
-	expected := "FROM " + metadata.DockerNamespace + ":" + runtime.GOARCH + "-" + metadata.Version
 	path := "dt"
+	expected := "FROM " + metadata.DockerNamespace + ":" + runtime.GOARCH + "-" + metadata.Version
 	viper.Set(path, "FROM $(DOCKER_NS):$(ARCH)-$(PROJECT_VERSION)")
 	actual := GetDockerfileFromConfig(path)
+	assert.Equal(t, expected, actual, "Error parsing Dockerfile Template. Expected \"%s\", got \"%s\"",
+		expected, actual)
+
+	expected = "FROM " + metadata.DockerNamespace + ":" + runtime.GOARCH + "-" + twoDigitVersion(metadata.Version)
+	viper.Set(path, "FROM $(DOCKER_NS):$(ARCH)-$(TWO_DIGIT_VERSION)")
+	actual = GetDockerfileFromConfig(path)
 	assert.Equal(t, expected, actual, "Error parsing Dockerfile Template. Expected \"%s\", got \"%s\"",
 		expected, actual)
 }
@@ -35,4 +41,16 @@ func TestUtil_GetDockertClient(t *testing.T) {
 	viper.Set("vm.endpoint", "unix:///var/run/docker.sock")
 	_, err := NewDockerClient()
 	assert.NoError(t, err, "Error getting docker client")
+}
+
+func TestTwoDigitVersion(t *testing.T) {
+	version := "2.0.0"
+	expected := "2.0"
+	actual := twoDigitVersion(version)
+	assert.Equal(t, expected, actual, `Error parsing two digit version. Expected "%s", got "%s"`, expected, actual)
+
+	version = "latest"
+	expected = "latest"
+	actual = twoDigitVersion(version)
+	assert.Equal(t, expected, actual, `Error parsing two digit version. Expected "%s", got "%s"`, expected, actual)
 }

--- a/examples/cluster/config/core.yaml
+++ b/examples/cluster/config/core.yaml
@@ -305,7 +305,7 @@ chaincode:
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:$(ARCH)-$(PROJECT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
 
     # timeout in millisecs for starting up a container and waiting for Register
     # to come through. 1sec should be plenty for chaincode unit tests

--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -154,7 +154,7 @@ chaincode:
   car:
     runtime: $(BASE_DOCKER_NS)/fabric-baseos:$(ARCH)-$(BASE_VERSION)
   java:
-    runtime: $(DOCKER_NS)/fabric-javaenv:$(ARCH)-$(PROJECT_VERSION)
+    runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
   node:
       runtime: $(BASE_DOCKER_NS)/fabric-baseimage:$(ARCH)-$(BASE_VERSION)
   startuptimeout: 300s

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -520,7 +520,7 @@ chaincode:
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:$(ARCH)-$(PROJECT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
 
     node:
         # need node.js engine at runtime, currently available in baseimage


### PR DESCRIPTION
#### Type of change

- Improvement

#### Description

By default Fabric was configured to use the following javaenv image for java chaincode:
`runtime: $(DOCKER_NS)/fabric-javaenv:$(ARCH)-$(PROJECT_VERSION)`

Since javaenv versioning may deviate from Fabric versioning,
it is important to decouple the versions. This commit updates
the javaenv reference to use the latest two digit version:
`runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)`

For example, Fabric v1.4.6 would utilize fabric-javaenv:1.4.

This is a backport of the two digit change in master, applied to javaenv.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>

#### Related issues

https://jira.hyperledger.org/browse/FAB-17431
https://github.com/hyperledger/fabric/pull/555