### PR TITLE
Move keys.go Utility to SW package

### DIFF
--- a/bccsp/pkcs11/impl_test.go
+++ b/bccsp/pkcs11/impl_test.go
@@ -743,7 +743,7 @@ func TestECDSAKeyImportFromECDSAPublicKey(t *testing.T) {
 		t.Fatalf("Failed getting ECDSA raw public key [%s]", err)
 	}
 
-	pub, err := utils.DERToPublicKey(pkRaw)
+	pub, err := x509.ParsePKIXPublicKey(pkRaw)
 	if err != nil {
 		t.Fatalf("Failed converting raw to ecdsa.PublicKey [%s]", err)
 	}
@@ -862,7 +862,7 @@ func TestKeyImportFromX509ECDSAPublicKey(t *testing.T) {
 		t.Fatalf("Failed getting ECDSA raw public key [%s]", err)
 	}
 
-	pub, err := utils.DERToPublicKey(pkRaw)
+	pub, err := x509.ParsePKIXPublicKey(pkRaw)
 	if err != nil {
 		t.Fatalf("Failed converting raw to ECDSA.PublicKey [%s]", err)
 	}

--- a/bccsp/signer/signer.go
+++ b/bccsp/signer/signer.go
@@ -8,10 +8,10 @@ package signer
 
 import (
 	"crypto"
+	"crypto/x509"
 	"io"
 
 	"github.com/hyperledger/fabric/bccsp"
-	"github.com/hyperledger/fabric/bccsp/utils"
 	"github.com/pkg/errors"
 )
 
@@ -47,7 +47,7 @@ func New(csp bccsp.BCCSP, key bccsp.Key) (crypto.Signer, error) {
 		return nil, errors.Wrap(err, "failed marshalling public key")
 	}
 
-	pk, err := utils.DERToPublicKey(raw)
+	pk, err := x509.ParsePKIXPublicKey(raw)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed marshalling der to public key")
 	}

--- a/bccsp/signer/signer_test.go
+++ b/bccsp/signer/signer_test.go
@@ -1,29 +1,20 @@
 /*
-Copyright IBM Corp. 2016 All Rights Reserved.
+Copyright the Hyperledger Fabric contributors. All rights reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-		 http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
 */
+
 package signer
 
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/x509"
 	"errors"
 	"testing"
 
 	"github.com/hyperledger/fabric/bccsp/mocks"
