### PR TITLE
[FAB-17547] fix cache load configuration file unittest

### DIFF
--- a/internal/configtxgen/genesisconfig/config.go
+++ b/internal/configtxgen/genesisconfig/config.go
@@ -470,19 +470,19 @@ func (c *configCache) load(config *viper.Viper, configPath string) (*TopLevel, e
 		if err != nil {
 			return nil, fmt.Errorf("Error unmarshaling config into struct: %s", err)
 		}
-		conf.completeInitialization(filepath.Dir(config.ConfigFileUsed()))
 
 		serializedConf, err = json.Marshal(conf)
 		if err != nil {
 			return nil, err
 		}
 		c.cache[configPath] = serializedConf
-		return conf, nil
 	}
 
 	err := json.Unmarshal(serializedConf, conf)
 	if err != nil {
 		return nil, err
 	}
+
+	conf.completeInitialization(filepath.Dir(config.ConfigFileUsed()))
 	return conf, nil
 }

--- a/orderer/common/localconfig/config_test.go
+++ b/orderer/common/localconfig/config_test.go
@@ -67,7 +67,7 @@ func TestLoadCached(t *testing.T) {
 	initial.General.LocalMSPDir = "/test/bad/mspDir"
 	updated, err = Load()
 	assert.NoError(t, err)
-	assert.NotEqual(t, initial, updated, "expected %#v to equal %#v", updated, initial)
+	assert.NotEqual(t, initial, updated, "expected %#v to not equal %#v", updated, initial)
 }
 
 func TestLoadMissingConfigFile(t *testing.T) {


### PR DESCRIPTION
#### Type of change

- Test update

#### Description
- fixes unit test for load configuration file in cache.

#### Related issues

[FAB-17547](https://jira.hyperledger.org/browse/FAB-17547)