### PR TITLE
Backport LabelHelp field to metrics option structs

### DIFF
--- a/common/metrics/provider.go
+++ b/common/metrics/provider.go
@@ -46,6 +46,10 @@ type CounterOpts struct {
 	// of these label names.
 	LabelNames []string
 
+	// LabelHelp provides help information for labels. When set, this information
+	// will be used to populate the documentation.
+	LabelHelp map[string]string
+
 	// StatsdFormat determines how the fully-qualified statsd bucket name is
 	// constructed from Namespace, Subsystem, Name, and Labels. This is done by
 	// including field references in `%{reference}` escape sequences.
@@ -92,6 +96,10 @@ type GaugeOpts struct {
 	// metric. When a metric is recorded, label values must be provided for each
 	// of these label names.
 	LabelNames []string
+
+	// LabelHelp provides help information for labels. When set, this information
+	// will be used to populate the documentation.
+	LabelHelp map[string]string
 
 	// StatsdFormat determines how the fully-qualified statsd bucket name is
 	// constructed from Namespace, Subsystem, Name, and Labels. This is done by
@@ -140,6 +148,10 @@ type HistogramOpts struct {
 	// metric. When a metric is recorded, label values must be provided for each
 	// of these label names.
 	LabelNames []string
+
+	// LabelHelp provides help information for labels. When set, this information
+	// will be used to populate the documentation.
+	LabelHelp map[string]string
 
 	// StatsdFormat determines how the fully-qualified statsd bucket name is
 	// constructed from Namespace, Subsystem, Name, and Labels. This is done by


### PR DESCRIPTION
#### Type of change

Backport code from master to release 1.4

#### Description

Backport LabelHelp field to metrics option structs
