### PR TITLE
[FAB-17591] Support adding an orderer endpoint to existing config

### DIFF
--- a/pkg/config/example_test.go
+++ b/pkg/config/example_test.go
@@ -446,6 +446,11 @@ func Example_usage() {
 		panic(err)
 	}
 
+	err = config.AddOrdererEndpoint(updatedConfig, "OrdererOrg2", "127.0.0.1:8050")
+	if err != nil {
+		panic(err)
+	}
+
 	// Compute the delta
 	configUpdate, err := config.ComputeUpdate(baseConfig, updatedConfig, "testChannel")
 	if err != nil {
@@ -629,7 +634,8 @@ func Example_usage() {
 	// 									"mod_policy": "Admins",
 	// 									"value": {
 	// 										"addresses": [
-	// 											"127.0.0.1:7050"
+	// 											"127.0.0.1:7050",
+	// 											"127.0.0.1:8050"
 	// 										]
 	// 									},
 	// 									"version": "0"

--- a/pkg/config/orderer.go
+++ b/pkg/config/orderer.go
@@ -284,3 +284,40 @@ func addOrdererPolicies(cg *cb.ConfigGroup, policyMap map[string]Policy, modPoli
 
 	return addPolicies(cg, policyMap, modPolicy)
 }
+
+// AddOrdererEndpoints adds an orderer's endpoint to an existing channel config transaction.
+// It must add the endpoint to an existing org and the endpoint must not already
+// exist in the org.
+func AddOrdererEndpoint(config *cb.Config, orgName string, endpoint string) error {
+	ordererOrgGroup, ok := config.ChannelGroup.Groups[OrdererGroupKey].Groups[orgName]
+	if !ok {
+		return fmt.Errorf("orderer org %s does not exist in channel config", orgName)
+	}
+
+	ordererAddrProto := &cb.OrdererAddresses{}
+
+	if ordererAddrConfigValue, ok := ordererOrgGroup.Values[EndpointsKey]; ok {
+		err := proto.Unmarshal(ordererAddrConfigValue.Value, ordererAddrProto)
+		if err != nil {
+			return fmt.Errorf("failed unmarshalling orderer org %s's  endpoints: %v", orgName, err)
+		}
+	}
+
+	existingOrdererEndpoints := ordererAddrProto.Addresses
+	for _, e := range existingOrdererEndpoints {
+		if e == endpoint {
+			return fmt.Errorf("orderer org %s already contains endpoint %s",
+				orgName, endpoint)
+		}
+	}
+
+	existingOrdererEndpoints = append(existingOrdererEndpoints, endpoint)
+
+	// Add orderer endpoints config value back to orderer org
+	err := addValue(ordererOrgGroup, endpointsValue(existingOrdererEndpoints), AdminsPolicyKey)
+	if err != nil {
+		return fmt.Errorf("failed to add endpoint %v to orderer org %s: %v", endpoint, orgName, err)
+	}
+
+	return nil
+}

--- a/pkg/config/orderer_test.go
+++ b/pkg/config/orderer_test.go
@@ -476,3 +476,162 @@ func baseOrderer() Orderer {
 		Addresses: []string{"localhost:123"},
 	}
 }
+
+// marshalOrPanic is a helper for proto marshal.
+func marshalOrPanic(pb proto.Message) []byte {
+	data, err := proto.Marshal(pb)
+	if err != nil {
+		panic(err)
+	}
+
+	return data
+}
+
+func TestAddOrdererEndpoint(t *testing.T) {
+	t.Parallel()
+
+	gt := NewGomegaWithT(t)
+
+	config := &cb.Config{
+		ChannelGroup: &cb.ConfigGroup{
+			Groups: map[string]*cb.ConfigGroup{
+				OrdererGroupKey: {
+					Version: 0,
+					Groups: map[string]*cb.ConfigGroup{
+						"Orderer1Org": {
+							Groups: map[string]*cb.ConfigGroup{},
+							Values: map[string]*cb.ConfigValue{
+								EndpointsKey: {
+									ModPolicy: AdminsPolicyKey,
+									Value: marshalOrPanic(&cb.OrdererAddresses{
+										Addresses: []string{"127.0.0.1:8050"},
+									}),
+								},
+							},
+							Policies: map[string]*cb.ConfigPolicy{},
+						},
+					},
+					Values:   map[string]*cb.ConfigValue{},
+					Policies: map[string]*cb.ConfigPolicy{},
+				},
+			},
+			Values:   map[string]*cb.ConfigValue{},
+			Policies: map[string]*cb.ConfigPolicy{},
+		},
+		Sequence: 0,
+	}
+
+	expectedUpdatedConfigJSON := `
+{
+	"channel_group": {
+		"groups": {
+			"Orderer": {
+				"groups": {
+                    "Orderer1Org": {
+						"groups": {},
+						"mod_policy": "",
+						"policies": {},
+						"values": {
+							"Endpoints": {
+								"mod_policy": "Admins",
+								"value": {
+									"addresses": [
+										"127.0.0.1:8050",
+										"127.0.0.1:9050"
+									]
+								},
+								"version": "0"
+							}
+						},
+						"version": "0"
+					}
+				},
+                "mod_policy": "",
+		        "policies": {},
+		        "values": {},
+				"version": "0"
+			}
+		},
+		"mod_policy": "",
+		"policies": {},
+		"values": {},
+		"version": "0"
+	},
+	"sequence": "0"
+}
+	`
+	expectedUpdatedConfig := &cb.Config{}
+	err := protolator.DeepUnmarshalJSON(bytes.NewBufferString(expectedUpdatedConfigJSON), expectedUpdatedConfig)
+	gt.Expect(err).ToNot(HaveOccurred())
+
+	newOrderer1OrgEndpoint := "127.0.0.1:9050"
+	err = AddOrdererEndpoint(config, "Orderer1Org", newOrderer1OrgEndpoint)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	gt.Expect(config).To(Equal(expectedUpdatedConfig))
+}
+
+func TestAddOrdererEndpointFailure(t *testing.T) {
+	t.Parallel()
+
+	config := &cb.Config{
+		ChannelGroup: &cb.ConfigGroup{
+			Groups: map[string]*cb.ConfigGroup{
+				OrdererGroupKey: {
+					Version: 0,
+					Groups: map[string]*cb.ConfigGroup{
+						"OrdererOrg": {
+							Groups: map[string]*cb.ConfigGroup{},
+							Values: map[string]*cb.ConfigValue{
+								EndpointsKey: {
+									ModPolicy: AdminsPolicyKey,
+									Value: marshalOrPanic(&cb.OrdererAddresses{
+										Addresses: []string{"127.0.0.1:7050"},
+									}),
+								},
+							},
+							Policies: map[string]*cb.ConfigPolicy{},
+						},
+					},
+					Values:   map[string]*cb.ConfigValue{},
+					Policies: map[string]*cb.ConfigPolicy{},
+				},
+			},
+			Values:   map[string]*cb.ConfigValue{},
+			Policies: map[string]*cb.ConfigPolicy{},
+		},
+		Sequence: 0,
+	}
+
+	tests := []struct {
+		testName    string
+		orgName     string
+		endpoint    string
+		expectedErr string
+	}{
+		{
+			testName:    "When the org for the orderer does not exist",
+			orgName:     "BadOrg",
+			endpoint:    "127.0.0.1:7050",
+			expectedErr: "orderer org BadOrg does not exist in channel config",
+		},
+		{
+			testName:    "When the orderer endpoint being added already exists in the org",
+			orgName:     "OrdererOrg",
+			endpoint:    "127.0.0.1:7050",
+			expectedErr: "orderer org OrdererOrg already contains endpoint 127.0.0.1:7050",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.testName, func(t *testing.T) {
+			t.Parallel()
+
+			gt := NewGomegaWithT(t)
+
+			err := AddOrdererEndpoint(config, tt.orgName, tt.endpoint)
+			gt.Expect(err).To(MatchError(tt.expectedErr))
+		})
+	}
+}


### PR DESCRIPTION
Description

Modify an existing channel configuration to add an orderer endpoint to an orderer org's config group.

Related issues

https://jira.hyperledger.org/browse/FAB-17591

Signed-off-by: xu wu <wuxu1103@163.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- New feature

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
