### PR TITLE
Refactor MSP-related pkg/config functions

### DIFF
--- a/pkg/config/application_test.go
+++ b/pkg/config/application_test.go
@@ -833,7 +833,7 @@ func TestAddApplicationOrg(t *testing.T) {
 		},
 	}
 
-	certBase64, pkBase64, crlBase64 := certPrivKeyCRLBase64(org.MSP)
+	certBase64, pkBase64, crlBase64 := certPrivKeyCRLBase64(t, org.MSP)
 	expectedConfigJSON := fmt.Sprintf(`
 {
 	"groups": {},

--- a/pkg/config/capabilities_test.go
+++ b/pkg/config/capabilities_test.go
@@ -280,7 +280,7 @@ func TestAddOrdererCapability(t *testing.T) {
 	c := New(config)
 
 	ordererOrgMSP := baseOrdererConf.Organizations[0].MSP
-	orgCertBase64, orgPKBase64, orgCRLBase64 := certPrivKeyCRLBase64(ordererOrgMSP)
+	orgCertBase64, orgPKBase64, orgCRLBase64 := certPrivKeyCRLBase64(t, ordererOrgMSP)
 
 	expectedConfigGroupJSON := fmt.Sprintf(`{
 	"groups": {
@@ -850,7 +850,7 @@ func TestRemoveOrdererCapability(t *testing.T) {
 	c := New(config)
 
 	ordererOrgMSP := baseOrdererConf.Organizations[0].MSP
-	orgCertBase64, orgPKBase64, orgCRLBase64 := certPrivKeyCRLBase64(ordererOrgMSP)
+	orgCertBase64, orgPKBase64, orgCRLBase64 := certPrivKeyCRLBase64(t, ordererOrgMSP)
 
 	expectedConfigGroupJSON := fmt.Sprintf(`{
 	"groups": {

--- a/pkg/config/consortiums_test.go
+++ b/pkg/config/consortiums_test.go
@@ -78,8 +78,8 @@ func TestAddOrgToConsortium(t *testing.T) {
 	gt := NewGomegaWithT(t)
 
 	consortiums := baseConsortiums(t)
-	org1CertBase64, org1PKBase64, org1CRLBase64 := certPrivKeyCRLBase64(consortiums[0].Organizations[0].MSP)
-	org2CertBase64, org2PKBase64, org2CRLBase64 := certPrivKeyCRLBase64(consortiums[0].Organizations[1].MSP)
+	org1CertBase64, org1PKBase64, org1CRLBase64 := certPrivKeyCRLBase64(t, consortiums[0].Organizations[0].MSP)
+	org2CertBase64, org2PKBase64, org2CRLBase64 := certPrivKeyCRLBase64(t, consortiums[0].Organizations[1].MSP)
 
 	consortiumsGroup, err := newConsortiumsGroup(consortiums)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -104,7 +104,7 @@ func TestAddOrgToConsortium(t *testing.T) {
 		Policies: orgStandardPolicies(),
 		MSP:      baseMSP(t),
 	}
-	org3CertBase64, org3PKBase64, org3CRLBase64 := certPrivKeyCRLBase64(orgToAdd.MSP)
+	org3CertBase64, org3PKBase64, org3CRLBase64 := certPrivKeyCRLBase64(t, orgToAdd.MSP)
 
 	expectedConfigJSON := fmt.Sprintf(`
 {

--- a/pkg/config/example_test.go
+++ b/pkg/config/example_test.go
@@ -1006,11 +1006,11 @@ func ExampleConfigTx_RemoveOrdererCapability() {
 	}
 }
 
-func ExampleConfigTx_UpdateMSP() {
+func ExampleConfigTx_UpdateApplicationMSP() {
 	baseConfig := fetchChannelConfig()
 	c := config.New(baseConfig)
 
-	msp, err := c.GetMSPConfigurationForApplicationOrg("Org1")
+	msp, err := c.ApplicationMSP("Org1")
 	if err != nil {
 		panic(err)
 	}
@@ -1022,7 +1022,7 @@ func ExampleConfigTx_UpdateMSP() {
 
 	msp.IntermediateCerts = append(msp.IntermediateCerts, newIntermediateCert)
 
-	err = c.UpdateMSP(msp, "Org1")
+	err = c.UpdateApplicationMSP(msp, "Org1")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/config/msp_test.go
+++ b/pkg/config/msp_test.go
@@ -14,7 +14,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"fmt"
-	"log"
 	"math/big"
 	"testing"
 	"time"
@@ -26,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestGetMSPConfigurationForApplicationOrg(t *testing.T) {
+func TestApplicationMSP(t *testing.T) {
 	t.Parallel()
 
 	gt := NewGomegaWithT(t)
@@ -65,12 +64,12 @@ func TestGetMSPConfigurationForApplicationOrg(t *testing.T) {
 		updated: config,
 	}
 
-	msp, err := c.GetMSPConfigurationForApplicationOrg("Org1")
+	msp, err := c.ApplicationMSP("Org1")
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(msp).To(Equal(expectedMSP))
 }
 
-func TestGetMSPConfigurationForOrdererOrg(t *testing.T) {
+func TestOrdererMSP(t *testing.T) {
 	t.Parallel()
 
 	gt := NewGomegaWithT(t)
@@ -94,12 +93,12 @@ func TestGetMSPConfigurationForOrdererOrg(t *testing.T) {
 		updated: config,
 	}
 
-	msp, err := c.GetMSPConfigurationForOrdererOrg("OrdererOrg")
+	msp, err := c.OrdererMSP("OrdererOrg")
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(msp).To(Equal(expectedMSP))
 }
 
-func TestGetMSPConfigurationForConsortiumOrg(t *testing.T) {
+func TestConsortiumMSP(t *testing.T) {
 	t.Parallel()
 
 	gt := NewGomegaWithT(t)
@@ -123,7 +122,7 @@ func TestGetMSPConfigurationForConsortiumOrg(t *testing.T) {
 		updated: config,
 	}
 
-	msp, err := c.GetMSPConfigurationForConsortiumOrg("Consortium1", "Org1")
+	msp, err := c.ConsortiumMSP("Consortium1", "Org1")
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(msp).To(Equal(expectedMSP))
 }
@@ -320,13 +319,13 @@ func TestGetMSPConfigurationFailures(t *testing.T) {
 
 			switch tt.orgType {
 			case ApplicationGroupKey:
-				_, err := c.GetMSPConfigurationForApplicationOrg(tt.orgName)
+				_, err := c.ApplicationMSP(tt.orgName)
 				gt.Expect(err).To(MatchError(tt.expectedErr))
 			case OrdererGroupKey:
-				_, err := c.GetMSPConfigurationForOrdererOrg(tt.orgName)
+				_, err := c.OrdererMSP(tt.orgName)
 				gt.Expect(err).To(MatchError(tt.expectedErr))
 			case ConsortiumsGroupKey:
-				_, err := c.GetMSPConfigurationForConsortiumOrg(tt.consortiumName, tt.orgName)
+				_, err := c.ConsortiumMSP(tt.consortiumName, tt.orgName)
 				gt.Expect(err).To(MatchError(tt.expectedErr))
 			default:
 				t.Fatalf("invalid org type %s", tt.orgType)
@@ -341,7 +340,7 @@ func TestMSPToProto(t *testing.T) {
 	gt := NewGomegaWithT(t)
 
 	msp := baseMSP(t)
-	certBase64, pkBase64, crlBase64 := certPrivKeyCRLBase64(msp)
+	certBase64, pkBase64, crlBase64 := certPrivKeyCRLBase64(t, msp)
 
 	expectedFabricMSPConfigProtoJSON := fmt.Sprintf(`
 {
@@ -424,966 +423,7 @@ func TestMSPToProtoFailure(t *testing.T) {
 	gt.Expect(fabricMSPConfigProto).To(BeNil())
 }
 
-func TestAddRootCAToMSP(t *testing.T) {
-	t.Parallel()
-	gt := NewGomegaWithT(t)
-
-	cert := &x509.Certificate{
-		KeyUsage: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		IsCA:     true,
-	}
-	certBase64 := base64.StdEncoding.EncodeToString(pemEncodeX509Certificate(cert))
-
-	application := baseApplication(t)
-	applicationGroup, err := newApplicationGroup(application)
-	gt.Expect(err).NotTo(HaveOccurred())
-
-	for _, org := range application.Organizations {
-		orgGroup, err := newOrgConfigGroup(org)
-		gt.Expect(err).NotTo(HaveOccurred())
-		applicationGroup.Groups[org.Name] = orgGroup
-	}
-
-	config := &cb.Config{
-		ChannelGroup: &cb.ConfigGroup{
-			Groups: map[string]*cb.ConfigGroup{
-				"Application": applicationGroup,
-			},
-			Values:   map[string]*cb.ConfigValue{},
-			Policies: map[string]*cb.ConfigPolicy{},
-		},
-	}
-
-	org1MSP := application.Organizations[0].MSP
-	org1CertBase64, org1PKBase64, org1CRLBase64 := certPrivKeyCRLBase64(org1MSP)
-	org2MSP := application.Organizations[1].MSP
-	org2CertBase64, org2PKBase64, org2CRLBase64 := certPrivKeyCRLBase64(org2MSP)
-
-	c := ConfigTx{
-		base:    config,
-		updated: config,
-	}
-
-	err = c.AddRootCAToMSP(cert, "Org1")
-	gt.Expect(err).ToNot(HaveOccurred())
-
-	expectedConfig := fmt.Sprintf(`
-{
-	"channel_group": {
-		"groups": {
-			"Application": {
-				"groups": {
-					"Org1": {
-						"groups": {},
-						"mod_policy": "Admins",
-						"policies": {
-							"Admins": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "MAJORITY",
-										"sub_policy": "Admins"
-									}
-								},
-								"version": "0"
-							},
-							"Endorsement": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "MAJORITY",
-										"sub_policy": "Endorsement"
-									}
-								},
-								"version": "0"
-							},
-							"LifecycleEndorsement": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "MAJORITY",
-										"sub_policy": "Endorsement"
-									}
-								},
-								"version": "0"
-							},
-							"Readers": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "ANY",
-										"sub_policy": "Readers"
-									}
-								},
-								"version": "0"
-							},
-							"Writers": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "ANY",
-										"sub_policy": "Writers"
-									}
-								},
-								"version": "0"
-							}
-						},
-						"values": {
-							"MSP": {
-								"mod_policy": "Admins",
-								"value": {
-									"config": {
-										"admins": [
-											"%[1]s"
-										],
-										"crypto_config": {
-											"identity_identifier_hash_function": "SHA256",
-											"signature_hash_family": "SHA3"
-										},
-										"fabric_node_ous": {
-											"admin_ou_identifier": {
-												"certificate": "%[1]s",
-												"organizational_unit_identifier": "OUID"
-											},
-											"client_ou_identifier": {
-												"certificate": "%[1]s",
-												"organizational_unit_identifier": "OUID"
-											},
-											"enable": false,
-											"orderer_ou_identifier": {
-												"certificate": "%[1]s",
-												"organizational_unit_identifier": "OUID"
-											},
-											"peer_ou_identifier": {
-												"certificate": "%[1]s",
-												"organizational_unit_identifier": "OUID"
-											}
-										},
-										"intermediate_certs": [
-											"%[1]s"
-										],
-										"name": "MSPID",
-										"organizational_unit_identifiers": [
-											{
-												"certificate": "%[1]s",
-												"organizational_unit_identifier": "OUID"
-											}
-										],
-										"revocation_list": [
-											"%[2]s"
-										],
-										"root_certs": [
-											"%[1]s",
-											"%[3]s"
-										],
-										"signing_identity": {
-											"private_signer": {
-												"key_identifier": "SKI-1",
-												"key_material": "%[4]s"
-											},
-											"public_signer": "%[1]s"
-										},
-										"tls_intermediate_certs": [
-											"%[1]s"
-										],
-										"tls_root_certs": [
-											"%[1]s"
-										]
-									},
-									"type": 0
-								},
-								"version": "0"
-							}
-						},
-						"version": "0"
-					},
-					"Org2": {
-						"groups": {},
-						"mod_policy": "Admins",
-						"policies": {
-							"Admins": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "MAJORITY",
-										"sub_policy": "Admins"
-									}
-								},
-								"version": "0"
-							},
-							"Endorsement": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "MAJORITY",
-										"sub_policy": "Endorsement"
-									}
-								},
-								"version": "0"
-							},
-							"LifecycleEndorsement": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "MAJORITY",
-										"sub_policy": "Endorsement"
-									}
-								},
-								"version": "0"
-							},
-							"Readers": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "ANY",
-										"sub_policy": "Readers"
-									}
-								},
-								"version": "0"
-							},
-							"Writers": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "ANY",
-										"sub_policy": "Writers"
-									}
-								},
-								"version": "0"
-							}
-						},
-						"values": {
-							"MSP": {
-								"mod_policy": "Admins",
-								"value": {
-									"config": {
-										"admins": [
-											"%[5]s"
-										],
-										"crypto_config": {
-											"identity_identifier_hash_function": "SHA256",
-											"signature_hash_family": "SHA3"
-										},
-										"fabric_node_ous": {
-											"admin_ou_identifier": {
-												"certificate": "%[5]s",
-												"organizational_unit_identifier": "OUID"
-											},
-											"client_ou_identifier": {
-												"certificate": "%[5]s",
-												"organizational_unit_identifier": "OUID"
-											},
-											"enable": false,
-											"orderer_ou_identifier": {
-												"certificate": "%[5]s",
-												"organizational_unit_identifier": "OUID"
-											},
-											"peer_ou_identifier": {
-												"certificate": "%[5]s",
-												"organizational_unit_identifier": "OUID"
-											}
-										},
-										"intermediate_certs": [
-											"%[5]s"
-										],
-										"name": "MSPID",
-										"organizational_unit_identifiers": [
-											{
-												"certificate": "%[5]s",
-												"organizational_unit_identifier": "OUID"
-											}
-										],
-										"revocation_list": [
-											"%[6]s"
-										],
-										"root_certs": [
-											"%[5]s"
-										],
-										"signing_identity": {
-											"private_signer": {
-												"key_identifier": "SKI-1",
-												"key_material": "%[7]s"
-											},
-											"public_signer": "%[5]s"
-										},
-										"tls_intermediate_certs": [
-											"%[5]s"
-										],
-										"tls_root_certs": [
-											"%[5]s"
-										]
-									},
-									"type": 0
-								},
-								"version": "0"
-							}
-						},
-						"version": "0"
-					}
-				},
-				"mod_policy": "Admins",
-				"policies": {
-					"Admins": {
-						"mod_policy": "Admins",
-						"policy": {
-							"type": 3,
-							"value": {
-								"rule": "MAJORITY",
-								"sub_policy": "Admins"
-							}
-						},
-						"version": "0"
-					},
-					"Readers": {
-						"mod_policy": "Admins",
-						"policy": {
-							"type": 3,
-							"value": {
-								"rule": "ANY",
-								"sub_policy": "Readers"
-							}
-						},
-						"version": "0"
-					},
-					"Writers": {
-						"mod_policy": "Admins",
-						"policy": {
-							"type": 3,
-							"value": {
-								"rule": "ANY",
-								"sub_policy": "Writers"
-							}
-						},
-						"version": "0"
-					}
-				},
-				"values": {
-					"ACLs": {
-						"mod_policy": "Admins",
-						"value": {
-							"acls": {
-								"acl1": {
-									"policy_ref": "hi"
-								}
-							}
-						},
-						"version": "0"
-					},
-					"Capabilities": {
-						"mod_policy": "Admins",
-						"value": {
-							"capabilities": {
-								"V1_3": {}
-							}
-						},
-						"version": "0"
-					}
-				},
-				"version": "0"
-			}
-		},
-		"mod_policy": "",
-		"policies": {},
-		"values": {},
-		"version": "0"
-	},
-	"sequence": "0"
-}
-`, org1CertBase64, org1CRLBase64, certBase64, org1PKBase64, org2CertBase64, org2CRLBase64, org2PKBase64)
-
-	expectedConfigProto := &cb.Config{}
-	err = protolator.DeepUnmarshalJSON(bytes.NewBufferString(expectedConfig), expectedConfigProto)
-	gt.Expect(err).NotTo(HaveOccurred())
-
-	gt.Expect(config).To(Equal(expectedConfigProto))
-}
-
-func TestAddRootCAToMSPFailure(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		spec        string
-		cert        *x509.Certificate
-		expectedErr string
-	}{
-		{
-			spec: "invalid key usage",
-			cert: &x509.Certificate{
-				KeyUsage: x509.KeyUsageKeyAgreement,
-			},
-			expectedErr: "certificate KeyUsage must be x509.KeyUsageCertSign",
-		},
-		{
-			spec: "certificate is not a CA",
-			cert: &x509.Certificate{
-				IsCA:     false,
-				KeyUsage: x509.KeyUsageCertSign,
-			},
-			expectedErr: "certificate must be a CA certificate",
-		},
-	}
-
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.spec, func(t *testing.T) {
-			t.Parallel()
-			gt := NewGomegaWithT(t)
-
-			channelGroup, err := baseApplicationChannelGroup(t)
-			gt.Expect(err).ToNot(HaveOccurred())
-			config := &cb.Config{
-				ChannelGroup: channelGroup,
-			}
-
-			c := ConfigTx{
-				base:    config,
-				updated: config,
-			}
-			err = c.AddRootCAToMSP(tc.cert, "Org1")
-			gt.Expect(err).To(MatchError(tc.expectedErr))
-		})
-	}
-}
-
-func TestRevokeCertificateFromMSP(t *testing.T) {
-	t.Parallel()
-	gt := NewGomegaWithT(t)
-
-	application := baseApplication(t)
-	applicationGroup, err := newApplicationGroup(application)
-	gt.Expect(err).NotTo(HaveOccurred())
-
-	for _, org := range application.Organizations {
-		orgGroup, err := newOrgConfigGroup(org)
-		gt.Expect(err).NotTo(HaveOccurred())
-		applicationGroup.Groups[org.Name] = orgGroup
-	}
-
-	config := &cb.Config{
-		ChannelGroup: &cb.ConfigGroup{
-			Groups: map[string]*cb.ConfigGroup{
-				"Application": applicationGroup,
-			},
-			Values:   map[string]*cb.ConfigValue{},
-			Policies: map[string]*cb.ConfigPolicy{},
-		},
-	}
-
-	c := ConfigTx{
-		base:    config,
-		updated: config,
-	}
-
-	org1MSP, err := c.GetMSPConfigurationForApplicationOrg("Org1")
-	gt.Expect(err).NotTo(HaveOccurred())
-	gt.Expect(org1MSP.RevocationList).To(HaveLen(1))
-
-	caCert := org1MSP.RootCerts[0]
-	caPrivKey := org1MSP.SigningIdentity.PrivateSigner.KeyMaterial.(*ecdsa.PrivateKey)
-	cert, _ := generateCertAndPrivateKeyFromCACert(t, "Org1", caCert, caPrivKey)
-
-	err = c.RevokeCertificateFromMSP("Org1", caCert, caPrivKey, cert)
-	gt.Expect(err).ToNot(HaveOccurred())
-
-	org1MSP, err = c.GetMSPConfigurationForApplicationOrg("Org1")
-	gt.Expect(err).NotTo(HaveOccurred())
-	gt.Expect(org1MSP.RevocationList).To(HaveLen(2))
-	fabricMSPConfig, err := org1MSP.toProto()
-	gt.Expect(err).NotTo(HaveOccurred())
-	newCRL, err := x509.ParseCRL(fabricMSPConfig.RevocationList[1])
-	err = caCert.CheckCRLSignature(newCRL)
-	gt.Expect(err).NotTo(HaveOccurred())
-	org2MSP, err := c.GetMSPConfigurationForApplicationOrg("Org2")
-	gt.Expect(err).NotTo(HaveOccurred())
-	org1CertBase64, org1PKBase64, org1CRLBase64 := certPrivKeyCRLBase64(org1MSP)
-	org2CertBase64, org2PKBase64, org2CRLBase64 := certPrivKeyCRLBase64(org2MSP)
-
-	newCRLBase64 := base64.StdEncoding.EncodeToString(fabricMSPConfig.RevocationList[1])
-	expectedConfig := fmt.Sprintf(`
-{
-	"channel_group": {
-		"groups": {
-			"Application": {
-				"groups": {
-					"Org1": {
-						"groups": {},
-						"mod_policy": "Admins",
-						"policies": {
-							"Admins": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "MAJORITY",
-										"sub_policy": "Admins"
-									}
-								},
-								"version": "0"
-							},
-							"Endorsement": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "MAJORITY",
-										"sub_policy": "Endorsement"
-									}
-								},
-								"version": "0"
-							},
-							"LifecycleEndorsement": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "MAJORITY",
-										"sub_policy": "Endorsement"
-									}
-								},
-								"version": "0"
-							},
-							"Readers": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "ANY",
-										"sub_policy": "Readers"
-									}
-								},
-								"version": "0"
-							},
-							"Writers": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "ANY",
-										"sub_policy": "Writers"
-									}
-								},
-								"version": "0"
-							}
-						},
-						"values": {
-							"MSP": {
-								"mod_policy": "Admins",
-								"value": {
-									"config": {
-										"admins": [
-											"%[1]s"
-										],
-										"crypto_config": {
-											"identity_identifier_hash_function": "SHA256",
-											"signature_hash_family": "SHA3"
-										},
-										"fabric_node_ous": {
-											"admin_ou_identifier": {
-												"certificate": "%[1]s",
-												"organizational_unit_identifier": "OUID"
-											},
-											"client_ou_identifier": {
-												"certificate": "%[1]s",
-												"organizational_unit_identifier": "OUID"
-											},
-											"enable": false,
-											"orderer_ou_identifier": {
-												"certificate": "%[1]s",
-												"organizational_unit_identifier": "OUID"
-											},
-											"peer_ou_identifier": {
-												"certificate": "%[1]s",
-												"organizational_unit_identifier": "OUID"
-											}
-										},
-										"intermediate_certs": [
-											"%[1]s"
-										],
-										"name": "MSPID",
-										"organizational_unit_identifiers": [
-											{
-												"certificate": "%[1]s",
-												"organizational_unit_identifier": "OUID"
-											}
-										],
-										"revocation_list": [
-											"%[2]s",
-											"%[3]s"
-										],
-										"root_certs": [
-											"%[1]s"
-										],
-										"signing_identity": {
-											"private_signer": {
-												"key_identifier": "SKI-1",
-												"key_material": "%[4]s"
-											},
-											"public_signer": "%[1]s"
-										},
-										"tls_intermediate_certs": [
-											"%[1]s"
-										],
-										"tls_root_certs": [
-											"%[1]s"
-										]
-									},
-									"type": 0
-								},
-								"version": "0"
-							}
-						},
-						"version": "0"
-					},
-					"Org2": {
-						"groups": {},
-						"mod_policy": "Admins",
-						"policies": {
-							"Admins": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "MAJORITY",
-										"sub_policy": "Admins"
-									}
-								},
-								"version": "0"
-							},
-							"Endorsement": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "MAJORITY",
-										"sub_policy": "Endorsement"
-									}
-								},
-								"version": "0"
-							},
-							"LifecycleEndorsement": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "MAJORITY",
-										"sub_policy": "Endorsement"
-									}
-								},
-								"version": "0"
-							},
-							"Readers": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "ANY",
-										"sub_policy": "Readers"
-									}
-								},
-								"version": "0"
-							},
-							"Writers": {
-								"mod_policy": "Admins",
-								"policy": {
-									"type": 3,
-									"value": {
-										"rule": "ANY",
-										"sub_policy": "Writers"
-									}
-								},
-								"version": "0"
-							}
-						},
-						"values": {
-							"MSP": {
-								"mod_policy": "Admins",
-								"value": {
-									"config": {
-										"admins": [
-											"%[5]s"
-										],
-										"crypto_config": {
-											"identity_identifier_hash_function": "SHA256",
-											"signature_hash_family": "SHA3"
-										},
-										"fabric_node_ous": {
-											"admin_ou_identifier": {
-												"certificate": "%[5]s",
-												"organizational_unit_identifier": "OUID"
-											},
-											"client_ou_identifier": {
-												"certificate": "%[5]s",
-												"organizational_unit_identifier": "OUID"
-											},
-											"enable": false,
-											"orderer_ou_identifier": {
-												"certificate": "%[5]s",
-												"organizational_unit_identifier": "OUID"
-											},
-											"peer_ou_identifier": {
-												"certificate": "%[5]s",
-												"organizational_unit_identifier": "OUID"
-											}
-										},
-										"intermediate_certs": [
-											"%[5]s"
-										],
-										"name": "MSPID",
-										"organizational_unit_identifiers": [
-											{
-												"certificate": "%[5]s",
-												"organizational_unit_identifier": "OUID"
-											}
-										],
-										"revocation_list": [
-											"%[6]s"
-										],
-										"root_certs": [
-											"%[5]s"
-										],
-										"signing_identity": {
-											"private_signer": {
-												"key_identifier": "SKI-1",
-												"key_material": "%[7]s"
-											},
-											"public_signer": "%[5]s"
-										},
-										"tls_intermediate_certs": [
-											"%[5]s"
-										],
-										"tls_root_certs": [
-											"%[5]s"
-										]
-									},
-									"type": 0
-								},
-								"version": "0"
-							}
-						},
-						"version": "0"
-					}
-				},
-				"mod_policy": "Admins",
-				"policies": {
-					"Admins": {
-						"mod_policy": "Admins",
-						"policy": {
-							"type": 3,
-							"value": {
-								"rule": "MAJORITY",
-								"sub_policy": "Admins"
-							}
-						},
-						"version": "0"
-					},
-					"Readers": {
-						"mod_policy": "Admins",
-						"policy": {
-							"type": 3,
-							"value": {
-								"rule": "ANY",
-								"sub_policy": "Readers"
-							}
-						},
-						"version": "0"
-					},
-					"Writers": {
-						"mod_policy": "Admins",
-						"policy": {
-							"type": 3,
-							"value": {
-								"rule": "ANY",
-								"sub_policy": "Writers"
-							}
-						},
-						"version": "0"
-					}
-				},
-				"values": {
-					"ACLs": {
-						"mod_policy": "Admins",
-						"value": {
-							"acls": {
-								"acl1": {
-									"policy_ref": "hi"
-								}
-							}
-						},
-						"version": "0"
-					},
-					"Capabilities": {
-						"mod_policy": "Admins",
-						"value": {
-							"capabilities": {
-								"V1_3": {}
-							}
-						},
-						"version": "0"
-					}
-				},
-				"version": "0"
-			}
-		},
-		"mod_policy": "",
-		"policies": {},
-		"values": {},
-		"version": "0"
-	},
-	"sequence": "0"
-}
-`, org1CertBase64, org1CRLBase64, newCRLBase64, org1PKBase64, org2CertBase64, org2CRLBase64, org2PKBase64)
-
-	expectedConfigProto := &cb.Config{}
-	err = protolator.DeepUnmarshalJSON(bytes.NewBufferString(expectedConfig), expectedConfigProto)
-	gt.Expect(err).NotTo(HaveOccurred())
-
-	gt.Expect(config).To(Equal(expectedConfigProto))
-}
-
-func TestRevokeCertificateFromMSPFailure(t *testing.T) {
-	t.Parallel()
-
-	unknownOrgCACert, unknownOrgCAPrivKey := generateCACertAndPrivateKey(t, "unknown-org")
-	unknownOrgCert, _ := generateCertAndPrivateKeyFromCACert(t, "unknown-org", unknownOrgCACert, unknownOrgCAPrivKey)
-
-	tests := []struct {
-		spec        string
-		orgName     string
-		cert        *x509.Certificate
-		expectedErr string
-	}{
-		{
-			spec:        "org not defined in config",
-			orgName:     "not-an-org",
-			expectedErr: "application org with name 'not-an-org' not found",
-		},
-		{
-			spec:        "cert not issued by rootCA certs",
-			orgName:     "Org1",
-			cert:        unknownOrgCert,
-			expectedErr: fmt.Sprintf("validating cert: certificate not issued by this MSP. serial number: %d", unknownOrgCert.SerialNumber),
-		},
-	}
-
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.spec, func(t *testing.T) {
-			t.Parallel()
-			gt := NewGomegaWithT(t)
-
-			channelGroup, err := baseApplicationChannelGroup(t)
-			gt.Expect(err).ToNot(HaveOccurred())
-			config := &cb.Config{
-				ChannelGroup: channelGroup,
-			}
-
-			c := ConfigTx{
-				base:    config,
-				updated: config,
-			}
-			org1MSP, err := c.GetMSPConfigurationForApplicationOrg("Org1")
-			gt.Expect(err).NotTo(HaveOccurred())
-			org1CACert := org1MSP.RootCerts[0]
-			org1CAPrivKey := org1MSP.SigningIdentity.PrivateSigner.KeyMaterial.(*ecdsa.PrivateKey)
-
-			err = c.RevokeCertificateFromMSP(tc.orgName, org1CACert, org1CAPrivKey, tc.cert)
-			gt.Expect(err).To(MatchError(tc.expectedErr))
-		})
-	}
-}
-
-func baseMSP(t *testing.T) MSP {
-	gt := NewGomegaWithT(t)
-
-	cert, privKey := generateCACertAndPrivateKey(t, "org1.example.com")
-	crlBytes, err := cert.CreateCRL(rand.Reader, privKey, nil, time.Now(), time.Now().Add(YEAR))
-	gt.Expect(err).NotTo(HaveOccurred())
-
-	crl, err := x509.ParseCRL(crlBytes)
-	gt.Expect(err).NotTo(HaveOccurred())
-
-	return MSP{
-		Name:              "MSPID",
-		RootCerts:         []*x509.Certificate{cert},
-		IntermediateCerts: []*x509.Certificate{cert},
-		Admins:            []*x509.Certificate{cert},
-		RevocationList:    []*pkix.CertificateList{crl},
-		SigningIdentity: SigningIdentityInfo{
-			PublicSigner: cert,
-			PrivateSigner: KeyInfo{
-				KeyIdentifier: "SKI-1",
-				KeyMaterial:   privKey,
-			},
-		},
-		OrganizationalUnitIdentifiers: []OUIdentifier{
-			{
-				Certificate:                  cert,
-				OrganizationalUnitIdentifier: "OUID",
-			},
-		},
-		CryptoConfig: CryptoConfig{
-			SignatureHashFamily:            "SHA3",
-			IdentityIdentifierHashFunction: "SHA256",
-		},
-		TLSRootCerts:         []*x509.Certificate{cert},
-		TLSIntermediateCerts: []*x509.Certificate{cert},
-		NodeOus: NodeOUs{
-			ClientOUIdentifier: OUIdentifier{
-				Certificate:                  cert,
-				OrganizationalUnitIdentifier: "OUID",
-			},
-			PeerOUIdentifier: OUIdentifier{
-				Certificate:                  cert,
-				OrganizationalUnitIdentifier: "OUID",
-			},
-			AdminOUIdentifier: OUIdentifier{
-				Certificate:                  cert,
-				OrganizationalUnitIdentifier: "OUID",
-			},
-			OrdererOUIdentifier: OUIdentifier{
-				Certificate:                  cert,
-				OrganizationalUnitIdentifier: "OUID",
-			},
-		},
-	}
-}
-
-// certPrivKeyCRLBase64 returns a base64 encoded representation of
-// the first root certificate, the private key, and the first revocation list
-// for the specified MSP. These are intended for use when formatting the
-// expected config in JSON format.
-func certPrivKeyCRLBase64(msp MSP) (string, string, string) {
-	cert := msp.RootCerts[0]
-	privKey := msp.SigningIdentity.PrivateSigner.KeyMaterial
-	crl := msp.RevocationList[0]
-
-	certBase64 := base64.StdEncoding.EncodeToString(pemEncodeX509Certificate(cert))
-	pkBytes, err := pemEncodePKCS8PrivateKey(privKey)
-	if err != nil {
-		log.Fatalf("Failed to pem encode private key: %s", err)
-	}
-
-	pkBase64 := base64.StdEncoding.EncodeToString(pkBytes)
-	pemCRLBytes, err := buildPemEncodedCRL([]*pkix.CertificateList{crl})
-	if err != nil {
-		log.Fatalf("Failed to pem encode private key: %s", err)
-	}
-	crlBase64 := base64.StdEncoding.EncodeToString(pemCRLBytes[0])
-
-	return certBase64, pkBase64, crlBase64
-}
-
-func TestUpdateMSP(t *testing.T) {
+func TestUpdateApplicationMSP(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
@@ -1395,22 +435,39 @@ func TestUpdateMSP(t *testing.T) {
 
 	c := New(config)
 
-	org1MSP, err := c.GetMSPConfigurationForApplicationOrg("Org1")
+	org1MSP, err := c.ApplicationMSP("Org1")
 	gt.Expect(err).NotTo(HaveOccurred())
-	org2MSP, err := c.GetMSPConfigurationForApplicationOrg("Org2")
+	org2MSP, err := c.ApplicationMSP("Org2")
 	gt.Expect(err).NotTo(HaveOccurred())
-	org1CertBase64, org1PKBase64, org1CRLBase64 := certPrivKeyCRLBase64(org1MSP)
-	org2CertBase64, org2PKBase64, org2CRLBase64 := certPrivKeyCRLBase64(org2MSP)
+	org1CertBase64, org1PKBase64, org1CRLBase64 := certPrivKeyCRLBase64(t, org1MSP)
+	org2CertBase64, org2PKBase64, org2CRLBase64 := certPrivKeyCRLBase64(t, org2MSP)
+
+	newRootCert, _ := generateCACertAndPrivateKey(t, "anotherca-org1.example.com")
+	newRootCertBase64 := base64.StdEncoding.EncodeToString(pemEncodeX509Certificate(newRootCert))
+	org1MSP.RootCerts = append(org1MSP.RootCerts, newRootCert)
 
 	newIntermediateCert := &x509.Certificate{
 		KeyUsage: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		IsCA:     true,
 	}
 	newIntermediateCertBase64 := base64.StdEncoding.EncodeToString(pemEncodeX509Certificate(newIntermediateCert))
-
 	org1MSP.IntermediateCerts = append(org1MSP.IntermediateCerts, newIntermediateCert)
 
-	err = c.UpdateMSP(org1MSP, "Org1")
+	cert, privKey, _ := certPrivKeyCRL(org1MSP)
+	certToRevoke, _ := generateCertAndPrivateKeyFromCACert(t, "org1.example.com", cert, privKey)
+	signingIdentity := &SigningIdentity{
+		Certificate: cert,
+		PrivateKey:  privKey,
+		MSPID:       "MSPID",
+	}
+	newCRL, err := c.CreateApplicationMSPCRL("Org1", signingIdentity, certToRevoke)
+	gt.Expect(err).NotTo(HaveOccurred())
+	pemNewCRL, err := pemEncodeCRL(newCRL)
+	gt.Expect(err).NotTo(HaveOccurred())
+	newCRLBase64 := base64.StdEncoding.EncodeToString(pemNewCRL)
+	org1MSP.RevocationList = append(org1MSP.RevocationList, newCRL)
+
+	err = c.UpdateApplicationMSP(org1MSP, "Org1")
 	gt.Expect(err).NotTo(HaveOccurred())
 
 	expectedConfigJSON := fmt.Sprintf(`
