### PR TITLE
Cleanup followup comments from FAB-17568

### DIFF
--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Config", func() {
 
 			By("adding the anchor peer for " + peer.Organization)
 			host, port := peerHostPort(network, peer)
-			err = config.AddAnchorPeer(updatedChannelConfig, peer.Organization, config.AnchorPeer{Host: host, Port: port})
+			err = config.AddAnchorPeer(updatedChannelConfig, peer.Organization, config.Address{Host: host, Port: port})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("computing the config update")

--- a/pkg/config/application_test.go
+++ b/pkg/config/application_test.go
@@ -168,12 +168,12 @@ func TestAddAnchorPeer(t *testing.T) {
 		},
 	}
 
-	newOrg1AnchorPeer := AnchorPeer{
+	newOrg1AnchorPeer := Address{
 		Host: "host3",
 		Port: 123,
 	}
 
-	newOrg2AnchorPeer := AnchorPeer{
+	newOrg2AnchorPeer := Address{
 		Host: "host4",
 		Port: 123,
 	}
@@ -316,14 +316,14 @@ func TestAddAnchorPeerFailure(t *testing.T) {
 		testName      string
 		orgName       string
 		configMod     func(*GomegaWithT, *cb.Config)
-		newAnchorPeer AnchorPeer
+		newAnchorPeer Address
 		expectedErr   string
 	}{
 		{
 			testName:      "When the org for the application does not exist",
 			orgName:       "BadOrg",
 			configMod:     nil,
-			newAnchorPeer: AnchorPeer{Host: "host3", Port: 123},
+			newAnchorPeer: Address{Host: "host3", Port: 123},
 			expectedErr:   "application org BadOrg does not exist in channel config",
 		},
 		{
@@ -345,7 +345,7 @@ func TestAddAnchorPeerFailure(t *testing.T) {
 					Value: v,
 				}
 			},
-			newAnchorPeer: AnchorPeer{Host: "host1", Port: 123},
+			newAnchorPeer: Address{Host: "host1", Port: 123},
 			expectedErr:   "application org Org1 already contains anchor peer endpoint host1:123",
 		},
 	}
@@ -496,7 +496,7 @@ func TestRemoveAnchorPeer(t *testing.T) {
 	"sequence": "0"
 }
 	`
-	anchorPeer1 := AnchorPeer{Host: "host1", Port: 123}
+	anchorPeer1 := Address{Host: "host1", Port: 123}
 	err = AddAnchorPeer(config, "Org1", anchorPeer1)
 	gt.Expect(err).NotTo(HaveOccurred())
 	expectedUpdatedConfig := &cb.Config{}
@@ -516,20 +516,20 @@ func TestRemoveAnchorPeerFailure(t *testing.T) {
 	tests := []struct {
 		testName           string
 		orgName            string
-		anchorPeerToRemove AnchorPeer
+		anchorPeerToRemove Address
 		expectedErr        string
 	}{
 		{
 			testName:           "When the org for the application does not exist",
 			orgName:            "BadOrg",
-			anchorPeerToRemove: AnchorPeer{Host: "host1", Port: 123},
+			anchorPeerToRemove: Address{Host: "host1", Port: 123},
 			expectedErr:        "application org BadOrg does not exist in channel config",
 		},
 		{
 			testName:           "When the anchor peer being removed doesn't exist in the org",
 			orgName:            "Org1",
-			anchorPeerToRemove: AnchorPeer{Host: "host2", Port: 123},
-			expectedErr:        "could not find anchor peer host2:123 in Org1's anchor peer endpoints",
+			anchorPeerToRemove: Address{Host: "host2", Port: 123},
+			expectedErr:        "could not find anchor peer host2:123 in application org Org1",
 		},
 	}
 
@@ -574,7 +574,7 @@ func TestGetAnchorPeer(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	expectedAnchorPeer := AnchorPeer{Host: "host1", Port: 123}
+	expectedAnchorPeer := Address{Host: "host1", Port: 123}
 
 	err = AddAnchorPeer(config, "Org1", expectedAnchorPeer)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -679,7 +679,7 @@ func TestAddApplicationOrg(t *testing.T) {
 		Name:     "Org3",
 		Policies: applicationOrgStandardPolicies(),
 		MSP:      baseMSP(t),
-		AnchorPeers: []AnchorPeer{
+		AnchorPeers: []Address{
 			{
 				Host: "127.0.0.1",
 				Port: 7051,

--- a/pkg/config/example_test.go
+++ b/pkg/config/example_test.go
@@ -502,7 +502,7 @@ func Example_usage() {
 			AbsoluteMaxBytes:  100,
 			PreferredMaxBytes: 100,
 		},
-		Addresses: []string{"127.0.0.1:7050"},
+		Addresses: []config.Address{{Host: "127.0.0.1", Port: 7050}},
 		State:     "STATE_NORMAL",
 	}
 
@@ -511,7 +511,7 @@ func Example_usage() {
 		panic(nil)
 	}
 
-	newAnchorPeer := config.AnchorPeer{
+	newAnchorPeer := config.Address{
 		Host: "127.0.0.2",
 		Port: 7051,
 	}
@@ -523,7 +523,7 @@ func Example_usage() {
 	}
 
 	// Remove an old anchor peer from Org1
-	oldAnchorPeer := config.AnchorPeer{
+	oldAnchorPeer := config.Address{
 		Host: "127.0.0.2",
 		Port: 7051,
 	}
@@ -558,7 +558,7 @@ func Example_usage() {
 				Rule: "ANY Writers",
 			},
 		},
-		AnchorPeers: []config.AnchorPeer{
+		AnchorPeers: []config.Address{
 			{
 				Host: "127.0.0.1",
 				Port: 7051,
@@ -600,12 +600,12 @@ func Example_usage() {
 		panic(err)
 	}
 
-	err = config.AddOrdererEndpoint(updatedConfig, "OrdererOrg2", "127.0.0.1:8050")
+	err = config.AddOrdererEndpoint(updatedConfig, "OrdererOrg2", config.Address{Host: "127.0.0.1", Port: 8050})
 	if err != nil {
 		panic(err)
 	}
 
-	err = config.RemoveOrdererEndpoint(updatedConfig, "OrdererOrg2", "127.0.0.1:9050")
+	err = config.RemoveOrdererEndpoint(updatedConfig, "OrdererOrg2", config.Address{Host: "127.0.0.1", Port: 9050})
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/config/organization.go
+++ b/pkg/config/organization.go
@@ -150,7 +150,7 @@ func getOrganization(orgGroup *cb.ConfigGroup, orgName string) (Organization, er
 		return Organization{}, err
 	}
 
-	var anchorPeers []AnchorPeer
+	var anchorPeers []Address
 	_, ok := orgGroup.Values[AnchorPeersKey]
 	if ok {
 		anchorProtos := &pb.AnchorPeers{}
@@ -159,7 +159,7 @@ func getOrganization(orgGroup *cb.ConfigGroup, orgName string) (Organization, er
 			return Organization{}, err
 		}
 		for _, anchorProto := range anchorProtos.AnchorPeers {
-			anchorPeers = append(anchorPeers, AnchorPeer{
+			anchorPeers = append(anchorPeers, Address{
 				Host: anchorProto.Host,
 				Port: int(anchorProto.Port),
 			})

--- a/pkg/config/organization_test.go
+++ b/pkg/config/organization_test.go
@@ -363,7 +363,7 @@ func baseApplicationOrg(t *testing.T) Organization {
 		Name:     "Org1",
 		Policies: standardPolicies(),
 		MSP:      baseMSP(t),
-		AnchorPeers: []AnchorPeer{
+		AnchorPeers: []Address{
 			{Host: "host3", Port: 123},
 		},
 	}


### PR DESCRIPTION
* Standardize Address type and wherever an endpoint is used in the API
* Cleanup slice filtering
* Move some exported functions to the top of respective file