### PR TITLE
Set default keepalive options for peer clients

### DIFF
--- a/internal/peer/common/peerclient.go
+++ b/internal/peer/common/peerclient.go
@@ -81,6 +81,8 @@ func NewPeerClientForAddress(address, tlsRootCertFile string) (*PeerClient, erro
 }
 
 func newPeerClientForClientConfig(address, override string, clientConfig comm.ClientConfig) (*PeerClient, error) {
+	// set the default keepalive options to match the server
+	clientConfig.KaOpts = comm.DefaultKeepaliveOptions
 	gClient, err := comm.NewGRPCClient(clientConfig)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create PeerClient from config")


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

The latest version of grpc now sets the default
client keepalive time to 10 seconds.  Prior to this,
if the timeout was set to 0, grpc actually used an
infinite timeout by default which effectively meant
no keepalives were ever sent.  Since it now sets the
default to 10 seconds and the server permitted timeout is
actual set to 20 seconds, we now see disconnects for
requests taking > 20 secs as the client is now violating
the policy.

#### Related issues

[FAB-17706](https://jira.hyperledger.org/browse/FAB-17706)
https://github.com/hyperledger/fabric/pull/930

Signed-off-by: Gari Singh <gari.r.singh@gmail.com>