### PR TITLE
Remove incorrect ref to SDK

### DIFF
--- a/docs/source/chaincode_lifecycle.md
+++ b/docs/source/chaincode_lifecycle.md
@@ -142,7 +142,7 @@ consistent across organizations:
   incremented to 2.
 - **Endorsement Policy:** Which organizations need to execute and validate the
   transaction output. The endorsement policy can be expressed as a string passed
-  to the CLI or the SDK, or it can reference a policy in the channel config. By
+  to the CLI, or it can reference a policy in the channel config. By
   default, the endorsement policy is set to ``Channel/Application/Endorsement``,
   which defaults to require that a majority of organizations in the channel
   endorse a transaction.


### PR DESCRIPTION
Signed-off-by: pama-ibm <pama@ibm.com>

Bret noticed in the Fabric chaincode lifecycle topic an incorrect reference to the SDK:

#### Type of change

- Documentation update

#### Description

In this sentence:
Endorsement Policy: Which organizations need to execute and validate the transaction output. The endorsement policy can be expressed as a string passed to the CLI or the SDK,

I removed `or the SDK,` per his request.

#### Additional details
