### PR TITLE
Remove unused function validateChannelHeaderType

### DIFF
--- a/protoutil/proputils.go
+++ b/protoutil/proputils.go
@@ -18,15 +18,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func validateChannelHeaderType(chdr *common.ChannelHeader, expectedTypes []common.HeaderType) error {
-	for _, t := range expectedTypes {
-		if common.HeaderType(chdr.Type) == t {
-			return nil
-		}
-	}
-	return errors.Errorf("invalid channel header type. expected one of %s, received %s", expectedTypes, common.HeaderType(chdr.Type))
-}
-
 // CreateChaincodeProposal creates a proposal from given input.
 // It returns the proposal and the transaction id associated to the proposal
 func CreateChaincodeProposal(typ common.HeaderType, channelID string, cis *peer.ChaincodeInvocationSpec, creator []byte) (*peer.Proposal, string, error) {


### PR DESCRIPTION
validateChannelHeaderType is no longer used.

Change-Id: Ia053c8ef283bc2167feab6fa83e284589ef8c5d3
Signed-off-by: yacovm <yacovm@il.ibm.com>
