### PR TITLE
Fix data race at discovery

### DIFF
--- a/gossip/discovery/discovery.go
+++ b/gossip/discovery/discovery.go
@@ -9,6 +9,7 @@ package discovery
 import (
 	"fmt"
 
+	protolib "github.com/golang/protobuf/proto"
 	proto "github.com/hyperledger/fabric-protos-go/gossip"
 	"github.com/hyperledger/fabric/gossip/common"
 	"github.com/hyperledger/fabric/gossip/protoext"
@@ -80,6 +81,28 @@ type NetworkMember struct {
 	InternalEndpoint string
 	Properties       *proto.Properties
 	*proto.Envelope
+}
+
+// Clone clones the NetworkMember
+func (n NetworkMember) Clone() NetworkMember {
+	pkiIDClone := make(common.PKIidType, len(n.PKIid))
+	copy(pkiIDClone, n.PKIid)
+	nmClone := NetworkMember{
+		Endpoint:         n.Endpoint,
+		Metadata:         n.Metadata,
+		InternalEndpoint: n.InternalEndpoint,
+		PKIid:            pkiIDClone,
+	}
+
+	if n.Properties != nil {
+		nmClone.Properties = protolib.Clone(n.Properties).(*proto.Properties)
+	}
+
+	if n.Envelope != nil {
+		nmClone.Envelope = protolib.Clone(n.Envelope).(*proto.Envelope)
+	}
+
+	return nmClone
 }
 
 // String returns a string representation of the NetworkMember

--- a/gossip/discovery/discovery_impl.go
+++ b/gossip/discovery/discovery_impl.go
@@ -703,7 +703,7 @@ func (d *gossipDiscoveryImpl) expireDeadMembers(dead []common.PKIidType) {
 	d.logger.Warning("Entering", dead)
 	defer d.logger.Warning("Exiting")
 
-	var deadMembers2Expire []*NetworkMember
+	var deadMembers2Expire []NetworkMember
 
 	d.lock.Lock()
 
@@ -711,7 +711,7 @@ func (d *gossipDiscoveryImpl) expireDeadMembers(dead []common.PKIidType) {
 		if _, isAlive := d.aliveLastTS[string(pkiID)]; !isAlive {
 			continue
 		}
-		deadMembers2Expire = append(deadMembers2Expire, d.id2Member[string(pkiID)])
+		deadMembers2Expire = append(deadMembers2Expire, d.id2Member[string(pkiID)].Clone())
 		// move lastTS from alive to dead
 		lastTS, hasLastTS := d.aliveLastTS[string(pkiID)]
 		if hasLastTS {
@@ -729,7 +729,7 @@ func (d *gossipDiscoveryImpl) expireDeadMembers(dead []common.PKIidType) {
 
 	for _, member2Expire := range deadMembers2Expire {
 		d.logger.Warning("Closing connection to", member2Expire)
-		d.comm.CloseConn(member2Expire)
+		d.comm.CloseConn(&member2Expire)
 	}
 }
 

--- a/gossip/discovery/discovery_test.go
+++ b/gossip/discovery/discovery_test.go
@@ -428,6 +428,27 @@ func bootPeer(port int) string {
 	return fmt.Sprintf("localhost:%d", port)
 }
 
+func TestClone(t *testing.T) {
+	nm := &NetworkMember{
+		PKIid: common.PKIidType("abc"),
+		Properties: &proto.Properties{
+			LedgerHeight: 1,
+			LeftChannel:  true,
+		},
+		Envelope: &proto.Envelope{
+			Payload: []byte("payload"),
+		},
+		InternalEndpoint: "internal",
+		Metadata:         []byte{1, 2, 3},
+		Endpoint:         "endpoint",
+	}
+
+	nm2 := nm.Clone()
+	assert.Equal(t, *nm, nm2, "Clones are different")
+	assert.False(t, nm.Properties == nm2.Properties, "Cloning should be deep and not shallow")
+	assert.False(t, nm.Envelope == nm2.Envelope, "Cloning should be deep and not shallow")
+}
+
 func TestHasExternalEndpoints(t *testing.T) {
 	memberWithEndpoint := NetworkMember{Endpoint: "foo"}
 	memberWithoutEndpoint := NetworkMember{}


### PR DESCRIPTION
When dead members are being expired, the expired members
are copied by reference into a slice under a lock.

These members can be changed under a lock, however
they are sometimes logged without the lock.

Implemented a Clone() method and used it when the network members
are logged.

Stack traces can be found in the discussion in the [JIRA](https://jira.hyperledger.org/browse/FAB-17608).

Change-Id: Ic40a802ce5ea47dd11c3d38ccaf125ce64d97402
Signed-off-by: yacovm <yacovm@il.ibm.com>
