### PR TITLE
grpc{logging,metrics} test flake updates

### DIFF
--- a/common/grpclogging/grpclogging_suite_test.go
+++ b/common/grpclogging/grpclogging_suite_test.go
@@ -32,6 +32,27 @@ func TestGrpclogging(t *testing.T) {
 	RunSpecs(t, "Grpclogging Suite")
 }
 
+var (
+	caCertPool        *x509.CertPool
+	clientCertWithKey tls.Certificate
+	serverCertWithKey tls.Certificate
+)
+
+var _ = BeforeSuite(func() {
+	var err error
+	caCert, caKey := generateCA("test-ca", "127.0.0.1")
+	clientCert, clientKey := issueCertificate(caCert, caKey, "client", "127.0.0.1")
+	clientCertWithKey, err = tls.X509KeyPair(clientCert, clientKey)
+	Expect(err).NotTo(HaveOccurred())
+	serverCert, serverKey := issueCertificate(caCert, caKey, "server", "127.0.0.1")
+	serverCertWithKey, err = tls.X509KeyPair(serverCert, serverKey)
+	Expect(err).NotTo(HaveOccurred())
+
+	caCertPool = x509.NewCertPool()
+	added := caCertPool.AppendCertsFromPEM(caCert)
+	Expect(added).To(BeTrue())
+})
+
 //go:generate counterfeiter -o fakes/echo_service.go --fake-name EchoServiceServer . echoServiceServer
 
 type echoServiceServer interface {

--- a/common/grpcmetrics/interceptor_test.go
+++ b/common/grpcmetrics/interceptor_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Interceptor", func() {
 		serveCompleteCh = make(chan error, 1)
 		go func() { serveCompleteCh <- server.Serve(listener) }()
 
-		cc, err := grpc.Dial(listener.Addr().String(), grpc.WithInsecure())
+		cc, err := grpc.Dial(listener.Addr().String(), grpc.WithInsecure(), grpc.WithBlock())
 		Expect(err).NotTo(HaveOccurred())
 		echoServiceClient = testpb.NewEchoServiceClient(cc)
 	})
@@ -276,7 +276,9 @@ var _ = Describe("Interceptor", func() {
 
 			BeforeEach(func() {
 				errCh = make(chan error)
-				fakeEchoService.EchoStreamStub = func(svs testpb.EchoService_EchoStreamServer) error { return <-errCh }
+				fakeEchoService.EchoStreamStub = func(svs testpb.EchoService_EchoStreamServer) error {
+					return <-errCh
+				}
 			})
 
 			It("does not increment the update count", func() {
@@ -292,6 +294,9 @@ var _ = Describe("Interceptor", func() {
 
 				err = streamClient.CloseSend()
 				Expect(err).NotTo(HaveOccurred())
+
+				_, err = streamClient.Recv()
+				Expect(err).To(MatchError(status.Errorf(codes.Unknown, "oh bother")))
 
 				Expect(fakeMessagesReceived.AddCallCount()).To(Equal(0))
 			})


### PR DESCRIPTION
1. Use the `grpc.WithBlock` option on `grpc.Dial` to ensure the network connection is established before attempting to use the client connection.
2. Perform a final `Recv` after calling `CloseSend` to ensure the server side stream processing has completed. This result of this call should be an `io.EOF` on successful stream termination or the error returned by the server.

FAB-17548