### PR TITLE
[FAB-17623] Replace OrdererAddressesKey with EndpointsKey in orderer org's Values

### DIFF
--- a/pkg/config/example_test.go
+++ b/pkg/config/example_test.go
@@ -38,7 +38,7 @@ func fetchChannelConfig() *cb.Config {
 						"OrdererOrg": {
 							Groups: map[string]*cb.ConfigGroup{},
 							Values: map[string]*cb.ConfigValue{
-								config.OrdererAddressesKey: {
+								config.EndpointsKey: {
 									ModPolicy: config.AdminsPolicyKey,
 									Value: marshalOrPanic(&cb.OrdererAddresses{
 										Addresses: []string{"127.0.0.1:7050"},


### PR DESCRIPTION
Signed-off-by: xu wu <wuxu1103@163.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Test update

#### Description

<!--- Describe your changes in detail, including motivation. -->
In common.Config, an orderer org's Values (map[string]*cb.ConfigValue) can only have MSP or Endpoints as its key. OrdererAddressesKey is a key for Values of ChannelGroup.
#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->
https://jira.hyperledger.org/browse/FAB-17623

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
