### PR TITLE
Nominate Brett Logan as Fabric maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,7 @@ Maintainers
 | Alessandro Sorniotti | ale-linux | aso | <ale.linux@sopit.net>
 | Artem Barger | c0rwin | c0rwin | <bartem@il.ibm.com>
 | Binh Nguyen | binhn | binhn | <binh1010010110@gmail.com>
+| Brett Logan | btl5037 | btl5037 | <brett.t.logan@ibm.com>
 | Chris Ferris | christo4ferris | cbf | <chris.ferris@gmail.com>
 | Dave Enyeart | denyeart | dave.enyeart | <enyeart@us.ibm.com>
 | Gari Singh | mastersingh24 | mastersingh24 | <gari.r.singh@gmail.com>
@@ -34,6 +35,7 @@ Maintainers
 
 | Name | GitHub | Chat | email
 |------|--------|------|----------------------
+| Brett Logan | btl5037 | btl5037 | <brett.t.logan@ibm.com>
 | Chris Ferris | christo4ferris | cbf | <chris.ferris@gmail.com>
 | Dave Enyeart | denyeart | dave.enyeart | <enyeart@us.ibm.com>
 | Gari Singh | mastersingh24 | mastersingh24 | <gari.r.singh@gmail.com>


### PR DESCRIPTION
Brett has been very active in the Fabric community for over a year.
He has taken an especially deep interest in everything related to Fabric
build, dependencies, CI, test, and release, and led the largest
transformation in these areas in the project's history. Brett drove
the adoption of GitHub, Azure pipelines, and artifactory, a process
that went smoother and quicker than imagined. These contributions
did not stop with the Fabric core project, but extended to all the related
Fabric GitHub projects.
More recently, Brett has been leading the Fabric system test effort,
improving the project's test strategy and coverage, which will help
ensure the project's quality for years to come.
Brett is one of the most active Fabric community builders, spending many
hours helping people in chat and stackoverflow, while also taking
the message on the road to conferences, meetups, and universities.

This nomination will also add Brett to the list of Release Managers,
a role that Brett has already embraced.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>