### PR TITLE
[FAB-17517] Only Initialize specified BCCSP provider

### DIFF
--- a/bccsp/factory/nopkcs11_test.go
+++ b/bccsp/factory/nopkcs11_test.go
@@ -1,0 +1,51 @@
+// +build !pkcs11
+
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package factory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitFactoriesWithMultipleProviders(t *testing.T) {
+	// testing SW Provider and ensuring other providers are not initialized
+	factoriesInitError = nil
+
+	err := initFactories(&FactoryOpts{
+		ProviderName: "SW",
+		SwOpts:       &SwOpts{},
+		PluginOpts:   &PluginOpts{},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed initializing BCCSP")
+	assert.NotContains(t, err.Error(), "Failed initializing PLUGIN.BCCSP")
+
+	// testing PLUGIN Provider and ensuring other providers are not initialized
+	factoriesInitError = nil
+
+	err = initFactories(&FactoryOpts{
+		ProviderName: "PLUGIN",
+		SwOpts:       &SwOpts{},
+		PluginOpts:   &PluginOpts{},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed initializing PLUGIN.BCCSP")
+	assert.NotContains(t, err.Error(), "Failed initializing BCCSP")
+
+}

--- a/bccsp/factory/pkcs11.go
+++ b/bccsp/factory/pkcs11.go
@@ -61,7 +61,7 @@ func setFactories(config *FactoryOpts) error {
 	bccspMap = make(map[string]bccsp.BCCSP)
 
 	// Software-Based BCCSP
-	if config.SwOpts != nil {
+	if config.ProviderName == "SW" && config.SwOpts != nil {
 		f := &SWFactory{}
 		err := initBCCSP(f, config)
 		if err != nil {
@@ -70,7 +70,7 @@ func setFactories(config *FactoryOpts) error {
 	}
 
 	// PKCS11-Based BCCSP
-	if config.Pkcs11Opts != nil {
+	if config.ProviderName == "PKCS11" && config.Pkcs11Opts != nil {
 		f := &PKCS11Factory{}
 		err := initBCCSP(f, config)
 		if err != nil {
@@ -79,11 +79,11 @@ func setFactories(config *FactoryOpts) error {
 	}
 
 	// BCCSP Plugin
-	if config.PluginOpts != nil {
+	if config.ProviderName == "PLUGIN" && config.PluginOpts != nil {
 		f := &PluginFactory{}
 		err := initBCCSP(f, config)
 		if err != nil {
-			factoriesInitError = errors.Wrapf(err, "Failed initializing PKCS11.BCCSP %s", factoriesInitError)
+			factoriesInitError = errors.Wrapf(err, "Failed initializing PLUGIN.BCCSP %s", factoriesInitError)
 		}
 	}
 

--- a/bccsp/factory/pkcs11_test.go
+++ b/bccsp/factory/pkcs11_test.go
@@ -41,6 +41,51 @@ func TestSetFactories(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestSetFactoriesWithMultipleProviders(t *testing.T) {
+	// testing SW Provider and ensuring other providers are not initialized
+	factoriesInitError = nil
+
+	err := setFactories(&FactoryOpts{
+		ProviderName: "SW",
+		SwOpts:       &SwOpts{},
+		Pkcs11Opts:   &pkcs11.PKCS11Opts{},
+		PluginOpts:   &PluginOpts{},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed initializing SW.BCCSP")
+	assert.NotContains(t, err.Error(), "Failed initializing PKCS11.BCCSP")
+	assert.NotContains(t, err.Error(), "Failed initializing PLUGIN.BCCSP")
+
+	// testing PKCS11 Provider and ensuring other providers are not initialized
+	factoriesInitError = nil
+
+	err = setFactories(&FactoryOpts{
+		ProviderName: "PKCS11",
+		SwOpts:       &SwOpts{},
+		Pkcs11Opts:   &pkcs11.PKCS11Opts{},
+		PluginOpts:   &PluginOpts{},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed initializing PKCS11.BCCSP")
+	assert.NotContains(t, err.Error(), "Failed initializing SW.BCCSP")
+	assert.NotContains(t, err.Error(), "Failed initializing PLUGIN.BCCSP")
+
+	// testing PLUGIN Provider and ensuring other providers are not initialized
+	factoriesInitError = nil
+
+	err = setFactories(&FactoryOpts{
+		ProviderName: "PLUGIN",
+		SwOpts:       &SwOpts{},
+		Pkcs11Opts:   &pkcs11.PKCS11Opts{},
+		PluginOpts:   &PluginOpts{},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed initializing PLUGIN.BCCSP")
+	assert.NotContains(t, err.Error(), "Failed initializing SW.BCCSP")
+	assert.NotContains(t, err.Error(), "Failed initializing PKCS11.BCCSP")
+
+}
+
 func TestSetFactoriesInvalidArgs(t *testing.T) {
 	err := setFactories(&FactoryOpts{
 		ProviderName: "SW",


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Code currently tries to initialize multiple providers based on
provided config Opts being nil or not.

This update ensures that only specified provider is initialized
based on ProviderName.

This fixes "Failed initializing PKCS11.BCCSP %!s(<nil>)" error
when the code complied with PKCS11 or PLUGINS enabled expects
configuration to not be nil even when Provider is set to SW.

Signed-off-by: Ahmed Sajid <ahmed.sajid@securekey.com>


#### Additional details

If this looks good I can do PR for release-2.0 and master.

#### Related issues

https://jira.hyperledger.org/browse/FAB-17517
#821 
#822 