### PR TITLE
Pull chaintool from jfrog instead of nexus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@
 
 BASE_VERSION = 1.1.2
 PREV_VERSION = 1.1.1
-CHAINTOOL_RELEASE=1.1.1
+CHAINTOOL_RELEASE=1.1.3
 BASEIMAGE_RELEASE=0.4.6
 
 # Allow to build as a submodule setting the main project to
@@ -85,7 +85,7 @@ GO_LDFLAGS = $(patsubst %,-X $(PKGNAME)/common/metadata.%,$(METADATA_VAR))
 
 GO_TAGS ?=
 
-CHAINTOOL_URL ?= https://nexus.hyperledger.org/content/repositories/releases/org/hyperledger/fabric/hyperledger-fabric/chaintool-$(CHAINTOOL_RELEASE)/hyperledger-fabric-chaintool-$(CHAINTOOL_RELEASE).jar
+CHAINTOOL_URL ?= https://hyperledger.jfrog.io/hyperledger/fabric-maven/org/hyperledger/fabric-chaintool/$(CHAINTOOL_RELEASE)/fabric-chaintool-$(CHAINTOOL_RELEASE).jar
 
 export GO_LDFLAGS GO_TAGS
 


### PR DESCRIPTION
To get v1.1 building again, need to switch chaintool reference
from nexus to jfrog artifactory.

Also update chaintool to v1.1.3.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
