### PR TITLE
Fix LevelDB.Open failures in TestSpawnEtcdRaft

### DIFF
--- a/orderer/common/server/etcdraft_test.go
+++ b/orderer/common/server/etcdraft_test.go
@@ -125,7 +125,7 @@ func testEtcdRaftOSNSuccess(gt *GomegaWithT, tempDir, configtxgen, orderer, fabr
 
 	// Launch the OSN
 	ordererProcess := launchOrderer(gt, orderer, tempDir, genesisBlockPath, fabricRootDir, cryptoPath)
-	defer ordererProcess.Kill()
+	defer func() { gt.Eventually(ordererProcess.Kill(), time.Minute).Should(gexec.Exit()) }()
 	// The following configuration parameters are not specified in the orderer.yaml, so let's ensure
 	// they are really configured autonomously via the localconfig code.
 	gt.Eventually(ordererProcess.Err, time.Minute).Should(gbytes.Say("General.Cluster.DialTimeout = 5s"))
@@ -159,7 +159,7 @@ func testEtcdRaftOSNFailureInvalidBootstrapBlock(gt *GomegaWithT, tempDir, order
 
 	// Launch the OSN
 	ordererProcess := launchOrderer(gt, orderer, tempDir, genesisBlockPath, fabricRootDir, cryptoPath)
-	defer ordererProcess.Kill()
+	defer func() { gt.Eventually(ordererProcess.Kill(), time.Minute).Should(gexec.Exit()) }()
 
 	expectedErr := "Failed validating bootstrap block: the block isn't a system channel block because it lacks ConsortiumsConfig"
 	gt.Eventually(ordererProcess.Err, time.Minute).Should(gbytes.Say(expectedErr))
@@ -179,7 +179,7 @@ func testEtcdRaftOSNNoTLSSingleListener(gt *GomegaWithT, tempDir, orderer, fabri
 	}
 	ordererProcess, err := gexec.Start(cmd, nil, nil)
 	gt.Expect(err).NotTo(HaveOccurred())
-	defer ordererProcess.Kill()
+	defer func() { gt.Eventually(ordererProcess.Kill(), time.Minute).Should(gexec.Exit()) }()
 
 	expectedErr := "TLS is required for running ordering nodes of type etcdraft."
 	gt.Eventually(ordererProcess.Err, time.Minute).Should(gbytes.Say(expectedErr))
@@ -212,7 +212,7 @@ func testEtcdRaftOSNNoTLSDualListener(gt *GomegaWithT, tempDir, orderer, fabricR
 	}
 	ordererProcess, err := gexec.Start(cmd, nil, nil)
 	gt.Expect(err).NotTo(HaveOccurred())
-	defer ordererProcess.Kill()
+	defer func() { gt.Eventually(ordererProcess.Kill(), time.Minute).Should(gexec.Exit()) }()
 
 	gt.Eventually(ordererProcess.Err, time.Minute).Should(gbytes.Say("Beginning to serve requests"))
 	gt.Eventually(ordererProcess.Err, time.Minute).Should(gbytes.Say("becomeLeader"))


### PR DESCRIPTION
TestSpawnEtcdRaft is structured as four sub-tests that start ordering nodes. All sub-tests share a common temporary directory and, by extension, a common block ledger directory. While the orderer(s) were killed at the end of each sub-test, the code did not wait for the termination to complete leaving a window where the block ledger file lock for a terminating orderer could be held while a new orderer instance was starting.

```
    --- FAIL: TestSpawnEtcdRaft/Good (1.86s)
        --- PASS: TestSpawnEtcdRaft/Good/TLS_disabled_dual_listener (1.63s)
        --- FAIL: TestSpawnEtcdRaft/Good/TLS_enabled_single_listener (0.23s)
            etcdraft_test.go:143:
                No future change is possible.  Bailing out early after 0.027s.
                Got stuck at:
                    ... <redacted> ...
                    	Metrics.Statsd.WriteInterval = 30s
                    	Metrics.Statsd.Prefix = ""
                    2020-03-16 20:51:07.566 EDT [orderer.common.server] initializeServerConfig -> INFO 003 Starting orderer with mutual TLS enabled
                    panic: Error opening leveldb: resource temporarily unavailable

                    goroutine 1 [running]:
                    github.com/hyperledger/fabric/common/ledger/util/leveldbhelper.(*DB).Open(0xc0002e5630)
                    	/Users/sykesm/workspace/fabric/src/github.com/hyperledger/fabric/common/ledger/util/leveldbhelper/leveldb_helper.go:75 +0x285
                    github.com/hyperledger/fabric/common/ledger/util/leveldbhelper.openDBAndCheckFormat(0xc000408980, 0x0, 0x0, 0x0)
                    	/Users/sykesm/workspace/fabric/src/github.com/hyperledger/fabric/common/ledger/util/leveldbhelper/leveldb_provider.go:63 +0x11b
                    github.com/hyperledger/fabric/common/ledger/util/leveldbhelper.NewProvider(0xc000408980, 0xc000408980, 0x4, 0xc00004cb00)
                    	/Users/sykesm/workspace/fabric/src/github.com/hyperledger/fabric/common/ledger/util/leveldbhelper/leveldb_provider.go:51 +0x2f
                    github.com/hyperledger/fabric/common/ledger/blkstorage/fsblkstorage.NewProvider(0xc000408940, 0xc000408960, 0x4df07c0, 0x55e7060, 0xc00004cae0, 0x5a, 0x0, 0x0)
                    	/Users/sykesm/workspace/fabric/src/github.com/hyperledger/fabric/common/ledger/blkstorage/fsblkstorage/fs_blockstore_provider.go:43 +0x158
                    github.com/hyperledger/fabric/common/ledger/blockledger/fileledger.New(0xc0002e6690, 0x4e, 0x4df07c0, 0x55e7060, 0x7100008, 0x0, 0xc0002ad630, 0x400ea28)
                    	/Users/sykesm/workspace/fabric/src/github.com/hyperledger/fabric/common/ledger/blockledger/fileledger/factory.go:71 +0x107
                    github.com/hyperledger/fabric/orderer/common/server.createLedgerFactory(0xc000304480, 0x4df07c0, 0x55e7060, 0xc00002e000, 0x37b, 0x57b, 0xc00002c300, 0xf1, 0x2f1)
                    	/Users/sykesm/workspace/fabric/src/github.com/hyperledger/fabric/orderer/common/server/util.go:29 +0xf8
                    github.com/hyperledger/fabric/orderer/common/server.Main()
                    	/Users/sykesm/workspace/fabric/src/github.com/hyperledger/fabric/orderer/common/server/main.go:113 +0x671
                    main.main()
                    	/Users/sykesm/workspace/fabric/src/github.com/hyperledger/fabric/cmd/orderer/main.go:15 +0x20

                Waiting for:
                    EvictionSuspicion not set, defaulting to 10m
FAIL
FAIL	github.com/hyperledger/fabric/orderer/common/server	23.793s
FAIL
```

This change has the sub-tests wait for orderer termination to complete before proceeding.