### PR TITLE
Get fabric-protos-go dependency from release-2.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -401,7 +401,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
+  branch = "release-2.0"
   digest = "1:395a5f977a65907f61b64aff820dcdeb250deacf27f9ebffe3b3f516a1e98d4e"
   name = "github.com/hyperledger/fabric-protos-go"
   packages = [

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -182,7 +182,7 @@ noverify = [
       non-go = false
 
 [[constraint]]
-  branch = "master"
+  branch = "release-2.0"
   name = "github.com/hyperledger/fabric-protos-go"
 
 [[constraint]]


### PR DESCRIPTION
Point to the release-2.0 branch of fabric-protos-go.