### PR TITLE
Optionally silence CLI commands in integration tests

### DIFF
--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -136,6 +136,7 @@ type Profile struct {
 
 // Network holds information about a fabric network.
 type Network struct {
+	SilenceCLI         bool
 	RootDir            string
 	StartPort          uint16
 	Components         *Components
@@ -1552,8 +1553,12 @@ func (n *Network) nextColor() string {
 // command line tools that are expected to run to completion.
 func (n *Network) StartSession(cmd *exec.Cmd, name string) (*gexec.Session, error) {
 	ansiColorCode := n.nextColor()
+	out := ginkgo.GinkgoWriter
+	if n.SilenceCLI {
+		out = ioutil.Discard
+	}
 	fmt.Fprintf(
-		ginkgo.GinkgoWriter,
+		out,
 		"\x1b[33m[d]\x1b[%s[%s]\x1b[0m starting %s %s\n",
 		ansiColorCode,
 		name,
@@ -1564,11 +1569,11 @@ func (n *Network) StartSession(cmd *exec.Cmd, name string) (*gexec.Session, erro
 		cmd,
 		gexec.NewPrefixedWriter(
 			fmt.Sprintf("\x1b[32m[o]\x1b[%s[%s]\x1b[0m ", ansiColorCode, name),
-			ginkgo.GinkgoWriter,
+			out,
 		),
 		gexec.NewPrefixedWriter(
 			fmt.Sprintf("\x1b[91m[e]\x1b[%s[%s]\x1b[0m ", ansiColorCode, name),
-			ginkgo.GinkgoWriter,
+			out,
 		),
 	)
 }


### PR DESCRIPTION
Sometimes during troubleshooting integration tests, we have commands
that either run several times due to Eventually-ies, or are just
chatty (like discover commands that return peers and their information).

This information is many times distracting and makes focusing on the logs
printed by the nodes harder.

This change set adds an option to silence CLIs via a flag.

Change-Id: I3480c4286dc8880b402831c1f9c8de7bd3538feb
Signed-off-by: yacovm <yacovm@il.ibm.com>
