### PR TITLE
[FAB-17624] Handle net.Listen error in gossip unit test

### DIFF
--- a/gossip/discovery/discovery_test.go
+++ b/gossip/discovery/discovery_test.go
@@ -403,7 +403,8 @@ func createDiscoveryInstanceThatGossipsWithInterceptors(port int, id string, boo
 	listenAddress := fmt.Sprintf("%s:%d", "", port)
 	ll, err := net.Listen("tcp", listenAddress)
 	if err != nil {
-		fmt.Printf("Error listening on %v, %v", listenAddress, err)
+		errMsg := fmt.Sprintf("Failed creating listener on address %v for gossip instance: %v", listenAddress, err)
+		panic(errMsg)
 	}
 	s := grpc.NewServer()
 


### PR DESCRIPTION
The function createDiscoveryInstanceThatGossipsWithInterceptors attempts
to create a net.Listener which binds on an address, and it can fail
if the port is in use.

The code currently just prints the error and continues, and later on
panics with a nil pointer.

I changed the code so that it now panics and doesn't continue the flow
of the test.

Change-Id: Ie55317a79d8fab03ab2f64d1e4a016cc416397ee
Signed-off-by: yacovm <yacovm@il.ibm.com>
