### PR TITLE
Add deprecation notice to BYFN

### DIFF
--- a/docs/source/build_network.rst
+++ b/docs/source/build_network.rst
@@ -1,12 +1,10 @@
 Building Your First Network
 ===========================
 
-.. note:: These instructions have been verified to work against the
-          latest stable Docker images and the pre-compiled
-          setup utilities within the supplied tar file. If you run
-          these commands with images or tools from the current master
-          branch, it is possible that you will see configuration and panic
-          errors.
+.. note:: The Build your first network (BYFN) tutorial has been deprecated. If
+          you are getting started with Hyperledger Fabric and would like to deploy
+          a basic network, see :doc:`test_network`. If you are deploying Fabric
+          in production, see the guide for :doc:`deployment_guide_overview`.
 
 The build your first network (BYFN) scenario provisions a sample Hyperledger
 Fabric network consisting of two organizations, each maintaining two peer


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>

#### Type of change

- Documentation update

#### Description

Add a note that BYFN is being deprecated, with links to the new test network and the deployment guide. Because of how long the tutorial has been around, and the number of external dependencies (Links to the documentation, etc), we cannot remove the tutorial yet. However, a note directing people elsewhere will make it easier to maintain the two networks.