### PR TITLE
Reduce TestDBRequestTimeout timeout value

### DIFF
--- a/core/ledger/util/couchdb/couchdb_test.go
+++ b/core/ledger/util/couchdb/couchdb_test.go
@@ -613,7 +613,7 @@ func TestDBRequestTimeout(t *testing.T) {
 	defer cleanup(database)
 
 	//create an impossibly short timeout
-	impossibleTimeout := time.Microsecond * 1
+	impossibleTimeout := time.Nanosecond
 
 	//create a new instance and database object with a timeout that will fail
 	//Also use a maxRetriesOnStartup=3 to reduce the number of retries


### PR DESCRIPTION
Unit tests for a PR recently failed when a DB request with a very small timeout seems to have completed successfully.

While a microsecond is an impossibly short period of time for an http request, a nanosecond is a thousand times shorter. (It's also the smallest time.Duration we can specify.)

This modifies the test timeout to a Nanosecond to make impossible things even less likely.

FAB-17375