### PR TITLE
[FAB-17581] Increase gossip timeout to prevent test flake

### DIFF
--- a/gossip/comm/comm_impl.go
+++ b/gossip/comm/comm_impl.go
@@ -154,7 +154,7 @@ func (c *commImpl) createConnection(endpoint string, expectedPKIID common.PKIidT
 
 	cl := proto.NewGossipClient(cc)
 
-	ctx, cancel = context.WithTimeout(context.Background(), DefConnTimeout)
+	ctx, cancel = context.WithTimeout(context.Background(), c.connTimeout)
 	defer cancel()
 	if _, err = cl.Ping(ctx, &proto.Empty{}); err != nil {
 		cc.Close()
@@ -271,7 +271,7 @@ func (c *commImpl) Probe(remotePeer *RemotePeer) error {
 	}
 	defer cc.Close()
 	cl := proto.NewGossipClient(cc)
-	ctx, cancel = context.WithTimeout(context.Background(), DefConnTimeout)
+	ctx, cancel = context.WithTimeout(context.Background(), c.connTimeout)
 	defer cancel()
 	_, err = cl.Ping(ctx, &proto.Empty{})
 	c.logger.Debugf("Returning %v", err)
@@ -293,7 +293,7 @@ func (c *commImpl) Handshake(remotePeer *RemotePeer) (api.PeerIdentityType, erro
 	defer cc.Close()
 
 	cl := proto.NewGossipClient(cc)
-	ctx, cancel = context.WithTimeout(context.Background(), DefConnTimeout)
+	ctx, cancel = context.WithTimeout(context.Background(), c.connTimeout)
 	defer cancel()
 	if _, err = cl.Ping(ctx, &proto.Empty{}); err != nil {
 		return nil, err

--- a/integration/pvtdata/implicit_coll_test.go
+++ b/integration/pvtdata/implicit_coll_test.go
@@ -41,12 +41,15 @@ var _ bool = Describe("Pvtdata dissemination for implicit collection", func() {
 			core.Peer.Gossip.PvtData.PullRetryThreshold = 0
 			// disable pvtdata reconciliation on all peers
 			core.Peer.Gossip.PvtData.ReconciliationEnabled = false
+			// set timeout to 10s to prevent test flake
+			core.Peer.Gossip.DialTimeout = 10 * time.Second
+			core.Peer.Gossip.ConnTimeout = 10 * time.Second
 			if p.Organization == "Org1" {
 				// enable dissemination on org1 peers
 				core.Peer.Gossip.PvtData.ImplicitCollDisseminationPolicy.RequiredPeerCount = 1
 				core.Peer.Gossip.PvtData.ImplicitCollDisseminationPolicy.MaxPeerCount = 3
-				// increase timeout to avoid test flake
-				core.Peer.Gossip.PvtData.PushAckTimeout = 6 * time.Second
+				// set timeout to 10s to prevent test flake
+				core.Peer.Gossip.PvtData.PushAckTimeout = 10 * time.Second
 			} else {
 				// disable dessemination on non-org1 peers
 				core.Peer.Gossip.PvtData.ImplicitCollDisseminationPolicy.RequiredPeerCount = 0


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Test update

#### Description
Update gossip connection code to use configured timeout instead of default value.
Increase gossip service timeout values to prevent test flake. 

#### Related issues
https://jira.hyperledger.org/browse/FAB-17581

