### PR TITLE
[FAB-17665] Fix bugs for policies in Consortium groups

### DIFF
--- a/pkg/config/policies.go
+++ b/pkg/config/policies.go
@@ -43,29 +43,13 @@ func (c *ConfigTx) UpdateConsortiumChannelCreationPolicy(consortiumName string, 
 	return nil
 }
 
-// GetPoliciesForConsortiums returns a map of policies for channel consortiums.
-func (c *ConfigTx) GetPoliciesForConsortiums() (map[string]Policy, error) {
-	consortiums, ok := c.base.ChannelGroup.Groups[ConsortiumsGroupKey]
-	if !ok {
-		return nil, errors.New("consortiums missing from config")
-	}
-
-	return getPolicies(consortiums.Policies)
-}
-
-// GetPoliciesForConsortium returns a map of policies for a specific consortium.
-func (c *ConfigTx) GetPoliciesForConsortium(consortiumName string) (map[string]Policy, error) {
+// GetPoliciesForConsortiumOrg returns a map of policies for a specific consortium org.
+func (c *ConfigTx) GetPoliciesForConsortiumOrg(consortiumName, orgName string) (map[string]Policy, error) {
 	consortium, ok := c.base.ChannelGroup.Groups[ConsortiumsGroupKey].Groups[consortiumName]
 	if !ok {
 		return nil, fmt.Errorf("consortium %s does not exist in channel config", consortiumName)
 	}
-
-	return getPolicies(consortium.Policies)
-}
-
-// GetPoliciesForConsortiumOrg returns a map of policies for a specific consortium org.
-func (c *ConfigTx) GetPoliciesForConsortiumOrg(consortiumName, orgName string) (map[string]Policy, error) {
-	org, ok := c.base.ChannelGroup.Groups[ConsortiumsGroupKey].Groups[consortiumName].Groups[orgName]
+	org, ok := consortium.Groups[orgName]
 	if !ok {
 		return nil, fmt.Errorf("consortium org %s does not exist in channel config", orgName)
 	}


### PR DESCRIPTION
Remove GetPoliciesForConsortiums, which returns a hardcoded policy.
Remove GetPoliciesForConsortium, which returns empty value.
In GetPoliciesForConsortiumOrg, add the judgment of whether the
consortiumName exists. And add unit tests for it.

Signed-off-by: xu wu <wuxu1103@163.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix
- Improvement (improvement to code, performance, etc)
- Test update

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues
https://jira.hyperledger.org/browse/FAB-17665
<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
