### PR TITLE
Discover CLI to support SEC 1 format private keys

### DIFF
--- a/cmd/common/signer/signer_test.go
+++ b/cmd/common/signer/signer_test.go
@@ -8,6 +8,10 @@ package signer
 
 import (
 	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,6 +36,59 @@ func TestSigner(t *testing.T) {
 
 	r, s, err := utils.UnmarshalECDSASignature(sig)
 	ecdsa.Verify(&signer.key.PublicKey, util.ComputeSHA256(msg), r, s)
+}
+
+func TestSignerDifferentFormats(t *testing.T) {
+	key := `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIOwCtOQIkowasuWoDQpXHgC547VHq+aBFaSyPOoV8mnGoAoGCCqGSM49
+AwEHoUQDQgAEEsrroAkPez9reWvJukufUqyfouJjakrKuhNBYuclkldqsLZ/TO+w
+ZsQXrlIqlmNalfYPX+NDDELqlpXQBeEqnA==
+-----END EC PRIVATE KEY-----`
+
+	pemBlock, _ := pem.Decode([]byte(key))
+	assert.NotNil(t, pemBlock)
+
+	ecPK, err := x509.ParseECPrivateKey(pemBlock.Bytes)
+	assert.NoError(t, err)
+
+	ec1, err := x509.MarshalECPrivateKey(ecPK)
+	assert.NoError(t, err)
+
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(ecPK)
+	assert.NoError(t, err)
+
+	for _, testCase := range []struct {
+		description string
+		keyBytes    []byte
+	}{
+		{
+			description: "EC1",
+			keyBytes:    pem.EncodeToMemory(&pem.Block{Type: "EC Private Key", Bytes: ec1}),
+		},
+		{
+			description: "PKCS8",
+			keyBytes:    pem.EncodeToMemory(&pem.Block{Type: "Private Key", Bytes: pkcs8}),
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			tmpFile, err := ioutil.TempFile("", "key")
+			assert.NoError(t, err)
+
+			defer os.Remove(tmpFile.Name())
+
+			err = ioutil.WriteFile(tmpFile.Name(), []byte(testCase.keyBytes), 0600)
+			assert.NoError(t, err)
+
+			signer, err := NewSigner(Config{
+				MSPID:        "MSPID",
+				IdentityPath: filepath.Join("testdata", "signer", "cert.pem"),
+				KeyPath:      tmpFile.Name(),
+			})
+
+			assert.NoError(t, err)
+			assert.NotNil(t, signer)
+		})
+	}
 }
 
 func TestSignerBadConfig(t *testing.T) {
@@ -71,6 +128,6 @@ func TestSignerBadConfig(t *testing.T) {
 	}
 
 	signer, err = NewSigner(conf)
-	assert.EqualError(t, err, "failed to parse private key from testdata/signer/empty_private_key: asn1: syntax error: sequence truncated")
+	assert.EqualError(t, err, "failed to parse private key: x509: failed to parse EC private key: asn1: syntax error: sequence truncated")
 	assert.Nil(t, signer)
 }


### PR DESCRIPTION
Keys that are generated with openssl ecparam should also be supported with the discover CLI.

This change set first checks if it's a PKCS8 private key, and then fallbacks to SEC 1. 

Change-Id: Iff6992a946a6b6cdf26b4064d1e01af196f778c6
Signed-off-by: yacovm <yacovm@il.ibm.com>
