### PR TITLE
Add Public() to SigningIdentity

### DIFF
--- a/pkg/config/signer.go
+++ b/pkg/config/signer.go
@@ -28,9 +28,15 @@ type ecdsaSignature struct {
 	R, S *big.Int
 }
 
-// Sign performs ECDSA sign with SigningIdentity's private key on given digest.
-// It ensures signatures are created with Low S values since Fabric normalizes
-// all signatures to Low S.
+// Public returns the public key associated with this signing
+// identity's certificate.
+func (s *SigningIdentity) Public() crypto.PublicKey {
+	return s.Certificate.PublicKey
+}
+
+// Sign performs ECDSA sign with this signing identity's private key on the
+// given digest. It ensures signatures are created with Low S values since
+// Fabric normalizes all signatures to Low S.
 // See https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki#low_s
 // for more detail.
 func (s *SigningIdentity) Sign(reader io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {

--- a/pkg/config/signer_test.go
+++ b/pkg/config/signer_test.go
@@ -73,6 +73,17 @@ func TestSign(t *testing.T) {
 	}
 }
 
+func TestPublic(t *testing.T) {
+	gt := NewGomegaWithT(t)
+
+	cert, privateKey := generateCertAndPrivateKey()
+	signingIdentity := &SigningIdentity{
+		Certificate: cert,
+		PrivateKey:  privateKey,
+	}
+	gt.Expect(signingIdentity.Public()).To(Equal(cert.PublicKey))
+}
+
 func TestToLowS(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

This makes SigningIdentity a crypto.Signer.


#### Related issues

[FAB-17529](https://jira.hyperledger.org/browse/FAB-17529)