### PR TITLE
Fix code block typo in add org tutorial

### DIFF
--- a/docs/source/channel_update_tutorial.rst
+++ b/docs/source/channel_update_tutorial.rst
@@ -47,6 +47,7 @@ You can now use the script to bring up the test network with one channel named
 
 If the command was successful, you can see the following message printed in your
 logs:
+
 .. code:: bash
 
   ========= Channel successfully joined ===========


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>


#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Documentation update

#### Description

Fixing this rst code block typo in the add an org tutorial (.. code:: bash should now show)
```
If the command was successful, you can see the following message printed in your logs: .. code:: bash

    ========= Channel successfully joined ===========
```