### PR TITLE
Add jq to the vagrant development environment

### DIFF
--- a/vagrant/essentials.sh
+++ b/vagrant/essentials.sh
@@ -21,6 +21,7 @@ apt-get install -y \
     curl \
     g++ \
     git \
+    jq \
     libtool \
     make \
     unzip


### PR DESCRIPTION
Install `jq` as required by the integration tests.