### PR TITLE
Nominate Danny Cao as Fabric maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,7 @@ Maintainers
 | Artem Barger | c0rwin | c0rwin | <bartem@il.ibm.com>
 | Binh Nguyen | binhn | binhn | <binh1010010110@gmail.com>
 | Chris Ferris | christo4ferris | cbf | <chris.ferris@gmail.com>
+| Danny Cao | caod123 | caod | <dcao@us.ibm.com>
 | Dave Enyeart | denyeart | dave.enyeart | <enyeart@us.ibm.com>
 | Gari Singh | mastersingh24 | mastersingh24 | <gari.r.singh@gmail.com>
 | Jason Yellick | jyellick | jyellick | <jyellick@us.ibm.com>


### PR DESCRIPTION
I would like to nominate Danny Cao as a Fabric maintainer.
Danny dove into the project last year and made significant
contributions in the areas of private data and gossip
dissemination. More recently, Danny has been leading a team
of contributors to add a library for channel configuration,
which has been a long-standing gap in the Fabric project.
Danny spends many hours coaching other contributors on
Go and Fabric internals, and has been an active PR
reviewer already.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
