### PR TITLE
[FAB-17529] general cleanups for config package

### DIFF
--- a/pkg/config/application_test.go
+++ b/pkg/config/application_test.go
@@ -134,12 +134,12 @@ func TestNewApplicationGroupSkipAsForeign(t *testing.T) {
 
 func baseApplication() *Application {
 	return &Application{
-		Policies: createStandardPolicies(),
+		Policies: standardPolicies(),
 		Organizations: []*Organization{
 			{
 				Name:     "Org1",
 				ID:       "Org1MSP",
-				Policies: createApplicationOrgStandardPolicies(),
+				Policies: applicationOrgStandardPolicies(),
 				AnchorPeers: []*AnchorPeer{
 					{Host: "host1", Port: 123},
 				},
@@ -147,7 +147,7 @@ func baseApplication() *Application {
 			{
 				Name:     "Org2",
 				ID:       "Org2MSP",
-				Policies: createApplicationOrgStandardPolicies(),
+				Policies: applicationOrgStandardPolicies(),
 				AnchorPeers: []*AnchorPeer{
 					{Host: "host1", Port: 123},
 				},

--- a/pkg/config/consortiums_test.go
+++ b/pkg/config/consortiums_test.go
@@ -65,7 +65,7 @@ func TestNewConsortiumsGroupFailure(t *testing.T) {
 	gt := NewGomegaWithT(t)
 
 	consortiums := baseConsortiums()
-	consortiums["Consortium1"].Organizations[0].Policies = nil
+	consortiums[0].Organizations[0].Policies = nil
 
 	mspConfig := &mb.MSPConfig{}
 
@@ -80,8 +80,8 @@ func TestSkipAsForeignForConsortiumOrg(t *testing.T) {
 	gt := NewGomegaWithT(t)
 
 	consortiums := baseConsortiums()
-	consortiums["Consortium1"].Organizations[0].SkipAsForeign = true
-	consortiums["Consortium1"].Organizations[1].SkipAsForeign = true
+	consortiums[0].Organizations[0].SkipAsForeign = true
+	consortiums[0].Organizations[1].SkipAsForeign = true
 
 	mspConfig := &mb.MSPConfig{}
 
@@ -102,19 +102,20 @@ func TestSkipAsForeignForConsortiumOrg(t *testing.T) {
 	}))
 }
 
-func baseConsortiums() map[string]*Consortium {
-	return map[string]*Consortium{
-		"Consortium1": {
+func baseConsortiums() []*Consortium {
+	return []*Consortium{
+		{
+			Name: "Consortium1",
 			Organizations: []*Organization{
 				{
 					Name:     "Org1",
 					ID:       "Org1MSP",
-					Policies: createOrgStandardPolicies(),
+					Policies: orgStandardPolicies(),
 				},
 				{
 					Name:     "Org2",
 					ID:       "Org2MSP",
-					Policies: createOrgStandardPolicies(),
+					Policies: orgStandardPolicies(),
 				},
 			},
 		},

--- a/pkg/config/orderer.go
+++ b/pkg/config/orderer.go
@@ -50,22 +50,22 @@ type Kafka struct {
 // how frequently they should be emitted, etc. as well as the organizations of the ordering network.
 // It sets the mod_policy of all elements to "Admins".
 // This group is always present in any channel configuration.
-func NewOrdererGroup(conf *Orderer, mspConfig *mb.MSPConfig) (*cb.ConfigGroup, error) {
+func NewOrdererGroup(orderer *Orderer, mspConfig *mb.MSPConfig) (*cb.ConfigGroup, error) {
 	ordererGroup := newConfigGroup()
 	ordererGroup.ModPolicy = AdminsPolicyKey
 
-	if err := addOrdererPolicies(ordererGroup, conf.Policies, AdminsPolicyKey); err != nil {
+	if err := addOrdererPolicies(ordererGroup, orderer.Policies, AdminsPolicyKey); err != nil {
 		return nil, err
 	}
 
 	// add orderer values
-	err := addOrdererValues(ordererGroup, conf)
+	err := addOrdererValues(ordererGroup, orderer)
 	if err != nil {
 		return nil, err
 	}
 
 	// add orderer groups
-	for _, org := range conf.Organizations {
+	for _, org := range orderer.Organizations {
 		ordererGroup.Groups[org.Name], err = newOrdererOrgGroup(org, mspConfig)
 		if err != nil {
 			return nil, fmt.Errorf("org group '%s': %v", org.Name, err)
@@ -78,8 +78,8 @@ func NewOrdererGroup(conf *Orderer, mspConfig *mb.MSPConfig) (*cb.ConfigGroup, e
 // newOrdererOrgGroup returns an orderer org component of the channel configuration.
 // It defines the crypto material for the organization (its MSP).
 // It sets the mod_policy of all elements to "Admins".
-func newOrdererOrgGroup(conf *Organization, mspConfig *mb.MSPConfig) (*cb.ConfigGroup, error) {
-	return generateOrgConfigGroup(conf, mspConfig)
+func newOrdererOrgGroup(org *Organization, mspConfig *mb.MSPConfig) (*cb.ConfigGroup, error) {
+	return newOrgConfigGroup(org, mspConfig)
 }
 
 // UpdateOrdererConfiguration modifies an existing config tx's Orderer configuration

--- a/pkg/config/orderer_test.go
+++ b/pkg/config/orderer_test.go
@@ -288,13 +288,13 @@ func TestUpdateOrdererConfiguration(t *testing.T) {
 
 func baseOrderer() *Orderer {
 	return &Orderer{
-		Policies:    createOrdererStandardPolicies(),
+		Policies:    ordererStandardPolicies(),
 		OrdererType: ConsensusTypeSolo,
 		Organizations: []*Organization{
 			{
 				Name:     "Org1",
 				ID:       "Org1MSP",
-				Policies: createOrgStandardPolicies(),
+				Policies: orgStandardPolicies(),
 				OrdererEndpoints: []string{
 					"localhost:123",
 				},
@@ -302,7 +302,7 @@ func baseOrderer() *Orderer {
 			{
 				Name:     "Org2",
 				ID:       "Org2MSP",
-				Policies: createOrgStandardPolicies(),
+				Policies: orgStandardPolicies(),
 				OrdererEndpoints: []string{
 					"localhost:123",
 				},

--- a/pkg/config/update.go
+++ b/pkg/config/update.go
@@ -16,7 +16,7 @@ import (
 
 // Compute computes the difference between two *cb.Configs and returns the
 // ReadSet and WriteSet diff as a *cb.ConfigUpdate
-func Compute(original, updated *cb.Config) (*cb.ConfigUpdate, error) {
+func computeConfigUpdate(original, updated *cb.Config) (*cb.ConfigUpdate, error) {
 	if original.ChannelGroup == nil {
 		return nil, fmt.Errorf("no channel group included for original config")
 	}

--- a/pkg/config/update_test.go
+++ b/pkg/config/update_test.go
@@ -20,7 +20,7 @@ func TestNoUpdate(t *testing.T) {
 	}
 	updated := &cb.ConfigGroup{}
 
-	_, err := Compute(&cb.Config{
+	_, err := computeConfigUpdate(&cb.Config{
 		ChannelGroup: original,
 	}, &cb.Config{
 		ChannelGroup: updated,
@@ -33,13 +33,13 @@ func TestMissingGroup(t *testing.T) {
 	gt := NewGomegaWithT(t)
 	group := &cb.ConfigGroup{}
 	t.Run("MissingOriginal", func(t *testing.T) {
-		_, err := Compute(&cb.Config{}, &cb.Config{ChannelGroup: group})
+		_, err := computeConfigUpdate(&cb.Config{}, &cb.Config{ChannelGroup: group})
 
 		gt.Expect(err).To(HaveOccurred())
 		gt.Expect(err).To(MatchError("no channel group included for original config"))
 	})
 	t.Run("MissingOriginal", func(t *testing.T) {
-		_, err := Compute(&cb.Config{ChannelGroup: group}, &cb.Config{})
+		_, err := computeConfigUpdate(&cb.Config{ChannelGroup: group}, &cb.Config{})
 
 		gt.Expect(err).To(HaveOccurred())
 		gt.Expect(err).To(MatchError("no channel group included for updated config"))
@@ -56,7 +56,7 @@ func TestGroupModPolicyUpdate(t *testing.T) {
 		ModPolicy: "bar",
 	}
 
-	cu, err := Compute(&cb.Config{
+	cu, err := computeConfigUpdate(&cb.Config{
 		ChannelGroup: original,
 	}, &cb.Config{
 		ChannelGroup: updated,
@@ -116,7 +116,7 @@ func TestGroupPolicyModification(t *testing.T) {
 		},
 	}
 
-	cu, err := Compute(&cb.Config{
+	cu, err := computeConfigUpdate(&cb.Config{
 		ChannelGroup: original,
 	}, &cb.Config{
 		ChannelGroup: updated,
@@ -176,7 +176,7 @@ func TestGroupValueModification(t *testing.T) {
 		},
 	}
 
-	cu, err := Compute(&cb.Config{
+	cu, err := computeConfigUpdate(&cb.Config{
 		ChannelGroup: original,
 	}, &cb.Config{
 		ChannelGroup: updated,
@@ -230,7 +230,7 @@ func TestGroupGroupsModification(t *testing.T) {
 		},
 	}
 
-	cu, err := Compute(&cb.Config{
+	cu, err := computeConfigUpdate(&cb.Config{
 		ChannelGroup: original,
 	}, &cb.Config{
 		ChannelGroup: updated,
@@ -294,7 +294,7 @@ func TestGroupValueAddition(t *testing.T) {
 		},
 	}
 
-	cu, err := Compute(&cb.Config{
+	cu, err := computeConfigUpdate(&cb.Config{
 		ChannelGroup: original,
 	}, &cb.Config{
 		ChannelGroup: updated,
@@ -359,7 +359,7 @@ func TestGroupPolicySwap(t *testing.T) {
 		},
 	}
 
-	cu, err := Compute(&cb.Config{
+	cu, err := computeConfigUpdate(&cb.Config{
 		ChannelGroup: original,
 	}, &cb.Config{
 		ChannelGroup: updated,
@@ -445,7 +445,7 @@ func TestComplex(t *testing.T) {
 		},
 	}
 
-	cu, err := Compute(&cb.Config{
+	cu, err := computeConfigUpdate(&cb.Config{
 		ChannelGroup: original,
 	}, &cb.Config{
 		ChannelGroup: updated,
@@ -536,7 +536,7 @@ func TestTwiceNestedModification(t *testing.T) {
 		},
 	}
 
-	cu, err := Compute(&cb.Config{
+	cu, err := computeConfigUpdate(&cb.Config{
 		ChannelGroup: original,
 	}, &cb.Config{
 		ChannelGroup: updated,


### PR DESCRIPTION
Signed-off-by: Chongxin Luo <Chongxin.Luo@ibm.com>

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description
- added name field to consortium struct, change Consortiums in channel from map to slice. 
- change compute function name to ComputeConfigUpdate.
- change profile naming to channel.
- clarity function names, removed words of generate, create, and replaced with new.
- use MatchJSON in config tests.

#### Related issues
[FAB-17529](https://jira.hyperledger.org/browse/FAB-17529)
