### PR TITLE
don't wait to expire dead endpoints if exiting

### DIFF
--- a/gossip/comm/comm_impl.go
+++ b/gossip/comm/comm_impl.go
@@ -602,10 +602,12 @@ func (c *commImpl) Ping(context.Context, *proto.Empty) (*proto.Empty, error) {
 }
 
 func (c *commImpl) disconnect(pkiID common.PKIidType) {
-	if c.isStopping() {
+	select {
+	case c.deadEndpoints <- pkiID:
+	case <-c.exitChan:
 		return
 	}
-	c.deadEndpoints <- pkiID
+
 	c.connStore.closeConnByPKIid(pkiID)
 }
 


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

deadEndpoints channel gets filled up. Exit occurs, and deadEndpoints is not drained. We can avoid putting more into the channel and creating hanging goroutines (many many many of them, this fills up my memory). There are still messages that get dropped on the floor sometimes that will cause a different hang.

#### Additional details

Seeing what looked like unbounded memory usage when running this in a loop.
There are anywhere between 80 and 600 messages for each side of the connection.
Each iteration through the loop results in a timer being created.
Avoid that and create one at the test start.

#### Related issues

FAB-17451 I reported this from https://github.com/hyperledger/fabric/pull/954#issuecomment-606809081
