### PR TITLE
[FAB-17611] IT: discover all peers before endorsement

### DIFF
--- a/integration/pvtdata/implicit_coll_test.go
+++ b/integration/pvtdata/implicit_coll_test.go
@@ -37,21 +37,19 @@ var _ bool = Describe("Pvtdata dissemination for implicit collection", func() {
 		By("disabling pvtdata pull/dissemination/reconciliation on all peers except for enabling dissemination on org1 peers")
 		for _, p := range network.Peers {
 			core := network.ReadPeerConfig(p)
-			// disble pvtdata pulling on all peers by setting PullRetryThreshold to 0
 			core.Peer.Gossip.PvtData.PullRetryThreshold = 0
-			// disable pvtdata reconciliation on all peers
 			core.Peer.Gossip.PvtData.ReconciliationEnabled = false
-			// set timeout to 10s to prevent test flake
-			core.Peer.Gossip.DialTimeout = 10 * time.Second
-			core.Peer.Gossip.ConnTimeout = 10 * time.Second
+			// set timeout and reconnect interval to prevent test flake
+			core.Peer.Gossip.DialTimeout = 5 * time.Second
+			core.Peer.Gossip.ConnTimeout = 5 * time.Second
+			core.Peer.Gossip.ReconnectInterval = 7 * time.Second
 			if p.Organization == "Org1" {
 				// enable dissemination on org1 peers
 				core.Peer.Gossip.PvtData.ImplicitCollDisseminationPolicy.RequiredPeerCount = 1
 				core.Peer.Gossip.PvtData.ImplicitCollDisseminationPolicy.MaxPeerCount = 3
-				// set timeout to 10s to prevent test flake
 				core.Peer.Gossip.PvtData.PushAckTimeout = 10 * time.Second
 			} else {
-				// disable dissemination  on non-org1 peers
+				// disable dissemination on non-org1 peers
 				core.Peer.Gossip.PvtData.ImplicitCollDisseminationPolicy.RequiredPeerCount = 0
 				core.Peer.Gossip.PvtData.ImplicitCollDisseminationPolicy.MaxPeerCount = 0
 			}
@@ -75,6 +73,14 @@ var _ bool = Describe("Pvtdata dissemination for implicit collection", func() {
 			isLegacy: false,
 		}
 		nwo.EnableCapabilities(network, channelID, "Application", "V2_0", orderer, network.Peers...)
+
+		By("verifying org1.peer0 discovers all peers to ensure that gossip has been initialized")
+		discoverAllPeers(network, network.Peer("Org1", "peer0"), channelID, 3, 5*time.Second)
+
+		By("verifying org1.peer1 discovers all peers to ensure that gossip has been initialized")
+		discoverAllPeers(network, network.Peer("Org1", "peer1"), channelID, 3, 5*time.Second)
+
+		By("deploying chaincode to all peers")
 		deployChaincode(network, orderer, testChaincode)
 	})
 
@@ -83,50 +89,53 @@ var _ bool = Describe("Pvtdata dissemination for implicit collection", func() {
 	})
 
 	It("disseminates pvtdata of implicit collection for the peer's own org but not implicit collection for another org", func() {
+		org1peer0 := network.Peer("Org1", "peer0")
+		org1peer1 := network.Peer("Org1", "peer1")
+		org2peer0 := network.Peer("Org2", "peer0")
+		org2peer1 := network.Peer("Org2", "peer1")
+
 		By("writing private data to org1's and org2's implicit collections")
-		peer1 := network.Peer("Org1", "peer0")
-		peer2 := network.Peer("Org2", "peer0")
 		writeInput := []kvexecutor.KVData{
 			{Collection: "_implicit_org_Org1MSP", Key: "org1_key1", Value: "org1_value1"},
 			{Collection: "_implicit_org_Org2MSP", Key: "org2_key1", Value: "org2_value1"},
 		}
-		writeImplicitCollection(network, orderer, testChaincode.Name, writeInput, peer1, peer2)
+		writeImplicitCollection(network, orderer, testChaincode.Name, writeInput, org1peer0, org2peer0)
 
 		By("querying org1.peer0 for _implicit_org_Org1MSP collection data, expecting pvtdata")
 		readInput1 := []kvexecutor.KVData{{Collection: "_implicit_org_Org1MSP", Key: "org1_key1"}}
 		expectedMsg1, err := json.Marshal(writeInput[:1])
 		Expect(err).NotTo(HaveOccurred())
-		readImplicitCollection(network, network.Peer("Org1", "peer0"), testChaincode.Name, readInput1, string(expectedMsg1), true)
+		readImplicitCollection(network, org1peer0, testChaincode.Name, readInput1, string(expectedMsg1), true)
 
 		// org1.peer1 should have _implicit_org_Org1MSP pvtdata because dissemination is enabled on org1 peers
 		By("querying org1.peer1 for _implicit_org_Org1MSP collection data, expecting pvtdata")
-		readImplicitCollection(network, network.Peer("Org1", "peer1"), testChaincode.Name, readInput1, string(expectedMsg1), true)
+		readImplicitCollection(network, org1peer1, testChaincode.Name, readInput1, string(expectedMsg1), true)
 
 		By("querying org2.peer0 for _implicit_org_Org1MSP collection data, expecting error")
-		readImplicitCollection(network, network.Peer("Org2", "peer0"), testChaincode.Name, readInput1,
+		readImplicitCollection(network, org2peer0, testChaincode.Name, readInput1,
 			"private data matching public hash version is not available", false)
 
 		By("querying org2.peer1 for _implicit_org_Org1MSP collection data, expecting error")
-		readImplicitCollection(network, network.Peer("Org2", "peer1"), testChaincode.Name, readInput1,
+		readImplicitCollection(network, org2peer1, testChaincode.Name, readInput1,
 			"private data matching public hash version is not available", false)
 
 		By("querying org2.peer0 for _implicit_org_Org2MSP collection data, expecting pvtdata")
 		readInput2 := []kvexecutor.KVData{{Collection: "_implicit_org_Org2MSP", Key: "org2_key1"}}
 		expectedMsg2, err := json.Marshal(writeInput[1:])
 		Expect(err).NotTo(HaveOccurred())
-		readImplicitCollection(network, network.Peer("Org2", "peer0"), testChaincode.Name, readInput2, string(expectedMsg2), true)
+		readImplicitCollection(network, org2peer0, testChaincode.Name, readInput2, string(expectedMsg2), true)
 
 		// org2.peer1 should have no _implicit_org_Org2MSP pvtdata because pull/dissemination/reconciliation are disabled on org2 peers
 		By("querying org2.peer1 for _implicit_org_Org2MSP collection data, expecting error")
-		readImplicitCollection(network, network.Peer("Org2", "peer1"), testChaincode.Name, readInput2,
+		readImplicitCollection(network, org2peer1, testChaincode.Name, readInput2,
 			"private data matching public hash version is not available", false)
 
 		By("querying org1.peer0 for _implicit_org_Org2MSP collection data, expecting error")
-		readImplicitCollection(network, network.Peer("Org1", "peer0"), testChaincode.Name, readInput2,
+		readImplicitCollection(network, org1peer0, testChaincode.Name, readInput2,
 			"private data matching public hash version is not available", false)
 
 		By("querying org1.peer1 for _implicit_org_Org2MSP collection data, expecting error")
-		readImplicitCollection(network, network.Peer("Org1", "peer1"), testChaincode.Name, readInput2,
+		readImplicitCollection(network, org1peer1, testChaincode.Name, readInput2,
 			"private data matching public hash version is not available", false)
 	})
 })
@@ -163,4 +172,17 @@ func readImplicitCollection(n *nwo.Network, peer *nwo.Peer, chaincodeName string
 		Ctor:      fmt.Sprintf(`{"Args":["readWriteKVs","%s","%s"]}`, readInputBase64, ""),
 	}
 	queryChaincode(n, peer, command, expectedMsg, expectSuccess)
+}
+
+func discoverAllPeers(n *nwo.Network, peer *nwo.Peer, channelID string, retries int, retryInterval time.Duration) {
+	var discoveredPeers []nwo.DiscoveredPeer
+	numPeers := len(n.Peers)
+	for i := 0; i < retries; i++ {
+		discoveredPeers = nwo.DiscoverPeers(n, peer, "User1", channelID)()
+		if len(discoveredPeers) == numPeers || i == retries-1 {
+			break
+		}
+		time.Sleep(retryInterval)
+	}
+	Expect(discoveredPeers).To(HaveLen(numPeers))
 }


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Test update

#### Description
To mitigate a test flake with private data dissemination,
this PR adds code to discover all the peers to ensure that
the gossip service has been successfully initialized.

#### Related issues
https://jira.hyperledger.org/browse/FAB-17611
