### PR TITLE
Updates for fabric release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## "v2.0.1"
+
+* [7282895](https://github.com/hyperledger/fabric/commit/7282895) [FAB-17515](https://jira.hyperledger.org/browse/FAB-17515) Support configuring BlockValidation policy for orderer group
+* [618a4ce](https://github.com/hyperledger/fabric/commit/618a4ce) [FAB-17491](https://jira.hyperledger.org/browse/FAB-17491) Do not disseminate pvtdata for other org's implicit collection
+* [727327d](https://github.com/hyperledger/fabric/commit/727327d) [FAB-17523](https://jira.hyperledger.org/browse/FAB-17523) Endorsing peer was not honoring RequiredPeerCount (#716) (#729)
+* [371c435](https://github.com/hyperledger/fabric/commit/371c435) Optimize inquire.IsSubset (#714)
+* [bb46909](https://github.com/hyperledger/fabric/commit/bb46909) [FAB-17059](https://jira.hyperledger.org/browse/FAB-17059) Extend private data integration tests to cover case when a new eligible peer with different certs joins the channel and attempts to fetch private data before processing the config update that adds its certs to the channel config
+* [0885c2f](https://github.com/hyperledger/fabric/commit/0885c2f) [FAB-17059](https://jira.hyperledger.org/browse/FAB-17059) Change collection membership eligibility checks to only compare mspID instead of Evaluating the certificate against the access policy
+* [f4e4a95](https://github.com/hyperledger/fabric/commit/f4e4a95) [FAB-17472](https://jira.hyperledger.org/browse/FAB-17472) Clarify doc and samples for NodeOU Certificate
+* [c742dd6](https://github.com/hyperledger/fabric/commit/c742dd6) [FAB-17453](https://jira.hyperledger.org/browse/FAB-17453) 'peer lifecycle chaincode package' mandates does not need to init crypto
+* [4665ec5](https://github.com/hyperledger/fabric/commit/4665ec5) [FAB-17479](https://jira.hyperledger.org/browse/FAB-17479) Migrated Kafka cluster can be safely expanded later (#645)
+* [61f5706](https://github.com/hyperledger/fabric/commit/61f5706) [FAB-14679](https://jira.hyperledger.org/browse/FAB-14679) Update commercial paper tutorial for new chaincode lifecycle
+* [c63e674](https://github.com/hyperledger/fabric/commit/c63e674) Explicitly enumerate orderer and peer metrics
+* [2daa2b0](https://github.com/hyperledger/fabric/commit/2daa2b0) Add link to policies topic to chaincode for operators (#659) (#660)
+* [dc8071c](https://github.com/hyperledger/fabric/commit/dc8071c) Update Copyright for 2020
+* [f8b21b1](https://github.com/hyperledger/fabric/commit/f8b21b1) fix typo
+* [4961395](https://github.com/hyperledger/fabric/commit/4961395) Fix typo in package error message
+* [993b7a0](https://github.com/hyperledger/fabric/commit/993b7a0) [FAB-17458](https://jira.hyperledger.org/browse/FAB-17458) check LifecycleV20 capability before getting cc info (#608)
+* [7a1d517](https://github.com/hyperledger/fabric/commit/7a1d517) Remove 1.x video from 2.0 docs
+* [5bf6583](https://github.com/hyperledger/fabric/commit/5bf6583) Remove Fabric functionalities doc
+* [361edb6](https://github.com/hyperledger/fabric/commit/361edb6) [FAB-17267](https://jira.hyperledger.org/browse/FAB-17267) Move add an org to a channel tutorial to test network
+* [b96f178](https://github.com/hyperledger/fabric/commit/b96f178) [FAB-17381](https://jira.hyperledger.org/browse/FAB-17381) Update policy concept for test network
+* [c987e77](https://github.com/hyperledger/fabric/commit/c987e77) Update branch to dynamic variable
+* [5fe6530](https://github.com/hyperledger/fabric/commit/5fe6530) Add support for placeholder replacement in doc builds
+* [13d12e5](https://github.com/hyperledger/fabric/commit/13d12e5) [FABCN-378] Update links to chaincode JSDoc
+* [721a6e7](https://github.com/hyperledger/fabric/commit/721a6e7) Remove link for node SDK tutorial
+* [913d770](https://github.com/hyperledger/fabric/commit/913d770) [FAB-17424](https://jira.hyperledger.org/browse/FAB-17424) Fix broken link in DevApps connection profile
+* [a521d2a](https://github.com/hyperledger/fabric/commit/a521d2a) Fix conditional_packages processing in UT script
+
 ## "v2.0.0"
 
 * [77ff3d2](https://github.com/hyperledger/fabric/commit/77ff3d2) Install doc and script updates for v2.0.0

--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,8 @@
 #   - help-docs - generate the command reference docs
 
 ALPINE_VER ?= 3.10
-BASE_VERSION = 2.0.0
-PREV_VERSION = 2.0.0-beta
-
-# BASEIMAGE_RELEASE should be removed now
-BASEIMAGE_RELEASE = 0.4.18
+BASE_VERSION = 2.0.1
+PREV_VERSION = 2.0.0
 
 # 3rd party image version
 # These versions are also set in the runners in ./integration/runners/

--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ open source architecture; Hyperledger Fabric is your starting point.
 
 ## Releases
 
+- [v2.0.1 - February 26, 2020](https://github.com/hyperledger/fabric/releases/tag/v2.0.1)
 - [v2.0.0 - January 29, 2020](https://github.com/hyperledger/fabric/releases/tag/v2.0.0)
 - [v2.0.0-beta - December 12, 2019](https://github.com/hyperledger/fabric/releases/tag/v2.0.0-beta)
 - [v2.0.0-alpha - April 9, 2019](https://github.com/hyperledger/fabric/releases/tag/v2.0.0-alpha)
+- [v1.4.6 - February 25, 2020](https://github.com/hyperledger/fabric/releases/tag/v1.4.6)
+- [v1.4.5 - November 19, 2020](https://github.com/hyperledger/fabric/releases/tag/v1.4.5)
 - [v1.4.4 - November 14, 2019](https://github.com/hyperledger/fabric/releases/tag/v1.4.4)
 - [v1.4.3 - August 26, 2019](https://github.com/hyperledger/fabric/releases/tag/v1.4.3)
 - [v1.4.2 - July 17, 2019](https://github.com/hyperledger/fabric/releases/tag/v1.4.2)

--- a/docker-env.mk
+++ b/docker-env.mk
@@ -23,9 +23,6 @@ endif
 
 DBUILD = docker build --force-rm $(DOCKER_BUILD_FLAGS)
 
-BASE_DOCKER_NS ?= hyperledger
-BASE_DOCKER_TAG=$(ARCH)-$(BASEIMAGE_RELEASE)
-
 DOCKER_NS ?= hyperledger
 DOCKER_TAG=$(ARCH)-$(PROJECT_VERSION)
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -53,12 +53,12 @@ the binaries and images.
 .. note:: If you want a specific release, pass a version identifier for Fabric,
           Fabric-ca and thirdparty Docker images.
           The command below demonstrates how to download the latest production releases -
-          **Fabric v2.0.0** and **Fabric CA v1.4.4**
+          **Fabric v2.0.1** and **Fabric CA v1.4.6**
 
 .. code:: bash
 
   curl -sSL https://bit.ly/2ysbOFE | bash -s -- <fabric_version> <fabric-ca_version> <thirdparty_version>
-  curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.0.0 1.4.4 0.4.18
+  curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.0.1 1.4.6 0.4.18
 
 .. note:: If you get an error running the above curl command, you may
           have too old a version of curl that does not handle

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -214,6 +214,7 @@ Specifically, take a look at the changes and deprecations that are being
 announced with the new Fabric v2.0 release.
 
 * `Fabric v2.0.0 release notes <https://github.com/hyperledger/fabric/releases/tag/v2.0.0>`_.
+* `Fabric v2.0.1 release notes <https://github.com/hyperledger/fabric/releases/tag/v2.0.1>`_.
 
 .. Licensed under Creative Commons Attribution 4.0 International License
    https://creativecommons.org/licenses/by/4.0/

--- a/release_notes/v2.0.1.md
+++ b/release_notes/v2.0.1.md
@@ -1,0 +1,94 @@
+v2.0.1 Release Notes - February 26, 2020
+========================================
+
+Fixes
+-----
+
+**FAB-17458: Rolling upgrade: Different endorsement results on v1.4.x and v2.0.0 peers**
+
+In a rolling upgrade scenario where V2_0 channel application capability is not yet set,
+and proposals are sent to v1.4.x peers and v2.0.0 peers,
+the endorsed read sets did not exactly match in the proposal response between
+the v1.4.x peers and v2.0.0 peers. This resulted in transaction
+invalidation at commit time with error message
+"marked as invalid by committer. Reason code [ENDORSEMENT_POLICY_FAILURE]".
+The proposal response is fixed in v2.0.1 so that the read sets will exactly
+match read sets on v1.4.x peers, enabling transactions to be endorsed across
+peers of different versions.
+
+**FAB-17479: Migrated Kafka cluster can be safely expanded later**
+
+When a new ordering service node was added to a migrated Kafka cluster,
+but was not added to all channels, the ordering service node would crash.
+The fix ensures that new ordering nodes can be added to a subset of channels.
+
+**FAB-17453: 'peer lifecycle chaincode package' required an MSP configured**
+
+'peer lifecycle chaincode package' is for local packaging of chaincode only,
+and therefore no longer requires a MSP to be configured.
+
+**FAB-17059: Change collection membership eligibility checks to only compare mspID**
+
+When a new CA root cert was added to an organization in the channel configuration,
+new peers with an identity from the new CA would not receive private data for
+blocks prior to the channel configuration change. This is because the peer didn't
+realize it was a member of the private data collection, even though it was
+based on the collection's mspid. The fix ensures that the peer evaluates
+private data collection membership based on its mspid. The fix is important
+when rotating CA root or intermediate certs, for example in a side-by-side
+migration scenario that uses new CA certs and new peers.
+
+**FAB-17519: Improve Discovery endorsement policy performance**
+
+Fix peer CPU spikes during evaluation of endorsement policy
+combinations, due to expensive reflection.
+
+**FAB-17523: Endorsing peer was not honoring private data RequiredPeerCount**
+
+If there were not enough known eligible peers to meet the private data collection RequiredPeerCount
+dissemination requirement, endorsement was succeeding rather than returning an error.
+
+**[FAB-17491] Do not disseminate private data for other organization's implicit collection**
+
+When using the new implicit private data collections in v2.0.0, in some use cases
+private data needs to be written to each of multiple organization's implicit
+private data collections in the same transaction. In these cases the endorsing peers were
+disseminating the private data to each of the respective organization's peers.
+Although not a security problem (each organization is authorized to receive its
+own implicit collection private data), dissemination should be managed by the endorsing
+peers of the implicit collection organization only. This fix ensures that only peers
+of the implicit collection organization disseminate the private data to their own
+organization's other peers.
+
+**[FAB-17515] Support configuring BlockValidation policy for orderer group**
+
+Prior to the fix, a configured BlockValidation policy (e.g. defined in configtx.yaml)
+would be ignored. The policy is now applied in the channel creation transaction, and
+must be specified.
+
+
+Known Issues and Workarounds
+----------------------------
+**FAB-12134: Same chaincode source receiving fingerprint mismatch error**
+
+When using the legacy chaincode lifecycle, chaincode installed in different
+ways may result in "chaincode fingerprint mismatch data mismatch" error
+upon instantiation.  This may happen when installing chaincode by using
+different SDKs. To workaround the problem, package the chaincode prior to
+installation and instantiation, by using the "peer chaincode package" command.
+
+
+Known Vulnerabilities
+---------------------
+**FAB-8664: Peer should detect and react when its org has been removed**
+
+This is a relatively low severity problem, because it requires a significant
+conspiracy of network admins, but it will be addressed in a future release.
+
+
+Resolved Vulnerabilities
+------------------------
+None.
+
+For the full list of changes, refer to the release change log:
+https://github.com/hyperledger/fabric/blob/release-2.0/CHANGELOG.md#v201

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -6,9 +6,9 @@
 #
 
 # if version not passed in, default to latest released version
-VERSION=2.0.0
+VERSION=2.0.1
 # if ca version not passed in, default to latest released version
-CA_VERSION=1.4.4
+CA_VERSION=1.4.6
 # current version of thirdparty images (couchdb, kafka and zookeeper) released
 THIRDPARTY_IMAGE_VERSION=0.4.18
 ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m | sed 's/x86_64/amd64/g')")
@@ -23,8 +23,8 @@ printHelp() {
     echo "-s : bypass fabric-samples repo clone"
     echo "-b : bypass download of platform-specific binaries"
     echo
-    echo "e.g. bootstrap.sh 2.0.0 1.4.4 0.4.18 -s"
-    echo "would download docker images and binaries for Fabric v2.0.0 and Fabric CA v1.4.4"
+    echo "e.g. bootstrap.sh 2.0.1 1.4.6 0.4.18 -s"
+    echo "would download docker images and binaries for Fabric v2.0.1 and Fabric CA v1.4.6"
 }
 
 # dockerPull() pulls docker images from fabric and chaincode repositories
@@ -32,7 +32,7 @@ printHelp() {
 # be skipped, since this script doesn't terminate upon errors.
 
 dockerPull() {
-    #three_digit_image_tag is passed in, e.g. "1.4.4"
+    #three_digit_image_tag is passed in, e.g. "1.4.6"
     three_digit_image_tag=$1
     shift
     #two_digit_image_tag is derived, e.g. "1.4", especially useful as a local tag for two digit references to most recent baseos, ccenv, javaenv, nodeenv patch releases


### PR DESCRIPTION
Updates for release v2.0.1 including release notes, version
reference updates, and removal of BASEIMAGE_RELEASE and related base
image environment variables which are no longer used in v2.x.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
