### PR TITLE
Call signal.Notify from main go routine

### DIFF
--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -222,7 +222,7 @@ func Main() {
 	)
 
 	logger.Infof("Starting %s", metadata.GetVersionInfo())
-	go handleSignals(addPlatformSignals(map[os.Signal]func(){
+	handleSignals(addPlatformSignals(map[os.Signal]func(){
 		syscall.SIGTERM: func() {
 			grpcServer.Stop()
 			if clusterGRPCServer != grpcServer {
@@ -388,10 +388,12 @@ func handleSignals(handlers map[os.Signal]func()) {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, signals...)
 
-	for sig := range signalChan {
-		logger.Infof("Received signal: %d (%s)", sig, sig)
-		handlers[sig]()
-	}
+	go func() {
+		for sig := range signalChan {
+			logger.Infof("Received signal: %d (%s)", sig, sig)
+			handlers[sig]()
+		}
+	}()
 }
 
 type loadPEMFunc func(string) ([]byte, error)


### PR DESCRIPTION
Prior to this change, signal handling was setup and executing in a go routine that was spawned during server initialization. This could result in `signal.Notify` getting called after the "readiness" message for the server is issued. Signals sent to the process within this window can be lost.

This change ensures that `signal.Notify` is called before "readiness" messages are written to help ensure that integration tests that exercise signal processing get consistent results.

FAB-17585 #done
