### PR TITLE
[FAB-17596] Remove unused Resources type from config

### DIFF
--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -19,7 +19,6 @@ import (
 type Application struct {
 	Organizations []*Organization
 	Capabilities  map[string]bool
-	Resources     *Resources
 	Policies      map[string]*Policy
 	ACLs          map[string]string
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,13 +41,6 @@ type Policy struct {
 	Rule string
 }
 
-// Resources is the default policy for the channel.
-type Resources struct {
-	// DefaultModPolicy is the label for the channel's policies.
-	// Options: https://github.com/hyperledger/fabric/blob/04d3bf296a7a387ad09513193e3cafff20b17388/common/policies/policy.go#L36-L6.
-	DefaultModPolicy string
-}
-
 // Organization is an organization in the channel configuration.
 type Organization struct {
 	Name      string


### PR DESCRIPTION
* Resources was a relic of old Fabric config properties that are no
longer specified in a configtx.yaml

[FAB-17596](https://jira.hyperledger.org/browse/FAB-17596)