### PR TITLE
[FAB-17663] Update a consortium group's channel creation policy value

### DIFF
--- a/pkg/config/policies_test.go
+++ b/pkg/config/policies_test.go
@@ -9,6 +9,7 @@ package config
 import (
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	. "github.com/onsi/gomega"
 )
@@ -798,4 +799,95 @@ func TestRemoveOrdererOrgPolicyFailures(t *testing.T) {
 
 	err = c.RemoveOrdererOrgPolicy("bad-org", "TestPolicy")
 	gt.Expect(err).To(MatchError("orderer org bad-org does not exist in channel config"))
+}
+
+func TestUpdateConsortiumChannelCreationPolicy(t *testing.T) {
+	t.Parallel()
+
+	gt := NewGomegaWithT(t)
+
+	consortiums := baseConsortiums(t)
+
+	consortiumsGroup, err := newConsortiumsGroup(consortiums)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	config := &cb.Config{
+		ChannelGroup: &cb.ConfigGroup{
+			Groups: map[string]*cb.ConfigGroup{
+				ConsortiumsGroupKey: consortiumsGroup,
+			},
+		},
+	}
+	c := &ConfigTx{
+		base:    config,
+		updated: config,
+	}
+
+	updatedPolicy := Policy{Type: ImplicitMetaPolicyType, Rule: "MAJORITY Admins"}
+
+	err = c.UpdateConsortiumChannelCreationPolicy("Consortium1", updatedPolicy)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	consortium := c.updated.ChannelGroup.Groups[ConsortiumsGroupKey].Groups["Consortium1"]
+	creationPolicy := consortium.Values[ChannelCreationPolicyKey]
+	policy := &cb.Policy{}
+	err = proto.Unmarshal(creationPolicy.Value, policy)
+	gt.Expect(err).NotTo(HaveOccurred())
+	imp := &cb.ImplicitMetaPolicy{}
+	err = proto.Unmarshal(policy.Value, imp)
+	gt.Expect(err).NotTo(HaveOccurred())
+	gt.Expect(imp.Rule).To(Equal(cb.ImplicitMetaPolicy_MAJORITY))
+	gt.Expect(imp.SubPolicy).To(Equal("Admins"))
+}
+
+func TestUpdateConsortiumChannelCreationPolicyFailures(t *testing.T) {
+	t.Parallel()
+
+	gt := NewGomegaWithT(t)
+
+	consortiums := baseConsortiums(t)
+
+	consortiumsGroup, err := newConsortiumsGroup(consortiums)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	config := &cb.Config{
+		ChannelGroup: &cb.ConfigGroup{
+			Groups: map[string]*cb.ConfigGroup{
+				ConsortiumsGroupKey: consortiumsGroup,
+			},
+		},
+	}
+	c := &ConfigTx{
+		base:    config,
+		updated: config,
+	}
+
+	tests := []struct {
+		name           string
+		consortiumName string
+		updatedpolicy  Policy
+		expectedErr    string
+	}{
+		{
+			name:           "when consortium does not exist in channel config",
+			consortiumName: "badConsortium",
+			updatedpolicy:  Policy{Type: ImplicitMetaPolicyType, Rule: "MAJORITY Admins"},
+			expectedErr:    "consortium badConsortium does not exist in channel config",
+		},
+		{
+			name:           "when policy is invalid",
+			consortiumName: "Consortium1",
+			updatedpolicy:  Policy{Type: ImplicitMetaPolicyType, Rule: "Bad Admins"},
+			expectedErr:    "invalid implicit meta policy rule 'Bad Admins': unknown rule type 'Bad', expected ALL, ANY, or MAJORITY",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			gt := NewGomegaWithT(t)
+			err := c.UpdateConsortiumChannelCreationPolicy(tt.consortiumName, tt.updatedpolicy)
+			gt.Expect(err).To(MatchError(tt.expectedErr))
+		})
+	}
 }


### PR DESCRIPTION
Signed-off-by: xu wu <wuxu1103@163.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- New feature

#### Description

The consortiums group is only defined in system channel. Therefore, I defined a function fetchSystemChannelConfig, which constructs a system channel information. Now it only has information related to the channel creation policy. Other information will be added when needed.

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

https://jira.hyperledger.org/browse/FAB-17663

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
