### PR TITLE
Fix fabcar chaincode invoke command in doc

### DIFF
--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -319,7 +319,7 @@ Chaincodes are invoked when a network member wants to transfer or change an
 asset on the ledger. Use the following command to change the owner of a car on
 the ledger by invoking the fabcar chaincode:
 ```
-peer chaincode invoke -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls true --cafile ${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem -C mychannel -n fabcar --peerAddresses localhost:7051 --tlsRootCertFiles ${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt --peerAddresses localhost:9051 --tlsRootCertFiles ${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt -c '{"function":"changeCarOwner","Args":["CAR9","Dave"]}'
+peer chaincode invoke -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls true --cafile ${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem -C mychannel -n fabcar --peerAddresses localhost:7051 --tlsRootCertFiles ${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt --peerAddresses localhost:9051 --tlsRootCertFiles ${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt -c '{"function":"changeCarOwner","Args":["CAR009","Dave"]}'
 ```
 
 If the command is successful, you should see the following response:


### PR DESCRIPTION
The current command does not update the ledger because CAR9 does not exists. The real name is CAR009

#### Type of change
- Documentation update

#### Description

If you flow the original doc this will lead to the error: 
`Error: endorsement failure during invoke. response: status:500 message:"error in simulation: transaction returned with failure: Car CAR9 does not exist"`

Go and Java implementations use a three-digit number for the key. 
[Example](https://github.com/hyperledger/fabric-samples/blob/4bb48a909cf7109f3915562fc08d1cbb4cb14dde/chaincode/fabcar/java/src/main/java/org/hyperledger/fabric/samples/fabcar/FabCar.java#L98)

Updating the name will possibly improve the user experience.

Signed-off-by: Stefan Obermeier <git@stefan-obermeier.de>