### PR TITLE
Replace gogo proto imports with golang proto

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1049,7 +1049,6 @@
     "github.com/go-kit/kit/metrics",
     "github.com/go-kit/kit/metrics/prometheus",
     "github.com/go-kit/kit/metrics/statsd",
-    "github.com/gogo/protobuf/proto",
     "github.com/golang/protobuf/jsonpb",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go",

--- a/common/genesis/genesis_test.go
+++ b/common/genesis/genesis_test.go
@@ -9,7 +9,7 @@ package genesis
 import (
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/stretchr/testify/assert"

--- a/common/grpclogging/fields.go
+++ b/common/grpclogging/fields.go
@@ -7,8 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package grpclogging
 
 import (
-	"github.com/gogo/protobuf/proto"
 	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )

--- a/common/ledger/blkstorage/fsblkstorage/pkg_test.go
+++ b/common/ledger/blkstorage/fsblkstorage/pkg_test.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/common/flogging"

--- a/core/common/privdata/util.go
+++ b/core/common/privdata/util.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package privdata
 
 import (
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	mspp "github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/common/cauthdsl"

--- a/core/peer/configtx_processor.go
+++ b/core/peer/configtx_processor.go
@@ -9,7 +9,7 @@ package peer
 import (
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/protoutil"

--- a/discovery/protoext/signedreq.go
+++ b/discovery/protoext/signedreq.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package protoext
 
 import (
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/discovery"
 )
 

--- a/discovery/protoext/signedreq_test.go
+++ b/discovery/protoext/signedreq_test.go
@@ -9,7 +9,7 @@ package protoext_test
 import (
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/discovery"
 	"github.com/hyperledger/fabric/discovery/protoext"
 	"github.com/stretchr/testify/assert"

--- a/pkg/config/consortiums.go
+++ b/pkg/config/consortiums.go
@@ -9,7 +9,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	mb "github.com/hyperledger/fabric-protos-go/msp"
 )


### PR DESCRIPTION
It looks like `goimports` has been pulling gogo/protobuf into some of our packages instead of google/protobuf. Replace these with the correct package and update the package lock.