### PR TITLE
Update sample channel config to 2.0 channel

### DIFF
--- a/docs/source/config_update.md
+++ b/docs/source/config_update.md
@@ -41,742 +41,838 @@ Note: for simplicity, we are only showing an application channel configuration h
   </summary>
   ```
   {
-  "channel_group": {
-    "groups": {
-      "Application": {
-        "groups": {
-          "Org1MSP": {
-            "groups": {},
-            "mod_policy": "Admins",
-            "policies": {
-              "Admins": {
-                "mod_policy": "Admins",
-                "policy": {
-                  "type": 1,
-                  "value": {
-                    "identities": [
-                      {
-                        "principal": {
-                          "msp_identifier": "Org1MSP",
-                          "role": "ADMIN"
-                        },
-                        "principal_classification": "ROLE"
-                      }
-                    ],
-                    "rule": {
-                      "n_out_of": {
-                        "n": 1,
-                        "rules": [
-                          {
-                            "signed_by": 0
-                          }
-                        ]
-                      }
-                    },
-                    "version": 0
-                  }
-                },
-                "version": "0"
-              },
-              "Readers": {
-                "mod_policy": "Admins",
-                "policy": {
-                  "type": 1,
-                  "value": {
-                    "identities": [
-                      {
-                        "principal": {
-                          "msp_identifier": "Org1MSP",
-                          "role": "ADMIN"
-                        },
-                        "principal_classification": "ROLE"
-                      },
-                      {
-                        "principal": {
-                          "msp_identifier": "Org1MSP",
-                          "role": "PEER"
-                        },
-                        "principal_classification": "ROLE"
-                      },
-                      {
-                        "principal": {
-                          "msp_identifier": "Org1MSP",
-                          "role": "CLIENT"
-                        },
-                        "principal_classification": "ROLE"
-                      }
-                    ],
-                    "rule": {
-                      "n_out_of": {
-                        "n": 1,
-                        "rules": [
-                          {
-                            "signed_by": 0
+    "channel_group": {
+      "groups": {
+        "Application": {
+          "groups": {
+            "Org1MSP": {
+              "groups": {},
+              "mod_policy": "Admins",
+              "policies": {
+                "Admins": {
+                  "mod_policy": "Admins",
+                  "policy": {
+                    "type": 1,
+                    "value": {
+                      "identities": [
+                        {
+                          "principal": {
+                            "msp_identifier": "Org1MSP",
+                            "role": "ADMIN"
                           },
-                          {
-                            "signed_by": 1
-                          },
-                          {
-                            "signed_by": 2
-                          }
-                        ]
-                      }
-                    },
-                    "version": 0
-                  }
-                },
-                "version": "0"
-              },
-              "Writers": {
-                "mod_policy": "Admins",
-                "policy": {
-                  "type": 1,
-                  "value": {
-                    "identities": [
-                      {
-                        "principal": {
-                          "msp_identifier": "Org1MSP",
-                          "role": "ADMIN"
-                        },
-                        "principal_classification": "ROLE"
+                          "principal_classification": "ROLE"
+                        }
+                      ],
+                      "rule": {
+                        "n_out_of": {
+                          "n": 1,
+                          "rules": [
+                            {
+                              "signed_by": 0
+                            }
+                          ]
+                        }
                       },
-                      {
-                        "principal": {
-                          "msp_identifier": "Org1MSP",
-                          "role": "CLIENT"
-                        },
-                        "principal_classification": "ROLE"
-                      }
-                    ],
-                    "rule": {
-                      "n_out_of": {
-                        "n": 1,
-                        "rules": [
-                          {
-                            "signed_by": 0
-                          },
-                          {
-                            "signed_by": 1
-                          }
-                        ]
-                      }
-                    },
-                    "version": 0
-                  }
-                },
-                "version": "0"
-              }
-            },
-            "values": {
-              "AnchorPeers": {
-                "mod_policy": "Admins",
-                "value": {
-                  "anchor_peers": [
-                    {
-                      "host": "peer0.org1.example.com",
-                      "port": 7051
+                      "version": 0
                     }
-                  ]
-                },
-                "version": "0"
-              },
-              "MSP": {
-                "mod_policy": "Admins",
-                "value": {
-                  "config": {
-                    "admins": [],
-                    "crypto_config": {
-                      "identity_identifier_hash_function": "SHA256",
-                      "signature_hash_family": "SHA2"
-                    },
-                    "fabric_node_ous": {
-                      "admin_ou_identifier": {
-                        "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNVakNDQWZpZ0F3SUJBZ0lSQVBYKzVxL21nckhNR280NFB5bjhYRnd3Q2dZSUtvWkl6ajBFQXdJd2N6RUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhHVEFYQmdOVkJBb1RFRzl5WnpFdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekV1WlhoaGJYQnNaUzVqYjIwd0hoY05NVGt4TVRFME1UTTBPREF3V2hjTk1qa3hNVEV4TVRNME9EQXcKV2pCek1Rc3dDUVlEVlFRR0V3SlZVekVUTUJFR0ExVUVDQk1LUTJGc2FXWnZjbTVwWVRFV01CUUdBMVVFQnhNTgpVMkZ1SUVaeVlXNWphWE5qYnpFWk1CY0dBMVVFQ2hNUWIzSm5NUzVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFCkF4TVRZMkV1YjNKbk1TNWxlR0Z0Y0d4bExtTnZiVEJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUEKQkV5TWtxZndLUkJCWDNKY2xGM3c0UkJZdGFGZytPeFgzSW9RanRrZzJodGxsV3dMV3YrWExXdVl2dkpUMTdxZAp1ei9uWGlWRWhhYnQ2VmVkRnBzanJuR2piVEJyTUE0R0ExVWREd0VCL3dRRUF3SUJwakFkQmdOVkhTVUVGakFVCkJnZ3JCZ0VGQlFjREFnWUlLd1lCQlFVSEF3RXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QXBCZ05WSFE0RUlnUWcKVytUN0RIb2puYXh0TkpJTHAvREd4UmVONkpPZENSUlBIdVhPNzZXY3k5OHdDZ1lJS29aSXpqMEVBd0lEU0FBdwpSUUloQUtUaHZNaFlBR3p6aVpNR1B1TjFpTTBEcHVpaFNydHJXRHJ6NkQ4QTBXOXBBaUI0MTFrTnJzVjN4ZU05ClNnaHFNc2lzK2QxWThEWE9DOXVrZGhBcU5GZ25FUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
-                        "organizational_unit_identifier": "admin"
-                      },
-                      "client_ou_identifier": {
-                        "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNVakNDQWZpZ0F3SUJBZ0lSQVBYKzVxL21nckhNR280NFB5bjhYRnd3Q2dZSUtvWkl6ajBFQXdJd2N6RUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhHVEFYQmdOVkJBb1RFRzl5WnpFdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekV1WlhoaGJYQnNaUzVqYjIwd0hoY05NVGt4TVRFME1UTTBPREF3V2hjTk1qa3hNVEV4TVRNME9EQXcKV2pCek1Rc3dDUVlEVlFRR0V3SlZVekVUTUJFR0ExVUVDQk1LUTJGc2FXWnZjbTVwWVRFV01CUUdBMVVFQnhNTgpVMkZ1SUVaeVlXNWphWE5qYnpFWk1CY0dBMVVFQ2hNUWIzSm5NUzVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFCkF4TVRZMkV1YjNKbk1TNWxlR0Z0Y0d4bExtTnZiVEJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUEKQkV5TWtxZndLUkJCWDNKY2xGM3c0UkJZdGFGZytPeFgzSW9RanRrZzJodGxsV3dMV3YrWExXdVl2dkpUMTdxZAp1ei9uWGlWRWhhYnQ2VmVkRnBzanJuR2piVEJyTUE0R0ExVWREd0VCL3dRRUF3SUJwakFkQmdOVkhTVUVGakFVCkJnZ3JCZ0VGQlFjREFnWUlLd1lCQlFVSEF3RXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QXBCZ05WSFE0RUlnUWcKVytUN0RIb2puYXh0TkpJTHAvREd4UmVONkpPZENSUlBIdVhPNzZXY3k5OHdDZ1lJS29aSXpqMEVBd0lEU0FBdwpSUUloQUtUaHZNaFlBR3p6aVpNR1B1TjFpTTBEcHVpaFNydHJXRHJ6NkQ4QTBXOXBBaUI0MTFrTnJzVjN4ZU05ClNnaHFNc2lzK2QxWThEWE9DOXVrZGhBcU5GZ25FUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
-                        "organizational_unit_identifier": "client"
-                      },
-                      "enable": true,
-                      "orderer_ou_identifier": {
-                        "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNVakNDQWZpZ0F3SUJBZ0lSQVBYKzVxL21nckhNR280NFB5bjhYRnd3Q2dZSUtvWkl6ajBFQXdJd2N6RUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhHVEFYQmdOVkJBb1RFRzl5WnpFdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekV1WlhoaGJYQnNaUzVqYjIwd0hoY05NVGt4TVRFME1UTTBPREF3V2hjTk1qa3hNVEV4TVRNME9EQXcKV2pCek1Rc3dDUVlEVlFRR0V3SlZVekVUTUJFR0ExVUVDQk1LUTJGc2FXWnZjbTVwWVRFV01CUUdBMVVFQnhNTgpVMkZ1SUVaeVlXNWphWE5qYnpFWk1CY0dBMVVFQ2hNUWIzSm5NUzVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFCkF4TVRZMkV1YjNKbk1TNWxlR0Z0Y0d4bExtTnZiVEJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUEKQkV5TWtxZndLUkJCWDNKY2xGM3c0UkJZdGFGZytPeFgzSW9RanRrZzJodGxsV3dMV3YrWExXdVl2dkpUMTdxZAp1ei9uWGlWRWhhYnQ2VmVkRnBzanJuR2piVEJyTUE0R0ExVWREd0VCL3dRRUF3SUJwakFkQmdOVkhTVUVGakFVCkJnZ3JCZ0VGQlFjREFnWUlLd1lCQlFVSEF3RXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QXBCZ05WSFE0RUlnUWcKVytUN0RIb2puYXh0TkpJTHAvREd4UmVONkpPZENSUlBIdVhPNzZXY3k5OHdDZ1lJS29aSXpqMEVBd0lEU0FBdwpSUUloQUtUaHZNaFlBR3p6aVpNR1B1TjFpTTBEcHVpaFNydHJXRHJ6NkQ4QTBXOXBBaUI0MTFrTnJzVjN4ZU05ClNnaHFNc2lzK2QxWThEWE9DOXVrZGhBcU5GZ25FUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
-                        "organizational_unit_identifier": "orderer"
-                      },
-                      "peer_ou_identifier": {
-                        "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNVakNDQWZpZ0F3SUJBZ0lSQVBYKzVxL21nckhNR280NFB5bjhYRnd3Q2dZSUtvWkl6ajBFQXdJd2N6RUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhHVEFYQmdOVkJBb1RFRzl5WnpFdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekV1WlhoaGJYQnNaUzVqYjIwd0hoY05NVGt4TVRFME1UTTBPREF3V2hjTk1qa3hNVEV4TVRNME9EQXcKV2pCek1Rc3dDUVlEVlFRR0V3SlZVekVUTUJFR0ExVUVDQk1LUTJGc2FXWnZjbTVwWVRFV01CUUdBMVVFQnhNTgpVMkZ1SUVaeVlXNWphWE5qYnpFWk1CY0dBMVVFQ2hNUWIzSm5NUzVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFCkF4TVRZMkV1YjNKbk1TNWxlR0Z0Y0d4bExtTnZiVEJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUEKQkV5TWtxZndLUkJCWDNKY2xGM3c0UkJZdGFGZytPeFgzSW9RanRrZzJodGxsV3dMV3YrWExXdVl2dkpUMTdxZAp1ei9uWGlWRWhhYnQ2VmVkRnBzanJuR2piVEJyTUE0R0ExVWREd0VCL3dRRUF3SUJwakFkQmdOVkhTVUVGakFVCkJnZ3JCZ0VGQlFjREFnWUlLd1lCQlFVSEF3RXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QXBCZ05WSFE0RUlnUWcKVytUN0RIb2puYXh0TkpJTHAvREd4UmVONkpPZENSUlBIdVhPNzZXY3k5OHdDZ1lJS29aSXpqMEVBd0lEU0FBdwpSUUloQUtUaHZNaFlBR3p6aVpNR1B1TjFpTTBEcHVpaFNydHJXRHJ6NkQ4QTBXOXBBaUI0MTFrTnJzVjN4ZU05ClNnaHFNc2lzK2QxWThEWE9DOXVrZGhBcU5GZ25FUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
-                        "organizational_unit_identifier": "peer"
-                      }
-                    },
-                    "intermediate_certs": [],
-                    "name": "Org1MSP",
-                    "organizational_unit_identifiers": [],
-                    "revocation_list": [],
-                    "root_certs": [
-                      "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNVakNDQWZpZ0F3SUJBZ0lSQVBYKzVxL21nckhNR280NFB5bjhYRnd3Q2dZSUtvWkl6ajBFQXdJd2N6RUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhHVEFYQmdOVkJBb1RFRzl5WnpFdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekV1WlhoaGJYQnNaUzVqYjIwd0hoY05NVGt4TVRFME1UTTBPREF3V2hjTk1qa3hNVEV4TVRNME9EQXcKV2pCek1Rc3dDUVlEVlFRR0V3SlZVekVUTUJFR0ExVUVDQk1LUTJGc2FXWnZjbTVwWVRFV01CUUdBMVVFQnhNTgpVMkZ1SUVaeVlXNWphWE5qYnpFWk1CY0dBMVVFQ2hNUWIzSm5NUzVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFCkF4TVRZMkV1YjNKbk1TNWxlR0Z0Y0d4bExtTnZiVEJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUEKQkV5TWtxZndLUkJCWDNKY2xGM3c0UkJZdGFGZytPeFgzSW9RanRrZzJodGxsV3dMV3YrWExXdVl2dkpUMTdxZAp1ei9uWGlWRWhhYnQ2VmVkRnBzanJuR2piVEJyTUE0R0ExVWREd0VCL3dRRUF3SUJwakFkQmdOVkhTVUVGakFVCkJnZ3JCZ0VGQlFjREFnWUlLd1lCQlFVSEF3RXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QXBCZ05WSFE0RUlnUWcKVytUN0RIb2puYXh0TkpJTHAvREd4UmVONkpPZENSUlBIdVhPNzZXY3k5OHdDZ1lJS29aSXpqMEVBd0lEU0FBdwpSUUloQUtUaHZNaFlBR3p6aVpNR1B1TjFpTTBEcHVpaFNydHJXRHJ6NkQ4QTBXOXBBaUI0MTFrTnJzVjN4ZU05ClNnaHFNc2lzK2QxWThEWE9DOXVrZGhBcU5GZ25FUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
-                    ],
-                    "signing_identity": null,
-                    "tls_intermediate_certs": [],
-                    "tls_root_certs": [
-                      "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNWekNDQWY2Z0F3SUJBZ0lSQUtvOGhJS0JjeldFOFQrSUZSVWVmZm93Q2dZSUtvWkl6ajBFQXdJd2RqRUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhHVEFYQmdOVkJBb1RFRzl5WnpFdVpYaGhiWEJzWlM1amIyMHhIekFkQmdOVkJBTVRGblJzCmMyTmhMbTl5WnpFdVpYaGhiWEJzWlM1amIyMHdIaGNOTVRreE1URTBNVE0wT0RBd1doY05Namt4TVRFeE1UTTAKT0RBd1dqQjJNUXN3Q1FZRFZRUUdFd0pWVXpFVE1CRUdBMVVFQ0JNS1EyRnNhV1p2Y201cFlURVdNQlFHQTFVRQpCeE1OVTJGdUlFWnlZVzVqYVhOamJ6RVpNQmNHQTFVRUNoTVFiM0puTVM1bGVHRnRjR3hsTG1OdmJURWZNQjBHCkExVUVBeE1XZEd4elkyRXViM0puTVM1bGVHRnRjR3hsTG1OdmJUQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDkKQXdFSEEwSUFCRUdGY3N6UmNJWXJnUVltK1JwL0owR3NrRXk4OFlDS2xqY2lSY1BoS3FKVWI3L29aSExRSWRtNQpSV0pLcVNZeSs3R2FqWHlROFQxNG1mY2IrM0ZodkpTamJUQnJNQTRHQTFVZER3RUIvd1FFQXdJQnBqQWRCZ05WCkhTVUVGakFVQmdnckJnRUZCUWNEQWdZSUt3WUJCUVVIQXdFd0R3WURWUjBUQVFIL0JBVXdBd0VCL3pBcEJnTlYKSFE0RUlnUWdOZzd3RHhRSkMwREYvQWo5YUwvbXJQVlJNMkozb2VRelEwdnV2cWgzdm5Fd0NnWUlLb1pJemowRQpBd0lEUndBd1JBSWdkYWZXMjJ0WXZuZVd6bEp2Mlg5WC9qM2VCbTdxSG9xejZ2QmV2cENZd3Q4Q0lHYXJJTm5oCnArRnFyaUVoaDI5SDgrcEVTV1NvZXQ1UzFKQVRrd0srNTJMawotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
-                    ]
                   },
-                  "type": 0
+                  "version": "0"
                 },
-                "version": "0"
-              }
-            },
-            "version": "1"
-          },
-          "Org2MSP": {
-            "groups": {},
-            "mod_policy": "Admins",
-            "policies": {
-              "Admins": {
-                "mod_policy": "Admins",
-                "policy": {
-                  "type": 1,
-                  "value": {
-                    "identities": [
-                      {
-                        "principal": {
-                          "msp_identifier": "Org2MSP",
-                          "role": "ADMIN"
-                        },
-                        "principal_classification": "ROLE"
-                      }
-                    ],
-                    "rule": {
-                      "n_out_of": {
-                        "n": 1,
-                        "rules": [
-                          {
-                            "signed_by": 0
-                          }
-                        ]
-                      }
-                    },
-                    "version": 0
-                  }
-                },
-                "version": "0"
-              },
-              "Readers": {
-                "mod_policy": "Admins",
-                "policy": {
-                  "type": 1,
-                  "value": {
-                    "identities": [
-                      {
-                        "principal": {
-                          "msp_identifier": "Org2MSP",
-                          "role": "ADMIN"
-                        },
-                        "principal_classification": "ROLE"
-                      },
-                      {
-                        "principal": {
-                          "msp_identifier": "Org2MSP",
-                          "role": "PEER"
-                        },
-                        "principal_classification": "ROLE"
-                      },
-                      {
-                        "principal": {
-                          "msp_identifier": "Org2MSP",
-                          "role": "CLIENT"
-                        },
-                        "principal_classification": "ROLE"
-                      }
-                    ],
-                    "rule": {
-                      "n_out_of": {
-                        "n": 1,
-                        "rules": [
-                          {
-                            "signed_by": 0
+                "Endorsement": {
+                  "mod_policy": "Admins",
+                  "policy": {
+                    "type": 1,
+                    "value": {
+                      "identities": [
+                        {
+                          "principal": {
+                            "msp_identifier": "Org1MSP",
+                            "role": "PEER"
                           },
-                          {
-                            "signed_by": 1
-                          },
-                          {
-                            "signed_by": 2
-                          }
-                        ]
-                      }
-                    },
-                    "version": 0
-                  }
-                },
-                "version": "0"
-              },
-              "Writers": {
-                "mod_policy": "Admins",
-                "policy": {
-                  "type": 1,
-                  "value": {
-                    "identities": [
-                      {
-                        "principal": {
-                          "msp_identifier": "Org2MSP",
-                          "role": "ADMIN"
-                        },
-                        "principal_classification": "ROLE"
+                          "principal_classification": "ROLE"
+                        }
+                      ],
+                      "rule": {
+                        "n_out_of": {
+                          "n": 1,
+                          "rules": [
+                            {
+                              "signed_by": 0
+                            }
+                          ]
+                        }
                       },
-                      {
-                        "principal": {
-                          "msp_identifier": "Org2MSP",
-                          "role": "CLIENT"
-                        },
-                        "principal_classification": "ROLE"
-                      }
-                    ],
-                    "rule": {
-                      "n_out_of": {
-                        "n": 1,
-                        "rules": [
-                          {
-                            "signed_by": 0
-                          },
-                          {
-                            "signed_by": 1
-                          }
-                        ]
-                      }
-                    },
-                    "version": 0
-                  }
-                },
-                "version": "0"
-              }
-            },
-            "values": {
-              "AnchorPeers": {
-                "mod_policy": "Admins",
-                "value": {
-                  "anchor_peers": [
-                    {
-                      "host": "peer0.org2.example.com",
-                      "port": 9051
+                      "version": 0
                     }
-                  ]
+                  },
+                  "version": "0"
                 },
-                "version": "0"
+                "Readers": {
+                  "mod_policy": "Admins",
+                  "policy": {
+                    "type": 1,
+                    "value": {
+                      "identities": [
+                        {
+                          "principal": {
+                            "msp_identifier": "Org1MSP",
+                            "role": "ADMIN"
+                          },
+                          "principal_classification": "ROLE"
+                        },
+                        {
+                          "principal": {
+                            "msp_identifier": "Org1MSP",
+                            "role": "PEER"
+                          },
+                          "principal_classification": "ROLE"
+                        },
+                        {
+                          "principal": {
+                            "msp_identifier": "Org1MSP",
+                            "role": "CLIENT"
+                          },
+                          "principal_classification": "ROLE"
+                        }
+                      ],
+                      "rule": {
+                        "n_out_of": {
+                          "n": 1,
+                          "rules": [
+                            {
+                              "signed_by": 0
+                            },
+                            {
+                              "signed_by": 1
+                            },
+                            {
+                              "signed_by": 2
+                            }
+                          ]
+                        }
+                      },
+                      "version": 0
+                    }
+                  },
+                  "version": "0"
+                },
+                "Writers": {
+                  "mod_policy": "Admins",
+                  "policy": {
+                    "type": 1,
+                    "value": {
+                      "identities": [
+                        {
+                          "principal": {
+                            "msp_identifier": "Org1MSP",
+                            "role": "ADMIN"
+                          },
+                          "principal_classification": "ROLE"
+                        },
+                        {
+                          "principal": {
+                            "msp_identifier": "Org1MSP",
+                            "role": "CLIENT"
+                          },
+                          "principal_classification": "ROLE"
+                        }
+                      ],
+                      "rule": {
+                        "n_out_of": {
+                          "n": 1,
+                          "rules": [
+                            {
+                              "signed_by": 0
+                            },
+                            {
+                              "signed_by": 1
+                            }
+                          ]
+                        }
+                      },
+                      "version": 0
+                    }
+                  },
+                  "version": "0"
+                }
               },
-              "MSP": {
-                "mod_policy": "Admins",
-                "value": {
-                  "config": {
-                    "admins": [],
-                    "crypto_config": {
-                      "identity_identifier_hash_function": "SHA256",
-                      "signature_hash_family": "SHA2"
-                    },
-                    "fabric_node_ous": {
-                      "admin_ou_identifier": {
-                        "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNVakNDQWZpZ0F3SUJBZ0lSQU1JaCt2V1lHTGs5bUFTT1JNb05iVkl3Q2dZSUtvWkl6ajBFQXdJd2N6RUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhHVEFYQmdOVkJBb1RFRzl5WnpJdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekl1WlhoaGJYQnNaUzVqYjIwd0hoY05NVGt4TVRFME1UTTBPREF3V2hjTk1qa3hNVEV4TVRNME9EQXcKV2pCek1Rc3dDUVlEVlFRR0V3SlZVekVUTUJFR0ExVUVDQk1LUTJGc2FXWnZjbTVwWVRFV01CUUdBMVVFQnhNTgpVMkZ1SUVaeVlXNWphWE5qYnpFWk1CY0dBMVVFQ2hNUWIzSm5NaTVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFCkF4TVRZMkV1YjNKbk1pNWxlR0Z0Y0d4bExtTnZiVEJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUEKQlBBc2FrbklPUmx2M0pPdnBsQld5VCt0SUlFZWo2U2ZQaTlKTS8yQmYzOWkxdFVpRCt2aVV1Tk43MGlKcXRwRQpUbm50V2htWjA5elAzaVUwcklXWGJLcWpiVEJyTUE0R0ExVWREd0VCL3dRRUF3SUJwakFkQmdOVkhTVUVGakFVCkJnZ3JCZ0VGQlFjREFnWUlLd1lCQlFVSEF3RXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QXBCZ05WSFE0RUlnUWcKQzl3Y0RKb3FKL2dyUGF3S1d4RnVjNVB3MitTdTBsQVpFcFRGaEdDQlJSTXdDZ1lJS29aSXpqMEVBd0lEU0FBdwpSUUloQU1JaFJOVDVJMHpwTlRaa1dCSkdyblJqSUhkWXYwS2lWL1JKbkd5Yi9XVFFBaUJ6eUJqYnR3L1JyWEV3Clpzb0N1MmtoOUUwOUZIdXl5dGgydUtWc3Y0ZTlnUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
-                        "organizational_unit_identifier": "admin"
-                      },
-                      "client_ou_identifier": {
-                        "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNVakNDQWZpZ0F3SUJBZ0lSQU1JaCt2V1lHTGs5bUFTT1JNb05iVkl3Q2dZSUtvWkl6ajBFQXdJd2N6RUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhHVEFYQmdOVkJBb1RFRzl5WnpJdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekl1WlhoaGJYQnNaUzVqYjIwd0hoY05NVGt4TVRFME1UTTBPREF3V2hjTk1qa3hNVEV4TVRNME9EQXcKV2pCek1Rc3dDUVlEVlFRR0V3SlZVekVUTUJFR0ExVUVDQk1LUTJGc2FXWnZjbTVwWVRFV01CUUdBMVVFQnhNTgpVMkZ1SUVaeVlXNWphWE5qYnpFWk1CY0dBMVVFQ2hNUWIzSm5NaTVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFCkF4TVRZMkV1YjNKbk1pNWxlR0Z0Y0d4bExtTnZiVEJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUEKQlBBc2FrbklPUmx2M0pPdnBsQld5VCt0SUlFZWo2U2ZQaTlKTS8yQmYzOWkxdFVpRCt2aVV1Tk43MGlKcXRwRQpUbm50V2htWjA5elAzaVUwcklXWGJLcWpiVEJyTUE0R0ExVWREd0VCL3dRRUF3SUJwakFkQmdOVkhTVUVGakFVCkJnZ3JCZ0VGQlFjREFnWUlLd1lCQlFVSEF3RXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QXBCZ05WSFE0RUlnUWcKQzl3Y0RKb3FKL2dyUGF3S1d4RnVjNVB3MitTdTBsQVpFcFRGaEdDQlJSTXdDZ1lJS29aSXpqMEVBd0lEU0FBdwpSUUloQU1JaFJOVDVJMHpwTlRaa1dCSkdyblJqSUhkWXYwS2lWL1JKbkd5Yi9XVFFBaUJ6eUJqYnR3L1JyWEV3Clpzb0N1MmtoOUUwOUZIdXl5dGgydUtWc3Y0ZTlnUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
-                        "organizational_unit_identifier": "client"
-                      },
-                      "enable": true,
-                      "orderer_ou_identifier": {
-                        "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNVakNDQWZpZ0F3SUJBZ0lSQU1JaCt2V1lHTGs5bUFTT1JNb05iVkl3Q2dZSUtvWkl6ajBFQXdJd2N6RUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhHVEFYQmdOVkJBb1RFRzl5WnpJdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekl1WlhoaGJYQnNaUzVqYjIwd0hoY05NVGt4TVRFME1UTTBPREF3V2hjTk1qa3hNVEV4TVRNME9EQXcKV2pCek1Rc3dDUVlEVlFRR0V3SlZVekVUTUJFR0ExVUVDQk1LUTJGc2FXWnZjbTVwWVRFV01CUUdBMVVFQnhNTgpVMkZ1SUVaeVlXNWphWE5qYnpFWk1CY0dBMVVFQ2hNUWIzSm5NaTVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFCkF4TVRZMkV1YjNKbk1pNWxlR0Z0Y0d4bExtTnZiVEJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUEKQlBBc2FrbklPUmx2M0pPdnBsQld5VCt0SUlFZWo2U2ZQaTlKTS8yQmYzOWkxdFVpRCt2aVV1Tk43MGlKcXRwRQpUbm50V2htWjA5elAzaVUwcklXWGJLcWpiVEJyTUE0R0ExVWREd0VCL3dRRUF3SUJwakFkQmdOVkhTVUVGakFVCkJnZ3JCZ0VGQlFjREFnWUlLd1lCQlFVSEF3RXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QXBCZ05WSFE0RUlnUWcKQzl3Y0RKb3FKL2dyUGF3S1d4RnVjNVB3MitTdTBsQVpFcFRGaEdDQlJSTXdDZ1lJS29aSXpqMEVBd0lEU0FBdwpSUUloQU1JaFJOVDVJMHpwTlRaa1dCSkdyblJqSUhkWXYwS2lWL1JKbkd5Yi9XVFFBaUJ6eUJqYnR3L1JyWEV3Clpzb0N1MmtoOUUwOUZIdXl5dGgydUtWc3Y0ZTlnUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
-                        "organizational_unit_identifier": "orderer"
-                      },
-                      "peer_ou_identifier": {
-                        "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNVakNDQWZpZ0F3SUJBZ0lSQU1JaCt2V1lHTGs5bUFTT1JNb05iVkl3Q2dZSUtvWkl6ajBFQXdJd2N6RUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhHVEFYQmdOVkJBb1RFRzl5WnpJdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekl1WlhoaGJYQnNaUzVqYjIwd0hoY05NVGt4TVRFME1UTTBPREF3V2hjTk1qa3hNVEV4TVRNME9EQXcKV2pCek1Rc3dDUVlEVlFRR0V3SlZVekVUTUJFR0ExVUVDQk1LUTJGc2FXWnZjbTVwWVRFV01CUUdBMVVFQnhNTgpVMkZ1SUVaeVlXNWphWE5qYnpFWk1CY0dBMVVFQ2hNUWIzSm5NaTVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFCkF4TVRZMkV1YjNKbk1pNWxlR0Z0Y0d4bExtTnZiVEJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUEKQlBBc2FrbklPUmx2M0pPdnBsQld5VCt0SUlFZWo2U2ZQaTlKTS8yQmYzOWkxdFVpRCt2aVV1Tk43MGlKcXRwRQpUbm50V2htWjA5elAzaVUwcklXWGJLcWpiVEJyTUE0R0ExVWREd0VCL3dRRUF3SUJwakFkQmdOVkhTVUVGakFVCkJnZ3JCZ0VGQlFjREFnWUlLd1lCQlFVSEF3RXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QXBCZ05WSFE0RUlnUWcKQzl3Y0RKb3FKL2dyUGF3S1d4RnVjNVB3MitTdTBsQVpFcFRGaEdDQlJSTXdDZ1lJS29aSXpqMEVBd0lEU0FBdwpSUUloQU1JaFJOVDVJMHpwTlRaa1dCSkdyblJqSUhkWXYwS2lWL1JKbkd5Yi9XVFFBaUJ6eUJqYnR3L1JyWEV3Clpzb0N1MmtoOUUwOUZIdXl5dGgydUtWc3Y0ZTlnUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
-                        "organizational_unit_identifier": "peer"
+              "values": {
+                "AnchorPeers": {
+                  "mod_policy": "Admins",
+                  "value": {
+                    "anchor_peers": [
+                      {
+                        "host": "peer0.org1.example.com",
+                        "port": 7051
                       }
-                    },
-                    "intermediate_certs": [],
-                    "name": "Org2MSP",
-                    "organizational_unit_identifiers": [],
-                    "revocation_list": [],
-                    "root_certs": [
-                      "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNVakNDQWZpZ0F3SUJBZ0lSQU1JaCt2V1lHTGs5bUFTT1JNb05iVkl3Q2dZSUtvWkl6ajBFQXdJd2N6RUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhHVEFYQmdOVkJBb1RFRzl5WnpJdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekl1WlhoaGJYQnNaUzVqYjIwd0hoY05NVGt4TVRFME1UTTBPREF3V2hjTk1qa3hNVEV4TVRNME9EQXcKV2pCek1Rc3dDUVlEVlFRR0V3SlZVekVUTUJFR0ExVUVDQk1LUTJGc2FXWnZjbTVwWVRFV01CUUdBMVVFQnhNTgpVMkZ1SUVaeVlXNWphWE5qYnpFWk1CY0dBMVVFQ2hNUWIzSm5NaTVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFCkF4TVRZMkV1YjNKbk1pNWxlR0Z0Y0d4bExtTnZiVEJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUEKQlBBc2FrbklPUmx2M0pPdnBsQld5VCt0SUlFZWo2U2ZQaTlKTS8yQmYzOWkxdFVpRCt2aVV1Tk43MGlKcXRwRQpUbm50V2htWjA5elAzaVUwcklXWGJLcWpiVEJyTUE0R0ExVWREd0VCL3dRRUF3SUJwakFkQmdOVkhTVUVGakFVCkJnZ3JCZ0VGQlFjREFnWUlLd1lCQlFVSEF3RXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QXBCZ05WSFE0RUlnUWcKQzl3Y0RKb3FKL2dyUGF3S1d4RnVjNVB3MitTdTBsQVpFcFRGaEdDQlJSTXdDZ1lJS29aSXpqMEVBd0lEU0FBdwpSUUloQU1JaFJOVDVJMHpwTlRaa1dCSkdyblJqSUhkWXYwS2lWL1JKbkd5Yi9XVFFBaUJ6eUJqYnR3L1JyWEV3Clpzb0N1MmtoOUUwOUZIdXl5dGgydUtWc3Y0ZTlnUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
-                    ],
-                    "signing_identity": null,
-                    "tls_intermediate_certs": [],
-                    "tls_root_certs": [
-                      "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNXRENDQWY2Z0F3SUJBZ0lSQVBoOGJPUzV1aVZLK2xwdjBKZDN5ZUl3Q2dZSUtvWkl6ajBFQXdJd2RqRUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhHVEFYQmdOVkJBb1RFRzl5WnpJdVpYaGhiWEJzWlM1amIyMHhIekFkQmdOVkJBTVRGblJzCmMyTmhMbTl5WnpJdVpYaGhiWEJzWlM1amIyMHdIaGNOTVRreE1URTBNVE0wT0RBd1doY05Namt4TVRFeE1UTTAKT0RBd1dqQjJNUXN3Q1FZRFZRUUdFd0pWVXpFVE1CRUdBMVVFQ0JNS1EyRnNhV1p2Y201cFlURVdNQlFHQTFVRQpCeE1OVTJGdUlFWnlZVzVqYVhOamJ6RVpNQmNHQTFVRUNoTVFiM0puTWk1bGVHRnRjR3hsTG1OdmJURWZNQjBHCkExVUVBeE1XZEd4elkyRXViM0puTWk1bGVHRnRjR3hsTG1OdmJUQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDkKQXdFSEEwSUFCRHlhdEd3R2ZLSmFLazZ5ZmVJMGpObHVyWU5rbjdOaG5uNGVYbnVTd0hCazBRMDY4bnZ1Ujg4awprQTBRWm5vR2ZRWkEwU3RRM3JqVCt4b3BnMHFMcVBhamJUQnJNQTRHQTFVZER3RUIvd1FFQXdJQnBqQWRCZ05WCkhTVUVGakFVQmdnckJnRUZCUWNEQWdZSUt3WUJCUVVIQXdFd0R3WURWUjBUQVFIL0JBVXdBd0VCL3pBcEJnTlYKSFE0RUlnUWdGVDh3UThUcWlIVUxqMU1sY21JRWoreUFPSDF1R1NDNGxFRUVadUlTVkZBd0NnWUlLb1pJemowRQpBd0lEU0FBd1JRSWhBTExXb3Z2Z2JWTnJwcC9mbzZwTStoVXNMTTFkT3NncGRKNlRNd2FFdzQrTkFpQnJ0WFArCno5MFd6ZEQvRWpFWlcyM0xmeVhNMWRscXcyVHJEL3FWUVlGYXJRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
                     ]
                   },
-                  "type": 0
+                  "version": "0"
                 },
-                "version": "0"
-              }
-            },
-            "version": "1"
-          }
-        },
-        "mod_policy": "Admins",
-        "policies": {
-          "Admins": {
-            "mod_policy": "Admins",
-            "policy": {
-              "type": 3,
-              "value": {
-                "rule": "MAJORITY",
-                "sub_policy": "Admins"
-              }
-            },
-            "version": "0"
-          },
-          "Readers": {
-            "mod_policy": "Admins",
-            "policy": {
-              "type": 3,
-              "value": {
-                "rule": "ANY",
-                "sub_policy": "Readers"
-              }
-            },
-            "version": "0"
-          },
-          "Writers": {
-            "mod_policy": "Admins",
-            "policy": {
-              "type": 3,
-              "value": {
-                "rule": "ANY",
-                "sub_policy": "Writers"
-              }
-            },
-            "version": "0"
-          }
-        },
-        "values": {
-          "Capabilities": {
-            "mod_policy": "Admins",
-            "value": {
-              "capabilities": {
-                "V1_4_2": {}
-              }
-            },
-            "version": "0"
-          }
-        },
-        "version": "1"
-      },
-      "Orderer": {
-        "groups": {
-          "OrdererOrg": {
-            "groups": {},
-            "mod_policy": "Admins",
-            "policies": {
-              "Admins": {
-                "mod_policy": "Admins",
-                "policy": {
-                  "type": 1,
+                "MSP": {
+                  "mod_policy": "Admins",
                   "value": {
-                    "identities": [
-                      {
-                        "principal": {
-                          "msp_identifier": "OrdererMSP",
-                          "role": "ADMIN"
+                    "config": {
+                      "admins": [],
+                      "crypto_config": {
+                        "identity_identifier_hash_function": "SHA256",
+                        "signature_hash_family": "SHA2"
+                      },
+                      "fabric_node_ous": {
+                        "admin_ou_identifier": {
+                          "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNKekNDQWMyZ0F3SUJBZ0lVYWVSeWNkQytlR1lUTUNyWTg2UFVXUEdzQUw0d0NnWUlLb1pJemowRUF3SXcKY0RFTE1Ba0dBMVVFQmhNQ1ZWTXhGekFWQmdOVkJBZ1REazV2Y25Sb0lFTmhjbTlzYVc1aE1ROHdEUVlEVlFRSApFd1pFZFhKb1lXMHhHVEFYQmdOVkJBb1RFRzl5WnpFdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekV1WlhoaGJYQnNaUzVqYjIwd0hoY05NakF3TXpJME1qQXhPREF3V2hjTk16VXdNekl4TWpBeE9EQXcKV2pCd01Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR0ExVUVDQk1PVG05eWRHZ2dRMkZ5YjJ4cGJtRXhEekFOQmdOVgpCQWNUQmtSMWNtaGhiVEVaTUJjR0ExVUVDaE1RYjNKbk1TNWxlR0Z0Y0d4bExtTnZiVEVjTUJvR0ExVUVBeE1UClkyRXViM0puTVM1bGVHRnRjR3hsTG1OdmJUQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJLWXIKSmtqcEhjRkcxMVZlU200emxwSmNCZEtZVjc3SEgvdzI0V09sZnphYWZWK3VaaEZ2YTFhQm9aaGx5RloyMGRWeApwMkRxb09BblZ4MzZ1V3o2SXl1alJUQkRNQTRHQTFVZER3RUIvd1FFQXdJQkJqQVNCZ05WSFJNQkFmOEVDREFHCkFRSC9BZ0VCTUIwR0ExVWREZ1FXQkJTcHpDQWdPaGRuSkE3VVpxUWlFSVFXSFpnYXZEQUtCZ2dxaGtqT1BRUUQKQWdOSUFEQkZBaUVBbEZtYWdIQkJoblFUd3dDOXBQRTRGbFY2SlhIbTdnQ1JyWUxUbVgvc0VySUNJRUhLZG51KwpIWDgrVTh1ZkFKbTdrL1laZEtVVnlWS2E3bGREUjlWajNveTIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
+                          "organizational_unit_identifier": "admin"
                         },
-                        "principal_classification": "ROLE"
-                      }
-                    ],
-                    "rule": {
-                      "n_out_of": {
-                        "n": 1,
-                        "rules": [
-                          {
-                            "signed_by": 0
-                          }
-                        ]
-                      }
+                        "client_ou_identifier": {
+                          "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNKekNDQWMyZ0F3SUJBZ0lVYWVSeWNkQytlR1lUTUNyWTg2UFVXUEdzQUw0d0NnWUlLb1pJemowRUF3SXcKY0RFTE1Ba0dBMVVFQmhNQ1ZWTXhGekFWQmdOVkJBZ1REazV2Y25Sb0lFTmhjbTlzYVc1aE1ROHdEUVlEVlFRSApFd1pFZFhKb1lXMHhHVEFYQmdOVkJBb1RFRzl5WnpFdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekV1WlhoaGJYQnNaUzVqYjIwd0hoY05NakF3TXpJME1qQXhPREF3V2hjTk16VXdNekl4TWpBeE9EQXcKV2pCd01Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR0ExVUVDQk1PVG05eWRHZ2dRMkZ5YjJ4cGJtRXhEekFOQmdOVgpCQWNUQmtSMWNtaGhiVEVaTUJjR0ExVUVDaE1RYjNKbk1TNWxlR0Z0Y0d4bExtTnZiVEVjTUJvR0ExVUVBeE1UClkyRXViM0puTVM1bGVHRnRjR3hsTG1OdmJUQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJLWXIKSmtqcEhjRkcxMVZlU200emxwSmNCZEtZVjc3SEgvdzI0V09sZnphYWZWK3VaaEZ2YTFhQm9aaGx5RloyMGRWeApwMkRxb09BblZ4MzZ1V3o2SXl1alJUQkRNQTRHQTFVZER3RUIvd1FFQXdJQkJqQVNCZ05WSFJNQkFmOEVDREFHCkFRSC9BZ0VCTUIwR0ExVWREZ1FXQkJTcHpDQWdPaGRuSkE3VVpxUWlFSVFXSFpnYXZEQUtCZ2dxaGtqT1BRUUQKQWdOSUFEQkZBaUVBbEZtYWdIQkJoblFUd3dDOXBQRTRGbFY2SlhIbTdnQ1JyWUxUbVgvc0VySUNJRUhLZG51KwpIWDgrVTh1ZkFKbTdrL1laZEtVVnlWS2E3bGREUjlWajNveTIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
+                          "organizational_unit_identifier": "client"
+                        },
+                        "enable": true,
+                        "orderer_ou_identifier": {
+                          "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNKekNDQWMyZ0F3SUJBZ0lVYWVSeWNkQytlR1lUTUNyWTg2UFVXUEdzQUw0d0NnWUlLb1pJemowRUF3SXcKY0RFTE1Ba0dBMVVFQmhNQ1ZWTXhGekFWQmdOVkJBZ1REazV2Y25Sb0lFTmhjbTlzYVc1aE1ROHdEUVlEVlFRSApFd1pFZFhKb1lXMHhHVEFYQmdOVkJBb1RFRzl5WnpFdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekV1WlhoaGJYQnNaUzVqYjIwd0hoY05NakF3TXpJME1qQXhPREF3V2hjTk16VXdNekl4TWpBeE9EQXcKV2pCd01Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR0ExVUVDQk1PVG05eWRHZ2dRMkZ5YjJ4cGJtRXhEekFOQmdOVgpCQWNUQmtSMWNtaGhiVEVaTUJjR0ExVUVDaE1RYjNKbk1TNWxlR0Z0Y0d4bExtTnZiVEVjTUJvR0ExVUVBeE1UClkyRXViM0puTVM1bGVHRnRjR3hsTG1OdmJUQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJLWXIKSmtqcEhjRkcxMVZlU200emxwSmNCZEtZVjc3SEgvdzI0V09sZnphYWZWK3VaaEZ2YTFhQm9aaGx5RloyMGRWeApwMkRxb09BblZ4MzZ1V3o2SXl1alJUQkRNQTRHQTFVZER3RUIvd1FFQXdJQkJqQVNCZ05WSFJNQkFmOEVDREFHCkFRSC9BZ0VCTUIwR0ExVWREZ1FXQkJTcHpDQWdPaGRuSkE3VVpxUWlFSVFXSFpnYXZEQUtCZ2dxaGtqT1BRUUQKQWdOSUFEQkZBaUVBbEZtYWdIQkJoblFUd3dDOXBQRTRGbFY2SlhIbTdnQ1JyWUxUbVgvc0VySUNJRUhLZG51KwpIWDgrVTh1ZkFKbTdrL1laZEtVVnlWS2E3bGREUjlWajNveTIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
+                          "organizational_unit_identifier": "orderer"
+                        },
+                        "peer_ou_identifier": {
+                          "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNKekNDQWMyZ0F3SUJBZ0lVYWVSeWNkQytlR1lUTUNyWTg2UFVXUEdzQUw0d0NnWUlLb1pJemowRUF3SXcKY0RFTE1Ba0dBMVVFQmhNQ1ZWTXhGekFWQmdOVkJBZ1REazV2Y25Sb0lFTmhjbTlzYVc1aE1ROHdEUVlEVlFRSApFd1pFZFhKb1lXMHhHVEFYQmdOVkJBb1RFRzl5WnpFdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekV1WlhoaGJYQnNaUzVqYjIwd0hoY05NakF3TXpJME1qQXhPREF3V2hjTk16VXdNekl4TWpBeE9EQXcKV2pCd01Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR0ExVUVDQk1PVG05eWRHZ2dRMkZ5YjJ4cGJtRXhEekFOQmdOVgpCQWNUQmtSMWNtaGhiVEVaTUJjR0ExVUVDaE1RYjNKbk1TNWxlR0Z0Y0d4bExtTnZiVEVjTUJvR0ExVUVBeE1UClkyRXViM0puTVM1bGVHRnRjR3hsTG1OdmJUQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJLWXIKSmtqcEhjRkcxMVZlU200emxwSmNCZEtZVjc3SEgvdzI0V09sZnphYWZWK3VaaEZ2YTFhQm9aaGx5RloyMGRWeApwMkRxb09BblZ4MzZ1V3o2SXl1alJUQkRNQTRHQTFVZER3RUIvd1FFQXdJQkJqQVNCZ05WSFJNQkFmOEVDREFHCkFRSC9BZ0VCTUIwR0ExVWREZ1FXQkJTcHpDQWdPaGRuSkE3VVpxUWlFSVFXSFpnYXZEQUtCZ2dxaGtqT1BRUUQKQWdOSUFEQkZBaUVBbEZtYWdIQkJoblFUd3dDOXBQRTRGbFY2SlhIbTdnQ1JyWUxUbVgvc0VySUNJRUhLZG51KwpIWDgrVTh1ZkFKbTdrL1laZEtVVnlWS2E3bGREUjlWajNveTIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
+                          "organizational_unit_identifier": "peer"
+                        }
+                      },
+                      "intermediate_certs": [],
+                      "name": "Org1MSP",
+                      "organizational_unit_identifiers": [],
+                      "revocation_list": [],
+                      "root_certs": [
+                        "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNKekNDQWMyZ0F3SUJBZ0lVYWVSeWNkQytlR1lUTUNyWTg2UFVXUEdzQUw0d0NnWUlLb1pJemowRUF3SXcKY0RFTE1Ba0dBMVVFQmhNQ1ZWTXhGekFWQmdOVkJBZ1REazV2Y25Sb0lFTmhjbTlzYVc1aE1ROHdEUVlEVlFRSApFd1pFZFhKb1lXMHhHVEFYQmdOVkJBb1RFRzl5WnpFdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekV1WlhoaGJYQnNaUzVqYjIwd0hoY05NakF3TXpJME1qQXhPREF3V2hjTk16VXdNekl4TWpBeE9EQXcKV2pCd01Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR0ExVUVDQk1PVG05eWRHZ2dRMkZ5YjJ4cGJtRXhEekFOQmdOVgpCQWNUQmtSMWNtaGhiVEVaTUJjR0ExVUVDaE1RYjNKbk1TNWxlR0Z0Y0d4bExtTnZiVEVjTUJvR0ExVUVBeE1UClkyRXViM0puTVM1bGVHRnRjR3hsTG1OdmJUQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJLWXIKSmtqcEhjRkcxMVZlU200emxwSmNCZEtZVjc3SEgvdzI0V09sZnphYWZWK3VaaEZ2YTFhQm9aaGx5RloyMGRWeApwMkRxb09BblZ4MzZ1V3o2SXl1alJUQkRNQTRHQTFVZER3RUIvd1FFQXdJQkJqQVNCZ05WSFJNQkFmOEVDREFHCkFRSC9BZ0VCTUIwR0ExVWREZ1FXQkJTcHpDQWdPaGRuSkE3VVpxUWlFSVFXSFpnYXZEQUtCZ2dxaGtqT1BRUUQKQWdOSUFEQkZBaUVBbEZtYWdIQkJoblFUd3dDOXBQRTRGbFY2SlhIbTdnQ1JyWUxUbVgvc0VySUNJRUhLZG51KwpIWDgrVTh1ZkFKbTdrL1laZEtVVnlWS2E3bGREUjlWajNveTIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+                      ],
+                      "signing_identity": null,
+                      "tls_intermediate_certs": [],
+                      "tls_root_certs": [
+                        "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNKekNDQWMyZ0F3SUJBZ0lVYWVSeWNkQytlR1lUTUNyWTg2UFVXUEdzQUw0d0NnWUlLb1pJemowRUF3SXcKY0RFTE1Ba0dBMVVFQmhNQ1ZWTXhGekFWQmdOVkJBZ1REazV2Y25Sb0lFTmhjbTlzYVc1aE1ROHdEUVlEVlFRSApFd1pFZFhKb1lXMHhHVEFYQmdOVkJBb1RFRzl5WnpFdVpYaGhiWEJzWlM1amIyMHhIREFhQmdOVkJBTVRFMk5oCkxtOXlaekV1WlhoaGJYQnNaUzVqYjIwd0hoY05NakF3TXpJME1qQXhPREF3V2hjTk16VXdNekl4TWpBeE9EQXcKV2pCd01Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR0ExVUVDQk1PVG05eWRHZ2dRMkZ5YjJ4cGJtRXhEekFOQmdOVgpCQWNUQmtSMWNtaGhiVEVaTUJjR0ExVUVDaE1RYjNKbk1TNWxlR0Z0Y0d4bExtTnZiVEVjTUJvR0ExVUVBeE1UClkyRXViM0puTVM1bGVHRnRjR3hsTG1OdmJUQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJLWXIKSmtqcEhjRkcxMVZlU200emxwSmNCZEtZVjc3SEgvdzI0V09sZnphYWZWK3VaaEZ2YTFhQm9aaGx5RloyMGRWeApwMkRxb09BblZ4MzZ1V3o2SXl1alJUQkRNQTRHQTFVZER3RUIvd1FFQXdJQkJqQVNCZ05WSFJNQkFmOEVDREFHCkFRSC9BZ0VCTUIwR0ExVWREZ1FXQkJTcHpDQWdPaGRuSkE3VVpxUWlFSVFXSFpnYXZEQUtCZ2dxaGtqT1BRUUQKQWdOSUFEQkZBaUVBbEZtYWdIQkJoblFUd3dDOXBQRTRGbFY2SlhIbTdnQ1JyWUxUbVgvc0VySUNJRUhLZG51KwpIWDgrVTh1ZkFKbTdrL1laZEtVVnlWS2E3bGREUjlWajNveTIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+                      ]
                     },
-                    "version": 0
-                  }
-                },
-                "version": "0"
+                    "type": 0
+                  },
+                  "version": "0"
+                }
               },
-              "Readers": {
-                "mod_policy": "Admins",
-                "policy": {
-                  "type": 1,
-                  "value": {
-                    "identities": [
-                      {
-                        "principal": {
-                          "msp_identifier": "OrdererMSP",
-                          "role": "MEMBER"
-                        },
-                        "principal_classification": "ROLE"
-                      }
-                    ],
-                    "rule": {
-                      "n_out_of": {
-                        "n": 1,
-                        "rules": [
-                          {
-                            "signed_by": 0
-                          }
-                        ]
-                      }
-                    },
-                    "version": 0
-                  }
-                },
-                "version": "0"
-              },
-              "Writers": {
-                "mod_policy": "Admins",
-                "policy": {
-                  "type": 1,
-                  "value": {
-                    "identities": [
-                      {
-                        "principal": {
-                          "msp_identifier": "OrdererMSP",
-                          "role": "MEMBER"
-                        },
-                        "principal_classification": "ROLE"
-                      }
-                    ],
-                    "rule": {
-                      "n_out_of": {
-                        "n": 1,
-                        "rules": [
-                          {
-                            "signed_by": 0
-                          }
-                        ]
-                      }
-                    },
-                    "version": 0
-                  }
-                },
-                "version": "0"
-              }
+              "version": "1"
             },
-            "values": {
-              "MSP": {
-                "mod_policy": "Admins",
-                "value": {
-                  "config": {
-                    "admins": [],
-                    "crypto_config": {
-                      "identity_identifier_hash_function": "SHA256",
-                      "signature_hash_family": "SHA2"
-                    },
-                    "fabric_node_ous": {
-                      "admin_ou_identifier": {
-                        "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNQVENDQWVTZ0F3SUJBZ0lSQUxCOWVtTVhObkxaWW56TitkMHNJQ2N3Q2dZSUtvWkl6ajBFQXdJd2FURUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhGREFTQmdOVkJBb1RDMlY0WVcxd2JHVXVZMjl0TVJjd0ZRWURWUVFERXc1allTNWxlR0Z0CmNHeGxMbU52YlRBZUZ3MHhPVEV4TVRReE16UTRNREJhRncweU9URXhNVEV4TXpRNE1EQmFNR2t4Q3pBSkJnTlYKQkFZVEFsVlRNUk13RVFZRFZRUUlFd3BEWVd4cFptOXlibWxoTVJZd0ZBWURWUVFIRXcxVFlXNGdSbkpoYm1OcApjMk52TVJRd0VnWURWUVFLRXd0bGVHRnRjR3hsTG1OdmJURVhNQlVHQTFVRUF4TU9ZMkV1WlhoaGJYQnNaUzVqCmIyMHdXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CQndOQ0FBVGVXYjlZWUdMNmgwMVlFckdzVS9xZmFzUmEKbUpHcFlWZGxsVTNwNldNUTMwZjcyazBFQitPRVQ3WWM3K0w2TWxxTTdNUDJBYnQ2RWUwV2w2OGpjZGxXbzIwdwphekFPQmdOVkhROEJBZjhFQkFNQ0FhWXdIUVlEVlIwbEJCWXdGQVlJS3dZQkJRVUhBd0lHQ0NzR0FRVUZCd01CCk1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0tRWURWUjBPQkNJRUlMQ0ZrREpzNkJNNzQ1YlVMUUhPY3RscFRtbFIKTTR6ZGpDaHlicW11QVNqb01Bb0dDQ3FHU000OUJBTUNBMGNBTUVRQ0lIQllZTVplZ2V3Wk5BUU1iU3hoQUhZMApqZnNCdDJOOHVTZ3prNHRIUWMvQ0FpQklCSjVXK3AyVTRzYi9zWjhPeS9mZjBIdFBBekZCSWV4VERkUGNnNUxBCk1RPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
-                        "organizational_unit_identifier": "admin"
+            "Org2MSP": {
+              "groups": {},
+              "mod_policy": "Admins",
+              "policies": {
+                "Admins": {
+                  "mod_policy": "Admins",
+                  "policy": {
+                    "type": 1,
+                    "value": {
+                      "identities": [
+                        {
+                          "principal": {
+                            "msp_identifier": "Org2MSP",
+                            "role": "ADMIN"
+                          },
+                          "principal_classification": "ROLE"
+                        }
+                      ],
+                      "rule": {
+                        "n_out_of": {
+                          "n": 1,
+                          "rules": [
+                            {
+                              "signed_by": 0
+                            }
+                          ]
+                        }
                       },
-                      "client_ou_identifier": {
-                        "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNQVENDQWVTZ0F3SUJBZ0lSQUxCOWVtTVhObkxaWW56TitkMHNJQ2N3Q2dZSUtvWkl6ajBFQXdJd2FURUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhGREFTQmdOVkJBb1RDMlY0WVcxd2JHVXVZMjl0TVJjd0ZRWURWUVFERXc1allTNWxlR0Z0CmNHeGxMbU52YlRBZUZ3MHhPVEV4TVRReE16UTRNREJhRncweU9URXhNVEV4TXpRNE1EQmFNR2t4Q3pBSkJnTlYKQkFZVEFsVlRNUk13RVFZRFZRUUlFd3BEWVd4cFptOXlibWxoTVJZd0ZBWURWUVFIRXcxVFlXNGdSbkpoYm1OcApjMk52TVJRd0VnWURWUVFLRXd0bGVHRnRjR3hsTG1OdmJURVhNQlVHQTFVRUF4TU9ZMkV1WlhoaGJYQnNaUzVqCmIyMHdXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CQndOQ0FBVGVXYjlZWUdMNmgwMVlFckdzVS9xZmFzUmEKbUpHcFlWZGxsVTNwNldNUTMwZjcyazBFQitPRVQ3WWM3K0w2TWxxTTdNUDJBYnQ2RWUwV2w2OGpjZGxXbzIwdwphekFPQmdOVkhROEJBZjhFQkFNQ0FhWXdIUVlEVlIwbEJCWXdGQVlJS3dZQkJRVUhBd0lHQ0NzR0FRVUZCd01CCk1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0tRWURWUjBPQkNJRUlMQ0ZrREpzNkJNNzQ1YlVMUUhPY3RscFRtbFIKTTR6ZGpDaHlicW11QVNqb01Bb0dDQ3FHU000OUJBTUNBMGNBTUVRQ0lIQllZTVplZ2V3Wk5BUU1iU3hoQUhZMApqZnNCdDJOOHVTZ3prNHRIUWMvQ0FpQklCSjVXK3AyVTRzYi9zWjhPeS9mZjBIdFBBekZCSWV4VERkUGNnNUxBCk1RPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
-                        "organizational_unit_identifier": "client"
+                      "version": 0
+                    }
+                  },
+                  "version": "0"
+                },
+                "Endorsement": {
+                  "mod_policy": "Admins",
+                  "policy": {
+                    "type": 1,
+                    "value": {
+                      "identities": [
+                        {
+                          "principal": {
+                            "msp_identifier": "Org2MSP",
+                            "role": "PEER"
+                          },
+                          "principal_classification": "ROLE"
+                        }
+                      ],
+                      "rule": {
+                        "n_out_of": {
+                          "n": 1,
+                          "rules": [
+                            {
+                              "signed_by": 0
+                            }
+                          ]
+                        }
                       },
-                      "enable": true,
-                      "orderer_ou_identifier": {
-                        "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNQVENDQWVTZ0F3SUJBZ0lSQUxCOWVtTVhObkxaWW56TitkMHNJQ2N3Q2dZSUtvWkl6ajBFQXdJd2FURUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhGREFTQmdOVkJBb1RDMlY0WVcxd2JHVXVZMjl0TVJjd0ZRWURWUVFERXc1allTNWxlR0Z0CmNHeGxMbU52YlRBZUZ3MHhPVEV4TVRReE16UTRNREJhRncweU9URXhNVEV4TXpRNE1EQmFNR2t4Q3pBSkJnTlYKQkFZVEFsVlRNUk13RVFZRFZRUUlFd3BEWVd4cFptOXlibWxoTVJZd0ZBWURWUVFIRXcxVFlXNGdSbkpoYm1OcApjMk52TVJRd0VnWURWUVFLRXd0bGVHRnRjR3hsTG1OdmJURVhNQlVHQTFVRUF4TU9ZMkV1WlhoaGJYQnNaUzVqCmIyMHdXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CQndOQ0FBVGVXYjlZWUdMNmgwMVlFckdzVS9xZmFzUmEKbUpHcFlWZGxsVTNwNldNUTMwZjcyazBFQitPRVQ3WWM3K0w2TWxxTTdNUDJBYnQ2RWUwV2w2OGpjZGxXbzIwdwphekFPQmdOVkhROEJBZjhFQkFNQ0FhWXdIUVlEVlIwbEJCWXdGQVlJS3dZQkJRVUhBd0lHQ0NzR0FRVUZCd01CCk1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0tRWURWUjBPQkNJRUlMQ0ZrREpzNkJNNzQ1YlVMUUhPY3RscFRtbFIKTTR6ZGpDaHlicW11QVNqb01Bb0dDQ3FHU000OUJBTUNBMGNBTUVRQ0lIQllZTVplZ2V3Wk5BUU1iU3hoQUhZMApqZnNCdDJOOHVTZ3prNHRIUWMvQ0FpQklCSjVXK3AyVTRzYi9zWjhPeS9mZjBIdFBBekZCSWV4VERkUGNnNUxBCk1RPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
-                        "organizational_unit_identifier": "orderer"
+                      "version": 0
+                    }
+                  },
+                  "version": "0"
+                },
+                "Readers": {
+                  "mod_policy": "Admins",
+                  "policy": {
+                    "type": 1,
+                    "value": {
+                      "identities": [
+                        {
+                          "principal": {
+                            "msp_identifier": "Org2MSP",
+                            "role": "ADMIN"
+                          },
+                          "principal_classification": "ROLE"
+                        },
+                        {
+                          "principal": {
+                            "msp_identifier": "Org2MSP",
+                            "role": "PEER"
+                          },
+                          "principal_classification": "ROLE"
+                        },
+                        {
+                          "principal": {
+                            "msp_identifier": "Org2MSP",
+                            "role": "CLIENT"
+                          },
+                          "principal_classification": "ROLE"
+                        }
+                      ],
+                      "rule": {
+                        "n_out_of": {
+                          "n": 1,
+                          "rules": [
+                            {
+                              "signed_by": 0
+                            },
+                            {
+                              "signed_by": 1
+                            },
+                            {
+                              "signed_by": 2
+                            }
+                          ]
+                        }
                       },
-                      "peer_ou_identifier": {
-                        "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNQVENDQWVTZ0F3SUJBZ0lSQUxCOWVtTVhObkxaWW56TitkMHNJQ2N3Q2dZSUtvWkl6ajBFQXdJd2FURUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhGREFTQmdOVkJBb1RDMlY0WVcxd2JHVXVZMjl0TVJjd0ZRWURWUVFERXc1allTNWxlR0Z0CmNHeGxMbU52YlRBZUZ3MHhPVEV4TVRReE16UTRNREJhRncweU9URXhNVEV4TXpRNE1EQmFNR2t4Q3pBSkJnTlYKQkFZVEFsVlRNUk13RVFZRFZRUUlFd3BEWVd4cFptOXlibWxoTVJZd0ZBWURWUVFIRXcxVFlXNGdSbkpoYm1OcApjMk52TVJRd0VnWURWUVFLRXd0bGVHRnRjR3hsTG1OdmJURVhNQlVHQTFVRUF4TU9ZMkV1WlhoaGJYQnNaUzVqCmIyMHdXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CQndOQ0FBVGVXYjlZWUdMNmgwMVlFckdzVS9xZmFzUmEKbUpHcFlWZGxsVTNwNldNUTMwZjcyazBFQitPRVQ3WWM3K0w2TWxxTTdNUDJBYnQ2RWUwV2w2OGpjZGxXbzIwdwphekFPQmdOVkhROEJBZjhFQkFNQ0FhWXdIUVlEVlIwbEJCWXdGQVlJS3dZQkJRVUhBd0lHQ0NzR0FRVUZCd01CCk1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0tRWURWUjBPQkNJRUlMQ0ZrREpzNkJNNzQ1YlVMUUhPY3RscFRtbFIKTTR6ZGpDaHlicW11QVNqb01Bb0dDQ3FHU000OUJBTUNBMGNBTUVRQ0lIQllZTVplZ2V3Wk5BUU1iU3hoQUhZMApqZnNCdDJOOHVTZ3prNHRIUWMvQ0FpQklCSjVXK3AyVTRzYi9zWjhPeS9mZjBIdFBBekZCSWV4VERkUGNnNUxBCk1RPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
-                        "organizational_unit_identifier": "peer"
+                      "version": 0
+                    }
+                  },
+                  "version": "0"
+                },
+                "Writers": {
+                  "mod_policy": "Admins",
+                  "policy": {
+                    "type": 1,
+                    "value": {
+                      "identities": [
+                        {
+                          "principal": {
+                            "msp_identifier": "Org2MSP",
+                            "role": "ADMIN"
+                          },
+                          "principal_classification": "ROLE"
+                        },
+                        {
+                          "principal": {
+                            "msp_identifier": "Org2MSP",
+                            "role": "CLIENT"
+                          },
+                          "principal_classification": "ROLE"
+                        }
+                      ],
+                      "rule": {
+                        "n_out_of": {
+                          "n": 1,
+                          "rules": [
+                            {
+                              "signed_by": 0
+                            },
+                            {
+                              "signed_by": 1
+                            }
+                          ]
+                        }
+                      },
+                      "version": 0
+                    }
+                  },
+                  "version": "0"
+                }
+              },
+              "values": {
+                "AnchorPeers": {
+                  "mod_policy": "Admins",
+                  "value": {
+                    "anchor_peers": [
+                      {
+                        "host": "peer0.org2.example.com",
+                        "port": 9051
                       }
-                    },
-                    "intermediate_certs": [],
-                    "name": "OrdererMSP",
-                    "organizational_unit_identifiers": [],
-                    "revocation_list": [],
-                    "root_certs": [
-                      "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNQVENDQWVTZ0F3SUJBZ0lSQUxCOWVtTVhObkxaWW56TitkMHNJQ2N3Q2dZSUtvWkl6ajBFQXdJd2FURUwKTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnVENrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhGREFTQmdOVkJBb1RDMlY0WVcxd2JHVXVZMjl0TVJjd0ZRWURWUVFERXc1allTNWxlR0Z0CmNHeGxMbU52YlRBZUZ3MHhPVEV4TVRReE16UTRNREJhRncweU9URXhNVEV4TXpRNE1EQmFNR2t4Q3pBSkJnTlYKQkFZVEFsVlRNUk13RVFZRFZRUUlFd3BEWVd4cFptOXlibWxoTVJZd0ZBWURWUVFIRXcxVFlXNGdSbkpoYm1OcApjMk52TVJRd0VnWURWUVFLRXd0bGVHRnRjR3hsTG1OdmJURVhNQlVHQTFVRUF4TU9ZMkV1WlhoaGJYQnNaUzVqCmIyMHdXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CQndOQ0FBVGVXYjlZWUdMNmgwMVlFckdzVS9xZmFzUmEKbUpHcFlWZGxsVTNwNldNUTMwZjcyazBFQitPRVQ3WWM3K0w2TWxxTTdNUDJBYnQ2RWUwV2w2OGpjZGxXbzIwdwphekFPQmdOVkhROEJBZjhFQkFNQ0FhWXdIUVlEVlIwbEJCWXdGQVlJS3dZQkJRVUhBd0lHQ0NzR0FRVUZCd01CCk1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0tRWURWUjBPQkNJRUlMQ0ZrREpzNkJNNzQ1YlVMUUhPY3RscFRtbFIKTTR6ZGpDaHlicW11QVNqb01Bb0dDQ3FHU000OUJBTUNBMGNBTUVRQ0lIQllZTVplZ2V3Wk5BUU1iU3hoQUhZMApqZnNCdDJOOHVTZ3prNHRIUWMvQ0FpQklCSjVXK3AyVTRzYi9zWjhPeS9mZjBIdFBBekZCSWV4VERkUGNnNUxBCk1RPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
-                    ],
-                    "signing_identity": null,
-                    "tls_intermediate_certs": [],
-                    "tls_root_certs": [
-                      "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNRekNDQWVtZ0F3SUJBZ0lRYmVteDhRa200VTNMT1EwWWJibzNmVEFLQmdncWhrak9QUVFEQWpCc01Rc3cKQ1FZRFZRUUdFd0pWVXpFVE1CRUdBMVVFQ0JNS1EyRnNhV1p2Y201cFlURVdNQlFHQTFVRUJ4TU5VMkZ1SUVaeQpZVzVqYVhOamJ6RVVNQklHQTFVRUNoTUxaWGhoYlhCc1pTNWpiMjB4R2pBWUJnTlZCQU1URVhSc2MyTmhMbVY0CllXMXdiR1V1WTI5dE1CNFhEVEU1TVRFeE5ERXpORGd3TUZvWERUSTVNVEV4TVRFek5EZ3dNRm93YkRFTE1Ba0cKQTFVRUJoTUNWVk14RXpBUkJnTlZCQWdUQ2tOaGJHbG1iM0p1YVdFeEZqQVVCZ05WQkFjVERWTmhiaUJHY21GdQpZMmx6WTI4eEZEQVNCZ05WQkFvVEMyVjRZVzF3YkdVdVkyOXRNUm93R0FZRFZRUURFeEYwYkhOallTNWxlR0Z0CmNHeGxMbU52YlRCWk1CTUdCeXFHU000OUFnRUdDQ3FHU000OUF3RUhBMElBQkR4aWpEY3FDMjlja0JOb21lam4KKzliaHVhc05yNlRMZjlIOStibTFPNTZJcko4ZmZ6WnEwaUJ4MWlpdmJSVGRDb2gwQ1d6ZUxRRHQyR3VBTkMrTgpBMDJqYlRCck1BNEdBMVVkRHdFQi93UUVBd0lCcGpBZEJnTlZIU1VFRmpBVUJnZ3JCZ0VGQlFjREFnWUlLd1lCCkJRVUhBd0V3RHdZRFZSMFRBUUgvQkFVd0F3RUIvekFwQmdOVkhRNEVJZ1Fnbm56SFBNRlFsSk50d1NqRXNBUUkKdnBFb3BvK2R4RElxbVB3bW0xczErT1V3Q2dZSUtvWkl6ajBFQXdJRFNBQXdSUUloQUtCTGhsSTlTcVkwTTZzTQozdC9DVG9sSXVEcXNmUVF0eWxhTkZpOTFYZjVZQWlCb1JCVWNCdy95SExTU01BSEwwcXBqVStUWHdDVzBzZ29FCmZ3NUNnU2s4MWc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
                     ]
                   },
-                  "type": 0
+                  "version": "0"
                 },
-                "version": "0"
-              }
+                "MSP": {
+                  "mod_policy": "Admins",
+                  "value": {
+                    "config": {
+                      "admins": [],
+                      "crypto_config": {
+                        "identity_identifier_hash_function": "SHA256",
+                        "signature_hash_family": "SHA2"
+                      },
+                      "fabric_node_ous": {
+                        "admin_ou_identifier": {
+                          "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNIakNDQWNXZ0F3SUJBZ0lVQVFkb1B0S0E0bEk2a0RrMituYzk5NzNhSC9Vd0NnWUlLb1pJemowRUF3SXcKYkRFTE1Ba0dBMVVFQmhNQ1ZVc3hFakFRQmdOVkJBZ1RDVWhoYlhCemFHbHlaVEVRTUE0R0ExVUVCeE1IU0hWeQpjMnhsZVRFWk1CY0dBMVVFQ2hNUWIzSm5NaTVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFQXhNVFkyRXViM0puCk1pNWxlR0Z0Y0d4bExtTnZiVEFlRncweU1EQXpNalF5TURFNE1EQmFGdzB6TlRBek1qRXlNREU0TURCYU1Hd3gKQ3pBSkJnTlZCQVlUQWxWTE1SSXdFQVlEVlFRSUV3bElZVzF3YzJocGNtVXhFREFPQmdOVkJBY1RCMGgxY25OcwpaWGt4R1RBWEJnTlZCQW9URUc5eVp6SXVaWGhoYlhCc1pTNWpiMjB4SERBYUJnTlZCQU1URTJOaExtOXlaekl1ClpYaGhiWEJzWlM1amIyMHdXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CQndOQ0FBVFk3VGJqQzdYSHNheC8Kem1yVk1nWnpmODBlb3JFbTNIdis2ZnRqMFgzd2cxdGZVM3hyWWxXZVJwR0JGeFQzNnJmVkdLLzhUQWJ2cnRuZgpUQ1hKak93a28wVXdRekFPQmdOVkhROEJBZjhFQkFNQ0FRWXdFZ1lEVlIwVEFRSC9CQWd3QmdFQi93SUJBVEFkCkJnTlZIUTRFRmdRVWJJNkV4dVRZSEpjczRvNEl5dXZWOVFRa1lGZ3dDZ1lJS29aSXpqMEVBd0lEUndBd1JBSWcKWndjdElBNmdoSlFCZmpDRXdRK1NmYi9iemdsQlV4b0g3ZHVtOUJrUjFkd0NJQlRqcEZkWlcyS2UzSVBMS1h2aApERmQvVmMrcloyMksyeVdKL1BIYXZWWmkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
+                          "organizational_unit_identifier": "admin"
+                        },
+                        "client_ou_identifier": {
+                          "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNIakNDQWNXZ0F3SUJBZ0lVQVFkb1B0S0E0bEk2a0RrMituYzk5NzNhSC9Vd0NnWUlLb1pJemowRUF3SXcKYkRFTE1Ba0dBMVVFQmhNQ1ZVc3hFakFRQmdOVkJBZ1RDVWhoYlhCemFHbHlaVEVRTUE0R0ExVUVCeE1IU0hWeQpjMnhsZVRFWk1CY0dBMVVFQ2hNUWIzSm5NaTVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFQXhNVFkyRXViM0puCk1pNWxlR0Z0Y0d4bExtTnZiVEFlRncweU1EQXpNalF5TURFNE1EQmFGdzB6TlRBek1qRXlNREU0TURCYU1Hd3gKQ3pBSkJnTlZCQVlUQWxWTE1SSXdFQVlEVlFRSUV3bElZVzF3YzJocGNtVXhFREFPQmdOVkJBY1RCMGgxY25OcwpaWGt4R1RBWEJnTlZCQW9URUc5eVp6SXVaWGhoYlhCc1pTNWpiMjB4SERBYUJnTlZCQU1URTJOaExtOXlaekl1ClpYaGhiWEJzWlM1amIyMHdXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CQndOQ0FBVFk3VGJqQzdYSHNheC8Kem1yVk1nWnpmODBlb3JFbTNIdis2ZnRqMFgzd2cxdGZVM3hyWWxXZVJwR0JGeFQzNnJmVkdLLzhUQWJ2cnRuZgpUQ1hKak93a28wVXdRekFPQmdOVkhROEJBZjhFQkFNQ0FRWXdFZ1lEVlIwVEFRSC9CQWd3QmdFQi93SUJBVEFkCkJnTlZIUTRFRmdRVWJJNkV4dVRZSEpjczRvNEl5dXZWOVFRa1lGZ3dDZ1lJS29aSXpqMEVBd0lEUndBd1JBSWcKWndjdElBNmdoSlFCZmpDRXdRK1NmYi9iemdsQlV4b0g3ZHVtOUJrUjFkd0NJQlRqcEZkWlcyS2UzSVBMS1h2aApERmQvVmMrcloyMksyeVdKL1BIYXZWWmkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
+                          "organizational_unit_identifier": "client"
+                        },
+                        "enable": true,
+                        "orderer_ou_identifier": {
+                          "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNIakNDQWNXZ0F3SUJBZ0lVQVFkb1B0S0E0bEk2a0RrMituYzk5NzNhSC9Vd0NnWUlLb1pJemowRUF3SXcKYkRFTE1Ba0dBMVVFQmhNQ1ZVc3hFakFRQmdOVkJBZ1RDVWhoYlhCemFHbHlaVEVRTUE0R0ExVUVCeE1IU0hWeQpjMnhsZVRFWk1CY0dBMVVFQ2hNUWIzSm5NaTVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFQXhNVFkyRXViM0puCk1pNWxlR0Z0Y0d4bExtTnZiVEFlRncweU1EQXpNalF5TURFNE1EQmFGdzB6TlRBek1qRXlNREU0TURCYU1Hd3gKQ3pBSkJnTlZCQVlUQWxWTE1SSXdFQVlEVlFRSUV3bElZVzF3YzJocGNtVXhFREFPQmdOVkJBY1RCMGgxY25OcwpaWGt4R1RBWEJnTlZCQW9URUc5eVp6SXVaWGhoYlhCc1pTNWpiMjB4SERBYUJnTlZCQU1URTJOaExtOXlaekl1ClpYaGhiWEJzWlM1amIyMHdXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CQndOQ0FBVFk3VGJqQzdYSHNheC8Kem1yVk1nWnpmODBlb3JFbTNIdis2ZnRqMFgzd2cxdGZVM3hyWWxXZVJwR0JGeFQzNnJmVkdLLzhUQWJ2cnRuZgpUQ1hKak93a28wVXdRekFPQmdOVkhROEJBZjhFQkFNQ0FRWXdFZ1lEVlIwVEFRSC9CQWd3QmdFQi93SUJBVEFkCkJnTlZIUTRFRmdRVWJJNkV4dVRZSEpjczRvNEl5dXZWOVFRa1lGZ3dDZ1lJS29aSXpqMEVBd0lEUndBd1JBSWcKWndjdElBNmdoSlFCZmpDRXdRK1NmYi9iemdsQlV4b0g3ZHVtOUJrUjFkd0NJQlRqcEZkWlcyS2UzSVBMS1h2aApERmQvVmMrcloyMksyeVdKL1BIYXZWWmkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
+                          "organizational_unit_identifier": "orderer"
+                        },
+                        "peer_ou_identifier": {
+                          "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNIakNDQWNXZ0F3SUJBZ0lVQVFkb1B0S0E0bEk2a0RrMituYzk5NzNhSC9Vd0NnWUlLb1pJemowRUF3SXcKYkRFTE1Ba0dBMVVFQmhNQ1ZVc3hFakFRQmdOVkJBZ1RDVWhoYlhCemFHbHlaVEVRTUE0R0ExVUVCeE1IU0hWeQpjMnhsZVRFWk1CY0dBMVVFQ2hNUWIzSm5NaTVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFQXhNVFkyRXViM0puCk1pNWxlR0Z0Y0d4bExtTnZiVEFlRncweU1EQXpNalF5TURFNE1EQmFGdzB6TlRBek1qRXlNREU0TURCYU1Hd3gKQ3pBSkJnTlZCQVlUQWxWTE1SSXdFQVlEVlFRSUV3bElZVzF3YzJocGNtVXhFREFPQmdOVkJBY1RCMGgxY25OcwpaWGt4R1RBWEJnTlZCQW9URUc5eVp6SXVaWGhoYlhCc1pTNWpiMjB4SERBYUJnTlZCQU1URTJOaExtOXlaekl1ClpYaGhiWEJzWlM1amIyMHdXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CQndOQ0FBVFk3VGJqQzdYSHNheC8Kem1yVk1nWnpmODBlb3JFbTNIdis2ZnRqMFgzd2cxdGZVM3hyWWxXZVJwR0JGeFQzNnJmVkdLLzhUQWJ2cnRuZgpUQ1hKak93a28wVXdRekFPQmdOVkhROEJBZjhFQkFNQ0FRWXdFZ1lEVlIwVEFRSC9CQWd3QmdFQi93SUJBVEFkCkJnTlZIUTRFRmdRVWJJNkV4dVRZSEpjczRvNEl5dXZWOVFRa1lGZ3dDZ1lJS29aSXpqMEVBd0lEUndBd1JBSWcKWndjdElBNmdoSlFCZmpDRXdRK1NmYi9iemdsQlV4b0g3ZHVtOUJrUjFkd0NJQlRqcEZkWlcyS2UzSVBMS1h2aApERmQvVmMrcloyMksyeVdKL1BIYXZWWmkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
+                          "organizational_unit_identifier": "peer"
+                        }
+                      },
+                      "intermediate_certs": [],
+                      "name": "Org2MSP",
+                      "organizational_unit_identifiers": [],
+                      "revocation_list": [],
+                      "root_certs": [
+                        "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNIakNDQWNXZ0F3SUJBZ0lVQVFkb1B0S0E0bEk2a0RrMituYzk5NzNhSC9Vd0NnWUlLb1pJemowRUF3SXcKYkRFTE1Ba0dBMVVFQmhNQ1ZVc3hFakFRQmdOVkJBZ1RDVWhoYlhCemFHbHlaVEVRTUE0R0ExVUVCeE1IU0hWeQpjMnhsZVRFWk1CY0dBMVVFQ2hNUWIzSm5NaTVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFQXhNVFkyRXViM0puCk1pNWxlR0Z0Y0d4bExtTnZiVEFlRncweU1EQXpNalF5TURFNE1EQmFGdzB6TlRBek1qRXlNREU0TURCYU1Hd3gKQ3pBSkJnTlZCQVlUQWxWTE1SSXdFQVlEVlFRSUV3bElZVzF3YzJocGNtVXhFREFPQmdOVkJBY1RCMGgxY25OcwpaWGt4R1RBWEJnTlZCQW9URUc5eVp6SXVaWGhoYlhCc1pTNWpiMjB4SERBYUJnTlZCQU1URTJOaExtOXlaekl1ClpYaGhiWEJzWlM1amIyMHdXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CQndOQ0FBVFk3VGJqQzdYSHNheC8Kem1yVk1nWnpmODBlb3JFbTNIdis2ZnRqMFgzd2cxdGZVM3hyWWxXZVJwR0JGeFQzNnJmVkdLLzhUQWJ2cnRuZgpUQ1hKak93a28wVXdRekFPQmdOVkhROEJBZjhFQkFNQ0FRWXdFZ1lEVlIwVEFRSC9CQWd3QmdFQi93SUJBVEFkCkJnTlZIUTRFRmdRVWJJNkV4dVRZSEpjczRvNEl5dXZWOVFRa1lGZ3dDZ1lJS29aSXpqMEVBd0lEUndBd1JBSWcKWndjdElBNmdoSlFCZmpDRXdRK1NmYi9iemdsQlV4b0g3ZHVtOUJrUjFkd0NJQlRqcEZkWlcyS2UzSVBMS1h2aApERmQvVmMrcloyMksyeVdKL1BIYXZWWmkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+                      ],
+                      "signing_identity": null,
+                      "tls_intermediate_certs": [],
+                      "tls_root_certs": [
+                        "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNIakNDQWNXZ0F3SUJBZ0lVQVFkb1B0S0E0bEk2a0RrMituYzk5NzNhSC9Vd0NnWUlLb1pJemowRUF3SXcKYkRFTE1Ba0dBMVVFQmhNQ1ZVc3hFakFRQmdOVkJBZ1RDVWhoYlhCemFHbHlaVEVRTUE0R0ExVUVCeE1IU0hWeQpjMnhsZVRFWk1CY0dBMVVFQ2hNUWIzSm5NaTVsZUdGdGNHeGxMbU52YlRFY01Cb0dBMVVFQXhNVFkyRXViM0puCk1pNWxlR0Z0Y0d4bExtTnZiVEFlRncweU1EQXpNalF5TURFNE1EQmFGdzB6TlRBek1qRXlNREU0TURCYU1Hd3gKQ3pBSkJnTlZCQVlUQWxWTE1SSXdFQVlEVlFRSUV3bElZVzF3YzJocGNtVXhFREFPQmdOVkJBY1RCMGgxY25OcwpaWGt4R1RBWEJnTlZCQW9URUc5eVp6SXVaWGhoYlhCc1pTNWpiMjB4SERBYUJnTlZCQU1URTJOaExtOXlaekl1ClpYaGhiWEJzWlM1amIyMHdXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CQndOQ0FBVFk3VGJqQzdYSHNheC8Kem1yVk1nWnpmODBlb3JFbTNIdis2ZnRqMFgzd2cxdGZVM3hyWWxXZVJwR0JGeFQzNnJmVkdLLzhUQWJ2cnRuZgpUQ1hKak93a28wVXdRekFPQmdOVkhROEJBZjhFQkFNQ0FRWXdFZ1lEVlIwVEFRSC9CQWd3QmdFQi93SUJBVEFkCkJnTlZIUTRFRmdRVWJJNkV4dVRZSEpjczRvNEl5dXZWOVFRa1lGZ3dDZ1lJS29aSXpqMEVBd0lEUndBd1JBSWcKWndjdElBNmdoSlFCZmpDRXdRK1NmYi9iemdsQlV4b0g3ZHVtOUJrUjFkd0NJQlRqcEZkWlcyS2UzSVBMS1h2aApERmQvVmMrcloyMksyeVdKL1BIYXZWWmkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+                      ]
+                    },
+                    "type": 0
+                  },
+                  "version": "0"
+                }
+              },
+              "version": "1"
+            }
+          },
+          "mod_policy": "Admins",
+          "policies": {
+            "Admins": {
+              "mod_policy": "Admins",
+              "policy": {
+                "type": 3,
+                "value": {
+                  "rule": "MAJORITY",
+                  "sub_policy": "Admins"
+                }
+              },
+              "version": "0"
             },
-            "version": "0"
-          }
+            "Endorsement": {
+              "mod_policy": "Admins",
+              "policy": {
+                "type": 3,
+                "value": {
+                  "rule": "MAJORITY",
+                  "sub_policy": "Endorsement"
+                }
+              },
+              "version": "0"
+            },
+            "LifecycleEndorsement": {
+              "mod_policy": "Admins",
+              "policy": {
+                "type": 3,
+                "value": {
+                  "rule": "MAJORITY",
+                  "sub_policy": "Endorsement"
+                }
+              },
+              "version": "0"
+            },
+            "Readers": {
+              "mod_policy": "Admins",
+              "policy": {
+                "type": 3,
+                "value": {
+                  "rule": "ANY",
+                  "sub_policy": "Readers"
+                }
+              },
+              "version": "0"
+            },
+            "Writers": {
+              "mod_policy": "Admins",
+              "policy": {
+                "type": 3,
+                "value": {
+                  "rule": "ANY",
+                  "sub_policy": "Writers"
+                }
+              },
+              "version": "0"
+            }
+          },
+          "values": {
+            "Capabilities": {
+              "mod_policy": "Admins",
+              "value": {
+                "capabilities": {
+                  "V2_0": {}
+                }
+              },
+              "version": "0"
+            }
+          },
+          "version": "1"
         },
-        "mod_policy": "Admins",
-        "policies": {
-          "Admins": {
-            "mod_policy": "Admins",
-            "policy": {
-              "type": 3,
-              "value": {
-                "rule": "MAJORITY",
-                "sub_policy": "Admins"
-              }
-            },
-            "version": "0"
+        "Orderer": {
+          "groups": {
+            "OrdererOrg": {
+              "groups": {},
+              "mod_policy": "Admins",
+              "policies": {
+                "Admins": {
+                  "mod_policy": "Admins",
+                  "policy": {
+                    "type": 1,
+                    "value": {
+                      "identities": [
+                        {
+                          "principal": {
+                            "msp_identifier": "OrdererMSP",
+                            "role": "ADMIN"
+                          },
+                          "principal_classification": "ROLE"
+                        }
+                      ],
+                      "rule": {
+                        "n_out_of": {
+                          "n": 1,
+                          "rules": [
+                            {
+                              "signed_by": 0
+                            }
+                          ]
+                        }
+                      },
+                      "version": 0
+                    }
+                  },
+                  "version": "0"
+                },
+                "Readers": {
+                  "mod_policy": "Admins",
+                  "policy": {
+                    "type": 1,
+                    "value": {
+                      "identities": [
+                        {
+                          "principal": {
+                            "msp_identifier": "OrdererMSP",
+                            "role": "MEMBER"
+                          },
+                          "principal_classification": "ROLE"
+                        }
+                      ],
+                      "rule": {
+                        "n_out_of": {
+                          "n": 1,
+                          "rules": [
+                            {
+                              "signed_by": 0
+                            }
+                          ]
+                        }
+                      },
+                      "version": 0
+                    }
+                  },
+                  "version": "0"
+                },
+                "Writers": {
+                  "mod_policy": "Admins",
+                  "policy": {
+                    "type": 1,
+                    "value": {
+                      "identities": [
+                        {
+                          "principal": {
+                            "msp_identifier": "OrdererMSP",
+                            "role": "MEMBER"
+                          },
+                          "principal_classification": "ROLE"
+                        }
+                      ],
+                      "rule": {
+                        "n_out_of": {
+                          "n": 1,
+                          "rules": [
+                            {
+                              "signed_by": 0
+                            }
+                          ]
+                        }
+                      },
+                      "version": 0
+                    }
+                  },
+                  "version": "0"
+                }
+              },
+              "values": {
+                "MSP": {
+                  "mod_policy": "Admins",
+                  "value": {
+                    "config": {
+                      "admins": [],
+                      "crypto_config": {
+                        "identity_identifier_hash_function": "SHA256",
+                        "signature_hash_family": "SHA2"
+                      },
+                      "fabric_node_ous": {
+                        "admin_ou_identifier": {
+                          "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNDekNDQWJHZ0F3SUJBZ0lVUkgyT0tlV1loaStFMkFHZ3IwWUdlVTRUOWs0d0NnWUlLb1pJemowRUF3SXcKWWpFTE1Ba0dBMVVFQmhNQ1ZWTXhFVEFQQmdOVkJBZ1RDRTVsZHlCWmIzSnJNUkV3RHdZRFZRUUhFd2hPWlhjZwpXVzl5YXpFVU1CSUdBMVVFQ2hNTFpYaGhiWEJzWlM1amIyMHhGekFWQmdOVkJBTVREbU5oTG1WNFlXMXdiR1V1ClkyOXRNQjRYRFRJd01ETXlOREl3TVRnd01Gb1hEVE0xTURNeU1USXdNVGd3TUZvd1lqRUxNQWtHQTFVRUJoTUMKVlZNeEVUQVBCZ05WQkFnVENFNWxkeUJaYjNKck1SRXdEd1lEVlFRSEV3aE9aWGNnV1c5eWF6RVVNQklHQTFVRQpDaE1MWlhoaGJYQnNaUzVqYjIweEZ6QVZCZ05WQkFNVERtTmhMbVY0WVcxd2JHVXVZMjl0TUZrd0V3WUhLb1pJCnpqMENBUVlJS29aSXpqMERBUWNEUWdBRS9yb2dWY0hFcEVQMDhTUTl3VTVpdkNxaUFDKzU5WUx1dkRDNkx6UlIKWXdyZkFxdncvT0FodVlQRkhnRFZ1SFExOVdXMGxSV2FKWmpVcDFxNmRCWEhlYU5GTUVNd0RnWURWUjBQQVFILwpCQVFEQWdFR01CSUdBMVVkRXdFQi93UUlNQVlCQWY4Q0FRRXdIUVlEVlIwT0JCWUVGTG9kWFpjaTVNNlFxYkNUCm1YZ3lTbU1aYlZHWE1Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ0hFTElvajJUNG15ODI0SENQRFc2bEZFRTEKSDc1c2FyN1V4TVJSNmFWckZnSWdMZUxYT0ZoSDNjZ0pGeDhJckVyTjlhZmdjVVIyd0ZYUkQ0V0V0MVp1bmxBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==",
+                          "organizational_unit_identifier": "admin"
+                        },
+                        "client_ou_identifier": {
+                          "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNDekNDQWJHZ0F3SUJBZ0lVUkgyT0tlV1loaStFMkFHZ3IwWUdlVTRUOWs0d0NnWUlLb1pJemowRUF3SXcKWWpFTE1Ba0dBMVVFQmhNQ1ZWTXhFVEFQQmdOVkJBZ1RDRTVsZHlCWmIzSnJNUkV3RHdZRFZRUUhFd2hPWlhjZwpXVzl5YXpFVU1CSUdBMVVFQ2hNTFpYaGhiWEJzWlM1amIyMHhGekFWQmdOVkJBTVREbU5oTG1WNFlXMXdiR1V1ClkyOXRNQjRYRFRJd01ETXlOREl3TVRnd01Gb1hEVE0xTURNeU1USXdNVGd3TUZvd1lqRUxNQWtHQTFVRUJoTUMKVlZNeEVUQVBCZ05WQkFnVENFNWxkeUJaYjNKck1SRXdEd1lEVlFRSEV3aE9aWGNnV1c5eWF6RVVNQklHQTFVRQpDaE1MWlhoaGJYQnNaUzVqYjIweEZ6QVZCZ05WQkFNVERtTmhMbVY0WVcxd2JHVXVZMjl0TUZrd0V3WUhLb1pJCnpqMENBUVlJS29aSXpqMERBUWNEUWdBRS9yb2dWY0hFcEVQMDhTUTl3VTVpdkNxaUFDKzU5WUx1dkRDNkx6UlIKWXdyZkFxdncvT0FodVlQRkhnRFZ1SFExOVdXMGxSV2FKWmpVcDFxNmRCWEhlYU5GTUVNd0RnWURWUjBQQVFILwpCQVFEQWdFR01CSUdBMVVkRXdFQi93UUlNQVlCQWY4Q0FRRXdIUVlEVlIwT0JCWUVGTG9kWFpjaTVNNlFxYkNUCm1YZ3lTbU1aYlZHWE1Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ0hFTElvajJUNG15ODI0SENQRFc2bEZFRTEKSDc1c2FyN1V4TVJSNmFWckZnSWdMZUxYT0ZoSDNjZ0pGeDhJckVyTjlhZmdjVVIyd0ZYUkQ0V0V0MVp1bmxBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==",
+                          "organizational_unit_identifier": "client"
+                        },
+                        "enable": true,
+                        "orderer_ou_identifier": {
+                          "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNDekNDQWJHZ0F3SUJBZ0lVUkgyT0tlV1loaStFMkFHZ3IwWUdlVTRUOWs0d0NnWUlLb1pJemowRUF3SXcKWWpFTE1Ba0dBMVVFQmhNQ1ZWTXhFVEFQQmdOVkJBZ1RDRTVsZHlCWmIzSnJNUkV3RHdZRFZRUUhFd2hPWlhjZwpXVzl5YXpFVU1CSUdBMVVFQ2hNTFpYaGhiWEJzWlM1amIyMHhGekFWQmdOVkJBTVREbU5oTG1WNFlXMXdiR1V1ClkyOXRNQjRYRFRJd01ETXlOREl3TVRnd01Gb1hEVE0xTURNeU1USXdNVGd3TUZvd1lqRUxNQWtHQTFVRUJoTUMKVlZNeEVUQVBCZ05WQkFnVENFNWxkeUJaYjNKck1SRXdEd1lEVlFRSEV3aE9aWGNnV1c5eWF6RVVNQklHQTFVRQpDaE1MWlhoaGJYQnNaUzVqYjIweEZ6QVZCZ05WQkFNVERtTmhMbVY0WVcxd2JHVXVZMjl0TUZrd0V3WUhLb1pJCnpqMENBUVlJS29aSXpqMERBUWNEUWdBRS9yb2dWY0hFcEVQMDhTUTl3VTVpdkNxaUFDKzU5WUx1dkRDNkx6UlIKWXdyZkFxdncvT0FodVlQRkhnRFZ1SFExOVdXMGxSV2FKWmpVcDFxNmRCWEhlYU5GTUVNd0RnWURWUjBQQVFILwpCQVFEQWdFR01CSUdBMVVkRXdFQi93UUlNQVlCQWY4Q0FRRXdIUVlEVlIwT0JCWUVGTG9kWFpjaTVNNlFxYkNUCm1YZ3lTbU1aYlZHWE1Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ0hFTElvajJUNG15ODI0SENQRFc2bEZFRTEKSDc1c2FyN1V4TVJSNmFWckZnSWdMZUxYT0ZoSDNjZ0pGeDhJckVyTjlhZmdjVVIyd0ZYUkQ0V0V0MVp1bmxBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==",
+                          "organizational_unit_identifier": "orderer"
+                        },
+                        "peer_ou_identifier": {
+                          "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNDekNDQWJHZ0F3SUJBZ0lVUkgyT0tlV1loaStFMkFHZ3IwWUdlVTRUOWs0d0NnWUlLb1pJemowRUF3SXcKWWpFTE1Ba0dBMVVFQmhNQ1ZWTXhFVEFQQmdOVkJBZ1RDRTVsZHlCWmIzSnJNUkV3RHdZRFZRUUhFd2hPWlhjZwpXVzl5YXpFVU1CSUdBMVVFQ2hNTFpYaGhiWEJzWlM1amIyMHhGekFWQmdOVkJBTVREbU5oTG1WNFlXMXdiR1V1ClkyOXRNQjRYRFRJd01ETXlOREl3TVRnd01Gb1hEVE0xTURNeU1USXdNVGd3TUZvd1lqRUxNQWtHQTFVRUJoTUMKVlZNeEVUQVBCZ05WQkFnVENFNWxkeUJaYjNKck1SRXdEd1lEVlFRSEV3aE9aWGNnV1c5eWF6RVVNQklHQTFVRQpDaE1MWlhoaGJYQnNaUzVqYjIweEZ6QVZCZ05WQkFNVERtTmhMbVY0WVcxd2JHVXVZMjl0TUZrd0V3WUhLb1pJCnpqMENBUVlJS29aSXpqMERBUWNEUWdBRS9yb2dWY0hFcEVQMDhTUTl3VTVpdkNxaUFDKzU5WUx1dkRDNkx6UlIKWXdyZkFxdncvT0FodVlQRkhnRFZ1SFExOVdXMGxSV2FKWmpVcDFxNmRCWEhlYU5GTUVNd0RnWURWUjBQQVFILwpCQVFEQWdFR01CSUdBMVVkRXdFQi93UUlNQVlCQWY4Q0FRRXdIUVlEVlIwT0JCWUVGTG9kWFpjaTVNNlFxYkNUCm1YZ3lTbU1aYlZHWE1Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ0hFTElvajJUNG15ODI0SENQRFc2bEZFRTEKSDc1c2FyN1V4TVJSNmFWckZnSWdMZUxYT0ZoSDNjZ0pGeDhJckVyTjlhZmdjVVIyd0ZYUkQ0V0V0MVp1bmxBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==",
+                          "organizational_unit_identifier": "peer"
+                        }
+                      },
+                      "intermediate_certs": [],
+                      "name": "OrdererMSP",
+                      "organizational_unit_identifiers": [],
+                      "revocation_list": [],
+                      "root_certs": [
+                        "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNDekNDQWJHZ0F3SUJBZ0lVUkgyT0tlV1loaStFMkFHZ3IwWUdlVTRUOWs0d0NnWUlLb1pJemowRUF3SXcKWWpFTE1Ba0dBMVVFQmhNQ1ZWTXhFVEFQQmdOVkJBZ1RDRTVsZHlCWmIzSnJNUkV3RHdZRFZRUUhFd2hPWlhjZwpXVzl5YXpFVU1CSUdBMVVFQ2hNTFpYaGhiWEJzWlM1amIyMHhGekFWQmdOVkJBTVREbU5oTG1WNFlXMXdiR1V1ClkyOXRNQjRYRFRJd01ETXlOREl3TVRnd01Gb1hEVE0xTURNeU1USXdNVGd3TUZvd1lqRUxNQWtHQTFVRUJoTUMKVlZNeEVUQVBCZ05WQkFnVENFNWxkeUJaYjNKck1SRXdEd1lEVlFRSEV3aE9aWGNnV1c5eWF6RVVNQklHQTFVRQpDaE1MWlhoaGJYQnNaUzVqYjIweEZ6QVZCZ05WQkFNVERtTmhMbVY0WVcxd2JHVXVZMjl0TUZrd0V3WUhLb1pJCnpqMENBUVlJS29aSXpqMERBUWNEUWdBRS9yb2dWY0hFcEVQMDhTUTl3VTVpdkNxaUFDKzU5WUx1dkRDNkx6UlIKWXdyZkFxdncvT0FodVlQRkhnRFZ1SFExOVdXMGxSV2FKWmpVcDFxNmRCWEhlYU5GTUVNd0RnWURWUjBQQVFILwpCQVFEQWdFR01CSUdBMVVkRXdFQi93UUlNQVlCQWY4Q0FRRXdIUVlEVlIwT0JCWUVGTG9kWFpjaTVNNlFxYkNUCm1YZ3lTbU1aYlZHWE1Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ0hFTElvajJUNG15ODI0SENQRFc2bEZFRTEKSDc1c2FyN1V4TVJSNmFWckZnSWdMZUxYT0ZoSDNjZ0pGeDhJckVyTjlhZmdjVVIyd0ZYUkQ0V0V0MVp1bmxBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+                      ],
+                      "signing_identity": null,
+                      "tls_intermediate_certs": [],
+                      "tls_root_certs": [
+                        "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNDekNDQWJHZ0F3SUJBZ0lVUkgyT0tlV1loaStFMkFHZ3IwWUdlVTRUOWs0d0NnWUlLb1pJemowRUF3SXcKWWpFTE1Ba0dBMVVFQmhNQ1ZWTXhFVEFQQmdOVkJBZ1RDRTVsZHlCWmIzSnJNUkV3RHdZRFZRUUhFd2hPWlhjZwpXVzl5YXpFVU1CSUdBMVVFQ2hNTFpYaGhiWEJzWlM1amIyMHhGekFWQmdOVkJBTVREbU5oTG1WNFlXMXdiR1V1ClkyOXRNQjRYRFRJd01ETXlOREl3TVRnd01Gb1hEVE0xTURNeU1USXdNVGd3TUZvd1lqRUxNQWtHQTFVRUJoTUMKVlZNeEVUQVBCZ05WQkFnVENFNWxkeUJaYjNKck1SRXdEd1lEVlFRSEV3aE9aWGNnV1c5eWF6RVVNQklHQTFVRQpDaE1MWlhoaGJYQnNaUzVqYjIweEZ6QVZCZ05WQkFNVERtTmhMbVY0WVcxd2JHVXVZMjl0TUZrd0V3WUhLb1pJCnpqMENBUVlJS29aSXpqMERBUWNEUWdBRS9yb2dWY0hFcEVQMDhTUTl3VTVpdkNxaUFDKzU5WUx1dkRDNkx6UlIKWXdyZkFxdncvT0FodVlQRkhnRFZ1SFExOVdXMGxSV2FKWmpVcDFxNmRCWEhlYU5GTUVNd0RnWURWUjBQQVFILwpCQVFEQWdFR01CSUdBMVVkRXdFQi93UUlNQVlCQWY4Q0FRRXdIUVlEVlIwT0JCWUVGTG9kWFpjaTVNNlFxYkNUCm1YZ3lTbU1aYlZHWE1Bb0dDQ3FHU000OUJBTUNBMGdBTUVVQ0lRQ0hFTElvajJUNG15ODI0SENQRFc2bEZFRTEKSDc1c2FyN1V4TVJSNmFWckZnSWdMZUxYT0ZoSDNjZ0pGeDhJckVyTjlhZmdjVVIyd0ZYUkQ0V0V0MVp1bmxBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+                      ]
+                    },
+                    "type": 0
+                  },
+                  "version": "0"
+                }
+              },
+              "version": "0"
+            }
           },
-          "BlockValidation": {
-            "mod_policy": "Admins",
-            "policy": {
-              "type": 3,
-              "value": {
-                "rule": "ANY",
-                "sub_policy": "Writers"
-              }
+          "mod_policy": "Admins",
+          "policies": {
+            "Admins": {
+              "mod_policy": "Admins",
+              "policy": {
+                "type": 3,
+                "value": {
+                  "rule": "MAJORITY",
+                  "sub_policy": "Admins"
+                }
+              },
+              "version": "0"
             },
-            "version": "0"
+            "BlockValidation": {
+              "mod_policy": "Admins",
+              "policy": {
+                "type": 3,
+                "value": {
+                  "rule": "ANY",
+                  "sub_policy": "Writers"
+                }
+              },
+              "version": "0"
+            },
+            "Readers": {
+              "mod_policy": "Admins",
+              "policy": {
+                "type": 3,
+                "value": {
+                  "rule": "ANY",
+                  "sub_policy": "Readers"
+                }
+              },
+              "version": "0"
+            },
+            "Writers": {
+              "mod_policy": "Admins",
+              "policy": {
+                "type": 3,
+                "value": {
+                  "rule": "ANY",
+                  "sub_policy": "Writers"
+                }
+              },
+              "version": "0"
+            }
           },
-          "Readers": {
-            "mod_policy": "Admins",
-            "policy": {
-              "type": 3,
+          "values": {
+            "BatchSize": {
+              "mod_policy": "Admins",
               "value": {
-                "rule": "ANY",
-                "sub_policy": "Readers"
-              }
+                "absolute_max_bytes": 103809024,
+                "max_message_count": 10,
+                "preferred_max_bytes": 524288
+              },
+              "version": "0"
             },
-            "version": "0"
+            "BatchTimeout": {
+              "mod_policy": "Admins",
+              "value": {
+                "timeout": "2s"
+              },
+              "version": "0"
+            },
+            "Capabilities": {
+              "mod_policy": "Admins",
+              "value": {
+                "capabilities": {
+                  "V2_0": {}
+                }
+              },
+              "version": "0"
+            },
+            "ChannelRestrictions": {
+              "mod_policy": "Admins",
+              "value": null,
+              "version": "0"
+            },
+            "ConsensusType": {
+              "mod_policy": "Admins",
+              "value": {
+                "metadata": {
+                  "consenters": [
+                    {
+                      "client_tls_cert": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN3akNDQW1pZ0F3SUJBZ0lVZG9JbmpzaW5vVnZua0llbE5WUU8wbDRMbEdrd0NnWUlLb1pJemowRUF3SXcKWWpFTE1Ba0dBMVVFQmhNQ1ZWTXhFVEFQQmdOVkJBZ1RDRTVsZHlCWmIzSnJNUkV3RHdZRFZRUUhFd2hPWlhjZwpXVzl5YXpFVU1CSUdBMVVFQ2hNTFpYaGhiWEJzWlM1amIyMHhGekFWQmdOVkJBTVREbU5oTG1WNFlXMXdiR1V1ClkyOXRNQjRYRFRJd01ETXlOREl3TVRnd01Gb1hEVEl4TURNeU5ESXdNak13TUZvd1lERUxNQWtHQTFVRUJoTUMKVlZNeEZ6QVZCZ05WQkFnVERrNXZjblJvSUVOaGNtOXNhVzVoTVJRd0VnWURWUVFLRXd0SWVYQmxjbXhsWkdkbApjakVRTUE0R0ExVUVDeE1IYjNKa1pYSmxjakVRTUE0R0ExVUVBeE1IYjNKa1pYSmxjakJaTUJNR0J5cUdTTTQ5CkFnRUdDQ3FHU000OUF3RUhBMElBQkdGaFd3SllGbHR3clBVellIQ3loNTMvU3VpVU1ZYnVJakdGTWRQMW9FRzMKSkcrUlRSOFR4NUNYTXdpV05sZ285dU00a1NGTzBINURZUWZPQU5MU0o5NmpnZjB3Z2Zvd0RnWURWUjBQQVFILwpCQVFEQWdPb01CMEdBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFNQmdOVkhSTUJBZjhFCkFqQUFNQjBHQTFVZERnUVdCQlJ2M3lNUmh5cHc0Qi9Cc1NHTlVJL0VpU1lNN2pBZkJnTlZIU01FR0RBV2dCUzYKSFYyWEl1VE9rS213azVsNE1rcGpHVzFSbHpBZUJnTlZIUkVFRnpBVmdoTnZjbVJsY21WeUxtVjRZVzF3YkdVdQpZMjl0TUZzR0NDb0RCQVVHQndnQkJFOTdJbUYwZEhKeklqcDdJbWhtTGtGbVptbHNhV0YwYVc5dUlqb2lJaXdpCmFHWXVSVzV5YjJ4c2JXVnVkRWxFSWpvaWIzSmtaWEpsY2lJc0ltaG1MbFI1Y0dVaU9pSnZjbVJsY21WeUluMTkKTUFvR0NDcUdTTTQ5QkFNQ0EwZ0FNRVVDSVFESHNrWUR5clNqeWpkTVVVWDNaT05McXJUNkdCcVNUdmZXN0dXMwpqVTg2cEFJZ0VIZkloVWxVV0VpN1hTb2Y4K2toaW9PYW5PWG80TWxQbGhlT0xjTGlqUzA9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
+                      "host": "orderer.example.com",
+                      "port": 7050,
+                      "server_tls_cert": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN3akNDQW1pZ0F3SUJBZ0lVZG9JbmpzaW5vVnZua0llbE5WUU8wbDRMbEdrd0NnWUlLb1pJemowRUF3SXcKWWpFTE1Ba0dBMVVFQmhNQ1ZWTXhFVEFQQmdOVkJBZ1RDRTVsZHlCWmIzSnJNUkV3RHdZRFZRUUhFd2hPWlhjZwpXVzl5YXpFVU1CSUdBMVVFQ2hNTFpYaGhiWEJzWlM1amIyMHhGekFWQmdOVkJBTVREbU5oTG1WNFlXMXdiR1V1ClkyOXRNQjRYRFRJd01ETXlOREl3TVRnd01Gb1hEVEl4TURNeU5ESXdNak13TUZvd1lERUxNQWtHQTFVRUJoTUMKVlZNeEZ6QVZCZ05WQkFnVERrNXZjblJvSUVOaGNtOXNhVzVoTVJRd0VnWURWUVFLRXd0SWVYQmxjbXhsWkdkbApjakVRTUE0R0ExVUVDeE1IYjNKa1pYSmxjakVRTUE0R0ExVUVBeE1IYjNKa1pYSmxjakJaTUJNR0J5cUdTTTQ5CkFnRUdDQ3FHU000OUF3RUhBMElBQkdGaFd3SllGbHR3clBVellIQ3loNTMvU3VpVU1ZYnVJakdGTWRQMW9FRzMKSkcrUlRSOFR4NUNYTXdpV05sZ285dU00a1NGTzBINURZUWZPQU5MU0o5NmpnZjB3Z2Zvd0RnWURWUjBQQVFILwpCQVFEQWdPb01CMEdBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFNQmdOVkhSTUJBZjhFCkFqQUFNQjBHQTFVZERnUVdCQlJ2M3lNUmh5cHc0Qi9Cc1NHTlVJL0VpU1lNN2pBZkJnTlZIU01FR0RBV2dCUzYKSFYyWEl1VE9rS213azVsNE1rcGpHVzFSbHpBZUJnTlZIUkVFRnpBVmdoTnZjbVJsY21WeUxtVjRZVzF3YkdVdQpZMjl0TUZzR0NDb0RCQVVHQndnQkJFOTdJbUYwZEhKeklqcDdJbWhtTGtGbVptbHNhV0YwYVc5dUlqb2lJaXdpCmFHWXVSVzV5YjJ4c2JXVnVkRWxFSWpvaWIzSmtaWEpsY2lJc0ltaG1MbFI1Y0dVaU9pSnZjbVJsY21WeUluMTkKTUFvR0NDcUdTTTQ5QkFNQ0EwZ0FNRVVDSVFESHNrWUR5clNqeWpkTVVVWDNaT05McXJUNkdCcVNUdmZXN0dXMwpqVTg2cEFJZ0VIZkloVWxVV0VpN1hTb2Y4K2toaW9PYW5PWG80TWxQbGhlT0xjTGlqUzA9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+                    }
+                  ],
+                  "options": {
+                    "election_tick": 10,
+                    "heartbeat_tick": 1,
+                    "max_inflight_blocks": 5,
+                    "snapshot_interval_size": 16777216,
+                    "tick_interval": "500ms"
+                  }
+                },
+                "state": "STATE_NORMAL",
+                "type": "etcdraft"
+              },
+              "version": "0"
+            }
           },
-          "Writers": {
-            "mod_policy": "Admins",
-            "policy": {
-              "type": 3,
-              "value": {
-                "rule": "ANY",
-                "sub_policy": "Writers"
-              }
-            },
-            "version": "0"
-          }
+          "version": "0"
+        }
+      },
+      "mod_policy": "Admins",
+      "policies": {
+        "Admins": {
+          "mod_policy": "Admins",
+          "policy": {
+            "type": 3,
+            "value": {
+              "rule": "MAJORITY",
+              "sub_policy": "Admins"
+            }
+          },
+          "version": "0"
         },
-        "values": {
-          "BatchSize": {
-            "mod_policy": "Admins",
+        "Readers": {
+          "mod_policy": "Admins",
+          "policy": {
+            "type": 3,
             "value": {
-              "absolute_max_bytes": 103809024,
-              "max_message_count": 10,
-              "preferred_max_bytes": 524288
-            },
-            "version": "0"
+              "rule": "ANY",
+              "sub_policy": "Readers"
+            }
           },
-          "BatchTimeout": {
-            "mod_policy": "Admins",
-            "value": {
-              "timeout": "2s"
-            },
-            "version": "0"
-          },
-          "Capabilities": {
-            "mod_policy": "Admins",
-            "value": {
-              "capabilities": {
-                "V1_4_2": {}
-              }
-            },
-            "version": "0"
-          },
-          "ChannelRestrictions": {
-            "mod_policy": "Admins",
-            "value": null,
-            "version": "0"
-          },
-          "ConsensusType": {
-            "mod_policy": "Admins",
-            "value": {
-              "metadata": null,
-              "state": "STATE_NORMAL",
-              "type": "solo"
-            },
-            "version": "0"
-          }
+          "version": "0"
         },
-        "version": "0"
-      }
-    },
-    "mod_policy": "Admins",
-    "policies": {
-      "Admins": {
-        "mod_policy": "Admins",
-        "policy": {
-          "type": 3,
+        "Writers": {
+          "mod_policy": "Admins",
+          "policy": {
+            "type": 3,
+            "value": {
+              "rule": "ANY",
+              "sub_policy": "Writers"
+            }
+          },
+          "version": "0"
+        }
+      },
+      "values": {
+        "BlockDataHashingStructure": {
+          "mod_policy": "Admins",
           "value": {
-            "rule": "MAJORITY",
-            "sub_policy": "Admins"
-          }
+            "width": 4294967295
+          },
+          "version": "0"
         },
-        "version": "0"
-      },
-      "Readers": {
-        "mod_policy": "Admins",
-        "policy": {
-          "type": 3,
+        "Capabilities": {
+          "mod_policy": "Admins",
           "value": {
-            "rule": "ANY",
-            "sub_policy": "Readers"
-          }
+            "capabilities": {
+              "V2_0": {}
+            }
+          },
+          "version": "0"
         },
-        "version": "0"
-      },
-      "Writers": {
-        "mod_policy": "Admins",
-        "policy": {
-          "type": 3,
+        "Consortium": {
+          "mod_policy": "Admins",
           "value": {
-            "rule": "ANY",
-            "sub_policy": "Writers"
-          }
+            "name": "SampleConsortium"
+          },
+          "version": "0"
         },
-        "version": "0"
-      }
+        "HashingAlgorithm": {
+          "mod_policy": "Admins",
+          "value": {
+            "name": "SHA256"
+          },
+          "version": "0"
+        },
+        "OrdererAddresses": {
+          "mod_policy": "/Channel/Orderer/Admins",
+          "value": {
+            "addresses": [
+              "orderer.example.com:7050"
+            ]
+          },
+          "version": "0"
+        }
+      },
+      "version": "0"
     },
-    "values": {
-      "BlockDataHashingStructure": {
-        "mod_policy": "Admins",
-        "value": {
-          "width": 4294967295
-        },
-        "version": "0"
-      },
-      "Capabilities": {
-        "mod_policy": "Admins",
-        "value": {
-          "capabilities": {
-            "V1_4_3": {}
-          }
-        },
-        "version": "0"
-      },
-      "Consortium": {
-        "mod_policy": "Admins",
-        "value": {
-          "name": "SampleConsortium"
-        },
-        "version": "0"
-      },
-      "HashingAlgorithm": {
-        "mod_policy": "Admins",
-        "value": {
-          "name": "SHA256"
-        },
-        "version": "0"
-      },
-      "OrdererAddresses": {
-        "mod_policy": "/Channel/Orderer/Admins",
-        "value": {
-          "addresses": [
-            "orderer.example.com:7050"
-          ]
-        },
-        "version": "0"
-      }
-    },
-    "version": "0"
-  },
-  "sequence": "3"
-}
+    "sequence": "3"
+  }
 ```
 </details>
 


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>

#### Type of change

- Documentation update

#### Description

This tutorial currently uses a Fabric 1.4 channel config. Lets update it to use a 2.0 channel config. the differences are in the new lifecycle endorsement policies.

