### PR TITLE
BCCSP initialization cleanup

### DIFF
--- a/bccsp/factory/factory.go
+++ b/bccsp/factory/factory.go
@@ -1,17 +1,7 @@
 /*
-Copyright IBM Corp. 2016 All Rights Reserved.
+Copyright IBM Corp. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-		 http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
 */
 
 package factory
@@ -25,22 +15,14 @@ import (
 )
 
 var (
-	// Default BCCSP
-	DefaultBCCSP bccsp.BCCSP
+	defaultBCCSP       bccsp.BCCSP // default BCCSP
+	factoriesInitOnce  sync.Once   // factories' Sync on Initialization
+	factoriesInitError error       // Factories' Initialization Error
 
 	// when InitFactories has not been called yet (should only happen
 	// in test cases), use this BCCSP temporarily
-	bootBCCSP bccsp.BCCSP
-
-	// BCCSP Factories
-	bccspMap map[string]bccsp.BCCSP
-
-	// factories' Sync on Initialization
-	factoriesInitOnce sync.Once
+	bootBCCSP         bccsp.BCCSP
 	bootBCCSPInitOnce sync.Once
-
-	// Factories' Initialization Error
-	factoriesInitError error
 
 	logger = flogging.MustGetLogger("bccsp")
 )
@@ -58,35 +40,25 @@ type BCCSPFactory interface {
 
 // GetDefault returns a non-ephemeral (long-term) BCCSP
 func GetDefault() bccsp.BCCSP {
-	if DefaultBCCSP == nil {
+	if defaultBCCSP == nil {
 		logger.Debug("Before using BCCSP, please call InitFactories(). Falling back to bootBCCSP.")
 		bootBCCSPInitOnce.Do(func() {
 			var err error
-			f := &SWFactory{}
-			bootBCCSP, err = f.Get(&FactoryOpts{
-				ProviderName: "SW",
-				SwOpts: &SwOpts{
-					HashFamily: "SHA2",
-					SecLevel:   256,
-
-					Ephemeral: true,
-				}})
+			bootBCCSP, err = (&SWFactory{}).Get(GetDefaultOpts())
 			if err != nil {
 				panic("BCCSP Internal error, failed initialization with GetDefaultOpts!")
 			}
 		})
 		return bootBCCSP
 	}
-	return DefaultBCCSP
+	return defaultBCCSP
 }
 
-func initBCCSP(f BCCSPFactory, config *FactoryOpts) error {
+func initBCCSP(f BCCSPFactory, config *FactoryOpts) (bccsp.BCCSP, error) {
 	csp, err := f.Get(config)
 	if err != nil {
-		return errors.Errorf("Could not initialize BCCSP %s [%s]", f.Name(), err)
+		return nil, errors.Errorf("Could not initialize BCCSP %s [%s]", f.Name(), err)
 	}
 
-	logger.Debugf("Initialize BCCSP [%s]", f.Name())
-	bccspMap[f.Name()] = csp
-	return nil
+	return csp, nil
 }

--- a/bccsp/factory/factory_test.go
+++ b/bccsp/factory/factory_test.go
@@ -1,26 +1,15 @@
 /*
-Copyright IBM Corp. 2016 All Rights Reserved.
+Copyright IBM Corp. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-		 http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
 */
+
 package factory
 
 import (
-	"bytes"
-	"encoding/json"
-	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hyperledger/fabric/bccsp/pkcs11"
@@ -29,20 +18,19 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	flag.Parse()
-	lib, pin, label := pkcs11.FindPKCS11Lib()
+	var yamlBCCSP *FactoryOpts
 
-	var jsonBCCSP, yamlBCCSP *FactoryOpts
-	jsonCFG := []byte(
-		`{ "default": "SW", "SW":{ "security": 384, "hash": "SHA3" } }`)
+	yamlCFG := `
+BCCSP:
+    default: SW
+    SW:
+        Hash: SHA3
+        Security: 256
+`
 
-	err := json.Unmarshal(jsonCFG, &jsonBCCSP)
-	if err != nil {
-		fmt.Printf("Could not parse JSON config [%s]", err)
-		os.Exit(-1)
-	}
-
-	yamlCFG := fmt.Sprintf(`
+	if pkcs11Enabled {
+		lib, pin, label := pkcs11.FindPKCS11Lib()
+		yamlCFG = fmt.Sprintf(`
 BCCSP:
     default: PKCS11
     SW:
@@ -56,19 +44,10 @@ BCCSP:
         Pin:     '%s'
         Label:   %s
         `, lib, pin, label)
-
-	if lib == "" {
-		fmt.Printf("Could not find PKCS11 libraries, running without\n")
-		yamlCFG = `
-BCCSP:
-    default: SW
-    SW:
-        Hash: SHA3
-        Security: 256`
 	}
 
 	viper.SetConfigType("yaml")
-	err = viper.ReadConfig(bytes.NewBuffer([]byte(yamlCFG)))
+	err := viper.ReadConfig(strings.NewReader(yamlCFG))
 	if err != nil {
 		fmt.Printf("Could not read YAML config [%s]", err)
 		os.Exit(-1)
@@ -81,28 +60,22 @@ BCCSP:
 	}
 
 	cfgVariations := []*FactoryOpts{
-		{
-			ProviderName: "SW",
-			SwOpts: &SwOpts{
-				HashFamily: "SHA2",
-				SecLevel:   256,
-
-				Ephemeral: true,
-			},
-		},
 		{},
-		{
-			ProviderName: "SW",
-		},
-		jsonBCCSP,
+		{ProviderName: "SW"},
+		{ProviderName: "SW", SwOpts: &SwOpts{HashFamily: "SHA2", SecLevel: 256, Ephemeral: true}},
 		yamlBCCSP,
 	}
 
 	for index, config := range cfgVariations {
 		fmt.Printf("Trying configuration [%d]\n", index)
-		InitFactories(config)
-		InitFactories(nil)
-		m.Run()
+		factoriesInitError = initFactories(config)
+		if factoriesInitError != nil {
+			fmt.Fprintf(os.Stderr, "initFactories failed: %s", factoriesInitError)
+			os.Exit(1)
+		}
+		if rc := m.Run(); rc != 0 {
+			os.Exit(rc)
+		}
 	}
 	os.Exit(0)
 }

--- a/bccsp/factory/nopkcs11.go
+++ b/bccsp/factory/nopkcs11.go
@@ -1,26 +1,19 @@
 // +build !pkcs11
 
 /*
-Copyright IBM Corp. 2017 All Rights Reserved.
+Copyright IBM Corp. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-		 http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
 */
+
 package factory
 
 import (
 	"github.com/hyperledger/fabric/bccsp"
 	"github.com/pkg/errors"
 )
+
+const pkcs11Enabled = false
 
 // FactoryOpts holds configuration information used to initialize factory implementations
 type FactoryOpts struct {
@@ -34,39 +27,41 @@ type FactoryOpts struct {
 // Error is returned only if defaultBCCSP cannot be found
 func InitFactories(config *FactoryOpts) error {
 	factoriesInitOnce.Do(func() {
-		// Take some precautions on default opts
-		if config == nil {
-			config = GetDefaultOpts()
-		}
-
-		if config.ProviderName == "" {
-			config.ProviderName = "SW"
-		}
-
-		if config.SwOpts == nil {
-			config.SwOpts = GetDefaultOpts().SwOpts
-		}
-
-		// Initialize factories map
-		bccspMap = make(map[string]bccsp.BCCSP)
-
-		// Software-Based BCCSP
-		if config.SwOpts != nil {
-			f := &SWFactory{}
-			err := initBCCSP(f, config)
-			if err != nil {
-				factoriesInitError = errors.Wrapf(err, "Failed initializing BCCSP.")
-			}
-		}
-
-		var ok bool
-		DefaultBCCSP, ok = bccspMap[config.ProviderName]
-		if !ok {
-			factoriesInitError = errors.Errorf("%s\nCould not find default `%s` BCCSP", factoriesInitError, config.ProviderName)
-		}
+		factoriesInitError = initFactories(config)
 	})
 
 	return factoriesInitError
+}
+
+func initFactories(config *FactoryOpts) error {
+	// Take some precautions on default opts
+	if config == nil {
+		config = GetDefaultOpts()
+	}
+
+	if config.ProviderName == "" {
+		config.ProviderName = "SW"
+	}
+
+	if config.SwOpts == nil {
+		config.SwOpts = GetDefaultOpts().SwOpts
+	}
+
+	// Software-Based BCCSP
+	if config.ProviderName == "SW" && config.SwOpts != nil {
+		f := &SWFactory{}
+		var err error
+		defaultBCCSP, err = initBCCSP(f, config)
+		if err != nil {
+			return errors.Wrapf(err, "Failed initializing BCCSP")
+		}
+	}
+
+	if defaultBCCSP == nil {
+		return errors.Errorf("Could not find default `%s` BCCSP", config.ProviderName)
+	}
+
+	return nil
 }
 
 // GetBCCSPFromOpts returns a BCCSP created according to the options passed in input.

--- a/bccsp/factory/nopkcs11_test.go
+++ b/bccsp/factory/nopkcs11_test.go
@@ -1,0 +1,28 @@
+// +build !pkcs11
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package factory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitFactories(t *testing.T) {
+	err := initFactories(&FactoryOpts{
+		ProviderName: "SW",
+		SwOpts:       &SwOpts{},
+	})
+	assert.EqualError(t, err, "Failed initializing BCCSP: Could not initialize BCCSP SW [Failed initializing configuration at [0,]: Hash Family not supported []]")
+
+	err = initFactories(&FactoryOpts{
+		ProviderName: "PKCS11",
+	})
+	assert.EqualError(t, err, "Could not find default `PKCS11` BCCSP")
+}

--- a/bccsp/factory/opts.go
+++ b/bccsp/factory/opts.go
@@ -24,8 +24,7 @@ func GetDefaultOpts() *FactoryOpts {
 		SwOpts: &SwOpts{
 			HashFamily: "SHA2",
 			SecLevel:   256,
-
-			Ephemeral: true,
+			Ephemeral:  true,
 		},
 	}
 }

--- a/bccsp/factory/pkcs11.go
+++ b/bccsp/factory/pkcs11.go
@@ -1,20 +1,11 @@
 // +build pkcs11
 
 /*
-Copyright IBM Corp. 2017 All Rights Reserved.
+Copyright IBM Corp. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-		 http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
 */
+
 package factory
 
 import (
@@ -22,6 +13,8 @@ import (
 	"github.com/hyperledger/fabric/bccsp/pkcs11"
 	"github.com/pkg/errors"
 )
+
+const pkcs11Enabled = false
 
 // FactoryOpts holds configuration information used to initialize factory implementations
 type FactoryOpts struct {
@@ -36,13 +29,13 @@ type FactoryOpts struct {
 // Error is returned only if defaultBCCSP cannot be found
 func InitFactories(config *FactoryOpts) error {
 	factoriesInitOnce.Do(func() {
-		setFactories(config)
+		factoriesInitError = initFactories(config)
 	})
 
 	return factoriesInitError
 }
 
-func setFactories(config *FactoryOpts) error {
+func initFactories(config *FactoryOpts) error {
 	// Take some precautions on default opts
 	if config == nil {
 		config = GetDefaultOpts()
@@ -56,34 +49,31 @@ func setFactories(config *FactoryOpts) error {
 		config.SwOpts = GetDefaultOpts().SwOpts
 	}
 
-	// Initialize factories map
-	bccspMap = make(map[string]bccsp.BCCSP)
-
 	// Software-Based BCCSP
-	if config.SwOpts != nil {
+	if config.ProviderName == "SW" && config.SwOpts != nil {
 		f := &SWFactory{}
-		err := initBCCSP(f, config)
+		var err error
+		defaultBCCSP, err = initBCCSP(f, config)
 		if err != nil {
-			factoriesInitError = errors.Wrap(err, "Failed initializing SW.BCCSP")
+			return errors.Wrap(err, "Failed initializing SW.BCCSP")
 		}
 	}
 
 	// PKCS11-Based BCCSP
 	if config.ProviderName == "PKCS11" && config.Pkcs11Opts != nil {
 		f := &PKCS11Factory{}
-		err := initBCCSP(f, config)
+		var err error
+		defaultBCCSP, err = initBCCSP(f, config)
 		if err != nil {
-			factoriesInitError = errors.Wrapf(err, "Failed initializing PKCS11.BCCSP %s", factoriesInitError)
+			return errors.Wrapf(err, "Failed initializing PKCS11.BCCSP")
 		}
 	}
 
-	var ok bool
-	DefaultBCCSP, ok = bccspMap[config.ProviderName]
-	if !ok {
-		factoriesInitError = errors.Errorf("%s\nCould not find default `%s` BCCSP", factoriesInitError, config.ProviderName)
+	if defaultBCCSP == nil {
+		return errors.Errorf("Could not find default `%s` BCCSP", config.ProviderName)
 	}
 
-	return factoriesInitError
+	return nil
 }
 
 // GetBCCSPFromOpts returns a BCCSP created according to the options passed in input.

--- a/bccsp/factory/pkcs11_test.go
+++ b/bccsp/factory/pkcs11_test.go
@@ -1,20 +1,11 @@
 // +build pkcs11
 
 /*
-Copyright IBM Corp. 2017 All Rights Reserved.
+Copyright IBM Corp. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-		 http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
 */
+
 package factory
 
 import (
@@ -25,62 +16,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInitFactories(t *testing.T) {
+func TestExportedInitFactories(t *testing.T) {
 	// Reset errors from previous negative test runs
-	factoriesInitError = nil
+	factoriesInitError = initFactories(nil)
 
 	err := InitFactories(nil)
 	assert.NoError(t, err)
 }
 
-func TestSetFactories(t *testing.T) {
-	err := setFactories(nil)
+func TestInitFactories(t *testing.T) {
+	err := initFactories(nil)
 	assert.NoError(t, err)
 
-	err = setFactories(&FactoryOpts{})
+	err = initFactories(&FactoryOpts{})
 	assert.NoError(t, err)
 }
 
-func TestSetFactoriesWithMultipleProviders(t *testing.T) {
-	// testing SW Provider and ensuring other providers are not initialized
-	factoriesInitError = nil
-
-	err := setFactories(&FactoryOpts{
-		ProviderName: "SW",
-		SwOpts:       &SwOpts{},
-		Pkcs11Opts:   &pkcs11.PKCS11Opts{},
-	})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Failed initializing SW.BCCSP")
-	assert.NotContains(t, err.Error(), "Failed initializing PKCS11.BCCSP")
-
-	// testing PKCS11 Provider and ensuring other providers are not initialized
-	factoriesInitError = nil
-
-	err = setFactories(&FactoryOpts{
-		ProviderName: "PKCS11",
-		SwOpts:       &SwOpts{},
-		Pkcs11Opts:   &pkcs11.PKCS11Opts{},
-	})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Failed initializing PKCS11.BCCSP")
-	assert.NotContains(t, err.Error(), "Failed initializing SW.BCCSP")
-}
-
-func TestSetFactoriesInvalidArgs(t *testing.T) {
-	err := setFactories(&FactoryOpts{
+func TestInitFactoriesInvalidArgs(t *testing.T) {
+	err := initFactories(&FactoryOpts{
 		ProviderName: "SW",
 		SwOpts:       &SwOpts{},
 	})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Failed initializing SW.BCCSP")
+	assert.EqualError(t, err, "Failed initializing SW.BCCSP: Could not initialize BCCSP SW [Failed initializing configuration at [0,]: Hash Family not supported []]")
 
-	err = setFactories(&FactoryOpts{
+	err = initFactories(&FactoryOpts{
 		ProviderName: "PKCS11",
 		Pkcs11Opts:   &pkcs11.PKCS11Opts{},
 	})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Failed initializing PKCS11.BCCSP")
+	assert.EqualError(t, err, "Failed initializing PKCS11.BCCSP: Could not initialize BCCSP PKCS11 [Failed initializing configuration: Hash Family not supported []]")
 }
 
 func TestGetBCCSPFromOpts(t *testing.T) {
@@ -109,7 +72,6 @@ func TestGetBCCSPFromOpts(t *testing.T) {
 	csp, err = GetBCCSPFromOpts(&FactoryOpts{
 		ProviderName: "BadName",
 	})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Could not find BCCSP, no 'BadName' provider")
+	assert.EqualError(t, err, "Could not find BCCSP, no 'BadName' provider")
 	assert.Nil(t, csp)
 }

--- a/common/channelconfig/msp_test.go
+++ b/common/channelconfig/msp_test.go
@@ -27,7 +27,7 @@ func TestMSPConfigManager(t *testing.T) {
 	mspVers := []msp.MSPVersion{msp.MSPv1_0, msp.MSPv1_1}
 
 	for _, ver := range mspVers {
-		mspCH := NewMSPConfigHandler(ver, factory.DefaultBCCSP)
+		mspCH := NewMSPConfigHandler(ver, factory.GetDefault())
 
 		_, err = mspCH.ProposeMSP(conf)
 		assert.NoError(t, err)

--- a/msp/msp_test.go
+++ b/msp/msp_test.go
@@ -106,7 +106,7 @@ func TestMSPSetupNoCryptoConf(t *testing.T) {
 	b, err := proto.Marshal(mspconf)
 	assert.NoError(t, err)
 	conf.Config = b
-	newmsp, err := newBccspMsp(MSPv1_0, factory.DefaultBCCSP)
+	newmsp, err := newBccspMsp(MSPv1_0, factory.GetDefault())
 	assert.NoError(t, err)
 	err = newmsp.Setup(conf)
 	assert.NoError(t, err)
@@ -119,7 +119,7 @@ func TestMSPSetupNoCryptoConf(t *testing.T) {
 	b, err = proto.Marshal(mspconf)
 	assert.NoError(t, err)
 	conf.Config = b
-	newmsp, err = newBccspMsp(MSPv1_0, factory.DefaultBCCSP)
+	newmsp, err = newBccspMsp(MSPv1_0, factory.GetDefault())
 	assert.NoError(t, err)
 	err = newmsp.Setup(conf)
 	assert.NoError(t, err)
@@ -131,7 +131,7 @@ func TestMSPSetupNoCryptoConf(t *testing.T) {
 	b, err = proto.Marshal(mspconf)
 	assert.NoError(t, err)
 	conf.Config = b
-	newmsp, err = newBccspMsp(MSPv1_0, factory.DefaultBCCSP)
+	newmsp, err = newBccspMsp(MSPv1_0, factory.GetDefault())
 	assert.NoError(t, err)
 	err = newmsp.Setup(conf)
 	assert.NoError(t, err)
@@ -1111,25 +1111,25 @@ func TestMain(m *testing.M) {
 		os.Exit(-1)
 	}
 
-	localMsp, err = newBccspMsp(MSPv1_0, factory.DefaultBCCSP)
+	localMsp, err = newBccspMsp(MSPv1_0, factory.GetDefault())
 	if err != nil {
 		fmt.Printf("Constructor for msp should have succeeded, got err %s instead", err)
 		os.Exit(-1)
 	}
 
-	localMspBad, err = newBccspMsp(MSPv1_0, factory.DefaultBCCSP)
+	localMspBad, err = newBccspMsp(MSPv1_0, factory.GetDefault())
 	if err != nil {
 		fmt.Printf("Constructor for msp should have succeeded, got err %s instead", err)
 		os.Exit(-1)
 	}
 
-	localMspV13, err = newBccspMsp(MSPv1_3, factory.DefaultBCCSP)
+	localMspV13, err = newBccspMsp(MSPv1_3, factory.GetDefault())
 	if err != nil {
 		fmt.Printf("Constructor for V1.3 msp should have succeeded, got err %s instead", err)
 		os.Exit(-1)
 	}
 
-	localMspV11, err = newBccspMsp(MSPv1_1, factory.DefaultBCCSP)
+	localMspV11, err = newBccspMsp(MSPv1_1, factory.GetDefault())
 	if err != nil {
 		fmt.Printf("Constructor for V1.1 msp should have succeeded, got err %s instead", err)
 		os.Exit(-1)

--- a/msp/ouconfig_test.go
+++ b/msp/ouconfig_test.go
@@ -47,7 +47,7 @@ func TestBadConfigOUCert(t *testing.T) {
 	conf, err := GetLocalMspConfig("testdata/badconfigoucert", nil, "SampleOrg")
 	assert.NoError(t, err)
 
-	thisMSP, err := newBccspMsp(MSPv1_0, factory.DefaultBCCSP)
+	thisMSP, err := newBccspMsp(MSPv1_0, factory.GetDefault())
 	assert.NoError(t, err)
 
 	err = thisMSP.Setup(conf)


### PR DESCRIPTION
- Address my own comments from #769.
- Remove export of `DefaultBCCSP`
- Update users of `DefaultBCCSP` to call `GetDefault()`

With the recent changes that have been merged, we no longer have a collection of factories - there is only one. That means anything implied by the plural "factories" or "default" is really nonsense and these all need to be cleaned up.