### PR TITLE
[FAB-17517] Only Initialize specified BCCSP provider

### DIFF
--- a/bccsp/factory/pkcs11.go
+++ b/bccsp/factory/pkcs11.go
@@ -60,7 +60,7 @@ func setFactories(config *FactoryOpts) error {
 	bccspMap = make(map[string]bccsp.BCCSP)
 
 	// Software-Based BCCSP
-	if config.SwOpts != nil {
+	if config.ProviderName == "SW" && config.SwOpts != nil {
 		f := &SWFactory{}
 		err := initBCCSP(f, config)
 		if err != nil {
@@ -69,7 +69,7 @@ func setFactories(config *FactoryOpts) error {
 	}
 
 	// PKCS11-Based BCCSP
-	if config.Pkcs11Opts != nil {
+	if config.ProviderName == "PKCS11" && config.Pkcs11Opts != nil {
 		f := &PKCS11Factory{}
 		err := initBCCSP(f, config)
 		if err != nil {

--- a/bccsp/factory/pkcs11_test.go
+++ b/bccsp/factory/pkcs11_test.go
@@ -41,6 +41,32 @@ func TestSetFactories(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestSetFactoriesWithMultipleProviders(t *testing.T) {
+	// testing SW Provider and ensuring other providers are not initialized
+	factoriesInitError = nil
+
+	err := setFactories(&FactoryOpts{
+		ProviderName: "SW",
+		SwOpts:       &SwOpts{},
+		Pkcs11Opts:   &pkcs11.PKCS11Opts{},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed initializing SW.BCCSP")
+	assert.NotContains(t, err.Error(), "Failed initializing PKCS11.BCCSP")
+
+	// testing PKCS11 Provider and ensuring other providers are not initialized
+	factoriesInitError = nil
+
+	err = setFactories(&FactoryOpts{
+		ProviderName: "PKCS11",
+		SwOpts:       &SwOpts{},
+		Pkcs11Opts:   &pkcs11.PKCS11Opts{},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed initializing PKCS11.BCCSP")
+	assert.NotContains(t, err.Error(), "Failed initializing SW.BCCSP")
+}
+
 func TestSetFactoriesInvalidArgs(t *testing.T) {
 	err := setFactories(&FactoryOpts{
 		ProviderName: "SW",


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Code currently tries to initialize multiple providers based on
provided config Opts being nil or not.

This update ensures that only specified provider is initialized
based on ProviderName.

This fixes "Failed initializing PKCS11.BCCSP %!s(<nil>)" error
when the code complied with PKCS11 enabled expects
configuration to not be nil even when Provider is set to SW.

Signed-off-by: Ahmed Sajid <ahmed.sajid@securekey.com>


#### Additional details

If this looks good I can do PR for release-2.0 and master.

#### Related issues

https://jira.hyperledger.org/browse/FAB-17517
#769 
#822 