### PR TITLE
[FAB-17629] Correctly Compile Integration Test List

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -8,36 +8,27 @@
 # script, they are treated as the directories containing the tests to run.
 # When no arguments are provided, all integration tests are executed.
 
-set -e -u
+set -eu
 
 fabric_dir="$(cd "$(dirname "$0")/.." && pwd)"
+cd ${fabric_dir}
 
-cd "$fabric_dir"
+declare -a test_dirs
+test_dirs=($(
+ go list -f '{{if or (len .TestGoFiles | ne 0) (len .XTestGoFiles | ne 0)}}{{println .Dir}}{{end}}' ./... | \
+ grep integration | \
+ sed "s,${fabric_dir},.,g"
+))
 
-dirs=()
-if [ "${#}" -eq 0 ]; then
-  specs=()
-  specs=("$(grep -Ril --exclude-dir=vendor --exclude-dir=scripts "RunSpecs" . | grep integration)")
-  for spec in ${specs[*]}; do
-    dirs+=("$(dirname "${spec}")")
-  done
-else
-  dirs=("$@")
-fi
+total_agents=${SYSTEM_TOTALJOBSINPHASE:-1}   # standard VSTS variables available using parallel execution; total number of parallel jobs running
+agent_number=${SYSTEM_JOBPOSITIONINPHASE:-1} # current job position
 
-totalAgents=${SYSTEM_TOTALJOBSINPHASE:-0}   # standard VSTS variables available using parallel execution; total number of parallel jobs running
-agentNumber=${SYSTEM_JOBPOSITIONINPHASE:-0} # current job position
-testCount=${#dirs[@]}
-
-# below conditions are used if parallel pipeline is not used. i.e. pipeline is running with single agent (no parallel configuration)
-if [ "$totalAgents" -eq 0 ]; then totalAgents=1; fi
-if [ "$agentNumber" -eq 0 ]; then agentNumber=1; fi
-
-declare -a files
-for ((i = "$agentNumber"; i <= "$testCount"; )); do
-  files+=("${dirs[$i - 1]}")
-  i=$((${i} + ${totalAgents}))
+declare -a dirs
+test_count=${#test_dirs[@]}
+for ((i = "$agent_number"; i <= "$test_count"; )); do
+  dirs+=("${test_dirs[$i - 1]}")
+  i=$((${i} + ${total_agents}))
 done
 
-echo "Running the following test suites: ${files[*]}"
-ginkgo -keepGoing --slowSpecThreshold 60 ${files[*]}
+printf "\nRunning the following test suites:\n\n$(echo ${dirs[*]} | tr -s ' ' '\n')\n\nStarting tests...\n\n"
+ginkgo -keepGoing --slowSpecThreshold 60 ${dirs[*]}


### PR DESCRIPTION
Uses `go list` to create the integration directory test list instead of `grep` which will properly ignore directories by default such as: vendor, scripts and hidden directories

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
