### PR TITLE
[FAB-17662] Remove Get prefix from exported ConfigTX functions

### DIFF
--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -24,10 +24,10 @@ type Application struct {
 	ACLs          map[string]string
 }
 
-// GetApplicationConfiguration returns the existing application configuration values from a config
+// ApplicationConfiguration returns the existing application configuration values from a config
 // transaction as an Application type. This can be used to retrieve existing values for the application
 // prior to updating the application configuration.
-func (c *ConfigTx) GetApplicationConfiguration() (Application, error) {
+func (c *ConfigTx) ApplicationConfiguration() (Application, error) {
 	applicationGroup, ok := c.base.ChannelGroup.Groups[ApplicationGroupKey]
 	if !ok {
 		return Application{}, errors.New("config does not contain application group")
@@ -35,7 +35,7 @@ func (c *ConfigTx) GetApplicationConfiguration() (Application, error) {
 
 	var applicationOrgs []Organization
 	for orgName := range applicationGroup.Groups {
-		orgConfig, err := c.GetApplicationOrg(orgName)
+		orgConfig, err := c.ApplicationOrg(orgName)
 		if err != nil {
 			return Application{}, fmt.Errorf("retrieving application org %s: %v", orgName, err)
 		}
@@ -43,17 +43,17 @@ func (c *ConfigTx) GetApplicationConfiguration() (Application, error) {
 		applicationOrgs = append(applicationOrgs, orgConfig)
 	}
 
-	capabilities, err := c.GetApplicationCapabilities()
+	capabilities, err := c.ApplicationCapabilities()
 	if err != nil {
 		return Application{}, fmt.Errorf("retrieving application capabilities: %v", err)
 	}
 
-	policies, err := c.GetPoliciesForApplication()
+	policies, err := c.ApplicationPolicies()
 	if err != nil {
 		return Application{}, fmt.Errorf("retrieving application policies: %v", err)
 	}
 
-	acls, err := c.GetApplicationACLs()
+	acls, err := c.ApplicationACLs()
 	if err != nil {
 		return Application{}, fmt.Errorf("retrieving application acls: %v", err)
 	}
@@ -194,8 +194,8 @@ func (c *ConfigTx) RemoveACLs(acls []string) error {
 	return nil
 }
 
-// GetApplicationACLs returns a map of application acls from a config transaction.
-func (c *ConfigTx) GetApplicationACLs() (map[string]string, error) {
+// ApplicationACLs returns a map of application acls from a config transaction.
+func (c *ConfigTx) ApplicationACLs() (map[string]string, error) {
 	return getACLs(c.base)
 }
 
@@ -220,8 +220,8 @@ func getACLs(config *cb.Config) (map[string]string, error) {
 	return retACLs, nil
 }
 
-// GetAnchorPeers retrieves existing anchor peers from a application organization.
-func (c *ConfigTx) GetAnchorPeers(orgName string) ([]Address, error) {
+// AnchorPeers retrieves existing anchor peers from a application organization.
+func (c *ConfigTx) AnchorPeers(orgName string) ([]Address, error) {
 	applicationOrgGroup, ok := c.base.ChannelGroup.Groups[ApplicationGroupKey].Groups[orgName]
 	if !ok {
 		return nil, fmt.Errorf("application org %s does not exist in channel config", orgName)

--- a/pkg/config/application_test.go
+++ b/pkg/config/application_test.go
@@ -578,7 +578,7 @@ func TestRemoveAnchorPeerFailure(t *testing.T) {
 	}
 }
 
-func TestGetAnchorPeer(t *testing.T) {
+func TestAnchorPeer(t *testing.T) {
 	t.Parallel()
 
 	gt := NewGomegaWithT(t)
@@ -602,13 +602,13 @@ func TestGetAnchorPeer(t *testing.T) {
 	err = c.AddAnchorPeer("Org1", expectedAnchorPeer)
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	anchorPeers, err := c.GetAnchorPeers("Org1")
+	anchorPeers, err := c.AnchorPeers("Org1")
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(len(anchorPeers)).To(Equal(1))
 	gt.Expect(anchorPeers[0]).To(Equal(expectedAnchorPeer))
 }
 
-func TestGetAnchorPeerFailures(t *testing.T) {
+func TestAnchorPeerFailures(t *testing.T) {
 	t.Parallel()
 
 	gt := NewGomegaWithT(t)
@@ -657,7 +657,7 @@ func TestGetAnchorPeerFailures(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			gt := NewGomegaWithT(t)
-			_, err := c.GetAnchorPeers(test.orgName)
+			_, err := c.AnchorPeers(test.orgName)
 			gt.Expect(err).To(MatchError(test.expectedErr))
 		})
 	}
@@ -1016,7 +1016,7 @@ func TestAddApplicationOrgFailures(t *testing.T) {
 	gt.Expect(err).To(MatchError("failed to create application org Org3: no policies defined"))
 }
 
-func TestGetApplicationConfiguration(t *testing.T) {
+func TestApplicationConfiguration(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
@@ -1041,7 +1041,7 @@ func TestGetApplicationConfiguration(t *testing.T) {
 		gt.Expect(err).NotTo(HaveOccurred())
 	}
 
-	applicationConfig, err := c.GetApplicationConfiguration()
+	applicationConfig, err := c.ApplicationConfiguration()
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(applicationConfig.ACLs).To(Equal(baseApplicationConf.ACLs))
 	gt.Expect(applicationConfig.Capabilities).To(Equal(baseApplicationConf.Capabilities))
@@ -1049,7 +1049,7 @@ func TestGetApplicationConfiguration(t *testing.T) {
 	gt.Expect(applicationConfig.Organizations).To(ContainElements(baseApplicationConf.Organizations))
 }
 
-func TestGetApplicationConfigurationFailure(t *testing.T) {
+func TestApplicationConfigurationFailure(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -1105,13 +1105,13 @@ func TestGetApplicationConfigurationFailure(t *testing.T) {
 				tt.configMod(c, baseApplicationConf, gt)
 			}
 
-			_, err = c.GetApplicationConfiguration()
+			_, err = c.ApplicationConfiguration()
 			gt.Expect(err).To(MatchError(tt.expectedErr))
 		})
 	}
 }
 
-func TestGetApplicationACLs(t *testing.T) {
+func TestApplicationACLs(t *testing.T) {
 	t.Parallel()
 
 	gt := NewGomegaWithT(t)
@@ -1132,12 +1132,12 @@ func TestGetApplicationACLs(t *testing.T) {
 		base: config,
 	}
 
-	applicationACLs, err := c.GetApplicationACLs()
+	applicationACLs, err := c.ApplicationACLs()
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(applicationACLs).To(Equal(baseApplicationConf.ACLs))
 }
 
-func TestGetApplicationACLsFailure(t *testing.T) {
+func TestApplicationACLsFailure(t *testing.T) {
 	t.Parallel()
 
 	gt := NewGomegaWithT(t)
@@ -1152,7 +1152,7 @@ func TestGetApplicationACLsFailure(t *testing.T) {
 		base: config,
 	}
 
-	applicationACLs, err := c.GetApplicationACLs()
+	applicationACLs, err := c.ApplicationACLs()
 	gt.Expect(err).To(MatchError("application does not exist in channel config"))
 	gt.Expect(applicationACLs).To(BeNil())
 }

--- a/pkg/config/capabilities.go
+++ b/pkg/config/capabilities.go
@@ -14,9 +14,9 @@ import (
 	cb "github.com/hyperledger/fabric-protos-go/common"
 )
 
-// GetChannelCapabilities returns a map of enabled channel capabilities
+// ChannelCapabilities returns a map of enabled channel capabilities
 // from a config transaction.
-func (c *ConfigTx) GetChannelCapabilities() ([]string, error) {
+func (c *ConfigTx) ChannelCapabilities() ([]string, error) {
 	capabilities, err := getCapabilities(c.base.ChannelGroup)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving channel capabilities: %v", err)
@@ -25,9 +25,9 @@ func (c *ConfigTx) GetChannelCapabilities() ([]string, error) {
 	return capabilities, nil
 }
 
-// GetOrdererCapabilities returns a map of enabled orderer capabilities
+// OrdererCapabilities returns a map of enabled orderer capabilities
 // from a config transaction.
-func (c *ConfigTx) GetOrdererCapabilities() ([]string, error) {
+func (c *ConfigTx) OrdererCapabilities() ([]string, error) {
 	orderer, ok := c.base.ChannelGroup.Groups[OrdererGroupKey]
 	if !ok {
 		return nil, errors.New("orderer missing from config")
@@ -41,9 +41,9 @@ func (c *ConfigTx) GetOrdererCapabilities() ([]string, error) {
 	return capabilities, nil
 }
 
-// GetApplicationCapabilities returns a map of enabled application capabilities
+// ApplicationCapabilities returns a map of enabled application capabilities
 // from a config transaction.
-func (c *ConfigTx) GetApplicationCapabilities() ([]string, error) {
+func (c *ConfigTx) ApplicationCapabilities() ([]string, error) {
 	application, ok := c.base.ChannelGroup.Groups[ApplicationGroupKey]
 	if !ok {
 		return nil, errors.New("application missing from config")
@@ -59,7 +59,7 @@ func (c *ConfigTx) GetApplicationCapabilities() ([]string, error) {
 
 // AddChannelCapability adds capability to the provided channel config.
 func (c *ConfigTx) AddChannelCapability(capability string) error {
-	capabilities, err := c.GetChannelCapabilities()
+	capabilities, err := c.ChannelCapabilities()
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (c *ConfigTx) AddChannelCapability(capability string) error {
 
 // AddOrdererCapability adds capability to the provided channel config.
 func (c *ConfigTx) AddOrdererCapability(capability string) error {
-	capabilities, err := c.GetOrdererCapabilities()
+	capabilities, err := c.OrdererCapabilities()
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func (c *ConfigTx) AddOrdererCapability(capability string) error {
 
 // AddApplicationCapability adds capability to the provided channel config.
 func (c *ConfigTx) AddApplicationCapability(capability string) error {
-	capabilities, err := c.GetApplicationCapabilities()
+	capabilities, err := c.ApplicationCapabilities()
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (c *ConfigTx) AddApplicationCapability(capability string) error {
 
 // RemoveChannelCapability removes capability to the provided channel config.
 func (c *ConfigTx) RemoveChannelCapability(capability string) error {
-	capabilities, err := c.GetChannelCapabilities()
+	capabilities, err := c.ChannelCapabilities()
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (c *ConfigTx) RemoveChannelCapability(capability string) error {
 
 // RemoveOrdererCapability removes capability to the provided channel config.
 func (c *ConfigTx) RemoveOrdererCapability(capability string) error {
-	capabilities, err := c.GetOrdererCapabilities()
+	capabilities, err := c.OrdererCapabilities()
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func (c *ConfigTx) RemoveOrdererCapability(capability string) error {
 
 // RemoveApplicationCapability removes capability to the provided channel config.
 func (c *ConfigTx) RemoveApplicationCapability(capability string) error {
-	capabilities, err := c.GetApplicationCapabilities()
+	capabilities, err := c.ApplicationCapabilities()
 	if err != nil {
 		return err
 	}

--- a/pkg/config/capabilities_test.go
+++ b/pkg/config/capabilities_test.go
@@ -19,7 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestGetChannelCapabilities(t *testing.T) {
+func TestChannelCapabilities(t *testing.T) {
 	t.Parallel()
 
 	gt := NewGomegaWithT(t)
@@ -40,18 +40,18 @@ func TestGetChannelCapabilities(t *testing.T) {
 	err := setValue(config.ChannelGroup, capabilitiesValue(expectedCapabilities), AdminsPolicyKey)
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	channelCapabilities, err := c.GetChannelCapabilities()
+	channelCapabilities, err := c.ChannelCapabilities()
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(channelCapabilities).To(Equal(expectedCapabilities))
 
 	// Delete the capabilities key and assert retrieval to return nil
 	delete(config.ChannelGroup.Values, CapabilitiesKey)
-	channelCapabilities, err = c.GetChannelCapabilities()
+	channelCapabilities, err = c.ChannelCapabilities()
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(channelCapabilities).To(BeNil())
 }
 
-func TestGetOrdererCapabilities(t *testing.T) {
+func TestOrdererCapabilities(t *testing.T) {
 	t.Parallel()
 
 	gt := NewGomegaWithT(t)
@@ -73,18 +73,18 @@ func TestGetOrdererCapabilities(t *testing.T) {
 		updated: config,
 	}
 
-	ordererCapabilities, err := c.GetOrdererCapabilities()
+	ordererCapabilities, err := c.OrdererCapabilities()
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(ordererCapabilities).To(Equal(baseOrdererConf.Capabilities))
 
 	// Delete the capabilities key and assert retrieval to return nil
 	delete(config.ChannelGroup.Groups[OrdererGroupKey].Values, CapabilitiesKey)
-	ordererCapabilities, err = c.GetOrdererCapabilities()
+	ordererCapabilities, err = c.OrdererCapabilities()
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(ordererCapabilities).To(BeNil())
 }
 
-func TestGetOrdererCapabilitiesFailure(t *testing.T) {
+func TestOrdererCapabilitiesFailure(t *testing.T) {
 	t.Parallel()
 
 	gt := NewGomegaWithT(t)
@@ -100,12 +100,12 @@ func TestGetOrdererCapabilitiesFailure(t *testing.T) {
 		updated: config,
 	}
 
-	ordererCapabilities, err := c.GetOrdererCapabilities()
+	ordererCapabilities, err := c.OrdererCapabilities()
 	gt.Expect(err).To(MatchError("orderer missing from config"))
 	gt.Expect(ordererCapabilities).To(BeNil())
 }
 
-func TestGetApplicationCapabilities(t *testing.T) {
+func TestApplicationCapabilities(t *testing.T) {
 	t.Parallel()
 
 	gt := NewGomegaWithT(t)
@@ -127,18 +127,18 @@ func TestGetApplicationCapabilities(t *testing.T) {
 		updated: config,
 	}
 
-	applicationCapabilities, err := c.GetApplicationCapabilities()
+	applicationCapabilities, err := c.ApplicationCapabilities()
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(applicationCapabilities).To(Equal(baseApplicationConf.Capabilities))
 
 	// Delete the capabilities key and assert retrieval to return nil
 	delete(config.ChannelGroup.Groups[ApplicationGroupKey].Values, CapabilitiesKey)
-	applicationCapabilities, err = c.GetApplicationCapabilities()
+	applicationCapabilities, err = c.ApplicationCapabilities()
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(applicationCapabilities).To(BeNil())
 }
 
-func TestGetApplicationCapabilitiesFailure(t *testing.T) {
+func TestApplicationCapabilitiesFailure(t *testing.T) {
 	t.Parallel()
 
 	gt := NewGomegaWithT(t)
@@ -154,7 +154,7 @@ func TestGetApplicationCapabilitiesFailure(t *testing.T) {
 		updated: config,
 	}
 
-	applicationCapabilities, err := c.GetApplicationCapabilities()
+	applicationCapabilities, err := c.ApplicationCapabilities()
 	gt.Expect(err).To(MatchError("application missing from config"))
 	gt.Expect(applicationCapabilities).To(BeNil())
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -132,14 +132,14 @@ func (c *ConfigTx) ChannelConfiguration() (Channel, error) {
 	}
 
 	if _, ok := channelGroup.Groups[ApplicationGroupKey]; ok {
-		application, err = c.GetApplicationConfiguration()
+		application, err = c.ApplicationConfiguration()
 		if err != nil {
 			return Channel{}, err
 		}
 	}
 
 	if _, ok := channelGroup.Groups[OrdererGroupKey]; ok {
-		orderer, err = c.GetOrdererConfiguration()
+		orderer, err = c.OrdererConfiguration()
 		if err != nil {
 			return Channel{}, err
 		}
@@ -153,13 +153,13 @@ func (c *ConfigTx) ChannelConfiguration() (Channel, error) {
 	}
 
 	if _, ok := channelGroup.Values[CapabilitiesKey]; ok {
-		capabilities, err = c.GetChannelCapabilities()
+		capabilities, err = c.ChannelCapabilities()
 		if err != nil {
 			return Channel{}, err
 		}
 	}
 
-	policies, err := c.GetPoliciesForChannel()
+	policies, err := c.ChannelPolicies()
 	if err != nil {
 		return Channel{}, err
 	}

--- a/pkg/config/example_test.go
+++ b/pkg/config/example_test.go
@@ -230,7 +230,7 @@ func Example_orderer() {
 
 	// Must retrieve the current orderer configuration from block and modify
 	// the desired values
-	orderer, err := c.GetOrdererConfiguration()
+	orderer, err := c.OrdererConfiguration()
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/config/msp_test.go
+++ b/pkg/config/msp_test.go
@@ -127,7 +127,7 @@ func TestConsortiumMSP(t *testing.T) {
 	gt.Expect(msp).To(Equal(expectedMSP))
 }
 
-func TestGetMSPConfigurationFailures(t *testing.T) {
+func TestMSPConfigurationFailures(t *testing.T) {
 	t.Parallel()
 
 	badCert := &x509.Certificate{}

--- a/pkg/config/orderer.go
+++ b/pkg/config/orderer.go
@@ -108,10 +108,10 @@ func (c *ConfigTx) UpdateOrdererConfiguration(o Orderer) error {
 	return nil
 }
 
-// GetOrdererConfiguration returns the existing orderer configuration values from a config
+// OrdererConfiguration returns the existing orderer configuration values from a config
 // transaction as an Orderer type. This can be used to retrieve existing values for the orderer
 // prior to updating the orderer configuration.
-func (c *ConfigTx) GetOrdererConfiguration() (Orderer, error) {
+func (c *ConfigTx) OrdererConfiguration() (Orderer, error) {
 	ordererGroup, ok := c.base.ChannelGroup.Groups[OrdererGroupKey]
 	if !ok {
 		return Orderer{}, errors.New("config does not contain orderer group")
@@ -181,7 +181,7 @@ func (c *ConfigTx) GetOrdererConfiguration() (Orderer, error) {
 	// ORDERER ORGS
 	var ordererOrgs []Organization
 	for orgName := range ordererGroup.Groups {
-		orgConfig, err := c.GetOrdererOrg(orgName)
+		orgConfig, err := c.OrdererOrg(orgName)
 		if err != nil {
 			return Orderer{}, fmt.Errorf("retrieving orderer org %s: %v", orgName, err)
 		}
@@ -203,7 +203,7 @@ func (c *ConfigTx) GetOrdererConfiguration() (Orderer, error) {
 	}
 
 	// POLICIES
-	policies, err := c.GetPoliciesForOrderer()
+	policies, err := c.OrdererPolicies()
 	if err != nil {
 		return Orderer{}, fmt.Errorf("retrieving orderer policies: %v", err)
 	}

--- a/pkg/config/orderer_test.go
+++ b/pkg/config/orderer_test.go
@@ -542,7 +542,7 @@ func TestUpdateOrdererConfiguration(t *testing.T) {
 	gt.Expect(buf.String()).To(MatchJSON(expectedConfigJSON))
 }
 
-func TestGetOrdererConfiguration(t *testing.T) {
+func TestOrdererConfiguration(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -596,14 +596,14 @@ func TestGetOrdererConfiguration(t *testing.T) {
 				updated: config,
 			}
 
-			ordererConf, err := c.GetOrdererConfiguration()
+			ordererConf, err := c.OrdererConfiguration()
 			gt.Expect(err).NotTo(HaveOccurred())
 			gt.Expect(ordererConf).To(Equal(baseOrdererConf))
 		})
 	}
 }
 
-func TestGetOrdererConfigurationFailure(t *testing.T) {
+func TestOrdererConfigurationFailure(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -697,7 +697,7 @@ func TestGetOrdererConfigurationFailure(t *testing.T) {
 				tt.configMod(c.updated, gt)
 			}
 
-			_, err = c.GetOrdererConfiguration()
+			_, err = c.OrdererConfiguration()
 			gt.Expect(err).To(MatchError(tt.expectedErr))
 		})
 	}

--- a/pkg/config/organization.go
+++ b/pkg/config/organization.go
@@ -15,8 +15,8 @@ import (
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 )
 
-// GetApplicationOrg retrieves an existing org from an application organization config group.
-func (c *ConfigTx) GetApplicationOrg(orgName string) (Organization, error) {
+// ApplicationOrg retrieves an existing org from an application organization config group.
+func (c *ConfigTx) ApplicationOrg(orgName string) (Organization, error) {
 	orgGroup, ok := c.base.ChannelGroup.Groups[ApplicationGroupKey].Groups[orgName]
 	if !ok {
 		return Organization{}, fmt.Errorf("application org %s does not exist in channel config", orgName)
@@ -25,8 +25,8 @@ func (c *ConfigTx) GetApplicationOrg(orgName string) (Organization, error) {
 	return getOrganization(orgGroup, orgName)
 }
 
-// GetOrdererOrg retrieves an existing org from an orderer organization config group.
-func (c *ConfigTx) GetOrdererOrg(orgName string) (Organization, error) {
+// OrdererOrg retrieves an existing org from an orderer organization config group.
+func (c *ConfigTx) OrdererOrg(orgName string) (Organization, error) {
 	orgGroup, ok := c.base.ChannelGroup.Groups[OrdererGroupKey].Groups[orgName]
 	if !ok {
 		return Organization{}, fmt.Errorf("orderer org %s does not exist in channel config", orgName)
@@ -55,8 +55,8 @@ func (c *ConfigTx) GetOrdererOrg(orgName string) (Organization, error) {
 	return org, err
 }
 
-// GetConsortiumOrg retrieves an existing org from a consortium organization config group.
-func (c *ConfigTx) GetConsortiumOrg(consortiumName, orgName string) (Organization, error) {
+// ConsortiumOrg retrieves an existing org from a consortium organization config group.
+func (c *ConfigTx) ConsortiumOrg(consortiumName, orgName string) (Organization, error) {
 	consortium, ok := c.base.ChannelGroup.Groups[ConsortiumsGroupKey].Groups[consortiumName]
 	if !ok {
 		return Organization{}, fmt.Errorf("consortium %s does not exist in channel config", consortiumName)

--- a/pkg/config/organization_test.go
+++ b/pkg/config/organization_test.go
@@ -17,7 +17,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestGetOrganization(t *testing.T) {
+func TestOrganization(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
@@ -30,7 +30,7 @@ func TestGetOrganization(t *testing.T) {
 	gt.Expect(expectedOrg).To(Equal(org))
 }
 
-func TestGetApplicationOrg(t *testing.T) {
+func TestApplicationOrg(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
@@ -81,7 +81,7 @@ func TestGetApplicationOrg(t *testing.T) {
 			t.Parallel()
 			gt := NewGomegaWithT(t)
 
-			org, err := c.GetApplicationOrg(tc.orgName)
+			org, err := c.ApplicationOrg(tc.orgName)
 			if tc.expectedErr != "" {
 				gt.Expect(Organization{}).To(Equal(org))
 				gt.Expect(err).To(MatchError(tc.expectedErr))
@@ -93,7 +93,7 @@ func TestGetApplicationOrg(t *testing.T) {
 	}
 }
 
-func TestGetOrdererOrg(t *testing.T) {
+func TestOrdererOrg(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
@@ -135,7 +135,7 @@ func TestGetOrdererOrg(t *testing.T) {
 			t.Parallel()
 			gt := NewGomegaWithT(t)
 
-			org, err := c.GetOrdererOrg(tc.orgName)
+			org, err := c.OrdererOrg(tc.orgName)
 			if tc.expectedErr != "" {
 				gt.Expect(err).To(MatchError(tc.expectedErr))
 				gt.Expect(Organization{}).To(Equal(org))
@@ -147,7 +147,7 @@ func TestGetOrdererOrg(t *testing.T) {
 	}
 }
 
-func TestGetConsortiumOrg(t *testing.T) {
+func TestConsortiumOrg(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
@@ -198,7 +198,7 @@ func TestGetConsortiumOrg(t *testing.T) {
 			t.Parallel()
 			gt := NewGomegaWithT(t)
 
-			org, err := c.GetConsortiumOrg(tc.consortiumName, tc.orgName)
+			org, err := c.ConsortiumOrg(tc.consortiumName, tc.orgName)
 			if tc.expectedErr != "" {
 				gt.Expect(Organization{}).To(Equal(org))
 				gt.Expect(err).To(MatchError(tc.expectedErr))

--- a/pkg/config/policies.go
+++ b/pkg/config/policies.go
@@ -43,12 +43,13 @@ func (c *ConfigTx) UpdateConsortiumChannelCreationPolicy(consortiumName string, 
 	return nil
 }
 
-// GetPoliciesForConsortiumOrg returns a map of policies for a specific consortium org.
-func (c *ConfigTx) GetPoliciesForConsortiumOrg(consortiumName, orgName string) (map[string]Policy, error) {
+// ConsortiumOrgPolicies returns a map of policies for a specific consortium org.
+func (c *ConfigTx) ConsortiumOrgPolicies(consortiumName, orgName string) (map[string]Policy, error) {
 	consortium, ok := c.base.ChannelGroup.Groups[ConsortiumsGroupKey].Groups[consortiumName]
 	if !ok {
 		return nil, fmt.Errorf("consortium %s does not exist in channel config", consortiumName)
 	}
+
 	org, ok := consortium.Groups[orgName]
 	if !ok {
 		return nil, fmt.Errorf("consortium org %s does not exist in channel config", orgName)
@@ -57,8 +58,8 @@ func (c *ConfigTx) GetPoliciesForConsortiumOrg(consortiumName, orgName string) (
 	return getPolicies(org.Policies)
 }
 
-// GetPoliciesForOrderer returns a map of policies for channel orderer.
-func (c *ConfigTx) GetPoliciesForOrderer() (map[string]Policy, error) {
+// OrdererPolicies returns a map of policies for channel orderer.
+func (c *ConfigTx) OrdererPolicies() (map[string]Policy, error) {
 	orderer, ok := c.base.ChannelGroup.Groups[OrdererGroupKey]
 	if !ok {
 		return nil, errors.New("orderer missing from config")
@@ -67,8 +68,8 @@ func (c *ConfigTx) GetPoliciesForOrderer() (map[string]Policy, error) {
 	return getPolicies(orderer.Policies)
 }
 
-// GetPoliciesForOrdererOrg returns a map of policies for a specific org.
-func (c *ConfigTx) GetPoliciesForOrdererOrg(orgName string) (map[string]Policy, error) {
+// OrdererOrgPolicies returns a map of policies for a specific org.
+func (c *ConfigTx) OrdererOrgPolicies(orgName string) (map[string]Policy, error) {
 	org, ok := c.base.ChannelGroup.Groups[OrdererGroupKey].Groups[orgName]
 	if !ok {
 		return nil, fmt.Errorf("orderer org %s does not exist in channel config", orgName)
@@ -77,8 +78,8 @@ func (c *ConfigTx) GetPoliciesForOrdererOrg(orgName string) (map[string]Policy, 
 	return getPolicies(org.Policies)
 }
 
-// GetPoliciesForApplication returns a map of policies for application config group.
-func (c *ConfigTx) GetPoliciesForApplication() (map[string]Policy, error) {
+// ApplicationPolicies returns a map of policies for application config group.
+func (c *ConfigTx) ApplicationPolicies() (map[string]Policy, error) {
 	application, ok := c.base.ChannelGroup.Groups[ApplicationGroupKey]
 	if !ok {
 		return nil, errors.New("application missing from config")
@@ -87,9 +88,9 @@ func (c *ConfigTx) GetPoliciesForApplication() (map[string]Policy, error) {
 	return getPolicies(application.Policies)
 }
 
-// GetPoliciesForApplicationOrg returns a map of policies for specific application
+// ApplicationOrgPolicies returns a map of policies for specific application
 // organization.
-func (c *ConfigTx) GetPoliciesForApplicationOrg(orgName string) (map[string]Policy, error) {
+func (c *ConfigTx) ApplicationOrgPolicies(orgName string) (map[string]Policy, error) {
 	orgGroup, ok := c.base.ChannelGroup.Groups[ApplicationGroupKey].Groups[orgName]
 	if !ok {
 		return nil, fmt.Errorf("application org %s does not exist in channel config", orgName)
@@ -98,8 +99,8 @@ func (c *ConfigTx) GetPoliciesForApplicationOrg(orgName string) (map[string]Poli
 	return getPolicies(orgGroup.Policies)
 }
 
-// GetPoliciesForChannel returns a map of policies for channel configuration.
-func (c *ConfigTx) GetPoliciesForChannel() (map[string]Policy, error) {
+// ChannelPolicies returns a map of policies for channel configuration.
+func (c *ConfigTx) ChannelPolicies() (map[string]Policy, error) {
 	return getPolicies(c.base.ChannelGroup.Policies)
 }
 
@@ -117,7 +118,7 @@ func (c *ConfigTx) AddApplicationPolicy(modPolicy, policyName string, policy Pol
 // RemoveApplicationPolicy removes an existing application policy configuration.
 // The policy must exist in the config.
 func (c *ConfigTx) RemoveApplicationPolicy(policyName string) error {
-	policies, err := c.GetPoliciesForApplication()
+	policies, err := c.ApplicationPolicies()
 	if err != nil {
 		return err
 	}
@@ -139,7 +140,7 @@ func (c *ConfigTx) AddApplicationOrgPolicy(orgName, modPolicy, policyName string
 // RemoveApplicationOrgPolicy removes an existing policy from an application organization.
 // The removed policy must exist.
 func (c *ConfigTx) RemoveApplicationOrgPolicy(orgName, policyName string) error {
-	policies, err := c.GetPoliciesForApplicationOrg(orgName)
+	policies, err := c.ApplicationOrgPolicies(orgName)
 	if err != nil {
 		return err
 	}
@@ -208,7 +209,7 @@ func (c *ConfigTx) RemoveOrdererPolicy(policyName string) error {
 		return errors.New("BlockValidation policy must be defined")
 	}
 
-	policies, err := c.GetPoliciesForOrderer()
+	policies, err := c.OrdererPolicies()
 	if err != nil {
 		return err
 	}
@@ -225,7 +226,7 @@ func (c *ConfigTx) AddOrdererOrgPolicy(orgName, modPolicy, policyName string, po
 // RemoveOrdererOrgPolicy removes an existing policy from an orderer organization.
 // The removed policy must exist however will not error if it does not exist in configuration.
 func (c *ConfigTx) RemoveOrdererOrgPolicy(orgName, policyName string) error {
-	policies, err := c.GetPoliciesForOrdererOrg(orgName)
+	policies, err := c.OrdererOrgPolicies(orgName)
 	if err != nil {
 		return err
 	}
@@ -242,7 +243,7 @@ func (c *ConfigTx) AddChannelPolicy(modPolicy, policyName string, policy Policy)
 // RemoveChannelPolicy removes an existing channel level policy.
 // The policy must exist in the config.
 func (c *ConfigTx) RemoveChannelPolicy(policyName string) error {
-	policies, err := c.GetPoliciesForChannel()
+	policies, err := c.ChannelPolicies()
 	if err != nil {
 		return err
 	}

--- a/pkg/config/policies_test.go
+++ b/pkg/config/policies_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestGetPolicies(t *testing.T) {
+func TestPolicies(t *testing.T) {
 	t.Parallel()
 	gt := NewGomegaWithT(t)
 
@@ -943,7 +943,7 @@ func TestRemoveChannelPolicy(t *testing.T) {
 	gt.Expect(baseChannel.Policies[ReadersPolicyKey]).ToNot(BeNil())
 }
 
-func TestGetPoliciesForConsortiumOrg(t *testing.T) {
+func TestConsortiumOrgPolicies(t *testing.T) {
 	t.Parallel()
 
 	gt := NewGomegaWithT(t)
@@ -984,12 +984,12 @@ func TestGetPoliciesForConsortiumOrg(t *testing.T) {
 		},
 	}
 
-	policies, err := c.GetPoliciesForConsortiumOrg("Consortium1", "Org1")
+	policies, err := c.ConsortiumOrgPolicies("Consortium1", "Org1")
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(policies).To(Equal(expectedPolicies))
 }
 
-func TestGetPoliciesForConsortiumOrgFailures(t *testing.T) {
+func TestConsortiumOrgPoliciesFailures(t *testing.T) {
 	t.Parallel()
 
 	gt := NewGomegaWithT(t)
@@ -1034,7 +1034,7 @@ func TestGetPoliciesForConsortiumOrgFailures(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.testName, func(t *testing.T) {
-			_, err = c.GetPoliciesForConsortiumOrg(tt.consortiumName, tt.orgName)
+			_, err = c.ConsortiumOrgPolicies(tt.consortiumName, tt.orgName)
 			gt.Expect(err).To(MatchError(tt.expectedErr))
 		})
 	}


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Remove Get prefix from exported ConfigTX functions. 

#### Related issues
[FAB-17662](https://jira.hyperledger.org/browse/FAB-17662)