### PR TITLE
Update commercial_paper.md

### DIFF
--- a/docs/source/tutorial/commercial_paper.md
+++ b/docs/source/tutorial/commercial_paper.md
@@ -518,14 +518,14 @@ DigiBank admin:
 The DigiBank administrator uses the `peer lifecycle chaincode commit` command
 to commit the chaincode definition of `papercontract` to `mychannel`:
 ```
-(magnetocorp admin)$ peer lifecycle chaincode commit -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --peerAddresses localhost:7051 --tlsRootCertFiles ${PEER0_ORG1_CA} --peerAddresses localhost:9051 --tlsRootCertFiles ${PEER0_ORG2_CA} --channelID mychannel --name papercontract -v 0 --sequence 1 --tls --cafile $ORDERER_CA --waitForEvent
+(digibank admin)$ peer lifecycle chaincode commit -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --peerAddresses localhost:7051 --tlsRootCertFiles ${PEER0_ORG1_CA} --peerAddresses localhost:9051 --tlsRootCertFiles ${PEER0_ORG2_CA} --channelID mychannel --name papercontract -v 0 --sequence 1 --tls --cafile $ORDERER_CA --waitForEvent
 ```
 The chaincode container will start after the chaincode definition has been
 committed to the channel. You can use the `docker ps` command to see
 `papercontract` container starting on both peers.
 
 ```
-(magnetocorp admin)$ docker ps
+(digibank admin)$ docker ps
 
 CONTAINER ID        IMAGE                                                                                                                                                               COMMAND                  CREATED             STATUS              PORTS                                        NAMES
 d4ba9dc9c55f        dev-peer0.org1.example.com-cp_0-ebef35e7f1f25eea1dcc6fcad5019477cd7f434c6a5dcaf4e81744e282903535-05cf67c20543ee1c24cf7dfe74abce99785374db15b3bc1de2da372700c25608   "docker-entrypoint.s…"   30 seconds ago      Up 28 seconds                                                    dev-peer0.org1.example.com-cp_0-ebef35e7f1f25eea1dcc6fcad5019477cd7f434c6a5dcaf4e81744e282903535


### PR DESCRIPTION
Minor typo on lines 521 and 528. Changed from (magnetocorp admin) to (digibank admin)

Signed-off-by: JoeFlux <sunilvb@gmail.com>
Signed-off-by: Ry Jones <ry@linux.com>


#### Type of change


#### Description

Cherry pick documentation fix