### PR TITLE
[FAB-17603] Support consensus type state field in config value

### DIFF
--- a/pkg/config/example_test.go
+++ b/pkg/config/example_test.go
@@ -387,6 +387,7 @@ func Example_usage() {
 			PreferredMaxBytes: 100,
 		},
 		Addresses: []string{"127.0.0.1:7050"},
+		State:     "STATE_NORMAL",
 	}
 
 	err := config.UpdateOrdererConfiguration(updatedConfig, orderer)

--- a/pkg/config/orderer_test.go
+++ b/pkg/config/orderer_test.go
@@ -138,6 +138,13 @@ func TestNewOrdererGroupFailure(t *testing.T) {
 			},
 			err: errors.New("org group 'OrdererOrg': no policies defined"),
 		},
+		{
+			testName: "When consensus state is invalid",
+			ordererMod: func(o *Orderer) {
+				o.State = "invalid state"
+			},
+			err: errors.New("unknown consensus state 'invalid state'"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -471,5 +478,6 @@ func baseOrderer() Orderer {
 			PreferredMaxBytes: 100,
 		},
 		Addresses: []string{"localhost:123"},
+		State:     ob.ConsensusType_State_name[0],
 	}
 }


### PR DESCRIPTION
#### Type of change

- New feature

#### Description
Support consensus type state field for use to allow a channel to be put in maintenance mode. 


#### Related issues
[FAB-17603](https://jira.hyperledger.org/browse/FAB-17603)