-	"github.com/hyperledger/fabric/bccsp/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,7 +43,7 @@ func TestInitFailures(t *testing.T) {
 func TestInit(t *testing.T) {
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	assert.NoError(t, err)
-	pkRaw, err := utils.PublicKeyToDER(&k.PublicKey)
+	pkRaw, err := x509.MarshalPKIXPublicKey(&k.PublicKey)
 	assert.NoError(t, err)
 
 	signer, err := New(&mocks.MockBCCSP{}, &mocks.MockKey{PK: &mocks.MockKey{BytesValue: pkRaw}})

--- a/bccsp/sw/aes_test.go
+++ b/bccsp/sw/aes_test.go
@@ -1,18 +1,9 @@
 /*
-Copyright IBM Corp. 2016 All Rights Reserved.
+Copyright the Hyperledger Fabric contributors. All rights reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-		 http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
 */
+
 package sw
 
 import (
@@ -26,7 +17,6 @@ import (
 
 	"github.com/hyperledger/fabric/bccsp"
 	"github.com/hyperledger/fabric/bccsp/mocks"
-	"github.com/hyperledger/fabric/bccsp/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -519,8 +509,8 @@ func TestVariousAESKeyEncoding(t *testing.T) {
 	}
 
 	// PEM format
-	pem := utils.AEStoPEM(key)
-	keyFromPEM, err := utils.PEMtoAES(pem, nil)
+	pem := aesToPEM(key)
+	keyFromPEM, err := pemToAES(pem, nil)
 	if err != nil {
 		t.Fatalf("Failed converting PEM to AES key [%s]", err)
 	}
@@ -529,11 +519,11 @@ func TestVariousAESKeyEncoding(t *testing.T) {
 	}
 
 	// Encrypted PEM format
-	pem, err = utils.AEStoEncryptedPEM(key, []byte("passwd"))
+	pem, err = aesToEncryptedPEM(key, []byte("passwd"))
 	if err != nil {
 		t.Fatalf("Failed converting AES key to Encrypted PEM [%s]", err)
 	}
-	keyFromPEM, err = utils.PEMtoAES(pem, []byte("passwd"))
+	keyFromPEM, err = pemToAES(pem, []byte("passwd"))
 	if err != nil {
 		t.Fatalf("Failed converting encrypted PEM to AES key [%s]", err)
 	}

--- a/bccsp/sw/fileks.go
+++ b/bccsp/sw/fileks.go
@@ -217,7 +217,7 @@ func (ks *fileBasedKeyStore) searchKeystoreForSKI(ski []byte) (k bccsp.Key, err 
 			continue
 		}
 
-		key, err := utils.PEMtoPrivateKey(raw, ks.pwd)
+		key, err := pemToPrivateKey(raw, ks.pwd)
 		if err != nil {
 			continue
 		}
@@ -258,7 +258,7 @@ func (ks *fileBasedKeyStore) getSuffix(alias string) string {
 }
 
 func (ks *fileBasedKeyStore) storePrivateKey(alias string, privateKey interface{}) error {
-	rawKey, err := utils.PrivateKeyToPEM(privateKey, ks.pwd)
+	rawKey, err := privateKeyToPEM(privateKey, ks.pwd)
 	if err != nil {
 		logger.Errorf("Failed converting private key to PEM [%s]: [%s]", alias, err)
 		return err
@@ -274,7 +274,7 @@ func (ks *fileBasedKeyStore) storePrivateKey(alias string, privateKey interface{
 }
 
 func (ks *fileBasedKeyStore) storePublicKey(alias string, publicKey interface{}) error {
-	rawKey, err := utils.PublicKeyToPEM(publicKey, ks.pwd)
+	rawKey, err := publicKeyToPEM(publicKey, ks.pwd)
 	if err != nil {
 		logger.Errorf("Failed converting public key to PEM [%s]: [%s]", alias, err)
 		return err
@@ -290,7 +290,7 @@ func (ks *fileBasedKeyStore) storePublicKey(alias string, publicKey interface{})
 }
 
 func (ks *fileBasedKeyStore) storeKey(alias string, key []byte) error {
-	pem, err := utils.AEStoEncryptedPEM(key, ks.pwd)
+	pem, err := aesToEncryptedPEM(key, ks.pwd)
 	if err != nil {
 		logger.Errorf("Failed converting key to PEM [%s]: [%s]", alias, err)
 		return err
@@ -316,7 +316,7 @@ func (ks *fileBasedKeyStore) loadPrivateKey(alias string) (interface{}, error) {
 		return nil, err
 	}
 
-	privateKey, err := utils.PEMtoPrivateKey(raw, ks.pwd)
+	privateKey, err := pemToPrivateKey(raw, ks.pwd)
 	if err != nil {
 		logger.Errorf("Failed parsing private key [%s]: [%s].", alias, err.Error())
 
@@ -337,7 +337,7 @@ func (ks *fileBasedKeyStore) loadPublicKey(alias string) (interface{}, error) {
 		return nil, err
 	}
 
-	privateKey, err := utils.PEMtoPublicKey(raw, ks.pwd)
+	privateKey, err := pemToPublicKey(raw, ks.pwd)
 	if err != nil {
 		logger.Errorf("Failed parsing private key [%s]: [%s].", alias, err.Error())
 
@@ -358,7 +358,7 @@ func (ks *fileBasedKeyStore) loadKey(alias string) ([]byte, error) {
 		return nil, err
 	}
 
-	key, err := utils.PEMtoAES(pem, ks.pwd)
+	key, err := pemToAES(pem, ks.pwd)
 	if err != nil {
 		logger.Errorf("Failed parsing key [%s]: [%s]", alias, err)
 

--- a/bccsp/sw/fileks_test.go
+++ b/bccsp/sw/fileks_test.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/hyperledger/fabric/bccsp/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -72,11 +71,11 @@ func TestBigKeyFile(t *testing.T) {
 
 	cspKey := &ecdsaPrivateKey{privKey}
 	ski := cspKey.SKI()
-	rawKey, err := utils.PrivateKeyToPEM(privKey, nil)
+	rawKey, err := privateKeyToPEM(privKey, nil)
 	assert.NoError(t, err)
 
 	// Large padding array, of some values PEM parser will NOOP
-	bigBuff := make([]byte, (1 << 17))
+	bigBuff := make([]byte, 1<<17)
 	for i := range bigBuff {
 		bigBuff[i] = '\n'
 	}

--- a/bccsp/sw/impl_test.go
+++ b/bccsp/sw/impl_test.go
@@ -697,7 +697,7 @@ func TestECDSAKeyImportFromECDSAPublicKey(t *testing.T) {
 		t.Fatalf("Failed getting ECDSA raw public key [%s]", err)
 	}
 
-	pub, err := utils.DERToPublicKey(pkRaw)
+	pub, err := derToPublicKey(pkRaw)
 	if err != nil {
 		t.Fatalf("Failed converting raw to ecdsa.PublicKey [%s]", err)
 	}
@@ -745,7 +745,7 @@ func TestECDSAKeyImportFromECDSAPrivateKey(t *testing.T) {
 	}
 
 	// Import the ecdsa.PrivateKey
-	priv, err := utils.PrivateKeyToDER(key)
+	priv, err := privateKeyToDER(key)
 	if err != nil {
 		t.Fatalf("Failed converting raw to ecdsa.PrivateKey [%s]", err)
 	}
@@ -759,7 +759,7 @@ func TestECDSAKeyImportFromECDSAPrivateKey(t *testing.T) {
 	}
 
 	// Import the ecdsa.PublicKey
-	pub, err := utils.PublicKeyToDER(&key.PublicKey)
+	pub, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
 	if err != nil {
 		t.Fatalf("Failed converting raw to ecdsa.PublicKey [%s]", err)
 	}
@@ -879,7 +879,7 @@ func TestKeyImportFromX509ECDSAPublicKey(t *testing.T) {
 		t.Fatalf("Failed getting ECDSA raw public key [%s]", err)
 	}
 
-	pub, err := utils.DERToPublicKey(pkRaw)
+	pub, err := derToPublicKey(pkRaw)
 	if err != nil {
 		t.Fatalf("Failed converting raw to ECDSA.PublicKey [%s]", err)
 	}

--- a/bccsp/sw/keyimport.go
+++ b/bccsp/sw/keyimport.go
@@ -63,7 +63,7 @@ func (*ecdsaPKIXPublicKeyImportOptsKeyImporter) KeyImport(raw interface{}, opts 
 		return nil, errors.New("Invalid raw. It must not be nil.")
 	}
 
-	lowLevelKey, err := utils.DERToPublicKey(der)
+	lowLevelKey, err := derToPublicKey(der)
 	if err != nil {
 		return nil, fmt.Errorf("Failed converting PKIX to ECDSA public key [%s]", err)
 	}
@@ -88,7 +88,7 @@ func (*ecdsaPrivateKeyImportOptsKeyImporter) KeyImport(raw interface{}, opts bcc
 		return nil, errors.New("[ECDSADERPrivateKeyImportOpts] Invalid raw. It must not be nil.")
 	}
 
-	lowLevelKey, err := utils.DERToPrivateKey(der)
+	lowLevelKey, err := derToPrivateKey(der)
 	if err != nil {
 		return nil, fmt.Errorf("Failed converting PKIX to ECDSA public key [%s]", err)
 	}

--- a/bccsp/sw/keys_test.go
+++ b/bccsp/sw/keys_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package utils
+package sw
 
 import (
 	"crypto/ecdsa"
@@ -95,11 +95,11 @@ func TestECDSAKeys(t *testing.T) {
 	}
 
 	// Private Key DER format
-	der, err := PrivateKeyToDER(key)
+	der, err := privateKeyToDER(key)
 	if err != nil {
 		t.Fatalf("Failed converting private key to DER [%s]", err)
 	}
-	keyFromDER, err := DERToPrivateKey(der)
+	keyFromDER, err := derToPrivateKey(der)
 	if err != nil {
 		t.Fatalf("Failed converting DER to private key [%s]", err)
 	}
@@ -116,7 +116,7 @@ func TestECDSAKeys(t *testing.T) {
 	}
 
 	// Private Key PEM format
-	rawPEM, err := PrivateKeyToPEM(key, nil)
+	rawPEM, err := privateKeyToPEM(key, nil)
 	if err != nil {
 		t.Fatalf("Failed converting private key to PEM [%s]", err)
 	}
@@ -128,7 +128,7 @@ func TestECDSAKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to parse PKCS#8 private key [%s]", err)
 	}
-	keyFromPEM, err := PEMtoPrivateKey(rawPEM, nil)
+	keyFromPEM, err := pemToPrivateKey(rawPEM, nil)
 	if err != nil {
 		t.Fatalf("Failed converting DER to private key [%s]", err)
 	}
@@ -145,49 +145,49 @@ func TestECDSAKeys(t *testing.T) {
 	}
 
 	// Nil Private Key <-> PEM
-	_, err = PrivateKeyToPEM(nil, nil)
+	_, err = privateKeyToPEM(nil, nil)
 	if err == nil {
 		t.Fatal("PublicKeyToPEM should fail on nil")
 	}
 
-	_, err = PrivateKeyToPEM((*ecdsa.PrivateKey)(nil), nil)
+	_, err = privateKeyToPEM((*ecdsa.PrivateKey)(nil), nil)
 	if err == nil {
 		t.Fatal("PrivateKeyToPEM should fail on nil")
 	}
 
-	_, err = PEMtoPrivateKey(nil, nil)
+	_, err = pemToPrivateKey(nil, nil)
 	if err == nil {
 		t.Fatal("PEMtoPublicKey should fail on nil")
 	}
 
-	_, err = PEMtoPrivateKey([]byte{0, 1, 3, 4}, nil)
+	_, err = pemToPrivateKey([]byte{0, 1, 3, 4}, nil)
 	if err == nil {
 		t.Fatal("PEMtoPublicKey should fail invalid PEM")
 	}
 
-	_, err = DERToPrivateKey(nil)
+	_, err = derToPrivateKey(nil)
 	if err == nil {
 		t.Fatal("DERToPrivateKey should fail on nil")
 	}
 
-	_, err = DERToPrivateKey([]byte{0, 1, 3, 4})
+	_, err = derToPrivateKey([]byte{0, 1, 3, 4})
 	if err == nil {
 		t.Fatal("DERToPrivateKey should fail on invalid DER")
 	}
 
-	_, err = PrivateKeyToDER(nil)
+	_, err = privateKeyToDER(nil)
 	if err == nil {
 		t.Fatal("DERToPrivateKey should fail on nil")
 	}
 
 	// Private Key Encrypted PEM format
-	encPEM, err := PrivateKeyToPEM(key, []byte("passwd"))
+	encPEM, err := privateKeyToPEM(key, []byte("passwd"))
 	if err != nil {
 		t.Fatalf("Failed converting private key to encrypted PEM [%s]", err)
 	}
-	_, err = PEMtoPrivateKey(encPEM, nil)
+	_, err = pemToPrivateKey(encPEM, nil)
 	assert.Error(t, err)
-	encKeyFromPEM, err := PEMtoPrivateKey(encPEM, []byte("passwd"))
+	encKeyFromPEM, err := pemToPrivateKey(encPEM, []byte("passwd"))
 	if err != nil {
 		t.Fatalf("Failed converting DER to private key [%s]", err)
 	}
@@ -204,7 +204,7 @@ func TestECDSAKeys(t *testing.T) {
 	}
 
 	// Public Key PEM format
-	rawPEM, err = PublicKeyToPEM(&key.PublicKey, nil)
+	rawPEM, err = publicKeyToPEM(&key.PublicKey, nil)
 	if err != nil {
 		t.Fatalf("Failed converting public key to PEM [%s]", err)
 	}
@@ -212,7 +212,7 @@ func TestECDSAKeys(t *testing.T) {
 	if pemBlock.Type != "PUBLIC KEY" {
 		t.Fatalf("Expected type 'PUBLIC KEY' but found '%s'", pemBlock.Type)
 	}
-	keyFromPEM, err = PEMtoPublicKey(rawPEM, nil)
+	keyFromPEM, err = pemToPublicKey(rawPEM, nil)
 	if err != nil {
 		t.Fatalf("Failed converting DER to public key [%s]", err)
 	}
@@ -226,29 +226,29 @@ func TestECDSAKeys(t *testing.T) {
 	}
 
 	// Nil Public Key <-> PEM
-	_, err = PublicKeyToPEM(nil, nil)
+	_, err = publicKeyToPEM(nil, nil)
 	if err == nil {
 		t.Fatal("PublicKeyToPEM should fail on nil")
 	}
 
-	_, err = PEMtoPublicKey(nil, nil)
+	_, err = pemToPublicKey(nil, nil)
 	if err == nil {
 		t.Fatal("PEMtoPublicKey should fail on nil")
 	}
 
-	_, err = PEMtoPublicKey([]byte{0, 1, 3, 4}, nil)
+	_, err = pemToPublicKey([]byte{0, 1, 3, 4}, nil)
 	if err == nil {
 		t.Fatal("PEMtoPublicKey should fail on invalid PEM")
 	}
 
 	// Public Key Encrypted PEM format
-	encPEM, err = PublicKeyToPEM(&key.PublicKey, []byte("passwd"))
+	encPEM, err = publicKeyToPEM(&key.PublicKey, []byte("passwd"))
 	if err != nil {
 		t.Fatalf("Failed converting private key to encrypted PEM [%s]", err)
 	}
-	_, err = PEMtoPublicKey(encPEM, nil)
+	_, err = pemToPublicKey(encPEM, nil)
 	assert.Error(t, err)
-	pkFromEncPEM, err := PEMtoPublicKey(encPEM, []byte("passwd"))
+	pkFromEncPEM, err := pemToPublicKey(encPEM, []byte("passwd"))
 	if err != nil {
 		t.Fatalf("Failed converting DER to private key [%s]", err)
 	}
@@ -261,35 +261,35 @@ func TestECDSAKeys(t *testing.T) {
 		t.Fatal("Failed converting encrypted PEM to private key. Invalid Y coordinate.")
 	}
 
-	_, err = PEMtoPublicKey(encPEM, []byte("passw"))
+	_, err = pemToPublicKey(encPEM, []byte("passw"))
 	if err == nil {
 		t.Fatal("PEMtoPublicKey should fail on wrong password")
 	}
 
-	_, err = PEMtoPublicKey(encPEM, []byte("passw"))
+	_, err = pemToPublicKey(encPEM, []byte("passw"))
 	if err == nil {
 		t.Fatal("PEMtoPublicKey should fail on nil password")
 	}
 
-	_, err = PEMtoPublicKey(nil, []byte("passwd"))
+	_, err = pemToPublicKey(nil, []byte("passwd"))
 	if err == nil {
 		t.Fatal("PEMtoPublicKey should fail on nil PEM")
 	}
 
-	_, err = PEMtoPublicKey([]byte{0, 1, 3, 4}, []byte("passwd"))
+	_, err = pemToPublicKey([]byte{0, 1, 3, 4}, []byte("passwd"))
 	if err == nil {
 		t.Fatal("PEMtoPublicKey should fail on invalid PEM")
 	}
 
-	_, err = PEMtoPublicKey(nil, []byte("passw"))
+	_, err = pemToPublicKey(nil, []byte("passw"))
 	if err == nil {
 		t.Fatal("PEMtoPublicKey should fail on nil PEM and wrong password")
 	}
 
 	// Public Key DER format
-	der, err = PublicKeyToDER(&key.PublicKey)
+	der, err = x509.MarshalPKIXPublicKey(&key.PublicKey)
 	assert.NoError(t, err)
-	keyFromDER, err = DERToPublicKey(der)
+	keyFromDER, err = derToPublicKey(der)
 	assert.NoError(t, err)
 	ecdsaPkFromPEM = keyFromDER.(*ecdsa.PublicKey)
 	// TODO: check the curve
@@ -303,76 +303,69 @@ func TestECDSAKeys(t *testing.T) {
 
 func TestAESKey(t *testing.T) {
 	k := []byte{0, 1, 2, 3, 4, 5}
-	pem := AEStoPEM(k)
+	pem := aesToPEM(k)
 
-	k2, err := PEMtoAES(pem, nil)
+	k2, err := pemToAES(pem, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, k, k2)
 
-	pem, err = AEStoEncryptedPEM(k, k)
+	pem, err = aesToEncryptedPEM(k, k)
 	assert.NoError(t, err)
 
-	k2, err = PEMtoAES(pem, k)
+	k2, err = pemToAES(pem, k)
 	assert.NoError(t, err)
 	assert.Equal(t, k, k2)
 
-	_, err = PEMtoAES(pem, nil)
+	_, err = pemToAES(pem, nil)
 	assert.Error(t, err)
 
-	_, err = AEStoEncryptedPEM(k, nil)
+	_, err = aesToEncryptedPEM(k, nil)
 	assert.NoError(t, err)
 
-	k2, err = PEMtoAES(pem, k)
+	k2, err = pemToAES(pem, k)
 	assert.NoError(t, err)
 	assert.Equal(t, k, k2)
 }
 
 func TestDERToPublicKey(t *testing.T) {
-	_, err := DERToPublicKey(nil)
+	_, err := derToPublicKey(nil)
 	assert.Error(t, err)
 }
 
 func TestNil(t *testing.T) {
-	_, err := PrivateKeyToEncryptedPEM(nil, nil)
+	_, err := privateKeyToEncryptedPEM(nil, nil)
 	assert.Error(t, err)
 
-	_, err = PrivateKeyToEncryptedPEM((*ecdsa.PrivateKey)(nil), nil)
+	_, err = privateKeyToEncryptedPEM((*ecdsa.PrivateKey)(nil), nil)
 	assert.Error(t, err)
 
-	_, err = PrivateKeyToEncryptedPEM("Hello World", nil)
+	_, err = privateKeyToEncryptedPEM("Hello World", nil)
 	assert.Error(t, err)
 
-	_, err = PEMtoAES(nil, nil)
+	_, err = pemToAES(nil, nil)
 	assert.Error(t, err)
 
-	_, err = AEStoEncryptedPEM(nil, nil)
+	_, err = aesToEncryptedPEM(nil, nil)
 	assert.Error(t, err)
 
-	_, err = PublicKeyToPEM(nil, nil)
+	_, err = publicKeyToPEM(nil, nil)
 	assert.Error(t, err)
-	_, err = PublicKeyToPEM((*ecdsa.PublicKey)(nil), nil)
+	_, err = publicKeyToPEM((*ecdsa.PublicKey)(nil), nil)
 	assert.Error(t, err)
-	_, err = PublicKeyToPEM(nil, []byte("hello world"))
-	assert.Error(t, err)
-
-	_, err = PublicKeyToPEM("hello world", nil)
-	assert.Error(t, err)
-	_, err = PublicKeyToPEM("hello world", []byte("hello world"))
+	_, err = publicKeyToPEM(nil, []byte("hello world"))
 	assert.Error(t, err)
 
-	_, err = PublicKeyToDER(nil)
+	_, err = publicKeyToPEM("hello world", nil)
 	assert.Error(t, err)
-	_, err = PublicKeyToDER((*ecdsa.PublicKey)(nil))
-	assert.Error(t, err)
-	_, err = PublicKeyToDER("hello world")
+	_, err = publicKeyToPEM("hello world", []byte("hello world"))
 	assert.Error(t, err)
 
-	_, err = PublicKeyToEncryptedPEM(nil, nil)
+	_, err = publicKeyToEncryptedPEM(nil, nil)
 	assert.Error(t, err)
-	_, err = PublicKeyToEncryptedPEM((*ecdsa.PublicKey)(nil), nil)
+	_, err = publicKeyToEncryptedPEM((*ecdsa.PublicKey)(nil), nil)
 	assert.Error(t, err)
-	_, err = PublicKeyToEncryptedPEM("hello world", nil)
+	_, err = publicKeyToEncryptedPEM("hello world", nil)
 	assert.Error(t, err)
-	_, err = PublicKeyToEncryptedPEM("hello world", []byte("Hello world"))
+	_, err = publicKeyToEncryptedPEM("hello world", []byte("Hello world"))
 	assert.Error(t, err)
 }

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -22,6 +22,8 @@ jobs:
       - checkout: self
         path: 'go/src/github.com/hyperledger/fabric'
         displayName: Checkout Fabric Code
+      - script: cat bccsp/sw/fileks.go | head -n 25
+      - script: git log -n 5
       - script: make basic-checks native
         displayName: Run Basic Checks
       - script: ./ci/scripts/evaluate_commits.sh


### PR DESCRIPTION
Moves the keys.go utility to the SW package where the majority the consumers are and kills off production code that existed entirely for driving tests.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
