### PR TITLE
Relax error assertion in health check test

### DIFF
--- a/integration/e2e/health_test.go
+++ b/integration/e2e/health_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Health", func() {
 				statusCode, status = DoHealthCheck(authClient, healthURL)
 				Expect(status.Status).To(Equal("Service Unavailable"))
 				Expect(status.FailedChecks[0].Component).To(Equal("couchdb"))
-				Expect(status.FailedChecks[0].Reason).Should((HavePrefix(fmt.Sprintf("failed to connect to couch db [Head http://%s: dial tcp %s: ", couchAddr, couchAddr))))
+				Expect(status.FailedChecks[0].Reason).To(MatchRegexp(fmt.Sprintf(`failed to connect to couch db \[Head "?http://%s"?: dial tcp %s: .*\]`, couchAddr, couchAddr)))
 			})
 		})
 	})


### PR DESCRIPTION
Newer version of go adds quotes around the endpoint.