### PR TITLE
Prepare for go 1.14

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -836,11 +836,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9c4fed825c10231651e81bf0ab2c12e3a6cc349dcc62a78f8d3a9dfb6744855e"
+  digest = "1:4fa2ca25ca372413905486e2c02570b1f5ae72eeab50d223660fcd190582e0c3"
   name = "golang.org/x/crypto"
   packages = ["sha3"]
   pruneopts = "NUT"
-  revision = "cc06ce4a13d484c0101a9e92913248488a75786d"
+  revision = "2aa609cf4a9d7d1126360de73b55b6002f9e052a"
 
 [[projects]]
   digest = "1:03004f72cd37290aa0cba90b66d418f3a7cfb47220207398b561e6abe7aa8f74"

--- a/core/ledger/util/couchdb/couchdb_test.go
+++ b/core/ledger/util/couchdb/couchdb_test.go
@@ -313,7 +313,7 @@ func TestIsEmpty(t *testing.T) {
 	couchInstance.conf.MaxRetries = 0
 	isEmpty, err = couchInstance.IsEmpty(ignore)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "unable to connect to CouchDB, check the hostname and port: Get http://junk/_all_dbs")
+	require.Regexp(t, `unable to connect to CouchDB, check the hostname and port: Get "?http://junk/_all_dbs"?`, err.Error())
 }
 
 func TestDBBadDatabaseName(t *testing.T) {

--- a/vendor/golang.org/x/crypto/sha3/hashes_generic.go
+++ b/vendor/golang.org/x/crypto/sha3/hashes_generic.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build gccgo appengine !s390x
+// +build gccgo appengine !s390x
 
 package sha3
 

--- a/vendor/golang.org/x/crypto/sha3/sha3.go
+++ b/vendor/golang.org/x/crypto/sha3/sha3.go
@@ -38,8 +38,9 @@ type state struct {
 	// [1] http://csrc.nist.gov/publications/drafts/fips-202/fips_202_draft.pdf
 	//     "Draft FIPS 202: SHA-3 Standard: Permutation-Based Hash and
 	//      Extendable-Output Functions (May 2014)"
-	dsbyte  byte
-	storage [maxRate]byte
+	dsbyte byte
+
+	storage storageBuf
 
 	// Specific to SHA-3 and SHAKE.
 	outputLen int             // the default output size in bytes
@@ -60,15 +61,15 @@ func (d *state) Reset() {
 		d.a[i] = 0
 	}
 	d.state = spongeAbsorbing
-	d.buf = d.storage[:0]
+	d.buf = d.storage.asBytes()[:0]
 }
 
 func (d *state) clone() *state {
 	ret := *d
 	if ret.state == spongeAbsorbing {
-		ret.buf = ret.storage[:len(ret.buf)]
+		ret.buf = ret.storage.asBytes()[:len(ret.buf)]
 	} else {
-		ret.buf = ret.storage[d.rate-cap(d.buf) : d.rate]
+		ret.buf = ret.storage.asBytes()[d.rate-cap(d.buf) : d.rate]
 	}
 
 	return &ret
@@ -82,13 +83,13 @@ func (d *state) permute() {
 		// If we're absorbing, we need to xor the input into the state
 		// before applying the permutation.
 		xorIn(d, d.buf)
-		d.buf = d.storage[:0]
+		d.buf = d.storage.asBytes()[:0]
 		keccakF1600(&d.a)
 	case spongeSqueezing:
 		// If we're squeezing, we need to apply the permutatin before
 		// copying more output.
 		keccakF1600(&d.a)
-		d.buf = d.storage[:d.rate]
+		d.buf = d.storage.asBytes()[:d.rate]
 		copyOut(d, d.buf)
 	}
 }
@@ -97,7 +98,7 @@ func (d *state) permute() {
 // the multi-bitrate 10..1 padding rule, and permutes the state.
 func (d *state) padAndPermute(dsbyte byte) {
 	if d.buf == nil {
-		d.buf = d.storage[:0]
+		d.buf = d.storage.asBytes()[:0]
 	}
 	// Pad with this instance's domain-separator bits. We know that there's
 	// at least one byte of space in d.buf because, if it were full,
@@ -105,7 +106,7 @@ func (d *state) padAndPermute(dsbyte byte) {
 	// first one bit for the padding. See the comment in the state struct.
 	d.buf = append(d.buf, dsbyte)
 	zerosStart := len(d.buf)
-	d.buf = d.storage[:d.rate]
+	d.buf = d.storage.asBytes()[:d.rate]
 	for i := zerosStart; i < d.rate; i++ {
 		d.buf[i] = 0
 	}
@@ -116,7 +117,7 @@ func (d *state) padAndPermute(dsbyte byte) {
 	// Apply the permutation
 	d.permute()
 	d.state = spongeSqueezing
-	d.buf = d.storage[:d.rate]
+	d.buf = d.storage.asBytes()[:d.rate]
 	copyOut(d, d.buf)
 }
 
@@ -127,7 +128,7 @@ func (d *state) Write(p []byte) (written int, err error) {
 		panic("sha3: write to sponge after read")
 	}
 	if d.buf == nil {
-		d.buf = d.storage[:0]
+		d.buf = d.storage.asBytes()[:0]
 	}
 	written = len(p)
 

--- a/vendor/golang.org/x/crypto/sha3/sha3_s390x.go
+++ b/vendor/golang.org/x/crypto/sha3/sha3_s390x.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !gccgo,!appengine
+// +build !gccgo,!appengine
 
 package sha3
 
@@ -112,7 +112,7 @@ func (s *asmState) Write(b []byte) (int, error) {
 		if len(s.buf) == 0 && len(b) >= cap(s.buf) {
 			// Hash the data directly and push any remaining bytes
 			// into the buffer.
-			remainder := len(s.buf) % s.rate
+			remainder := len(b) % s.rate
 			kimd(s.function, &s.a, b[:len(b)-remainder])
 			if remainder != 0 {
 				s.copyIntoBuf(b[len(b)-remainder:])

--- a/vendor/golang.org/x/crypto/sha3/sha3_s390x.s
+++ b/vendor/golang.org/x/crypto/sha3/sha3_s390x.s
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build !gccgo,!appengine
+// +build !gccgo,!appengine
 
 #include "textflag.h"
 

--- a/vendor/golang.org/x/crypto/sha3/shake_generic.go
+++ b/vendor/golang.org/x/crypto/sha3/shake_generic.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build gccgo appengine !s390x
+// +build gccgo appengine !s390x
 
 package sha3
 

--- a/vendor/golang.org/x/crypto/sha3/xor.go
+++ b/vendor/golang.org/x/crypto/sha3/xor.go
@@ -6,6 +6,13 @@
 
 package sha3
 
+// A storageBuf is an aligned array of maxRate bytes.
+type storageBuf [maxRate]byte
+
+func (b *storageBuf) asBytes() *[maxRate]byte {
+	return (*[maxRate]byte)(b)
+}
+
 var (
 	xorIn            = xorInGeneric
 	copyOut          = copyOutGeneric

--- a/vendor/golang.org/x/crypto/sha3/xor_unaligned.go
+++ b/vendor/golang.org/x/crypto/sha3/xor_unaligned.go
@@ -9,9 +9,16 @@ package sha3
 
 import "unsafe"
 
+// A storageBuf is an aligned array of maxRate bytes.
+type storageBuf [maxRate / 8]uint64
+
+func (b *storageBuf) asBytes() *[maxRate]byte {
+	return (*[maxRate]byte)(unsafe.Pointer(b))
+}
+
 func xorInUnaligned(d *state, buf []byte) {
-	bw := (*[maxRate / 8]uint64)(unsafe.Pointer(&buf[0]))
 	n := len(buf)
+	bw := (*[maxRate / 8]uint64)(unsafe.Pointer(&buf[0]))[: n/8 : n/8]
 	if n >= 72 {
 		d.a[0] ^= bw[0]
 		d.a[1] ^= bw[1]


### PR DESCRIPTION
Before we can move to go 1.14, we need to make sure things work with go 1.14...

- bump golang.org/x/crypto/sha3 to pick up checkptr fix
- soften assertion in error string to handle quotes present in go 1.14
  error that is not present in go 1.13