### PR TITLE
[FAB-17696] Fixed Wiki Link to Contributor meetings

### DIFF
--- a/docs/source/CONTRIBUTING.rst
+++ b/docs/source/CONTRIBUTING.rst
@@ -161,7 +161,7 @@ releases, and to discuss the technical and operational direction of the project
 and sub-projects.
 
 Please see the
-`wiki <https://wiki.hyperledger.org/display/fabric/Maintainer+Meetings>`__
+`wiki <https://wiki.hyperledger.org/display/fabric/Contributor+Meetings>`__
 for maintainer meeting details.
 
 New feature/enhancement proposals as described above should be presented to a


### PR DESCRIPTION
Signed-off-by: pama-ibm <pama@ibm.com>

Contributing topic was pointing to Maintainers Wiki instead of Contributors Wiki

#### Type of change
- Documentation update

#### Description

Changed link from 

https://wiki.hyperledger.org/display/fabric/Maintainer+Meetings
to
https://wiki.hyperledger.org/display/fabric/Contributor+Meetings


