### PR TITLE
Use session cache to reduce handshake time in test

### DIFF
--- a/common/grpclogging/server_test.go
+++ b/common/grpclogging/server_test.go
@@ -8,7 +8,6 @@ package grpclogging_test
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -73,13 +72,6 @@ var _ = Describe("Server", func() {
 			return stream.Send(msg)
 		}
 
-		serverTLSConfig := &tls.Config{
-			Certificates: []tls.Certificate{serverCertWithKey},
-			ClientAuth:   tls.VerifyClientCertIfGiven,
-			ClientCAs:    caCertPool,
-			RootCAs:      caCertPool,
-		}
-		serverTLSConfig.BuildNameToCertificate()
 		server = grpc.NewServer(
 			grpc.Creds(credentials.NewTLS(serverTLSConfig)),
 			grpc.StreamInterceptor(grpclogging.StreamServerInterceptor(logger)),
@@ -90,11 +82,6 @@ var _ = Describe("Server", func() {
 		serveCompleteCh = make(chan error, 1)
 		go func() { serveCompleteCh <- server.Serve(listener) }()
 
-		clientTLSConfig := &tls.Config{
-			Certificates: []tls.Certificate{clientCertWithKey},
-			RootCAs:      caCertPool,
-		}
-		clientTLSConfig.BuildNameToCertificate()
 		dialOpts := []grpc.DialOption{
 			grpc.WithTransportCredentials(credentials.NewTLS(clientTLSConfig)),
 			grpc.WithBlock(),


### PR DESCRIPTION
The gRPC logging tests are run with TLS mutual auth enabled. This exercises the TLS peer_subject field population in the gRPC logging interceptors. Each of these handshakes can take hundreds of milliseconds.

By reusing the tls.Config objects across tests and enabling a ClientSessionCache, abbreviated handshakes can be used. This significantly reduces the test time.

Before: Ran 31 of 31 Specs in 5.020 seconds
After: Ran 31 of 31 Specs in 1.092 seconds