### PR TITLE
[FAB-17606]  Fix the wrong word. Suported ---> Supported

### DIFF
--- a/common/capabilities/channel_test.go
+++ b/common/capabilities/channel_test.go
@@ -90,11 +90,11 @@ func TestChannelV143(t *testing.T) {
 	assert.True(t, cp.OrgSpecificOrdererEndpoints())
 }
 
-func TestChannelNotSuported(t *testing.T) {
+func TestChannelNotSupported(t *testing.T) {
 	cp := NewChannelProvider(map[string]*cb.Capability{
-		ChannelV1_1:          {},
-		ChannelV1_3:          {},
-		"Bogus_Not_suported": {},
+		ChannelV1_1:           {},
+		ChannelV1_3:           {},
+		"Bogus_Not_Supported": {},
 	})
-	assert.EqualError(t, cp.Supported(), "Channel capability Bogus_Not_suported is required but not supported")
+	assert.EqualError(t, cp.Supported(), "Channel capability Bogus_Not_Supported is required but not supported")
 }

--- a/common/capabilities/orderer_test.go
+++ b/common/capabilities/orderer_test.go
@@ -45,9 +45,9 @@ func TestOrdererV142(t *testing.T) {
 	assert.True(t, op.ConsensusTypeMigration())
 }
 
-func TestNotSuported(t *testing.T) {
+func TestNotSupported(t *testing.T) {
 	op := NewOrdererProvider(map[string]*cb.Capability{
-		OrdererV1_1: {}, "Bogus_Not_suported": {},
+		OrdererV1_1: {}, "Bogus_Not_Supported": {},
 	})
-	assert.EqualError(t, op.Supported(), "Orderer capability Bogus_Not_suported is required but not supported")
+	assert.EqualError(t, op.Supported(), "Orderer capability Bogus_Not_Supported is required but not supported")
 }


### PR DESCRIPTION
Signed-off-by: jilg <liguo_ji@outlook.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

<!--- Describe your changes in detail, including motivation. -->
the function name is error. 
```
func TestNotSuported(t *testing.T) {
   op := NewOrdererProvider(map[string]*cb.Capability{
      OrdererV1_1: {}, "Bogus_Not_suported": {},
   })
   assert.EqualError(t, op.Supported(), "Orderer capability Bogus_Not_suported is required but not supported")
}
```
#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->
[FAB-17606](https://jira.hyperledger.org/browse/FAB-17606)
<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
