### PR TITLE
[FAB-17575] Encapsulate msp configuration at an organization level

### DIFF
--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	cb "github.com/hyperledger/fabric-protos-go/common"
-	mb "github.com/hyperledger/fabric-protos-go/msp"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 )
 
@@ -32,7 +31,7 @@ type AnchorPeer struct {
 
 // NewApplicationGroup returns the application component of the channel configuration.
 // By default, tt sets the mod_policy of all elements to "Admins".
-func NewApplicationGroup(application *Application, mspConfig *mb.MSPConfig) (*cb.ConfigGroup, error) {
+func NewApplicationGroup(application *Application) (*cb.ConfigGroup, error) {
 	var err error
 
 	applicationGroup := newConfigGroup()
@@ -57,7 +56,7 @@ func NewApplicationGroup(application *Application, mspConfig *mb.MSPConfig) (*cb
 	}
 
 	for _, org := range application.Organizations {
-		applicationGroup.Groups[org.Name], err = newOrgConfigGroup(org, mspConfig)
+		applicationGroup.Groups[org.Name], err = newOrgConfigGroup(org)
 		if err != nil {
 			return nil, fmt.Errorf("org group '%s': %v", org.Name, err)
 		}

--- a/pkg/config/application_test.go
+++ b/pkg/config/application_test.go
@@ -22,9 +22,7 @@ func TestNewApplicationGroup(t *testing.T) {
 
 	application := baseApplication()
 
-	mspConfig := &mb.MSPConfig{}
-
-	applicationGroup, err := NewApplicationGroup(application, mspConfig)
+	applicationGroup, err := NewApplicationGroup(application)
 	gt.Expect(err).NotTo(HaveOccurred())
 
 	// ApplicationGroup checks
@@ -96,9 +94,7 @@ func TestNewApplicationGroupFailure(t *testing.T) {
 			application := baseApplication()
 			tt.applicationMod(application)
 
-			mspConfig := &mb.MSPConfig{}
-
-			configGrp, err := NewApplicationGroup(application, mspConfig)
+			configGrp, err := NewApplicationGroup(application)
 			gt.Expect(err).To(MatchError(tt.expectedErr))
 			gt.Expect(configGrp).To(BeNil())
 		})
@@ -114,9 +110,7 @@ func TestNewApplicationGroupSkipAsForeign(t *testing.T) {
 	application.Organizations[0].SkipAsForeign = true
 	application.Organizations[1].SkipAsForeign = true
 
-	mspConfig := &mb.MSPConfig{}
-
-	applicationGroup, err := NewApplicationGroup(application, mspConfig)
+	applicationGroup, err := NewApplicationGroup(application)
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(applicationGroup.Groups["Org1"]).To(Equal(&cb.ConfigGroup{
 		ModPolicy: AdminsPolicyKey,
@@ -143,6 +137,7 @@ func baseApplication() *Application {
 				AnchorPeers: []*AnchorPeer{
 					{Host: "host1", Port: 123},
 				},
+				MSPConfig: &mb.FabricMSPConfig{},
 			},
 			{
 				Name:     "Org2",
@@ -151,6 +146,7 @@ func baseApplication() *Application {
 				AnchorPeers: []*AnchorPeer{
 					{Host: "host1", Port: 123},
 				},
+				MSPConfig: &mb.FabricMSPConfig{},
 			},
 		},
 		Capabilities: map[string]bool{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -241,11 +241,10 @@ func TestNewCreateChannelTx(t *testing.T) {
 			t.Parallel()
 			gt := NewGomegaWithT(t)
 
-			mspConfig := &mb.FabricMSPConfig{}
 			profile := tt.profileMod()
 
 			// creating a create channel transaction
-			envelope, err := NewCreateChannelTx(profile, mspConfig)
+			envelope, err := NewCreateChannelTx(profile)
 			gt.Expect(err).ToNot(HaveOccurred())
 			gt.Expect(envelope).ToNot(BeNil())
 
@@ -481,10 +480,9 @@ func TestNewCreateChannelTxFailure(t *testing.T) {
 
 			gt := NewGomegaWithT(t)
 
-			mspConfig := &mb.FabricMSPConfig{}
 			profile := tt.profileMod()
 
-			env, err := NewCreateChannelTx(profile, mspConfig)
+			env, err := NewCreateChannelTx(profile)
 			gt.Expect(env).To(BeNil())
 			gt.Expect(err).To(MatchError(tt.err))
 		})
@@ -563,7 +561,7 @@ func TestCreateSignedConfigUpdateEnvelopeFailures(t *testing.T) {
 			configUpdate:    nil,
 			signingIdentity: signingIdentity,
 			configSignature: []*cb.ConfigSignature{configSignature},
-			expectedErr:     "failed to marshal config update: proto: Marshal called with nil",
+			expectedErr:     "marshalling config update: proto: Marshal called with nil",
 		},
 	}
 
@@ -589,14 +587,16 @@ func baseProfile() *Channel {
 			Policies: standardPolicies(),
 			Organizations: []*Organization{
 				{
-					Name:     "Org1",
-					ID:       "Org1MSP",
-					Policies: applicationOrgStandardPolicies(),
+					Name:      "Org1",
+					ID:        "Org1MSP",
+					Policies:  applicationOrgStandardPolicies(),
+					MSPConfig: &mb.FabricMSPConfig{},
 				},
 				{
-					Name:     "Org2",
-					ID:       "Org2MSP",
-					Policies: applicationOrgStandardPolicies(),
+					Name:      "Org2",
+					ID:        "Org2MSP",
+					Policies:  applicationOrgStandardPolicies(),
+					MSPConfig: &mb.FabricMSPConfig{},
 				},
 			},
 			Capabilities: map[string]bool{
@@ -742,11 +742,9 @@ func TestNewOrgConfigGroup(t *testing.T) {
 	"version": "0"
 }
 `
-		mspConfig := &mb.MSPConfig{}
-
 		org := baseProfile().Application.Organizations[0]
 		org.OrdererEndpoints = []string{"123.45.677:8080"}
-		configGroup, err := newOrgConfigGroup(org, mspConfig)
+		configGroup, err := newOrgConfigGroup(org)
 		gt.Expect(err).NotTo(HaveOccurred())
 
 		buf := bytes.Buffer{}
@@ -766,11 +764,9 @@ func TestNewOrgConfigGroup(t *testing.T) {
 		err := protolator.DeepMarshalJSON(&expectedBuf, expectedConfigGroup)
 		gt.Expect(err).NotTo(HaveOccurred())
 
-		mspConfig := &mb.MSPConfig{}
-
 		org := baseProfile().Application.Organizations[0]
 		org.SkipAsForeign = true
-		configGroup, err := newOrgConfigGroup(org, mspConfig)
+		configGroup, err := newOrgConfigGroup(org)
 		gt.Expect(err).NotTo(HaveOccurred())
 
 		buf := bytes.Buffer{}
@@ -787,7 +783,6 @@ func TestNewOrgConfigGroupFailure(t *testing.T) {
 	tests := []struct {
 		name            string
 		organizationMod func(*Organization)
-		mspConfig       *mb.MSPConfig
 		expectedErr     string
 	}{
 		{
@@ -795,15 +790,14 @@ func TestNewOrgConfigGroupFailure(t *testing.T) {
 			func(o *Organization) {
 				o.Policies = nil
 			},
-			&mb.MSPConfig{},
 			"no policies defined",
 		},
 		{
 			"When failing to add msp value",
 			func(o *Organization) {
+				o.MSPConfig = nil
 			},
-			nil,
-			"marshalling standard config value 'MSP': proto: Marshal called with nil",
+			"marshalling msp config: proto: Marshal called with nil",
 		},
 	}
 
@@ -815,7 +809,7 @@ func TestNewOrgConfigGroupFailure(t *testing.T) {
 			gt := NewGomegaWithT(t)
 			baseOrg := baseProfile().Application.Organizations[0]
 			tt.organizationMod(baseOrg)
-			configGroup, err := newOrgConfigGroup(baseOrg, tt.mspConfig)
+			configGroup, err := newOrgConfigGroup(baseOrg)
 			gt.Expect(err).To(MatchError(tt.expectedErr))
 			gt.Expect(configGroup).To(BeNil())
 		})

--- a/pkg/config/consortiums.go
+++ b/pkg/config/consortiums.go
@@ -25,7 +25,7 @@ type Consortium struct {
 // NewConsortiumsGroup returns the consortiums component of the channel configuration. This element is only defined for
 // the ordering system channel.
 // It sets the mod_policy for all elements to "/Channel/Orderer/Admins".
-func NewConsortiumsGroup(consortiums []*Consortium, mspConfig *mb.MSPConfig) (*cb.ConfigGroup, error) {
+func NewConsortiumsGroup(consortiums []*Consortium) (*cb.ConfigGroup, error) {
 	var err error
 
 	consortiumsGroup := newConfigGroup()
@@ -44,7 +44,7 @@ func NewConsortiumsGroup(consortiums []*Consortium, mspConfig *mb.MSPConfig) (*c
 	addPolicy(consortiumsGroup, signaturePolicy, ordererAdminsPolicyName)
 
 	for _, consortium := range consortiums {
-		consortiumsGroup.Groups[consortium.Name], err = newConsortiumGroup(consortium, mspConfig)
+		consortiumsGroup.Groups[consortium.Name], err = newConsortiumGroup(consortium)
 		if err != nil {
 			return nil, err
 		}
@@ -55,7 +55,7 @@ func NewConsortiumsGroup(consortiums []*Consortium, mspConfig *mb.MSPConfig) (*c
 
 // AddOrgToConsortium adds an org definition to a named consortium in a given
 // channel configuration.
-func AddOrgToConsortium(config *cb.Config, org *Organization, consortium string, mspConfig *mb.MSPConfig) error {
+func AddOrgToConsortium(config *cb.Config, org *Organization, consortium string) error {
 	var err error
 
 	if org == nil {
@@ -73,7 +73,7 @@ func AddOrgToConsortium(config *cb.Config, org *Organization, consortium string,
 		return fmt.Errorf("consortium '%s' does not exist", consortium)
 	}
 
-	consortiumGroup.Groups[org.Name], err = newOrgConfigGroup(org, mspConfig)
+	consortiumGroup.Groups[org.Name], err = newOrgConfigGroup(org)
 	if err != nil {
 		return fmt.Errorf("failed to create consortium org: %v", err)
 	}
@@ -82,14 +82,14 @@ func AddOrgToConsortium(config *cb.Config, org *Organization, consortium string,
 }
 
 // newConsortiumGroup returns a consortiums component of the channel configuration.
-func newConsortiumGroup(consortium *Consortium, mspConfig *mb.MSPConfig) (*cb.ConfigGroup, error) {
+func newConsortiumGroup(consortium *Consortium) (*cb.ConfigGroup, error) {
 	var err error
 
 	consortiumGroup := newConfigGroup()
 	consortiumGroup.ModPolicy = ordererAdminsPolicyName
 
 	for _, org := range consortium.Organizations {
-		consortiumGroup.Groups[org.Name], err = newOrgConfigGroup(org, mspConfig)
+		consortiumGroup.Groups[org.Name], err = newOrgConfigGroup(org)
 		if err != nil {
 			return nil, fmt.Errorf("org group '%s': %v", org.Name, err)
 		}

--- a/pkg/config/consortiums_test.go
+++ b/pkg/config/consortiums_test.go
@@ -24,9 +24,7 @@ func TestNewConsortiumsGroup(t *testing.T) {
 
 	consortiums := baseConsortiums()
 
-	mspConfig := &mb.MSPConfig{}
-
-	consortiumsGroup, err := NewConsortiumsGroup(consortiums, mspConfig)
+	consortiumsGroup, err := NewConsortiumsGroup(consortiums)
 	gt.Expect(err).NotTo(HaveOccurred())
 
 	// ConsortiumsGroup checks
@@ -70,9 +68,7 @@ func TestNewConsortiumsGroupFailure(t *testing.T) {
 	consortiums := baseConsortiums()
 	consortiums[0].Organizations[0].Policies = nil
 
-	mspConfig := &mb.MSPConfig{}
-
-	consortiumsGroup, err := NewConsortiumsGroup(consortiums, mspConfig)
+	consortiumsGroup, err := NewConsortiumsGroup(consortiums)
 	gt.Expect(err).To(MatchError("org group 'Org1': no policies defined"))
 	gt.Expect(consortiumsGroup).To(BeNil())
 }
@@ -84,7 +80,7 @@ func TestAddOrgToConsortium(t *testing.T) {
 
 	consortiums := baseConsortiums()
 
-	consortiumsGroup, err := NewConsortiumsGroup(consortiums, &mb.MSPConfig{})
+	consortiumsGroup, err := NewConsortiumsGroup(consortiums)
 	gt.Expect(err).NotTo(HaveOccurred())
 
 	config := &cb.Config{
@@ -96,9 +92,10 @@ func TestAddOrgToConsortium(t *testing.T) {
 	}
 
 	orgToAdd := &Organization{
-		Name:     "Org1",
-		ID:       "Org1MSP",
-		Policies: applicationOrgStandardPolicies(),
+		Name:      "Org1",
+		ID:        "Org1MSP",
+		Policies:  applicationOrgStandardPolicies(),
+		MSPConfig: &mb.FabricMSPConfig{},
 	}
 
 	expectedConfig := `
@@ -298,7 +295,7 @@ func TestAddOrgToConsortium(t *testing.T) {
 	err = protolator.DeepUnmarshalJSON(bytes.NewBufferString(expectedConfig), &expectedConfigProto)
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	err = AddOrgToConsortium(config, orgToAdd, "Consortium1", &mb.MSPConfig{})
+	err = AddOrgToConsortium(config, orgToAdd, "Consortium1")
 	gt.Expect(err).NotTo(HaveOccurred())
 
 	gt.Expect(proto.Equal(config, &expectedConfigProto)).To(BeTrue())
@@ -358,7 +355,7 @@ func TestAddOrgToConsortiumFailures(t *testing.T) {
 
 			consortiums := baseConsortiums()
 
-			consortiumsGroup, err := NewConsortiumsGroup(consortiums, &mb.MSPConfig{})
+			consortiumsGroup, err := NewConsortiumsGroup(consortiums)
 			gt.Expect(err).NotTo(HaveOccurred())
 
 			config := &cb.Config{
@@ -369,7 +366,7 @@ func TestAddOrgToConsortiumFailures(t *testing.T) {
 				},
 			}
 
-			err = AddOrgToConsortium(config, test.org, test.consortium, &mb.MSPConfig{})
+			err = AddOrgToConsortium(config, test.org, test.consortium)
 			gt.Expect(err).To(MatchError(test.expectedErr))
 		})
 	}
@@ -384,10 +381,8 @@ func TestSkipAsForeignForConsortiumOrg(t *testing.T) {
 	consortiums[0].Organizations[0].SkipAsForeign = true
 	consortiums[0].Organizations[1].SkipAsForeign = true
 
-	mspConfig := &mb.MSPConfig{}
-
 	// returns a consortiums group with consortium groups that have empty consortium org groups with only mod policy
-	consortiumsGroup, err := NewConsortiumsGroup(consortiums, mspConfig)
+	consortiumsGroup, err := NewConsortiumsGroup(consortiums)
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(consortiumsGroup.Groups["Consortium1"].Groups["Org1"]).To(Equal(&cb.ConfigGroup{
 		ModPolicy: AdminsPolicyKey,
@@ -409,14 +404,16 @@ func baseConsortiums() []*Consortium {
 			Name: "Consortium1",
 			Organizations: []*Organization{
 				{
-					Name:     "Org1",
-					ID:       "Org1MSP",
-					Policies: orgStandardPolicies(),
+					Name:      "Org1",
+					ID:        "Org1MSP",
+					Policies:  orgStandardPolicies(),
+					MSPConfig: &mb.FabricMSPConfig{},
 				},
 				{
-					Name:     "Org2",
-					ID:       "Org2MSP",
-					Policies: orgStandardPolicies(),
+					Name:      "Org2",
+					ID:        "Org2MSP",
+					Policies:  orgStandardPolicies(),
+					MSPConfig: &mb.FabricMSPConfig{},
 				},
 			},
 		},

--- a/pkg/config/orderer.go
+++ b/pkg/config/orderer.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	cb "github.com/hyperledger/fabric-protos-go/common"
-	mb "github.com/hyperledger/fabric-protos-go/msp"
 	ob "github.com/hyperledger/fabric-protos-go/orderer"
 	eb "github.com/hyperledger/fabric-protos-go/orderer/etcdraft"
 )
@@ -50,7 +49,7 @@ type Kafka struct {
 // how frequently they should be emitted, etc. as well as the organizations of the ordering network.
 // It sets the mod_policy of all elements to "Admins".
 // This group is always present in any channel configuration.
-func NewOrdererGroup(orderer *Orderer, mspConfig *mb.MSPConfig) (*cb.ConfigGroup, error) {
+func NewOrdererGroup(orderer *Orderer) (*cb.ConfigGroup, error) {
 	ordererGroup := newConfigGroup()
 	ordererGroup.ModPolicy = AdminsPolicyKey
 
@@ -66,7 +65,7 @@ func NewOrdererGroup(orderer *Orderer, mspConfig *mb.MSPConfig) (*cb.ConfigGroup
 
 	// add orderer groups
 	for _, org := range orderer.Organizations {
-		ordererGroup.Groups[org.Name], err = newOrgConfigGroup(org, mspConfig)
+		ordererGroup.Groups[org.Name], err = newOrgConfigGroup(org)
 		if err != nil {
 			return nil, fmt.Errorf("org group '%s': %v", org.Name, err)
 		}

--- a/pkg/config/orderer_test.go
+++ b/pkg/config/orderer_test.go
@@ -42,9 +42,7 @@ func TestNewOrdererGroup(t *testing.T) {
 			ordererConf.OrdererType = tt.ordererType
 			ordererConf.EtcdRaft = tt.configMetadata
 
-			mspConfig := &mb.MSPConfig{}
-
-			ordererGroup, err := NewOrdererGroup(ordererConf, mspConfig)
+			ordererGroup, err := NewOrdererGroup(ordererConf)
 			gt.Expect(err).NotTo(HaveOccurred())
 
 			// OrdererGroup checks
@@ -170,9 +168,7 @@ func TestNewOrdererGroupFailure(t *testing.T) {
 			ordererConf := baseOrderer()
 			tt.ordererMod(ordererConf)
 
-			mspConfig := &mb.MSPConfig{}
-
-			ordererGroup, err := NewOrdererGroup(ordererConf, mspConfig)
+			ordererGroup, err := NewOrdererGroup(ordererConf)
 			gt.Expect(err).To(MatchError(tt.err))
 			gt.Expect(ordererGroup).To(BeNil())
 		})
@@ -186,9 +182,7 @@ func TestUpdateOrdererConfiguration(t *testing.T) {
 
 	baseOrdererConf := baseOrderer()
 
-	mspConfig := &mb.MSPConfig{}
-
-	ordererGroup, err := NewOrdererGroup(baseOrdererConf, mspConfig)
+	ordererGroup, err := NewOrdererGroup(baseOrdererConf)
 	gt.Expect(err).NotTo(HaveOccurred())
 
 	originalOrdererAddresses, err := proto.Marshal(&cb.OrdererAddresses{
@@ -297,6 +291,7 @@ func baseOrderer() *Orderer {
 				OrdererEndpoints: []string{
 					"localhost:123",
 				},
+				MSPConfig: &mb.FabricMSPConfig{},
 			},
 			{
 				Name:     "Org2",
@@ -305,6 +300,7 @@ func baseOrderer() *Orderer {
 				OrdererEndpoints: []string{
 					"localhost:123",
 				},
+				MSPConfig: &mb.FabricMSPConfig{},
 			},
 		},
 		Capabilities: map[string]bool{


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

* Fixes bug where CreateChannelTx was passing a single msp configuration
used across all orgs

#### Related issues

[FAB-17575](https://jira.hyperledger.org/browse/FAB-17575)