@@ -1522,15 +579,17 @@ func TestUpdateMSP(t *testing.T) {
 											}
 										],
 										"revocation_list": [
-											"%[3]s"
+											"%[3]s",
+											"%[4]s"
 										],
 										"root_certs": [
-											"%[1]s"
+											"%[1]s",
+											"%[5]s"
 										],
 										"signing_identity": {
 											"private_signer": {
 												"key_identifier": "SKI-1",
-												"key_material": "%[4]s"
+												"key_material": "%[6]s"
 											},
 											"public_signer": "%[1]s"
 										},
@@ -1614,7 +673,7 @@ func TestUpdateMSP(t *testing.T) {
 								"value": {
 									"config": {
 										"admins": [
-											"%[5]s"
+											"%[7]s"
 										],
 										"crypto_config": {
 											"identity_identifier_hash_function": "SHA256",
@@ -1622,51 +681,51 @@ func TestUpdateMSP(t *testing.T) {
 										},
 										"fabric_node_ous": {
 											"admin_ou_identifier": {
-												"certificate": "%[5]s",
+												"certificate": "%[7]s",
 												"organizational_unit_identifier": "OUID"
 											},
 											"client_ou_identifier": {
-												"certificate": "%[5]s",
+												"certificate": "%[7]s",
 												"organizational_unit_identifier": "OUID"
 											},
 											"enable": false,
 											"orderer_ou_identifier": {
-												"certificate": "%[5]s",
+												"certificate": "%[7]s",
 												"organizational_unit_identifier": "OUID"
 											},
 											"peer_ou_identifier": {
-												"certificate": "%[5]s",
+												"certificate": "%[7]s",
 												"organizational_unit_identifier": "OUID"
 											}
 										},
 										"intermediate_certs": [
-											"%[5]s"
+											"%[7]s"
 										],
 										"name": "MSPID",
 										"organizational_unit_identifiers": [
 											{
-												"certificate": "%[5]s",
+												"certificate": "%[7]s",
 												"organizational_unit_identifier": "OUID"
 											}
 										],
 										"revocation_list": [
-											"%[6]s"
+											"%[8]s"
 										],
 										"root_certs": [
-											"%[5]s"
+											"%[7]s"
 										],
 										"signing_identity": {
 											"private_signer": {
 												"key_identifier": "SKI-1",
-												"key_material": "%[7]s"
+												"key_material": "%[9]s"
 											},
-											"public_signer": "%[5]s"
+											"public_signer": "%[7]s"
 										},
 										"tls_intermediate_certs": [
-											"%[5]s"
+											"%[7]s"
 										],
 										"tls_root_certs": [
-											"%[5]s"
+											"%[7]s"
 										]
 									},
 									"type": 0
@@ -1745,7 +804,7 @@ func TestUpdateMSP(t *testing.T) {
 	},
 	"sequence": "0"
 }
-`, org1CertBase64, newIntermediateCertBase64, org1CRLBase64, org1PKBase64, org2CertBase64, org2CRLBase64, org2PKBase64)
+`, org1CertBase64, newIntermediateCertBase64, org1CRLBase64, newCRLBase64, newRootCertBase64, org1PKBase64, org2CertBase64, org2CRLBase64, org2PKBase64)
 
 	buf := bytes.Buffer{}
 	err = protolator.DeepMarshalJSON(&buf, c.Updated())
@@ -1754,7 +813,7 @@ func TestUpdateMSP(t *testing.T) {
 	gt.Expect(buf.String()).To(MatchJSON(expectedConfigJSON))
 }
 
-func TestUpdateMSPFailure(t *testing.T) {
+func TestUpdateApplicationMSPFailure(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -1868,12 +927,198 @@ func TestUpdateMSPFailure(t *testing.T) {
 
 			c := New(config)
 
-			org1MSP, err := c.GetMSPConfigurationForApplicationOrg("Org1")
+			org1MSP, err := c.ApplicationMSP("Org1")
 			gt.Expect(err).NotTo(HaveOccurred())
 
 			org1MSP = tc.mspMod(org1MSP)
-			err = c.UpdateMSP(org1MSP, tc.orgName)
+			err = c.UpdateApplicationMSP(org1MSP, tc.orgName)
 			gt.Expect(err).To(MatchError(tc.expectedErr))
 		})
 	}
+}
+
+func TestCreateApplicationMSPCRL(t *testing.T) {
+	t.Parallel()
+	gt := NewGomegaWithT(t)
+
+	channelGroup, err := baseApplicationChannelGroup(t)
+	gt.Expect(err).ToNot(HaveOccurred())
+	config := &cb.Config{
+		ChannelGroup: channelGroup,
+	}
+
+	c := New(config)
+
+	org1MSP, err := c.ApplicationMSP("Org1")
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	cert, privKey, _ := certPrivKeyCRL(org1MSP)
+	certToRevoke, _ := generateCertAndPrivateKeyFromCACert(t, "org1.example.com", cert, privKey)
+	signingIdentity := &SigningIdentity{
+		Certificate: cert,
+		PrivateKey:  privKey,
+		MSPID:       "MSPID",
+	}
+	newCRL, err := c.CreateApplicationMSPCRL("Org1", signingIdentity, certToRevoke)
+	gt.Expect(err).NotTo(HaveOccurred())
+	gt.Expect(newCRL.TBSCertList.RevokedCertificates).To(HaveLen(1))
+	gt.Expect(newCRL.TBSCertList.RevokedCertificates[0].SerialNumber).To(Equal(certToRevoke.SerialNumber))
+
+	// TODO create a CRL using an intermediate cert
+}
+
+func TestCreateApplicationMSPCRLFailure(t *testing.T) {
+	t.Parallel()
+	gt := NewGomegaWithT(t)
+
+	channelGroup, err := baseApplicationChannelGroup(t)
+	gt.Expect(err).ToNot(HaveOccurred())
+	config := &cb.Config{
+		ChannelGroup: channelGroup,
+	}
+
+	c := New(config)
+
+	org1MSP, err := c.ApplicationMSP("Org1")
+	gt.Expect(err).NotTo(HaveOccurred())
+	org1Cert, org1PrivKey, _ := certPrivKeyCRL(org1MSP)
+	org1CertToRevoke, _ := generateCertAndPrivateKeyFromCACert(t, "org1.example.com", org1Cert, org1PrivKey)
+
+	org2MSP, err := c.ApplicationMSP("Org2")
+	gt.Expect(err).NotTo(HaveOccurred())
+	org2Cert, org2PrivKey, _ := certPrivKeyCRL(org2MSP)
+	org2CertToRevoke, _ := generateCertAndPrivateKeyFromCACert(t, "org2.example.com", org2Cert, org2PrivKey)
+
+	signingIdentity := &SigningIdentity{
+		Certificate: org1Cert,
+		PrivateKey:  org1PrivKey,
+	}
+	tests := []struct {
+		spec            string
+		mspMod          func(MSP) MSP
+		signingIdentity *SigningIdentity
+		certToRevoke    *x509.Certificate
+		orgName         string
+		expectedErr     string
+	}{
+		{
+			spec:            "application org msp not defined",
+			orgName:         "undefined-org",
+			signingIdentity: signingIdentity,
+			expectedErr:     "retrieving application msp: application org undefined-org does not exist in config",
+		},
+		{
+			spec:    "signing cert is not a root/intermediate cert for msp",
+			orgName: "Org1",
+			signingIdentity: &SigningIdentity{
+				Certificate: org2Cert,
+				PrivateKey:  org2PrivKey,
+			},
+			certToRevoke: org1CertToRevoke,
+			expectedErr:  "signing cert is not a root/intermediate cert for this MSP: MSPID",
+		},
+		{
+			spec:            "certificate not issued by this MSP",
+			orgName:         "Org1",
+			signingIdentity: signingIdentity,
+			certToRevoke:    org2CertToRevoke,
+			expectedErr:     fmt.Sprintf("certificate not issued by this MSP. serial number: %d", org2CertToRevoke.SerialNumber),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.spec, func(t *testing.T) {
+			t.Parallel()
+			gt := NewGomegaWithT(t)
+
+			newCRL, err := c.CreateApplicationMSPCRL(tc.orgName, tc.signingIdentity, tc.certToRevoke)
+			gt.Expect(err).To(MatchError(tc.expectedErr))
+			gt.Expect(newCRL).To(BeNil())
+		})
+	}
+}
+
+func baseMSP(t *testing.T) MSP {
+	gt := NewGomegaWithT(t)
+
+	cert, privKey := generateCACertAndPrivateKey(t, "org1.example.com")
+	crlBytes, err := cert.CreateCRL(rand.Reader, privKey, nil, time.Now(), time.Now().Add(YEAR))
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	crl, err := x509.ParseCRL(crlBytes)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	return MSP{
+		Name:              "MSPID",
+		RootCerts:         []*x509.Certificate{cert},
+		IntermediateCerts: []*x509.Certificate{cert},
+		Admins:            []*x509.Certificate{cert},
+		RevocationList:    []*pkix.CertificateList{crl},
+		SigningIdentity: SigningIdentityInfo{
+			PublicSigner: cert,
+			PrivateSigner: KeyInfo{
+				KeyIdentifier: "SKI-1",
+				KeyMaterial:   privKey,
+			},
+		},
+		OrganizationalUnitIdentifiers: []OUIdentifier{
+			{
+				Certificate:                  cert,
+				OrganizationalUnitIdentifier: "OUID",
+			},
+		},
+		CryptoConfig: CryptoConfig{
+			SignatureHashFamily:            "SHA3",
+			IdentityIdentifierHashFunction: "SHA256",
+		},
+		TLSRootCerts:         []*x509.Certificate{cert},
+		TLSIntermediateCerts: []*x509.Certificate{cert},
+		NodeOus: NodeOUs{
+			ClientOUIdentifier: OUIdentifier{
+				Certificate:                  cert,
+				OrganizationalUnitIdentifier: "OUID",
+			},
+			PeerOUIdentifier: OUIdentifier{
+				Certificate:                  cert,
+				OrganizationalUnitIdentifier: "OUID",
+			},
+			AdminOUIdentifier: OUIdentifier{
+				Certificate:                  cert,
+				OrganizationalUnitIdentifier: "OUID",
+			},
+			OrdererOUIdentifier: OUIdentifier{
+				Certificate:                  cert,
+				OrganizationalUnitIdentifier: "OUID",
+			},
+		},
+	}
+}
+
+func certPrivKeyCRL(msp MSP) (*x509.Certificate, *ecdsa.PrivateKey, *pkix.CertificateList) {
+	cert := msp.RootCerts[0]
+	privKey := msp.SigningIdentity.PrivateSigner.KeyMaterial.(*ecdsa.PrivateKey)
+	crl := msp.RevocationList[0]
+
+	return cert, privKey, crl
+}
+
+// certPrivKeyCRLBase64 returns a base64 encoded representation of
+// the first root certificate, the private key, and the first revocation list
+// for the specified MSP. These are intended for use when formatting the
+// expected config in JSON format.
+func certPrivKeyCRLBase64(t *testing.T, msp MSP) (string, string, string) {
+	gt := NewGomegaWithT(t)
+
+	cert, privKey, crl := certPrivKeyCRL(msp)
+
+	certBase64 := base64.StdEncoding.EncodeToString(pemEncodeX509Certificate(cert))
+	pkBytes, err := pemEncodePKCS8PrivateKey(privKey)
+	gt.Expect(err).NotTo(HaveOccurred())
+	pkBase64 := base64.StdEncoding.EncodeToString(pkBytes)
+	pemCRLBytes, err := buildPemEncodedRevocationList([]*pkix.CertificateList{crl})
+	gt.Expect(err).NotTo(HaveOccurred())
+	crlBase64 := base64.StdEncoding.EncodeToString(pemCRLBytes[0])
+
+	return certBase64, pkBase64, crlBase64
 }

