### PR TITLE
Add warning message for implicit meta endorsement policy failure

### DIFF
--- a/common/policies/implicitmeta.go
+++ b/common/policies/implicitmeta.go
@@ -73,7 +73,7 @@ func (imp *ImplicitMetaPolicy) EvaluateSignedData(signatureSet []*protoutil.Sign
 	defer func() {
 		if remaining != 0 {
 			// This log message may be large and expensive to construct, so worth checking the log level
-			if logger.IsEnabledFor(zapcore.DebugLevel) {
+			if logger.IsEnabledFor(zapcore.WarnLevel) {
 				var b bytes.Buffer
 				b.WriteString(fmt.Sprintf("Evaluation Failed: Only %d policies were satisfied, but needed %d of [ ", imp.Threshold-remaining, imp.Threshold))
 				for m := range imp.managers {
@@ -83,7 +83,7 @@ func (imp *ImplicitMetaPolicy) EvaluateSignedData(signatureSet []*protoutil.Sign
 					b.WriteString(" ")
 				}
 				b.WriteString("]")
-				logger.Debugf(b.String())
+				logger.Warnf(b.String())
 			}
 		}
 	}()
@@ -113,7 +113,7 @@ func (imp *ImplicitMetaPolicy) EvaluateIdentities(identities []msp.Identity) err
 		if remaining == 0 {
 			return
 		}
-		if !logger.IsEnabledFor(zapcore.DebugLevel) {
+		if !logger.IsEnabledFor(zapcore.WarnLevel) {
 			return
 		}
 
@@ -126,7 +126,7 @@ func (imp *ImplicitMetaPolicy) EvaluateIdentities(identities []msp.Identity) err
 			b.WriteString(" ")
 		}
 		b.WriteString("]")
-		logger.Debugf(b.String())
+		logger.Warnf(b.String())
 	}()
 
 	for _, policy := range imp.SubPolicies {

--- a/common/policies/policy.go
+++ b/common/policies/policy.go
@@ -285,6 +285,7 @@ func (pl *PolicyLogger) EvaluateSignedData(signatureSet []*protoutil.SignedData)
 
 	err := pl.Policy.EvaluateSignedData(signatureSet)
 	if err != nil {
+		err = errors.WithMessagef(err, "signature set did not satisfy policy %s", pl.policyName)
 		logger.Debugf("Signature set did not satisfy policy %s", pl.policyName)
 	} else {
 		logger.Debugf("Signature set satisfies policy %s", pl.policyName)
@@ -300,6 +301,7 @@ func (pl *PolicyLogger) EvaluateIdentities(identities []mspi.Identity) error {
 
 	err := pl.Policy.EvaluateIdentities(identities)
 	if err != nil {
+		err = errors.WithMessagef(err, "signature set did not satisfy policy %s", pl.policyName)
 		logger.Debugf("Signature set did not satisfy policy %s", pl.policyName)
 	} else {
 		logger.Debugf("Signature set satisfies policy %s", pl.policyName)


### PR DESCRIPTION
#### Type of change

- Improvement to logging

#### Description

Many users are unable to troubleshoot endorsement policy failures.

This change shifts a debug message to a warning message so that peer
will log the reason for the endorsement policy failure.

E.g. the following warning message will now help users troubleshoot the
reason for the failure:

"Evaluation Failed: Only 0 policies were satisfied,
but needed 2 of [ Org2MSP/Endorsement Org1MSP/Endorsement ]"

Also, the policy name is now added to associated error messages,
so that users know where to change the policy.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>