### PR TITLE
Wire disabled docker builder when docker disabled

### DIFF
--- a/integration/nwo/package.go
+++ b/integration/nwo/package.go
@@ -32,7 +32,7 @@ func writeTarGz(c Chaincode, w io.Writer) {
 	tw := tar.NewWriter(gw)
 	defer closeAll(tw, gw)
 
-	writeMetadataJSON(tw, c.Path, "binary", c.Label)
+	writeMetadataJSON(tw, c.Path, c.Lang, c.Label)
 
 	writeCodeTarGz(tw, c.CodeFiles)
 }

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -152,6 +152,12 @@ func (e externalVMAdapter) Build(
 	return i, err
 }
 
+type disabledDockerBuilder struct{}
+
+func (disabledDockerBuilder) Build(string, *persistence.ChaincodePackageMetadata, io.Reader) (container.Instance, error) {
+	return nil, errors.New("docker build is disabled")
+}
+
 type endorserChannelAdapter struct {
 	peer *peer.Peer
 }
@@ -517,15 +523,14 @@ func serve(args []string) error {
 
 	chaincodeConfig := chaincode.GlobalConfig()
 
-	var client *docker.Client
-	var dockerVM *dockercontroller.DockerVM
+	var dockerBuilder container.DockerBuilder
 	if coreConfig.VMEndpoint != "" {
-		client, err = createDockerClient(coreConfig)
+		client, err := createDockerClient(coreConfig)
 		if err != nil {
 			logger.Panicf("cannot create docker client: %s", err)
 		}
 
-		dockerVM = &dockercontroller.DockerVM{
+		dockerVM := &dockercontroller.DockerVM{
 			PeerID:        coreConfig.PeerID,
 			NetworkID:     coreConfig.NetworkID,
 			BuildMetrics:  dockercontroller.NewBuildMetrics(opsSystem.Provider),
@@ -551,6 +556,12 @@ func serve(args []string) error {
 		if err := opsSystem.RegisterChecker("docker", dockerVM); err != nil {
 			logger.Panicf("failed to register docker health check: %s", err)
 		}
+		dockerBuilder = dockerVM
+	}
+
+	// docker is disabled when we're missing the docker config
+	if dockerBuilder == nil {
+		dockerBuilder = &disabledDockerBuilder{}
 	}
 
 	externalVM := &externalbuilder.Detector{
@@ -561,7 +572,7 @@ func serve(args []string) error {
 	buildRegistry := &container.BuildRegistry{}
 
 	containerRouter := &container.Router{
-		DockerBuilder:   dockerVM,
+		DockerBuilder:   dockerBuilder,
 		ExternalBuilder: externalVMAdapter{externalVM},
 		PackageProvider: &persistence.FallbackPackageLocator{
 			ChaincodePackageLocator: &persistence.ChaincodePackageLocator{


### PR DESCRIPTION
This prevents a panic during chaincode install when external builders cannot handle the chaincode type.

[FAB-17757]