### PR TITLE
[FAB-17700] Fix wrong `docker rmi` in documents

### DIFF
--- a/docs/source/build_network.rst
+++ b/docs/source/build_network.rst
@@ -1388,7 +1388,7 @@ Troubleshooting
 
    .. code:: bash
 
-       docker rmi -f $(docker images | grep peer[0-9]-peer[0-9] | awk '{print $3}')
+       docker rmi -f $(docker images | grep dev-peer[0-9] | awk '{print $3}')
 
 -  If you see something similar to the following:
 

--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -571,7 +571,7 @@ If you have any problems with the tutorial, review the following:
    ``dev-peer0.org1.example.com-fabcar-1.0``) from prior runs. Remove them and try
    again.
    ```
-   docker rmi -f $(docker images | grep peer[0-9]-peer[0-9] | awk '{print $3}')
+   docker rmi -f $(docker images | grep dev-peer[0-9] | awk '{print $3}')
    ```
 
 -  If you see the below error:


### PR DESCRIPTION
This patch fixes wrong `docker rmi` in the documents.

Signed-off-by: Tatsuya Sato <Tatsuya.Sato@hal.hitachi.com>


#### Type of change

- Documentation update

#### Description

This patch fixes wrong `docker rmi` in the documents.

#### Additional details

#### Related issues

https://jira.hyperledger.org/browse/FAB-17700
