### PR TITLE
Wire disabled docker builder when docker disabled

### DIFF
--- a/integration/nwo/package.go
+++ b/integration/nwo/package.go
@@ -32,7 +32,7 @@ func writeTarGz(c Chaincode, w io.Writer) {
 	tw := tar.NewWriter(gw)
 	defer closeAll(tw, gw)
 
-	writeMetadataJSON(tw, c.Path, "binary", c.Label)
+	writeMetadataJSON(tw, c.Path, c.Lang, c.Label)
 
 	writeCodeTarGz(tw, c.CodeFiles)
 }


### PR DESCRIPTION
This prevents a panic during chaincode install when external builders cannot handle the chaincode type and docker is not configured.

[FAB-17757]