### PR TITLE
Use correct *testing.T in sub-tests

### DIFF
--- a/orderer/common/server/etcdraft_test.go
+++ b/orderer/common/server/etcdraft_test.go
@@ -68,11 +68,11 @@ func TestSpawnEtcdRaft(t *testing.T) {
 		// tests in this suite actually launch process with success, hence we need to avoid
 		// conflicts in listening port, opening files.
 		t.Run("TLS disabled dual listener", func(t *testing.T) {
-			testEtcdRaftOSNNoTLSDualListener(gt, tempDir, orderer, fabricRootDir, configtxgen, cryptoPath)
+			testEtcdRaftOSNNoTLSDualListener(NewGomegaWithT(t), tempDir, orderer, fabricRootDir, configtxgen, cryptoPath)
 		})
 
 		t.Run("TLS enabled single listener", func(t *testing.T) {
-			testEtcdRaftOSNSuccess(gt, tempDir, configtxgen, orderer, fabricRootDir, cryptoPath)
+			testEtcdRaftOSNSuccess(NewGomegaWithT(t), tempDir, configtxgen, orderer, fabricRootDir, cryptoPath)
 		})
 	})
 }


### PR DESCRIPTION
When `TestSpawnEtcdRaft` failed, the cause was not reported because the wrong `*testing.T` was used.

```
--- FAIL: TestSpawnEtcdRaft/Good (1.95s)
        --- FAIL: TestSpawnEtcdRaft/Good/TLS_enabled_single_listener
        (0.24s)
                    testing.go:864: test executed panic(nil) or
                    runtime.Goexit: subtest may have called FailNow
                    on a parent test
                            testing.go:864: test executed panic(nil)
                            or runtime.Goexit: subtest may have
                            called FailNow on a parent test
```