### PR TITLE
The operations subsystem is a singular entity

### DIFF
--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -219,7 +219,7 @@ func serve(args []string) error {
 	opsSystem := newOperationsSystem(coreConfig)
 	err = opsSystem.Start()
 	if err != nil {
-		return errors.WithMessage(err, "failed to initialize operations subsystems")
+		return errors.WithMessage(err, "failed to initialize operations subsystem")
 	}
 	defer opsSystem.Stop()
 


### PR DESCRIPTION
Update the error message to use the singular "subsystem" instead of "subsystems".

Relates to #797 