### PR TITLE
Use WithOptions to register log hook in test

### DIFF
--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -622,7 +622,7 @@ func TestConfigureClusterListener(t *testing.T) {
 	unUsedPort := allocatePort()
 
 	backupLogger := logger
-	logger = logger.With(zap.Hooks(func(entry zapcore.Entry) error {
+	logger = logger.WithOptions(zap.Hooks(func(entry zapcore.Entry) error {
 		logEntries <- entry.Message
 		return nil
 	}))
@@ -692,7 +692,7 @@ func TestConfigureClusterListener(t *testing.T) {
 			},
 			expectedPanic:      "Failed to load cluster server key from 'bad' (I/O error)",
 			generalSrv:         &comm.GRPCServer{},
-			expectedLogEntries: []string{"Failed to load cluster server certificate from 'bad' (I/O error)"},
+			expectedLogEntries: []string{"Failed to load cluster server key from 'bad' (I/O error)"},
 		},
 		{
 			name:        "invalid ca cert",
@@ -768,7 +768,7 @@ func TestConfigureClusterListener(t *testing.T) {
 				logEntry := <-logEntries
 				loggedMessages = append(loggedMessages, logEntry)
 			}
-			assert.Subset(t, testCase.expectedLogEntries, loggedMessages)
+			assert.Subset(t, loggedMessages, testCase.expectedLogEntries)
 		})
 	}
 }


### PR DESCRIPTION
The test output was pointing out a problem:

```
2020-03-16 19:29:10.284 EDT [orderer.common.server] TestConfigureClusterListener -> DPAN 03c Ignored key without a value.  ignored=zap.optionFunc(0x4799510)
```

Turns out that someone was adding the option as a log field instead of an option. Building on that bug, the order of arguments to assert.Subset were reversed so the assertions were always making sure that an empty slice was a subset of a slice of 0..n values. 😢
Fix the things.