### PR TITLE
Move common/ledger/util/Buffer to consumer

### DIFF
--- a/common/ledger/blkstorage/fsblkstorage/block_serialization.go
+++ b/common/ledger/blkstorage/fsblkstorage/block_serialization.go
@@ -9,7 +9,6 @@ package fsblkstorage
 import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
-	ledgerutil "github.com/hyperledger/fabric/common/ledger/util"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 )
@@ -47,7 +46,7 @@ func serializeBlock(block *common.Block) ([]byte, *serializedBlockInfo, error) {
 func deserializeBlock(serializedBlockBytes []byte) (*common.Block, error) {
 	block := &common.Block{}
 	var err error
-	b := ledgerutil.NewBuffer(serializedBlockBytes)
+	b := newBuffer(serializedBlockBytes)
 	if block.Header, err = extractHeader(b); err != nil {
 		return nil, err
 	}
@@ -63,7 +62,7 @@ func deserializeBlock(serializedBlockBytes []byte) (*common.Block, error) {
 func extractSerializedBlockInfo(serializedBlockBytes []byte) (*serializedBlockInfo, error) {
 	info := &serializedBlockInfo{}
 	var err error
-	b := ledgerutil.NewBuffer(serializedBlockBytes)
+	b := newBuffer(serializedBlockBytes)
 	info.blockHeader, err = extractHeader(b)
 	if err != nil {
 		return nil, err
@@ -131,7 +130,7 @@ func addMetadataBytes(blockMetadata *common.BlockMetadata, buf *proto.Buffer) er
 	return nil
 }
 
-func extractHeader(buf *ledgerutil.Buffer) (*common.BlockHeader, error) {
+func extractHeader(buf *buffer) (*common.BlockHeader, error) {
 	header := &common.BlockHeader{}
 	var err error
 	if header.Number, err = buf.DecodeVarint(); err != nil {
@@ -149,7 +148,7 @@ func extractHeader(buf *ledgerutil.Buffer) (*common.BlockHeader, error) {
 	return header, nil
 }
 
-func extractData(buf *ledgerutil.Buffer) (*common.BlockData, []*txindexInfo, error) {
+func extractData(buf *buffer) (*common.BlockData, []*txindexInfo, error) {
 	data := &common.BlockData{}
 	var txOffsets []*txindexInfo
 	var numItems uint64
@@ -177,7 +176,7 @@ func extractData(buf *ledgerutil.Buffer) (*common.BlockData, []*txindexInfo, err
 	return data, txOffsets, nil
 }
 
-func extractMetadata(buf *ledgerutil.Buffer) (*common.BlockMetadata, error) {
+func extractMetadata(buf *buffer) (*common.BlockMetadata, error) {
 	metadata := &common.BlockMetadata{}
 	var numItems uint64
 	var metadataEntry []byte

--- a/common/ledger/blkstorage/fsblkstorage/protobuf_util.go
+++ b/common/ledger/blkstorage/fsblkstorage/protobuf_util.go
@@ -14,27 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package fsblkstorage
 
 import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 )
 
-// Buffer provides a wrapper on top of proto.Buffer.
+// buffer provides a wrapper on top of proto.Buffer.
 // The purpose of this wrapper is to get to know the current position in the []byte
-type Buffer struct {
+type buffer struct {
 	buf      *proto.Buffer
 	position int
 }
 
-// NewBuffer constructs a new instance of Buffer
-func NewBuffer(b []byte) *Buffer {
-	return &Buffer{proto.NewBuffer(b), 0}
+// newBuffer constructs a new instance of Buffer
+func newBuffer(b []byte) *buffer {
+	return &buffer{proto.NewBuffer(b), 0}
 }
 
 // DecodeVarint wraps the actual method and updates the position
-func (b *Buffer) DecodeVarint() (uint64, error) {
+func (b *buffer) DecodeVarint() (uint64, error) {
 	val, err := b.buf.DecodeVarint()
 	if err == nil {
 		b.position += proto.SizeVarint(val)
@@ -45,7 +45,7 @@ func (b *Buffer) DecodeVarint() (uint64, error) {
 }
 
 // DecodeRawBytes wraps the actual method and updates the position
-func (b *Buffer) DecodeRawBytes(alloc bool) ([]byte, error) {
+func (b *buffer) DecodeRawBytes(alloc bool) ([]byte, error) {
 	val, err := b.buf.DecodeRawBytes(alloc)
 	if err == nil {
 		b.position += proto.SizeVarint(uint64(len(val))) + len(val)
@@ -56,6 +56,6 @@ func (b *Buffer) DecodeRawBytes(alloc bool) ([]byte, error) {
 }
 
 // GetBytesConsumed returns the offset of the current position in the underlying []byte
-func (b *Buffer) GetBytesConsumed() int {
+func (b *buffer) GetBytesConsumed() int {
 	return b.position
 }

--- a/common/ledger/blkstorage/fsblkstorage/protobuf_util_test.go
+++ b/common/ledger/blkstorage/fsblkstorage/protobuf_util_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package fsblkstorage
 
 import (
 	"testing"
@@ -34,7 +34,7 @@ func TestBuffer(t *testing.T) {
 	pb.EncodeVarint(1000000)
 	pos4 := len(pb.Bytes())
 
-	b := NewBuffer(pb.Bytes())
+	b := newBuffer(pb.Bytes())
 	b.DecodeVarint()
 	assert.Equal(t, pos1, b.GetBytesConsumed())
 	b.DecodeRawBytes(false)


### PR DESCRIPTION
- Relocate a small helper class out of the "common" utility package and
  into the single consuming package.
- Stop exporting the Buffer type as it's a detail of the consumer.