### PR TITLE
rm unnecessary import dependency from statecouchdb package 

### DIFF
--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/common_storage_db.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/common_storage_db.go
@@ -305,12 +305,16 @@ func (s *CommonStorageDB) HandleChaincodeDeploy(chaincodeDefinition *cceventmgmt
 		return nil
 	}
 
-	for directoryPath, archiveDirectoryEntries := range dbArtifacts {
+	for directoryPath, indexFiles := range dbArtifacts {
 		// split the directory name
 		directoryPathArray := strings.Split(directoryPath, "/")
 		// process the indexes for the chain
+		indexFilesData := make(map[string][]byte)
+		for _, f := range indexFiles {
+			indexFilesData[f.FileHeader.Name] = f.FileContent
+		}
 		if directoryPathArray[3] == "indexes" {
-			err := indexCapable.ProcessIndexesForChaincodeDeploy(chaincodeDefinition.Name, archiveDirectoryEntries)
+			err := indexCapable.ProcessIndexesForChaincodeDeploy(chaincodeDefinition.Name, indexFilesData)
 			if err != nil {
 				logger.Errorf("Error processing index for chaincode [%s]: %s", chaincodeDefinition.Name, err)
 			}
@@ -324,7 +328,7 @@ func (s *CommonStorageDB) HandleChaincodeDeploy(chaincodeDefinition *cceventmgmt
 				logger.Errorf("Error processing index for chaincode [%s]: cannot create an index for an undefined collection=[%s]", chaincodeDefinition.Name, collectionName)
 			} else {
 				err := indexCapable.ProcessIndexesForChaincodeDeploy(derivePvtDataNs(chaincodeDefinition.Name, collectionName),
-					archiveDirectoryEntries)
+					indexFilesData)
 				if err != nil {
 					logger.Errorf("Error processing collection index for chaincode [%s]: %s", chaincodeDefinition.Name, err)
 				}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/common/ledger/dataformat"
 	"github.com/hyperledger/fabric/common/metrics"
-	"github.com/hyperledger/fabric/core/common/ccprovider"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/hyperledger/fabric/core/ledger/util/couchdb"
@@ -252,17 +251,15 @@ func (vdb *VersionedDB) getNamespaceDBHandle(namespace string) (*couchdb.CouchDa
 }
 
 // ProcessIndexesForChaincodeDeploy creates indexes for a specified namespace
-func (vdb *VersionedDB) ProcessIndexesForChaincodeDeploy(namespace string, fileEntries []*ccprovider.TarFileEntry) error {
+func (vdb *VersionedDB) ProcessIndexesForChaincodeDeploy(namespace string, indexFilesData map[string][]byte) error {
 	db, err := vdb.getNamespaceDBHandle(namespace)
 	if err != nil {
 		return err
 	}
-	for _, fileEntry := range fileEntries {
-		indexData := fileEntry.FileContent
-		filename := fileEntry.FileHeader.Name
+	for indexFileName, indexData := range indexFilesData {
 		_, err = db.CreateIndex(string(indexData))
 		if err != nil {
-			return errors.WithMessagef(err, "error creating index from file [%s] for channel [%s]", filename, namespace)
+			return errors.WithMessagef(err, "error creating index from file [%s] for channel [%s]", indexFileName, namespace)
 		}
 	}
 	return nil

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
@@ -16,9 +16,7 @@ import (
 
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/common/ledger/dataformat"
-	"github.com/hyperledger/fabric/common/ledger/testutil"
 	"github.com/hyperledger/fabric/common/metrics/disabled"
-	"github.com/hyperledger/fabric/core/common/ccprovider"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/commontests"
@@ -576,15 +574,12 @@ func TestHandleChaincodeDeploy(t *testing.T) {
 	savePoint := version.NewHeight(2, 22)
 	db.ApplyUpdates(batch, savePoint)
 
-	//Create a tar file for test with 4 index definitions and 2 side dbs
-	dbArtifactsTarBytes := testutil.CreateTarBytesForTest(
-		[]*testutil.TarFileEntry{
-			{Name: "META-INF/statedb/couchdb/indexes/indexColorSortName.json", Body: `{"index":{"fields":[{"color":"desc"}]},"ddoc":"indexColorSortName","name":"indexColorSortName","type":"json"}`},
-			{Name: "META-INF/statedb/couchdb/indexes/indexSizeSortName.json", Body: `{"index":{"fields":[{"size":"desc"}]},"ddoc":"indexSizeSortName","name":"indexSizeSortName","type":"json"}`},
-			{Name: "META-INF/statedb/couchdb/collections/collectionMarbles/indexes/indexCollMarbles.json", Body: `{"index":{"fields":["docType","owner"]},"ddoc":"indexCollectionMarbles", "name":"indexCollectionMarbles","type":"json"}`},
-			{Name: "META-INF/statedb/couchdb/collections/collectionMarblesPrivateDetails/indexes/indexCollPrivDetails.json", Body: `{"index":{"fields":["docType","price"]},"ddoc":"indexPrivateDetails", "name":"indexPrivateDetails","type":"json"}`},
-		},
-	)
+	indexData := map[string][]byte{
+		"META-INF/statedb/couchdb/indexes/indexColorSortName.json":                                               []byte(`{"index":{"fields":[{"color":"desc"}]},"ddoc":"indexColorSortName","name":"indexColorSortName","type":"json"}`),
+		"META-INF/statedb/couchdb/indexes/indexSizeSortName.json":                                                []byte(`{"index":{"fields":[{"size":"desc"}]},"ddoc":"indexSizeSortName","name":"indexSizeSortName","type":"json"}`),
+		"META-INF/statedb/couchdb/collections/collectionMarbles/indexes/indexCollMarbles.json":                   []byte(`{"index":{"fields":["docType","owner"]},"ddoc":"indexCollectionMarbles", "name":"indexCollectionMarbles","type":"json"}`),
+		"META-INF/statedb/couchdb/collections/collectionMarblesPrivateDetails/indexes/indexCollPrivDetails.json": []byte(`{"index":{"fields":["docType","price"]},"ddoc":"indexPrivateDetails", "name":"indexPrivateDetails","type":"json"}`),
+	}
 
 	//Create a query
 	queryString := `{"selector":{"owner":"fred"}}`
@@ -604,10 +599,7 @@ func TestHandleChaincodeDeploy(t *testing.T) {
 		t.Fatalf("Couchdb state impl is expected to implement interface `statedb.IndexCapable`")
 	}
 
-	fileEntries, errExtract := ccprovider.ExtractFileEntries(dbArtifactsTarBytes, "couchdb")
-	assert.NoError(t, errExtract)
-
-	indexCapable.ProcessIndexesForChaincodeDeploy("ns1", fileEntries["META-INF/statedb/couchdb/indexes"])
+	indexCapable.ProcessIndexesForChaincodeDeploy("ns1", indexData)
 	//Sleep to allow time for index creation
 	time.Sleep(100 * time.Millisecond)
 	//Create a query with a sort
@@ -649,24 +641,18 @@ func TestHandleChaincodeDeployErroneousIndexFile(t *testing.T) {
 	batch.Put("ns1", "key1", []byte(`{"asset_name": "marble1","color": "blue","size": 1,"owner": "tom"}`), version.NewHeight(1, 1))
 	batch.Put("ns1", "key2", []byte(`{"asset_name": "marble2","color": "blue","size": 2,"owner": "jerry"}`), version.NewHeight(1, 2))
 
-	// Create a tar file for test with 2 index definitions - one of them being errorneous
 	badSyntaxFileContent := `{"index":{"fields": This is a bad json}`
-	dbArtifactsTarBytes := testutil.CreateTarBytesForTest(
-		[]*testutil.TarFileEntry{
-			{Name: "META-INF/statedb/couchdb/indexes/indexSizeSortName.json", Body: `{"index":{"fields":[{"size":"desc"}]},"ddoc":"indexSizeSortName","name":"indexSizeSortName","type":"json"}`},
-			{Name: "META-INF/statedb/couchdb/indexes/badSyntax.json", Body: badSyntaxFileContent},
-		},
-	)
+	indexData := map[string][]byte{
+		"META-INF/statedb/couchdb/indexes/indexSizeSortName.json": []byte(`{"index":{"fields":[{"size":"desc"}]},"ddoc":"indexSizeSortName","name":"indexSizeSortName","type":"json"}`),
+		"META-INF/statedb/couchdb/indexes/badSyntax.json":         []byte(badSyntaxFileContent),
+	}
 
 	indexCapable, ok := db.(statedb.IndexCapable)
 	if !ok {
 		t.Fatalf("Couchdb state impl is expected to implement interface `statedb.IndexCapable`")
 	}
 
-	fileEntries, errExtract := ccprovider.ExtractFileEntries(dbArtifactsTarBytes, "couchdb")
-	assert.NoError(t, errExtract)
-
-	indexCapable.ProcessIndexesForChaincodeDeploy("ns1", fileEntries["META-INF/statedb/couchdb/indexes"])
+	indexCapable.ProcessIndexesForChaincodeDeploy("ns1", indexData)
 
 	//Sleep to allow time for index creation
 	time.Sleep(100 * time.Millisecond)
@@ -791,12 +777,9 @@ func TestPaginatedQuery(t *testing.T) {
 	savePoint := version.NewHeight(2, 22)
 	db.ApplyUpdates(batch, savePoint)
 
-	// Create a tar file for test with an index for size
-	dbArtifactsTarBytes := testutil.CreateTarBytesForTest(
-		[]*testutil.TarFileEntry{
-			{Name: "META-INF/statedb/couchdb/indexes/indexSizeSortName.json", Body: `{"index":{"fields":[{"size":"desc"}]},"ddoc":"indexSizeSortName","name":"indexSizeSortName","type":"json"}`},
-		},
-	)
+	indexData := map[string][]byte{
+		"META-INF/statedb/couchdb/indexes/indexSizeSortName.json": []byte(`{"index":{"fields":[{"size":"desc"}]},"ddoc":"indexSizeSortName","name":"indexSizeSortName","type":"json"}`),
+	}
 
 	// Create a query
 	queryString := `{"selector":{"color":"red"}}`
@@ -813,10 +796,7 @@ func TestPaginatedQuery(t *testing.T) {
 		t.Fatalf("Couchdb state impl is expected to implement interface `statedb.IndexCapable`")
 	}
 
-	fileEntries, errExtract := ccprovider.ExtractFileEntries(dbArtifactsTarBytes, "couchdb")
-	assert.NoError(t, errExtract)
-
-	indexCapable.ProcessIndexesForChaincodeDeploy("ns1", fileEntries["META-INF/statedb/couchdb/indexes"])
+	indexCapable.ProcessIndexesForChaincodeDeploy("ns1", indexData)
 	// Sleep to allow time for index creation
 	time.Sleep(100 * time.Millisecond)
 	// Create a query with a sort

--- a/core/ledger/kvledger/txmgmt/statedb/statedb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statedb.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/hyperledger/fabric/core/common/ccprovider"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/util"
 )
@@ -85,7 +84,7 @@ type BulkOptimizable interface {
 //databases capable of index operations
 type IndexCapable interface {
 	GetDBType() string
-	ProcessIndexesForChaincodeDeploy(namespace string, fileEntries []*ccprovider.TarFileEntry) error
+	ProcessIndexesForChaincodeDeploy(namespace string, indexFilesData map[string][]byte) error
 }
 
 // CompositeKey encloses Namespace and Key components


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code)

#### Description

The [statecouchdb package](https://github.com/hyperledger/fabric/tree/master/core/ledger/kvledger/txmgmt/statedb/statecouchdb) should not be dependent on too many other packages. It should be self-sufficient. Currently, we have imported [ccprovider](https://github.com/hyperledger/fabric/tree/master/core/common/ccprovider) just for a struct. Further, the test file imports a ccprovider to call a utility function. As these are not justifiable, we remove it and duplicate code as needed.

#### Additional details

In the ledger refactoring work, we plan to merge the following packages to reduce the folder depth
- merge kvledger with the ledger package
- merge lockbasedtxmgr to txmgr
- many more 

Due to some unnecessary import dependency, we get import cycles in the refactoring process. Hence, we remove one such unnecessary dependency from the statecouchdb package. In the upcoming PR, we will move structs that are used across packages from `core/ledger` to `internal/pkg/ledger`. This will also help us reduce the import cycles and do the refactoring without any blockers. 

#### Related issues

[FAB-17699](https://jira.hyperledger.org/browse/FAB-17699)
