### PR TITLE
Fixed GRPCS certificate verification problem when using cryptogen

### DIFF
--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -999,28 +999,6 @@ func createChaincodeServer(coreConfig *peer.Config, ca tlsgen.CA, peerHostname s
 	// set the logger for the server
 	config.Logger = flogging.MustGetLogger("core.comm").With("server", "ChaincodeServer")
 
-	// Override TLS configuration if TLS is applicable
-	if config.SecOpts.UseTLS {
-		// Create a self-signed TLS certificate with a SAN that matches the computed chaincode endpoint
-		certKeyPair, err := ca.NewServerCertKeyPair(host)
-		if err != nil {
-			logger.Panicf("Failed generating TLS certificate for chaincode service: +%v", err)
-		}
-		config.SecOpts = comm.SecureOptions{
-			UseTLS: true,
-			// Require chaincode shim to authenticate itself
-			RequireClientCert: true,
-			// Trust only client certificates signed by ourselves
-			ClientRootCAs: [][]byte{ca.CertBytes()},
-			// Use our own self-signed TLS certificate and key
-			Certificate: certKeyPair.Cert,
-			Key:         certKeyPair.Key,
-			// No point in specifying server root CAs since this TLS config is only used for
-			// a gRPC server and not a client
-			ServerRootCAs: nil,
-		}
-	}
-
 	// Chaincode keepalive options - static for now
 	chaincodeKeepaliveOptions := comm.KeepaliveOptions{
 		ServerInterval:    time.Duration(2) * time.Hour,    // 2 hours - gRPC default


### PR DESCRIPTION
* Fixed ability to use cryptogen with GRPCS chaincode servers

* Fixed linter issues

#### Type of change

- Bug fix

#### Description

The issue was that I used cryptogen to generate the cryptographic material for two organisation aforehand. Then when running the setup inside a AWS EKS cluster the problem arose that the docker container executing the chaincode could not connect to the ChainCode address with TLS because the verification of the certificate failed. This was due to the fact the TLS credentials get generated on the fly inside the process and therefore you cannot get to it. 

My first quick fix was to write the SSL material to disk and use that but then the signing of the Chaincode failed but the connection was verified though. So the next step was to use the same certificates as the main Peer connection for ChainCode as well. 

#### Additional details

I generated the SSL certificates for two organisations aforehand and used those to run two separate pods inside a Kubernetes cluster. They connect through a single orderer and everything is exposed with services. The Kubernetes cluster also has a docker registry running inside and the two pods have a docker sidecar loaded in for executing the docker containers running the chaincode. 

I had a lot of trouble running the `make checks` as I kept running into Go project specific issues like usage of internal packages with `go vet` and I could not get a correct output. Is there a getting started document targeting how to exactly setup the local development environment? 

#### Related issues
