### PR TITLE
Fix debug message

### DIFF
--- a/core/ledger/util/couchdb/couchdb.go
+++ b/core/ledger/util/couchdb/couchdb.go
@@ -420,7 +420,7 @@ func (couchInstance *CouchInstance) VerifyCouchConfig() (*ConnectionInfo, *DBRet
 	}
 
 	// trace the database info response
-	logger.Debugw("VerifyConnection() dbResponseJSON: %s", dbResponse)
+	logger.Debugw("VerifyConnection()", "dbResponseJSON", dbResponse)
 
 	//check to see if the system databases exist
 	//Verifying the existence of the system database accomplishes two steps


### PR DESCRIPTION
When introducing zap based flogging, the debug method was changed without changing the arguments. This corrects the arguments.