--- a/pkg/config/orderer_test.go
+++ b/pkg/config/orderer_test.go
@@ -192,7 +192,7 @@ func TestUpdateOrdererConfiguration(t *testing.T) {
 	gt := NewGomegaWithT(t)
 
 	baseOrdererConf := baseSoloOrderer(t)
-	certBase64, pkBase64, crlBase64 := certPrivKeyCRLBase64(baseOrdererConf.Organizations[0].MSP)
+	certBase64, pkBase64, crlBase64 := certPrivKeyCRLBase64(t, baseOrdererConf.Organizations[0].MSP)
 
 	ordererGroup, err := newOrdererGroup(baseOrdererConf)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -732,7 +732,7 @@ func TestAddOrdererOrg(t *testing.T) {
 		},
 		MSP: baseMSP(t),
 	}
-	certBase64, pkBase64, crlBase64 := certPrivKeyCRLBase64(org.MSP)
+	certBase64, pkBase64, crlBase64 := certPrivKeyCRLBase64(t, org.MSP)
 
 	expectedConfigJSON := fmt.Sprintf(`
 {

--- a/pkg/config/organization_test.go
+++ b/pkg/config/organization_test.go
@@ -222,7 +222,7 @@ func TestNewOrgConfigGroup(t *testing.T) {
 		configGroup, err := newOrgConfigGroup(org)
 		gt.Expect(err).NotTo(HaveOccurred())
 
-		certBase64, pkBase64, crlBase64 := certPrivKeyCRLBase64(org.MSP)
+		certBase64, pkBase64, crlBase64 := certPrivKeyCRLBase64(t, org.MSP)
 
 		// The organization is from network.BasicSolo Profile
 		// configtxgen -printOrg Org1


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

- Rename getters for MSP configuration
- Remove single-use update functions (AddRootCAToMSP and RevokeCertificateFromMSP) in favor of using UpdateApplicationMSP
- Implement new CreateApplicationMSPCRL function based on the first half of the logic from the previous RevokeCertificateFromMSP function. 

#### Related issues

[FAB-17659](https://jira.hyperledger.org/browse/FAB-17659)