### PR TITLE
[FAB-17535] Fix intermittent test failure in implicit_coll_test

### DIFF
--- a/integration/pvtdata/implicit_coll_test.go
+++ b/integration/pvtdata/implicit_coll_test.go
@@ -42,7 +42,7 @@ var _ bool = Describe("Pvtdata dissemination for implicit collection", func() {
 			core.Peer.Gossip.PvtData.ReconciliationEnabled = false
 			if p.Organization == "Org1" {
 				// enable dissemination on org1 peers
-				core.Peer.Gossip.PvtData.ImplicitCollDisseminationPolicy.RequiredPeerCount = 0
+				core.Peer.Gossip.PvtData.ImplicitCollDisseminationPolicy.RequiredPeerCount = 1
 				core.Peer.Gossip.PvtData.ImplicitCollDisseminationPolicy.MaxPeerCount = 3
 			} else {
 				// disable dessemination on non-org1 peers


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Test update

#### Description
In implicit_coll_test.go, requiredPeerCount was originally set to 0, so endorsement will return without waiting for the pvtdata to be disseminated to other peer. As a result, the other peer may or may not receive the disseminated pvtdata at the time of query (depending on which is done first, commit+query vs. dissemination).

This PR changes requiredPeerCount to 1 in order to guarantee that the other peer receives the disseminated pvtdata during endorsement. 

#### Related issues
https://jira.hyperledger.org/browse/FAB-17535
