### PR TITLE
[FAB-17592] Support removing an orderer endpoint from existing config

### DIFF
--- a/pkg/config/example_test.go
+++ b/pkg/config/example_test.go
@@ -420,7 +420,7 @@ func Example_usage() {
 	org := config.Organization{
 		Name:             "OrdererOrg2",
 		MSP:              config.MSP{},
-		OrdererEndpoints: []string{"127.0.0.1:7050"},
+		OrdererEndpoints: []string{"127.0.0.1:7050", "127.0.0.1:9050"},
 		Policies: map[string]config.Policy{
 			config.AdminsPolicyKey: {
 				Type: config.ImplicitMetaPolicyType,
@@ -447,6 +447,11 @@ func Example_usage() {
 	}
 
 	err = config.AddOrdererEndpoint(updatedConfig, "OrdererOrg2", "127.0.0.1:8050")
+	if err != nil {
+		panic(err)
+	}
+
+	err = config.RemoveOrdererEndpoint(updatedConfig, "OrdererOrg2", "127.0.0.1:9050")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Description

Modify an existing channel configuration to remove an endpoint from an orderer org's config group.

Related issues

https://jira.hyperledger.org/browse/FAB-17592

Signed-off-by: xu wu <wuxu1103@163.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- New feature

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
