### PR TITLE
[FAB-17109] Retrieve ReconnectBackoffThreshold as duration

### DIFF
--- a/core/deliverservice/config.go
+++ b/core/deliverservice/config.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	DefaultReConnectBackoffThreshold   = float64(time.Hour)
+	DefaultReConnectBackoffThreshold   = time.Hour * 1
 	DefaultReConnectTotalTimeThreshold = time.Second * 60 * 60
 	DefaultConnectionTimeout           = time.Second * 3
 )
@@ -30,7 +30,7 @@ type DeliverServiceConfig struct {
 	// PeerTLSEnabled enables/disables Peer TLS.
 	PeerTLSEnabled bool
 	// ReConnectBackoffThreshold sets the delivery service maximal delay between consencutive retries.
-	ReConnectBackoffThreshold float64
+	ReConnectBackoffThreshold time.Duration
 	// ReconnectTotalTimeThreshold sets the total time the delivery service may spend in reconnection attempts
 	// until its retry logic gives up and returns an error.
 	ReconnectTotalTimeThreshold time.Duration
@@ -97,7 +97,7 @@ func LoadOverridesMap() (map[string]*orderers.Endpoint, error) {
 func (c *DeliverServiceConfig) loadDeliverServiceConfig() {
 	c.PeerTLSEnabled = viper.GetBool("peer.tls.enabled")
 
-	c.ReConnectBackoffThreshold = viper.GetFloat64("peer.deliveryclient.reConnectBackoffThreshold")
+	c.ReConnectBackoffThreshold = viper.GetDuration("peer.deliveryclient.reConnectBackoffThreshold")
 	if c.ReConnectBackoffThreshold == 0 {
 		c.ReConnectBackoffThreshold = DefaultReConnectBackoffThreshold
 	}

--- a/core/deliverservice/config_test.go
+++ b/core/deliverservice/config_test.go
@@ -84,7 +84,7 @@ func TestGlobalConfig(t *testing.T) {
 	defer viper.Reset()
 
 	viper.Set("peer.tls.enabled", true)
-	viper.Set("peer.deliveryclient.reConnectBackoffThreshold", 25.5)
+	viper.Set("peer.deliveryclient.reConnectBackoffThreshold", "25s")
 	viper.Set("peer.deliveryclient.reconnectTotalTimeThreshold", "20s")
 	viper.Set("peer.deliveryclient.connTimeout", "10s")
 	viper.Set("peer.keepalive.deliveryClient.interval", "5s")
@@ -94,7 +94,7 @@ func TestGlobalConfig(t *testing.T) {
 
 	expectedConfig := &deliverservice.DeliverServiceConfig{
 		PeerTLSEnabled:              true,
-		ReConnectBackoffThreshold:   25.5,
+		ReConnectBackoffThreshold:   25 * time.Second,
 		ReconnectTotalTimeThreshold: 20 * time.Second,
 		ConnectionTimeout:           10 * time.Second,
 		KeepaliveOptions: comm.KeepaliveOptions{

--- a/core/deliverservice/deliveryclient.go
+++ b/core/deliverservice/deliveryclient.go
@@ -133,7 +133,7 @@ func (d *deliverServiceImpl) StartDeliverForChannel(chainID string, ledgerInfo b
 		Signer:            d.conf.Signer,
 		DeliverStreamer:   DeliverAdapter{},
 		Logger:            flogging.MustGetLogger("peer.blocksprovider").With("channel", chainID),
-		MaxRetryDelay:     time.Duration(d.conf.DeliverServiceConfig.ReConnectBackoffThreshold),
+		MaxRetryDelay:     d.conf.DeliverServiceConfig.ReConnectBackoffThreshold,
 		MaxRetryDuration:  d.conf.DeliverServiceConfig.ReconnectTotalTimeThreshold,
 		InitialRetryDelay: 100 * time.Millisecond,
 		YieldLeadership:   !d.conf.IsStaticLeader,


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description

Retrieves and uses ReconnectBackoffThreshold from config as duration

#### Related issues

[FAB-17109](https://jira.hyperledger.org/browse/FAB-17109)