### PR TITLE
Fix another missing export instruction in docs/deploy_chaincode.md

### DIFF
--- a/docs/source/deploy_chaincode.md
+++ b/docs/source/deploy_chaincode.md
@@ -379,10 +379,10 @@ You need to approve a chaincode definition with an identity that has an admin ro
 
 We still need to approve the chaincode definition as Org1. Set the following environment variables to operate as the Org1 admin:
 ```
-CORE_PEER_LOCALMSPID="Org1MSP"
-CORE_PEER_MSPCONFIGPATH=${PWD}/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
-CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
-CORE_PEER_ADDRESS=localhost:7051
+export CORE_PEER_LOCALMSPID="Org1MSP"
+export CORE_PEER_MSPCONFIGPATH=${PWD}/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
+export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
+export CORE_PEER_ADDRESS=localhost:7051
 ```
 
 You can now approve the chaincode definition as Org1.


### PR DESCRIPTION
Signed-off-by: Svetoslav Blyahov <svetlio.blyahoff@gmail.com>

#### Type of change
- Documentation update

#### Description
Add missing `export`s to `deploy_chaincode.md`
