### PR TITLE
Update doc for Go v1.14.1

### DIFF
--- a/docs/source/commands/peerversion.md
+++ b/docs/source/commands/peerversion.md
@@ -8,7 +8,7 @@ information. For example:
  peer:
    Version: 2.1.0
    Commit SHA: b78d79b
-   Go version: go1.13.8
+   Go version: go1.14.1
    OS/Arch: linux/amd64
    Chaincode:
     Base Docker Label: org.hyperledger.fabric

--- a/docs/source/prereqs.rst
+++ b/docs/source/prereqs.rst
@@ -83,7 +83,7 @@ Go Programming Language
 Hyperledger Fabric uses the Go Programming Language for many of its
 components.
 
-  - `Go <https://golang.org/dl/>`__ version 1.13.x is required.
+  - `Go <https://golang.org/dl/>`__ version 1.14.x is required.
 
 Given that we will be writing chaincode programs in Go, there are two
 environment variables you will need to set properly; you can make these

--- a/docs/wrappers/peer_version_preamble.md
+++ b/docs/wrappers/peer_version_preamble.md
@@ -8,7 +8,7 @@ information. For example:
  peer:
    Version: 2.1.0
    Commit SHA: b78d79b
-   Go version: go1.13.8
+   Go version: go1.14.1
    OS/Arch: linux/amd64
    Chaincode:
     Base Docker Label: org.hyperledger.fabric


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

https://github.com/hyperledger/fabric/pull/934 updated Go to
v1.14.1. This change updates docs accordingly.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
