### PR TITLE
mv keys/update_batches to ledger/internal/state

### DIFF
--- a/core/ledger/internal/state/mock/results_iterator.go
+++ b/core/ledger/internal/state/mock/results_iterator.go
@@ -4,7 +4,7 @@ package mock
 import (
 	"sync"
 
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 )
 
 type ResultsIterator struct {
@@ -12,16 +12,16 @@ type ResultsIterator struct {
 	closeMutex       sync.RWMutex
 	closeArgsForCall []struct {
 	}
-	NextStub        func() (statedb.QueryResult, error)
+	NextStub        func() (state.QueryResult, error)
 	nextMutex       sync.RWMutex
 	nextArgsForCall []struct {
 	}
 	nextReturns struct {
-		result1 statedb.QueryResult
+		result1 state.QueryResult
 		result2 error
 	}
 	nextReturnsOnCall map[int]struct {
-		result1 statedb.QueryResult
+		result1 state.QueryResult
 		result2 error
 	}
 	invocations      map[string][][]interface{}
@@ -51,7 +51,7 @@ func (fake *ResultsIterator) CloseCalls(stub func()) {
 	fake.CloseStub = stub
 }
 
-func (fake *ResultsIterator) Next() (statedb.QueryResult, error) {
+func (fake *ResultsIterator) Next() (state.QueryResult, error) {
 	fake.nextMutex.Lock()
 	ret, specificReturn := fake.nextReturnsOnCall[len(fake.nextArgsForCall)]
 	fake.nextArgsForCall = append(fake.nextArgsForCall, struct {
@@ -74,34 +74,34 @@ func (fake *ResultsIterator) NextCallCount() int {
 	return len(fake.nextArgsForCall)
 }
 
-func (fake *ResultsIterator) NextCalls(stub func() (statedb.QueryResult, error)) {
+func (fake *ResultsIterator) NextCalls(stub func() (state.QueryResult, error)) {
 	fake.nextMutex.Lock()
 	defer fake.nextMutex.Unlock()
 	fake.NextStub = stub
 }
 
-func (fake *ResultsIterator) NextReturns(result1 statedb.QueryResult, result2 error) {
+func (fake *ResultsIterator) NextReturns(result1 state.QueryResult, result2 error) {
 	fake.nextMutex.Lock()
 	defer fake.nextMutex.Unlock()
 	fake.NextStub = nil
 	fake.nextReturns = struct {
-		result1 statedb.QueryResult
+		result1 state.QueryResult
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *ResultsIterator) NextReturnsOnCall(i int, result1 statedb.QueryResult, result2 error) {
+func (fake *ResultsIterator) NextReturnsOnCall(i int, result1 state.QueryResult, result2 error) {
 	fake.nextMutex.Lock()
 	defer fake.nextMutex.Unlock()
 	fake.NextStub = nil
 	if fake.nextReturnsOnCall == nil {
 		fake.nextReturnsOnCall = make(map[int]struct {
-			result1 statedb.QueryResult
+			result1 state.QueryResult
 			result2 error
 		})
 	}
 	fake.nextReturnsOnCall[i] = struct {
-		result1 statedb.QueryResult
+		result1 state.QueryResult
 		result2 error
 	}{result1, result2}
 }
@@ -132,4 +132,4 @@ func (fake *ResultsIterator) recordInvocation(key string, args []interface{}) {
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ statedb.ResultsIterator = new(ResultsIterator)
+var _ state.ResultsIterator = new(ResultsIterator)

--- a/core/ledger/internal/state/state.go
+++ b/core/ledger/internal/state/state.go
@@ -1,0 +1,423 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package state
+
+import (
+	"sort"
+
+	"github.com/hyperledger/fabric/core/ledger/internal/version"
+	"github.com/hyperledger/fabric/core/ledger/util"
+)
+
+// CompositeKey encloses Namespace and Key components
+type CompositeKey struct {
+	Namespace string
+	Key       string
+}
+
+// PvtdataCompositeKey encloses Namespace, CollectionName and Key components
+type PvtdataCompositeKey struct {
+	Namespace      string
+	CollectionName string
+	Key            string
+}
+
+// HashedCompositeKey encloses Namespace, CollectionName and KeyHash components
+type HashedCompositeKey struct {
+	Namespace      string
+	CollectionName string
+	KeyHash        string
+}
+
+// VersionedValue encloses value and corresponding version
+type VersionedValue struct {
+	Value    []byte
+	Metadata []byte
+	Version  *version.Height
+}
+
+// IsDelete returns true if this update indicates delete of a key
+func (vv *VersionedValue) IsDelete() bool {
+	return vv.Value == nil
+}
+
+// VersionedKV encloses key and corresponding VersionedValue
+type VersionedKV struct {
+	CompositeKey
+	VersionedValue
+}
+
+// PubHashPvtUpdateBatch encapsulates the updates to Public, Private, and Hashed data.
+// This is expected to contain a consistent set of updates
+type PubHashPvtUpdateBatch struct {
+	PubUpdates  *PubUpdateBatch
+	HashUpdates *HashedUpdateBatch
+	PvtUpdates  *PvtUpdateBatch
+}
+
+// PubUpdateBatch contains update for the public data
+type PubUpdateBatch struct {
+	*UpdateBatch
+}
+
+// HashedUpdateBatch contains updates for the hashes of the private data
+type HashedUpdateBatch struct {
+	NsCollUpdates
+}
+
+// PvtUpdateBatch contains updates for the private data
+type PvtUpdateBatch struct {
+	NsCollUpdates
+}
+
+// NewPubHashPvtUpdateBatch creates and empty UpdateBatch
+func NewPubHashPvtUpdateBatch() *PubHashPvtUpdateBatch {
+	return &PubHashPvtUpdateBatch{
+		PubUpdates:  NewPubUpdateBatch(),
+		HashUpdates: NewHashedUpdateBatch(),
+		PvtUpdates:  NewPvtUpdateBatch(),
+	}
+}
+
+// NewPubUpdateBatch creates an empty PubUpdateBatch
+func NewPubUpdateBatch() *PubUpdateBatch {
+	return &PubUpdateBatch{NewUpdateBatch()}
+}
+
+// NewHashedUpdateBatch creates an empty HashedUpdateBatch
+func NewHashedUpdateBatch() *HashedUpdateBatch {
+	return &HashedUpdateBatch{make(map[string]NsBatch)}
+}
+
+// NewPvtUpdateBatch creates an empty PvtUpdateBatch
+func NewPvtUpdateBatch() *PvtUpdateBatch {
+	return &PvtUpdateBatch{make(map[string]NsBatch)}
+}
+
+// Contains returns true if the given <ns,coll,keyHash> tuple is present in the batch
+func (h HashedUpdateBatch) Contains(ns, coll string, keyHash []byte) bool {
+	return h.NsCollUpdates.Contains(ns, coll, string(keyHash))
+}
+
+// Put overrides the function in NsCollUpdates for allowing the key to be a []byte instead of a string
+func (h HashedUpdateBatch) Put(ns, coll string, key []byte, value []byte, version *version.Height) {
+	h.PutValHashAndMetadata(ns, coll, key, value, nil, version)
+}
+
+// PutValHashAndMetadata adds a key with value and metadata
+// TODO introducing a new function to limit the refactoring. Later in a separate CR, the 'Put' function above should be removed
+func (h HashedUpdateBatch) PutValHashAndMetadata(ns, coll string, key []byte, value []byte, metadata []byte, version *version.Height) {
+	h.NsCollUpdates.PutValAndMetadata(ns, coll, string(key), value, metadata, version)
+}
+
+// Delete overrides the function in NsCollUpdates for allowing the key to be a []byte instead of a string
+func (h HashedUpdateBatch) Delete(ns, coll string, key []byte, version *version.Height) {
+	h.NsCollUpdates.Delete(ns, coll, string(key), version)
+}
+
+// ToCompositeKeyMap rearranges the update batch data in the form of a single map
+func (h HashedUpdateBatch) ToCompositeKeyMap() map[HashedCompositeKey]*VersionedValue {
+	m := make(map[HashedCompositeKey]*VersionedValue)
+	for ns, nsBatch := range h.NsCollUpdates {
+		for _, coll := range nsBatch.GetCollectionNames() {
+			for key, vv := range nsBatch.GetUpdates(coll) {
+				m[HashedCompositeKey{ns, coll, key}] = vv
+			}
+		}
+	}
+	return m
+}
+
+// PvtdataCompositeKeyMap is a map of PvtdataCompositeKey to VersionedValue
+type PvtdataCompositeKeyMap map[PvtdataCompositeKey]*VersionedValue
+
+// ToCompositeKeyMap rearranges the update batch data in the form of a single map
+func (p PvtUpdateBatch) ToCompositeKeyMap() PvtdataCompositeKeyMap {
+	m := make(PvtdataCompositeKeyMap)
+	for ns, nsBatch := range p.NsCollUpdates {
+		for _, coll := range nsBatch.GetCollectionNames() {
+			for key, vv := range nsBatch.GetUpdates(coll) {
+				m[PvtdataCompositeKey{ns, coll, key}] = vv
+			}
+		}
+	}
+	return m
+}
+
+// UpdateBatch encloses the details of multiple `updates`
+type UpdateBatch struct {
+	ContainsPostOrderWrites bool
+	Updates                 map[string]*nsUpdates
+}
+
+// NewUpdateBatch constructs an instance of a Batch
+func NewUpdateBatch() *UpdateBatch {
+	return &UpdateBatch{false, make(map[string]*nsUpdates)}
+}
+
+// Get returns the VersionedValue for the given namespace and key
+func (batch *UpdateBatch) Get(ns string, key string) *VersionedValue {
+	nsUpdates, ok := batch.Updates[ns]
+	if !ok {
+		return nil
+	}
+	vv, ok := nsUpdates.M[key]
+	if !ok {
+		return nil
+	}
+	return vv
+}
+
+// Put adds a key with value only. The metadata is assumed to be nil
+func (batch *UpdateBatch) Put(ns string, key string, value []byte, version *version.Height) {
+	batch.PutValAndMetadata(ns, key, value, nil, version)
+}
+
+// PutValAndMetadata adds a key with value and metadata
+// TODO introducing a new function to limit the refactoring. Later in a separate CR, the 'Put' function above should be removed
+func (batch *UpdateBatch) PutValAndMetadata(ns string, key string, value []byte, metadata []byte, version *version.Height) {
+	if value == nil {
+		panic("Nil value not allowed. Instead call 'Delete' function")
+	}
+	batch.Update(ns, key, &VersionedValue{value, metadata, version})
+}
+
+// Delete deletes a Key and associated value
+func (batch *UpdateBatch) Delete(ns string, key string, version *version.Height) {
+	batch.Update(ns, key, &VersionedValue{nil, nil, version})
+}
+
+// Exists checks whether the given key exists in the batch
+func (batch *UpdateBatch) Exists(ns string, key string) bool {
+	nsUpdates, ok := batch.Updates[ns]
+	if !ok {
+		return false
+	}
+	_, ok = nsUpdates.M[key]
+	return ok
+}
+
+// GetUpdatedNamespaces returns the names of the namespaces that are updated
+func (batch *UpdateBatch) GetUpdatedNamespaces() []string {
+	namespaces := make([]string, len(batch.Updates))
+	i := 0
+	for ns := range batch.Updates {
+		namespaces[i] = ns
+		i++
+	}
+	return namespaces
+}
+
+// GetUpdatedCollections returns the names of the namespaces that are updated
+func (batch *UpdateBatch) GetUpdatedCollections() []string {
+	collections := make([]string, len(batch.Updates))
+	i := 0
+	for ns := range batch.Updates {
+		collections[i] = ns
+		i++
+	}
+	return collections
+}
+
+// Update updates the batch with a latest entry for a namespace and a key
+func (batch *UpdateBatch) Update(ns string, key string, vv *VersionedValue) {
+	batch.getOrCreateNsUpdates(ns).M[key] = vv
+}
+
+// GetUpdates returns all the updates for a namespace
+func (batch *UpdateBatch) GetUpdates(ns string) map[string]*VersionedValue {
+	nsUpdates, ok := batch.Updates[ns]
+	if !ok {
+		return nil
+	}
+	return nsUpdates.M
+}
+
+// GetRangeScanIterator returns an iterator that iterates over keys of a specific namespace in sorted order
+// In other word this gives the same functionality over the contents in the `UpdateBatch` as
+// `VersionedDB.GetStateRangeScanIterator()` method gives over the contents in the statedb
+// This function can be used for querying the contents in the updateBatch before they are committed to the statedb.
+// For instance, a validator implementation can used this to verify the validity of a range query of a transaction
+// where the UpdateBatch represents the union of the modifications performed by the preceding valid transactions in the same block
+// (Assuming Group commit approach where we commit all the updates caused by a block together).
+func (batch *UpdateBatch) GetRangeScanIterator(ns string, startKey string, endKey string) QueryResultsIterator {
+	return newNsIterator(ns, startKey, endKey, batch)
+}
+
+// Merge merges another updates batch with this updates batch
+func (batch *UpdateBatch) Merge(toMerge *UpdateBatch) {
+	batch.ContainsPostOrderWrites = batch.ContainsPostOrderWrites || toMerge.ContainsPostOrderWrites
+	for ns, nsUpdates := range toMerge.Updates {
+		for key, vv := range nsUpdates.M {
+			batch.Update(ns, key, vv)
+		}
+	}
+}
+
+func (batch *UpdateBatch) getOrCreateNsUpdates(ns string) *nsUpdates {
+	nsUpdates := batch.Updates[ns]
+	if nsUpdates == nil {
+		nsUpdates = newNsUpdates()
+		batch.Updates[ns] = nsUpdates
+	}
+	return nsUpdates
+}
+
+// NsCollUpdates maintains entries of tuple <Namespace, UpdatesForNamespace>
+type NsCollUpdates map[string]NsBatch
+
+// NsBatch contains updates related to one namespace
+type NsBatch struct {
+	*UpdateBatch
+}
+
+// Put sets the value in the batch for a given combination of namespace and collection name
+func (b NsCollUpdates) Put(ns, coll, key string, value []byte, version *version.Height) {
+	b.PutValAndMetadata(ns, coll, key, value, nil, version)
+}
+
+// PutValAndMetadata adds a key with value and metadata
+func (b NsCollUpdates) PutValAndMetadata(ns, coll, key string, value []byte, metadata []byte, version *version.Height) {
+	nsBatch := b.getOrCreateNsBatch(ns)
+	nsBatch.PutValAndMetadata(coll, key, value, metadata, version)
+}
+
+// Delete adds a delete marker in the batch for a given combination of namespace and collection name
+func (b NsCollUpdates) Delete(ns, coll, key string, version *version.Height) {
+	nsBatch := b.getOrCreateNsBatch(ns)
+	nsBatch.Delete(coll, key, version)
+}
+
+// Get retrieves the value from the batch for a given combination of namespace and collection name
+func (b NsCollUpdates) Get(ns, coll, key string) *VersionedValue {
+	nsBatch, ok := b[ns]
+	if !ok {
+		return nil
+	}
+	return nsBatch.Get(coll, key)
+}
+
+// Contains returns true if the given <ns,coll,key> tuple is present in the batch
+func (b NsCollUpdates) Contains(ns, coll, key string) bool {
+	nsBatch, ok := b[ns]
+	if !ok {
+		return false
+	}
+	return nsBatch.Exists(coll, key)
+}
+
+// GetUpdatedNamespaces returns all updated namespaces
+func (b NsCollUpdates) GetUpdatedNamespaces() []string {
+	namespaces := []string{}
+	for ns := range b {
+		namespaces = append(namespaces, ns)
+	}
+	return namespaces
+}
+
+func (b NsCollUpdates) getOrCreateNsBatch(ns string) NsBatch {
+	batch, ok := b[ns]
+	if !ok {
+		batch = NsBatch{NewUpdateBatch()}
+		b[ns] = batch
+	}
+	return batch
+}
+
+// GetCollectionNames returns updated collections' name in the namespace update batch
+func (nsb NsBatch) GetCollectionNames() []string {
+	return nsb.GetUpdatedNamespaces()
+}
+
+// GetCollectionUpdates returns updated states in a given collection
+func (nsb NsBatch) GetCollectionUpdates(collName string) map[string]*VersionedValue {
+	return nsb.GetUpdates(collName)
+}
+
+// ResultsIterator iterates over query results
+type ResultsIterator interface {
+	Next() (QueryResult, error)
+	Close()
+}
+
+// QueryResultsIterator adds GetBookmarkAndClose method
+type QueryResultsIterator interface {
+	ResultsIterator
+	GetBookmarkAndClose() string
+}
+
+// QueryResult - a general interface for supporting different types of query results. Actual types differ for different queries
+type QueryResult interface{}
+
+type nsUpdates struct {
+	M map[string]*VersionedValue
+}
+
+func newNsUpdates() *nsUpdates {
+	return &nsUpdates{make(map[string]*VersionedValue)}
+}
+
+type nsIterator struct {
+	ns         string
+	nsUpdates  *nsUpdates
+	sortedKeys []string
+	nextIndex  int
+	lastIndex  int
+}
+
+func newNsIterator(ns string, startKey string, endKey string, batch *UpdateBatch) *nsIterator {
+	nsUpdates, ok := batch.Updates[ns]
+	if !ok {
+		return &nsIterator{}
+	}
+	sortedKeys := util.GetSortedKeys(nsUpdates.M)
+	var nextIndex int
+	var lastIndex int
+	if startKey == "" {
+		nextIndex = 0
+	} else {
+		nextIndex = sort.SearchStrings(sortedKeys, startKey)
+	}
+	if endKey == "" {
+		lastIndex = len(sortedKeys)
+	} else {
+		lastIndex = sort.SearchStrings(sortedKeys, endKey)
+	}
+	return &nsIterator{ns, nsUpdates, sortedKeys, nextIndex, lastIndex}
+}
+
+// Next gives next key and versioned value. It returns a nil when exhausted
+func (itr *nsIterator) Next() (QueryResult, error) {
+	if itr.nextIndex >= itr.lastIndex {
+		return nil, nil
+	}
+	key := itr.sortedKeys[itr.nextIndex]
+	vv := itr.nsUpdates.M[key]
+	itr.nextIndex++
+	return &VersionedKV{CompositeKey{itr.ns, key}, VersionedValue{vv.Value, vv.Metadata, vv.Version}}, nil
+}
+
+// Close implements the method from QueryResult interface
+func (itr *nsIterator) Close() {
+	// do nothing
+}
+
+// GetBookmarkAndClose implements the method from QueryResult interface
+func (itr *nsIterator) GetBookmarkAndClose() string {
+	// do nothing
+	return ""
+}
+
+// PvtKVWrite encloses Key, IsDelete, Value, and Version components
+type PvtKVWrite struct {
+	Key      string
+	IsDelete bool
+	Value    []byte
+	Version  *version.Height
+}
+
+//go:generate counterfeiter -o mock/results_iterator.go -fake-name ResultsIterator . ResultsIterator

--- a/core/ledger/internal/state/state_test.go
+++ b/core/ledger/internal/state/state_test.go
@@ -1,0 +1,292 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package state
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/hyperledger/fabric/core/ledger/internal/version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	exitCode := m.Run()
+	os.Exit(exitCode)
+}
+
+func TestNewPubHashPvtUpdateBatch(t *testing.T) {
+	updates := NewPubHashPvtUpdateBatch()
+	require.NotNil(t, updates.PubUpdates)
+	require.NotNil(t, updates.HashUpdates)
+	require.NotNil(t, updates.PvtUpdates)
+}
+
+func TestBatch(t *testing.T) {
+	batch := NsCollUpdates(make(map[string]NsBatch))
+	v := version.NewHeight(1, 1)
+	for i := 0; i < 5; i++ {
+		for j := 0; j < 5; j++ {
+			for k := 0; k < 5; k++ {
+				batch.Put(fmt.Sprintf("ns-%d", i), fmt.Sprintf("collection-%d", j), fmt.Sprintf("key-%d", k),
+					[]byte(fmt.Sprintf("value-%d-%d-%d", i, j, k)), v)
+			}
+		}
+	}
+	for i := 0; i < 5; i++ {
+		for j := 0; j < 5; j++ {
+			for k := 0; k < 5; k++ {
+				vv := batch.Get(fmt.Sprintf("ns-%d", i), fmt.Sprintf("collection-%d", j), fmt.Sprintf("key-%d", k))
+				require.NotNil(t, vv)
+				require.Equal(t,
+					&VersionedValue{Value: []byte(fmt.Sprintf("value-%d-%d-%d", i, j, k)), Version: v},
+					vv)
+			}
+		}
+	}
+	require.Nil(t, batch.Get("ns-1", "collection-1", "key-5"))
+	require.Nil(t, batch.Get("ns-1", "collection-5", "key-1"))
+	require.Nil(t, batch.Get("ns-5", "collection-1", "key-1"))
+
+}
+
+func TestHashBatchContains(t *testing.T) {
+	batch := NewHashedUpdateBatch()
+	batch.Put("ns1", "coll1", []byte("key1"), []byte("val1"), version.NewHeight(1, 1))
+	require.True(t, batch.Contains("ns1", "coll1", []byte("key1")))
+	require.False(t, batch.Contains("ns1", "coll1", []byte("key2")))
+	require.False(t, batch.Contains("ns1", "coll2", []byte("key1")))
+	require.False(t, batch.Contains("ns2", "coll1", []byte("key1")))
+
+	batch.Delete("ns1", "coll1", []byte("deleteKey"), version.NewHeight(1, 1))
+	require.True(t, batch.Contains("ns1", "coll1", []byte("deleteKey")))
+	require.False(t, batch.Contains("ns1", "coll1", []byte("deleteKey1")))
+	require.False(t, batch.Contains("ns1", "coll2", []byte("deleteKey")))
+	require.False(t, batch.Contains("ns2", "coll1", []byte("deleteKey")))
+
+	batch.Put("ns2", "coll2", []byte("key1"), []byte("val1"), version.NewHeight(1, 1))
+	batch.Put("ns2", "coll3", []byte("key1"), []byte("val1"), version.NewHeight(1, 1))
+	updatedNamespace := batch.NsCollUpdates["ns2"].GetUpdatedCollections()
+	expectedNamespaces := []string{"coll2", "coll3"}
+	require.ElementsMatch(t, expectedNamespaces, updatedNamespace)
+}
+
+func TestGetUpdatedNsColls(t *testing.T) {
+	batch := NewHashedUpdateBatch()
+	batch.Put("ns1", "coll2", []byte("key1"), []byte("val1"), version.NewHeight(1, 1))
+	batch.Put("ns2", "coll2", []byte("key1"), []byte("val1"), version.NewHeight(1, 1))
+	batch.Put("ns2", "coll3", []byte("key1"), []byte("val1"), version.NewHeight(1, 1))
+
+	updatedNs := batch.NsCollUpdates.GetUpdatedNamespaces()
+	expectedNs := []string{"ns1", "ns2"}
+	require.ElementsMatch(t, expectedNs, updatedNs)
+
+	updatedNs2Colls := batch.NsCollUpdates["ns2"].GetUpdatedCollections()
+	expectedNs2Colls := []string{"coll2", "coll3"}
+	require.ElementsMatch(t, expectedNs2Colls, updatedNs2Colls)
+
+	updatedNs2Coll2Updates := batch.NsCollUpdates["ns2"].GetCollectionUpdates("coll2")
+	expectedNs2Coll2Updates := map[string]*VersionedValue{
+		"key1": {
+			Value:   []byte("val1"),
+			Version: version.NewHeight(1, 1),
+		},
+	}
+	require.Equal(t, expectedNs2Coll2Updates, updatedNs2Coll2Updates)
+}
+
+func TestCompositeKeyMap(t *testing.T) {
+	b := NewPvtUpdateBatch()
+	b.Put("ns1", "coll1", "key1", []byte("testVal1"), nil)
+	b.Delete("ns1", "coll2", "key2", nil)
+	b.Put("ns2", "coll1", "key1", []byte("testVal3"), nil)
+	b.Put("ns2", "coll2", "key2", []byte("testVal4"), nil)
+	m := b.ToCompositeKeyMap()
+	require.Len(t, m, 4)
+	vv, ok := m[PvtdataCompositeKey{"ns1", "coll1", "key1"}]
+	require.True(t, ok)
+	require.Equal(t, []byte("testVal1"), vv.Value)
+	vv, ok = m[PvtdataCompositeKey{"ns1", "coll2", "key2"}]
+	require.Nil(t, vv.Value)
+	require.True(t, ok)
+	_, ok = m[PvtdataCompositeKey{"ns2", "coll1", "key1"}]
+	require.True(t, ok)
+	_, ok = m[PvtdataCompositeKey{"ns2", "coll2", "key2"}]
+	require.True(t, ok)
+	_, ok = m[PvtdataCompositeKey{"ns2", "coll1", "key8888"}]
+	require.False(t, ok)
+}
+
+func TestHashToCompositeKeyMap(t *testing.T) {
+	b := NewHashedUpdateBatch()
+	b.Put("ns1", "coll1", []byte("key1"), []byte("testVal1"), nil)
+	b.Delete("ns1", "coll2", []byte("key2"), nil)
+	b.Put("ns2", "coll1", []byte("key1"), []byte("testVal3"), nil)
+	b.Put("ns2", "coll2", []byte("key2"), []byte("testVal4"), nil)
+	m := b.ToCompositeKeyMap()
+	require.Len(t, m, 4)
+	vv, ok := m[HashedCompositeKey{"ns1", "coll1", "key1"}]
+	require.True(t, ok)
+	require.Equal(t, []byte("testVal1"), vv.Value)
+	vv, ok = m[HashedCompositeKey{"ns1", "coll2", "key2"}]
+	require.Nil(t, vv.Value)
+	require.True(t, ok)
+	_, ok = m[HashedCompositeKey{"ns2", "coll1", "key1"}]
+	require.True(t, ok)
+	_, ok = m[HashedCompositeKey{"ns2", "coll2", "key2"}]
+	require.True(t, ok)
+	_, ok = m[HashedCompositeKey{"ns2", "coll1", "key8888"}]
+	require.False(t, ok)
+}
+
+func TestPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("Nil value to Put() did not panic\n")
+		}
+	}()
+
+	batch := NewUpdateBatch()
+	// The following call to Put() should result in panic
+	batch.Put("ns1", "key1", nil, nil)
+}
+
+//Test Put(), Get(), and Delete()
+func TestPutGetDeleteExistsGetUpdates(t *testing.T) {
+	batch := NewUpdateBatch()
+	batch.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 1))
+
+	//Get() should return above inserted <k,v> pair
+	actualVersionedValue := batch.Get("ns1", "key1")
+	require.Equal(t, &VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}, actualVersionedValue)
+	//Exists() should return false as key2 does not exist
+	actualResult := batch.Exists("ns1", "key2")
+	expectedResult := false
+	require.Equal(t, expectedResult, actualResult)
+
+	//Exists() should return false as ns3 does not exist
+	actualResult = batch.Exists("ns3", "key2")
+	expectedResult = false
+	require.Equal(t, expectedResult, actualResult)
+
+	//Get() should return nil as key2 does not exist
+	actualVersionedValue = batch.Get("ns1", "key2")
+	require.Nil(t, actualVersionedValue)
+	//Get() should return nil as ns3 does not exist
+	actualVersionedValue = batch.Get("ns3", "key2")
+	require.Nil(t, actualVersionedValue)
+
+	batch.Put("ns1", "key2", []byte("value2"), version.NewHeight(1, 2))
+	//Exists() should return true as key2 exists
+	actualResult = batch.Exists("ns1", "key2")
+	expectedResult = true
+	require.Equal(t, expectedResult, actualResult)
+
+	//GetUpdatedNamespaces should return 3 namespaces
+	batch.Put("ns2", "key2", []byte("value2"), version.NewHeight(1, 2))
+	batch.Put("ns3", "key2", []byte("value2"), version.NewHeight(1, 2))
+	actualNamespaces := batch.GetUpdatedNamespaces()
+	sort.Strings(actualNamespaces)
+	expectedNamespaces := []string{"ns1", "ns2", "ns3"}
+	require.Equal(t, expectedNamespaces, actualNamespaces)
+
+	//GetUpdates should return two VersionedValues for the namespace ns1
+	expectedUpdates := make(map[string]*VersionedValue)
+	expectedUpdates["key1"] = &VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}
+	expectedUpdates["key2"] = &VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 2)}
+	actualUpdates := batch.GetUpdates("ns1")
+	require.Equal(t, expectedUpdates, actualUpdates)
+
+	actualUpdates = batch.GetUpdates("ns4")
+	require.Nil(t, actualUpdates)
+
+	//Delete the above inserted <k,v> pair
+	batch.Delete("ns1", "key2", version.NewHeight(1, 2))
+	//Exists() should return true after deleting key2
+	//Exists() should return true iff the key has action(Put/Delete) in this batch
+	actualResult = batch.Exists("ns1", "key2")
+	expectedResult = true
+	require.Equal(t, expectedResult, actualResult)
+
+}
+
+func TestUpdateBatchIterator(t *testing.T) {
+	batch := NewUpdateBatch()
+	batch.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 1))
+	batch.Put("ns1", "key2", []byte("value2"), version.NewHeight(1, 2))
+	batch.Put("ns1", "key3", []byte("value3"), version.NewHeight(1, 3))
+
+	batch.Put("ns2", "key6", []byte("value6"), version.NewHeight(2, 3))
+	batch.Put("ns2", "key5", []byte("value5"), version.NewHeight(2, 2))
+	batch.Put("ns2", "key4", []byte("value4"), version.NewHeight(2, 1))
+
+	checkItrResults(t, batch.GetRangeScanIterator("ns1", "key2", "key3"), []*VersionedKV{
+		{CompositeKey{"ns1", "key2"}, VersionedValue{[]byte("value2"), nil, version.NewHeight(1, 2)}},
+	})
+
+	checkItrResults(t, batch.GetRangeScanIterator("ns2", "key0", "key8"), []*VersionedKV{
+		{CompositeKey{"ns2", "key4"}, VersionedValue{[]byte("value4"), nil, version.NewHeight(2, 1)}},
+		{CompositeKey{"ns2", "key5"}, VersionedValue{[]byte("value5"), nil, version.NewHeight(2, 2)}},
+		{CompositeKey{"ns2", "key6"}, VersionedValue{[]byte("value6"), nil, version.NewHeight(2, 3)}},
+	})
+
+	checkItrResults(t, batch.GetRangeScanIterator("ns2", "", ""), []*VersionedKV{
+		{CompositeKey{"ns2", "key4"}, VersionedValue{[]byte("value4"), nil, version.NewHeight(2, 1)}},
+		{CompositeKey{"ns2", "key5"}, VersionedValue{[]byte("value5"), nil, version.NewHeight(2, 2)}},
+		{CompositeKey{"ns2", "key6"}, VersionedValue{[]byte("value6"), nil, version.NewHeight(2, 3)}},
+	})
+
+	checkItrResults(t, batch.GetRangeScanIterator("non-existing-ns", "", ""), nil)
+}
+
+func checkItrResults(t *testing.T, itr QueryResultsIterator, expectedResults []*VersionedKV) {
+	for i := 0; i < len(expectedResults); i++ {
+		res, _ := itr.Next()
+		require.Equal(t, expectedResults[i], res)
+	}
+	lastRes, err := itr.Next()
+	require.NoError(t, err)
+	require.Nil(t, lastRes)
+	itr.Close()
+}
+
+func TestMergeUpdateBatch(t *testing.T) {
+	batch1 := NewUpdateBatch()
+	batch1.Put("ns1", "key1", []byte("batch1_value1"), version.NewHeight(1, 1))
+	batch1.Put("ns1", "key2", []byte("batch1_value2"), version.NewHeight(2, 2))
+	batch1.Put("ns1", "key3", []byte("batch1_value3"), version.NewHeight(3, 3))
+
+	batch2 := NewUpdateBatch()
+	batch2.ContainsPostOrderWrites = true
+	batch2.Put("ns1", "key1", []byte("batch2_value1"), version.NewHeight(4, 4)) // overwrite key1 with new value
+	batch2.Delete("ns1", "key2", version.NewHeight(5, 5))                       // overwrite key2 with deletion
+	batch2.Put("ns1", "key4", []byte("batch2_value4"), version.NewHeight(6, 6)) // new key only in batch2
+	batch2.Delete("ns1", "key5", version.NewHeight(7, 7))                       // delete key only in batch2
+	batch2.Put("ns2", "key6", []byte("batch2_value6"), version.NewHeight(8, 8)) // namespace only in batch2
+
+	batch1.Merge(batch2)
+
+	// prepare final expected batch by writing all updates in the above order
+	expectedBatch := NewUpdateBatch()
+	expectedBatch.ContainsPostOrderWrites = true
+	expectedBatch.Put("ns1", "key1", []byte("batch1_value1"), version.NewHeight(1, 1))
+	expectedBatch.Put("ns1", "key2", []byte("batch1_value2"), version.NewHeight(2, 2))
+	expectedBatch.Put("ns1", "key3", []byte("batch1_value3"), version.NewHeight(3, 3))
+	expectedBatch.Put("ns1", "key1", []byte("batch2_value1"), version.NewHeight(4, 4))
+	expectedBatch.Delete("ns1", "key2", version.NewHeight(5, 5))
+	expectedBatch.Put("ns1", "key4", []byte("batch2_value4"), version.NewHeight(6, 6))
+	expectedBatch.Delete("ns1", "key5", version.NewHeight(7, 7))
+	expectedBatch.Put("ns2", "key6", []byte("batch2_value6"), version.NewHeight(8, 8))
+	require.Equal(t, expectedBatch, batch1)
+}
+
+func TestVersionedValueDelete(t *testing.T) {
+	vv := &VersionedValue{}
+	require.True(t, vv.IsDelete())
+}

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/db.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/db.go
@@ -7,9 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package privacyenabledstate
 
 import (
-	"fmt"
-
 	"github.com/hyperledger/fabric/core/ledger/cceventmgmt"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 )
@@ -26,209 +25,18 @@ type DBProvider interface {
 type DB interface {
 	statedb.VersionedDB
 	IsBulkOptimizable() bool
-	LoadCommittedVersionsOfPubAndHashedKeys(pubKeys []*statedb.CompositeKey, hashedKeys []*HashedCompositeKey) error
+	LoadCommittedVersionsOfPubAndHashedKeys(pubKeys []*state.CompositeKey, hashedKeys []*state.HashedCompositeKey) error
 	GetCachedKeyHashVersion(namespace, collection string, keyHash []byte) (*version.Height, bool)
 	ClearCachedVersions()
 	GetChaincodeEventListener() cceventmgmt.ChaincodeLifecycleEventListener
-	GetPrivateData(namespace, collection, key string) (*statedb.VersionedValue, error)
-	GetPrivateDataHash(namespace, collection, key string) (*statedb.VersionedValue, error)
-	GetValueHash(namespace, collection string, keyHash []byte) (*statedb.VersionedValue, error)
+	GetPrivateData(namespace, collection, key string) (*state.VersionedValue, error)
+	GetPrivateDataHash(namespace, collection, key string) (*state.VersionedValue, error)
+	GetValueHash(namespace, collection string, keyHash []byte) (*state.VersionedValue, error)
 	GetKeyHashVersion(namespace, collection string, keyHash []byte) (*version.Height, error)
-	GetPrivateDataMultipleKeys(namespace, collection string, keys []string) ([]*statedb.VersionedValue, error)
-	GetPrivateDataRangeScanIterator(namespace, collection, startKey, endKey string) (statedb.ResultsIterator, error)
+	GetPrivateDataMultipleKeys(namespace, collection string, keys []string) ([]*state.VersionedValue, error)
+	GetPrivateDataRangeScanIterator(namespace, collection, startKey, endKey string) (state.ResultsIterator, error)
 	GetStateMetadata(namespace, key string) ([]byte, error)
 	GetPrivateDataMetadataByHash(namespace, collection string, keyHash []byte) ([]byte, error)
-	ExecuteQueryOnPrivateData(namespace, collection, query string) (statedb.ResultsIterator, error)
-	ApplyPrivacyAwareUpdates(updates *UpdateBatch, height *version.Height) error
-}
-
-// PvtdataCompositeKey encloses Namespace, CollectionName and Key components
-type PvtdataCompositeKey struct {
-	Namespace      string
-	CollectionName string
-	Key            string
-}
-
-// HashedCompositeKey encloses Namespace, CollectionName and KeyHash components
-type HashedCompositeKey struct {
-	Namespace      string
-	CollectionName string
-	KeyHash        string
-}
-
-// PvtKVWrite encloses Key, IsDelete, Value, and Version components
-type PvtKVWrite struct {
-	Key      string
-	IsDelete bool
-	Value    []byte
-	Version  *version.Height
-}
-
-// UpdateBatch encapsulates the updates to Public, Private, and Hashed data.
-// This is expected to contain a consistent set of updates
-type UpdateBatch struct {
-	PubUpdates  *PubUpdateBatch
-	HashUpdates *HashedUpdateBatch
-	PvtUpdates  *PvtUpdateBatch
-}
-
-// PubUpdateBatch contains update for the public data
-type PubUpdateBatch struct {
-	*statedb.UpdateBatch
-}
-
-// HashedUpdateBatch contains updates for the hashes of the private data
-type HashedUpdateBatch struct {
-	UpdateMap
-}
-
-// PvtUpdateBatch contains updates for the private data
-type PvtUpdateBatch struct {
-	UpdateMap
-}
-
-// UpdateMap maintains entries of tuple <Namespace, UpdatesForNamespace>
-type UpdateMap map[string]nsBatch
-
-// nsBatch contains updates related to one namespace
-type nsBatch struct {
-	*statedb.UpdateBatch
-}
-
-// NewUpdateBatch creates and empty UpdateBatch
-func NewUpdateBatch() *UpdateBatch {
-	return &UpdateBatch{NewPubUpdateBatch(), NewHashedUpdateBatch(), NewPvtUpdateBatch()}
-}
-
-// NewPubUpdateBatch creates an empty PubUpdateBatch
-func NewPubUpdateBatch() *PubUpdateBatch {
-	return &PubUpdateBatch{statedb.NewUpdateBatch()}
-}
-
-// NewHashedUpdateBatch creates an empty HashedUpdateBatch
-func NewHashedUpdateBatch() *HashedUpdateBatch {
-	return &HashedUpdateBatch{make(map[string]nsBatch)}
-}
-
-// NewPvtUpdateBatch creates an empty PvtUpdateBatch
-func NewPvtUpdateBatch() *PvtUpdateBatch {
-	return &PvtUpdateBatch{make(map[string]nsBatch)}
-}
-
-// IsEmpty returns true if there exists any updates
-func (b UpdateMap) IsEmpty() bool {
-	return len(b) == 0
-}
-
-// Put sets the value in the batch for a given combination of namespace and collection name
-func (b UpdateMap) Put(ns, coll, key string, value []byte, version *version.Height) {
-	b.PutValAndMetadata(ns, coll, key, value, nil, version)
-}
-
-// PutValAndMetadata adds a key with value and metadata
-func (b UpdateMap) PutValAndMetadata(ns, coll, key string, value []byte, metadata []byte, version *version.Height) {
-	b.getOrCreateNsBatch(ns).PutValAndMetadata(coll, key, value, metadata, version)
-}
-
-// Delete adds a delete marker in the batch for a given combination of namespace and collection name
-func (b UpdateMap) Delete(ns, coll, key string, version *version.Height) {
-	b.getOrCreateNsBatch(ns).Delete(coll, key, version)
-}
-
-// Get retrieves the value from the batch for a given combination of namespace and collection name
-func (b UpdateMap) Get(ns, coll, key string) *statedb.VersionedValue {
-	nsPvtBatch, ok := b[ns]
-	if !ok {
-		return nil
-	}
-	return nsPvtBatch.Get(coll, key)
-}
-
-// Contains returns true if the given <ns,coll,key> tuple is present in the batch
-func (b UpdateMap) Contains(ns, coll, key string) bool {
-	nsBatch, ok := b[ns]
-	if !ok {
-		return false
-	}
-	return nsBatch.Exists(coll, key)
-}
-
-func (nsb nsBatch) GetCollectionNames() []string {
-	return nsb.GetUpdatedNamespaces()
-}
-
-func (nsb nsBatch) getCollectionUpdates(collName string) map[string]*statedb.VersionedValue {
-	return nsb.GetUpdates(collName)
-}
-
-func (b UpdateMap) getUpdatedNamespaces() []string {
-	namespaces := []string{}
-	for ns := range b {
-		namespaces = append(namespaces, ns)
-	}
-	return namespaces
-}
-
-func (b UpdateMap) getOrCreateNsBatch(ns string) nsBatch {
-	batch, ok := b[ns]
-	if !ok {
-		batch = nsBatch{statedb.NewUpdateBatch()}
-		b[ns] = batch
-	}
-	return batch
-}
-
-// Contains returns true if the given <ns,coll,keyHash> tuple is present in the batch
-func (h HashedUpdateBatch) Contains(ns, coll string, keyHash []byte) bool {
-	return h.UpdateMap.Contains(ns, coll, string(keyHash))
-}
-
-// Put overrides the function in UpdateMap for allowing the key to be a []byte instead of a string
-func (h HashedUpdateBatch) Put(ns, coll string, key []byte, value []byte, version *version.Height) {
-	h.PutValHashAndMetadata(ns, coll, key, value, nil, version)
-}
-
-// PutValHashAndMetadata adds a key with value and metadata
-// TODO introducing a new function to limit the refactoring. Later in a separate CR, the 'Put' function above should be removed
-func (h HashedUpdateBatch) PutValHashAndMetadata(ns, coll string, key []byte, value []byte, metadata []byte, version *version.Height) {
-	h.UpdateMap.PutValAndMetadata(ns, coll, string(key), value, metadata, version)
-}
-
-// Delete overrides the function in UpdateMap for allowing the key to be a []byte instead of a string
-func (h HashedUpdateBatch) Delete(ns, coll string, key []byte, version *version.Height) {
-	h.UpdateMap.Delete(ns, coll, string(key), version)
-}
-
-// ToCompositeKeyMap rearranges the update batch data in the form of a single map
-func (h HashedUpdateBatch) ToCompositeKeyMap() map[HashedCompositeKey]*statedb.VersionedValue {
-	m := make(map[HashedCompositeKey]*statedb.VersionedValue)
-	for ns, nsBatch := range h.UpdateMap {
-		for _, coll := range nsBatch.GetCollectionNames() {
-			for key, vv := range nsBatch.GetUpdates(coll) {
-				m[HashedCompositeKey{ns, coll, key}] = vv
-			}
-		}
-	}
-	return m
-}
-
-// PvtdataCompositeKeyMap is a map of PvtdataCompositeKey to VersionedValue
-type PvtdataCompositeKeyMap map[PvtdataCompositeKey]*statedb.VersionedValue
-
-// ToCompositeKeyMap rearranges the update batch data in the form of a single map
-func (p PvtUpdateBatch) ToCompositeKeyMap() PvtdataCompositeKeyMap {
-	m := make(PvtdataCompositeKeyMap)
-	for ns, nsBatch := range p.UpdateMap {
-		for _, coll := range nsBatch.GetCollectionNames() {
-			for key, vv := range nsBatch.GetUpdates(coll) {
-				m[PvtdataCompositeKey{ns, coll, key}] = vv
-			}
-		}
-	}
-	return m
-}
-
-// String returns a print friendly form of HashedCompositeKey
-func (hck *HashedCompositeKey) String() string {
-	return fmt.Sprintf("ns=%s, collection=%s, keyHash=%x", hck.Namespace, hck.CollectionName, hck.KeyHash)
+	ExecuteQueryOnPrivateData(namespace, collection, query string) (state.ResultsIterator, error)
+	ApplyPrivacyAwareUpdates(updates *state.PubHashPvtUpdateBatch, height *version.Height) error
 }

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/optimization.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/optimization.go
@@ -8,6 +8,7 @@ package privacyenabledstate
 
 import (
 	"github.com/hyperledger/fabric/common/ledger/util/leveldbhelper"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 )
 
 type metadataHint struct {
@@ -30,7 +31,7 @@ func (h *metadataHint) metadataEverUsedFor(namespace string) bool {
 	return h.cache[namespace]
 }
 
-func (h *metadataHint) setMetadataUsedFlag(updates *UpdateBatch) {
+func (h *metadataHint) setMetadataUsedFlag(updates *state.PubHashPvtUpdateBatch) {
 	batch := leveldbhelper.NewUpdateBatch()
 	for ns := range filterNamespacesThatHasMetadata(updates) {
 		if h.cache[ns] {
@@ -42,7 +43,7 @@ func (h *metadataHint) setMetadataUsedFlag(updates *UpdateBatch) {
 	h.bookkeeper.WriteBatch(batch, true)
 }
 
-func filterNamespacesThatHasMetadata(updates *UpdateBatch) map[string]bool {
+func filterNamespacesThatHasMetadata(updates *state.PubHashPvtUpdateBatch) map[string]bool {
 	namespaces := map[string]bool{}
 	pubUpdates, hashUpdates := updates.PubUpdates, updates.HashUpdates
 	// add ns for public data
@@ -55,7 +56,7 @@ func filterNamespacesThatHasMetadata(updates *UpdateBatch) map[string]bool {
 		}
 	}
 	// add ns for private hashes
-	for ns, nsBatch := range hashUpdates.UpdateMap {
+	for ns, nsBatch := range hashUpdates.NsCollUpdates {
 		for _, coll := range nsBatch.GetCollectionNames() {
 			for _, vv := range nsBatch.GetUpdates(coll) {
 				if vv.Metadata == nil {

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/optimization_test.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/optimization_test.go
@@ -9,6 +9,7 @@ package privacyenabledstate
 import (
 	"testing"
 
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/bookkeeping"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/mock"
@@ -23,7 +24,7 @@ func TestMetadataHintCorrectness(t *testing.T) {
 	metadataHint := newMetadataHint(bookkeeper)
 	assert.False(t, metadataHint.metadataEverUsedFor("ns1"))
 
-	updates := NewUpdateBatch()
+	updates := state.NewPubHashPvtUpdateBatch()
 	updates.PubUpdates.PutValAndMetadata("ns1", "key", []byte("value"), []byte("metadata"), version.NewHeight(1, 1))
 	updates.PubUpdates.PutValAndMetadata("ns2", "key", []byte("value"), []byte("metadata"), version.NewHeight(1, 2))
 	updates.PubUpdates.PutValAndMetadata("ns3", "key", []byte("value"), nil, version.NewHeight(1, 3))
@@ -60,7 +61,7 @@ func TestMetadataHintOptimizationSkippingGoingToDB(t *testing.T) {
 	mockVersionedDB := &mock.VersionedDB{}
 	db, err := NewCommonStorageDB(mockVersionedDB, "testledger", newMetadataHint(bookkeeper))
 	assert.NoError(t, err)
-	updates := NewUpdateBatch()
+	updates := state.NewPubHashPvtUpdateBatch()
 	updates.PubUpdates.PutValAndMetadata("ns1", "key", []byte("value"), []byte("metadata"), version.NewHeight(1, 1))
 	updates.PubUpdates.PutValAndMetadata("ns2", "key", []byte("value"), nil, version.NewHeight(1, 2))
 	db.ApplyPrivacyAwareUpdates(updates, version.NewHeight(1, 3))

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/update_batch_bytes_test.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/update_batch_bytes_test.go
@@ -10,12 +10,13 @@ import (
 	"testing"
 
 	proto "github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestUpdateBatchBytesBuilderOnlyPublicWrites(t *testing.T) {
-	updateBatch := NewUpdateBatch()
+	updateBatch := state.NewPubHashPvtUpdateBatch()
 	updateBatch.PubUpdates.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 1))
 	updateBatch.PubUpdates.Put("ns1", "key2", []byte("value2"), version.NewHeight(1, 2))
 	updateBatch.PubUpdates.Put("ns2", "key3", []byte("value3"), version.NewHeight(1, 3))
@@ -75,7 +76,7 @@ func TestUpdateBatchBytesBuilderOnlyPublicWrites(t *testing.T) {
 }
 
 func TestUpdateBatchBytesBuilderPublicWritesAndColls(t *testing.T) {
-	updateBatch := NewUpdateBatch()
+	updateBatch := state.NewPubHashPvtUpdateBatch()
 	updateBatch.PubUpdates.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 1))
 	updateBatch.PubUpdates.Put("ns1", "key2", []byte("value2"), version.NewHeight(1, 2))
 	updateBatch.HashUpdates.Put("ns1", "coll1", []byte("key3"), []byte("value3"), version.NewHeight(1, 3))
@@ -142,7 +143,7 @@ func TestUpdateBatchBytesBuilderPublicWritesAndColls(t *testing.T) {
 }
 
 func TestUpdateBatchBytesBuilderOnlyChannelConfig(t *testing.T) {
-	updateBatch := NewUpdateBatch()
+	updateBatch := state.NewPubHashPvtUpdateBatch()
 	updateBatch.PubUpdates.Put("", "resourcesconfigtx.CHANNEL_CONFIG_KEY", []byte("value1"), version.NewHeight(1, 1))
 
 	bb := &UpdatesBytesBuilder{}

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_schedule_builder_test.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_schedule_builder_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	btltestutil "github.com/hyperledger/fabric/core/ledger/pvtdatapolicy/testutil"
 	"github.com/hyperledger/fabric/core/ledger/util"
 	"github.com/stretchr/testify/assert"
@@ -26,7 +26,7 @@ func TestBuildExpirySchedule(t *testing.T) {
 			{"ns3", "coll4"}: 0,
 		},
 	)
-	updates := privacyenabledstate.NewUpdateBatch()
+	updates := state.NewPubHashPvtUpdateBatch()
 	updates.PubUpdates.Put("ns1", "pubkey1", []byte("pubvalue1"), version.NewHeight(1, 1))
 	putPvtAndHashUpdates(t, updates, "ns1", "coll1", "pvtkey1", []byte("pvtvalue1"), version.NewHeight(1, 1))
 	putPvtAndHashUpdates(t, updates, "ns1", "coll2", "pvtkey2", []byte("pvtvalue2"), version.NewHeight(2, 1))
@@ -67,7 +67,7 @@ func TestBuildExpiryScheduleWithMissingPvtdata(t *testing.T) {
 		},
 	)
 
-	updates := privacyenabledstate.NewUpdateBatch()
+	updates := state.NewPubHashPvtUpdateBatch()
 
 	// This update should appear in the expiry schedule with both the key and the hash
 	putPvtAndHashUpdates(t, updates, "ns1", "coll1", "pvtkey1", []byte("pvtvalue1"), version.NewHeight(50, 1))
@@ -106,24 +106,24 @@ func TestBuildExpiryScheduleWithMissingPvtdata(t *testing.T) {
 	assert.ElementsMatch(t, expectedListExpInfo, listExpinfo)
 }
 
-func putPvtAndHashUpdates(t *testing.T, updates *privacyenabledstate.UpdateBatch, ns, coll, key string, value []byte, ver *version.Height) {
+func putPvtAndHashUpdates(t *testing.T, updates *state.PubHashPvtUpdateBatch, ns, coll, key string, value []byte, ver *version.Height) {
 	putPvtUpdates(updates, ns, coll, key, value, ver)
 	putHashUpdates(updates, ns, coll, key, value, ver)
 }
 
-func deletePvtAndHashUpdates(t *testing.T, updates *privacyenabledstate.UpdateBatch, ns, coll, key string, ver *version.Height) {
+func deletePvtAndHashUpdates(t *testing.T, updates *state.PubHashPvtUpdateBatch, ns, coll, key string, ver *version.Height) {
 	updates.PvtUpdates.Delete(ns, coll, key, ver)
 	deleteHashUpdates(updates, ns, coll, key, ver)
 }
 
-func putHashUpdates(updates *privacyenabledstate.UpdateBatch, ns, coll, key string, value []byte, ver *version.Height) {
+func putHashUpdates(updates *state.PubHashPvtUpdateBatch, ns, coll, key string, value []byte, ver *version.Height) {
 	updates.HashUpdates.Put(ns, coll, util.ComputeStringHash(key), util.ComputeHash(value), ver)
 }
 
-func putPvtUpdates(updates *privacyenabledstate.UpdateBatch, ns, coll, key string, value []byte, ver *version.Height) {
+func putPvtUpdates(updates *state.PubHashPvtUpdateBatch, ns, coll, key string, value []byte, ver *version.Height) {
 	updates.PvtUpdates.Put(ns, coll, key, value, ver)
 }
 
-func deleteHashUpdates(updates *privacyenabledstate.UpdateBatch, ns, coll, key string, ver *version.Height) {
+func deleteHashUpdates(updates *state.PubHashPvtUpdateBatch, ns, coll, key string, ver *version.Height) {
 	updates.HashUpdates.Delete(ns, coll, util.ComputeStringHash(key), ver)
 }

--- a/core/ledger/kvledger/txmgmt/queryutil/mock/query_executer.go
+++ b/core/ledger/kvledger/txmgmt/queryutil/mock/query_executer.go
@@ -4,12 +4,12 @@ package mock
 import (
 	"sync"
 
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/queryutil"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 )
 
 type QueryExecuter struct {
-	GetPrivateDataHashStub        func(string, string, string) (*statedb.VersionedValue, error)
+	GetPrivateDataHashStub        func(string, string, string) (*state.VersionedValue, error)
 	getPrivateDataHashMutex       sync.RWMutex
 	getPrivateDataHashArgsForCall []struct {
 		arg1 string
@@ -17,28 +17,28 @@ type QueryExecuter struct {
 		arg3 string
 	}
 	getPrivateDataHashReturns struct {
-		result1 *statedb.VersionedValue
+		result1 *state.VersionedValue
 		result2 error
 	}
 	getPrivateDataHashReturnsOnCall map[int]struct {
-		result1 *statedb.VersionedValue
+		result1 *state.VersionedValue
 		result2 error
 	}
-	GetStateStub        func(string, string) (*statedb.VersionedValue, error)
+	GetStateStub        func(string, string) (*state.VersionedValue, error)
 	getStateMutex       sync.RWMutex
 	getStateArgsForCall []struct {
 		arg1 string
 		arg2 string
 	}
 	getStateReturns struct {
-		result1 *statedb.VersionedValue
+		result1 *state.VersionedValue
 		result2 error
 	}
 	getStateReturnsOnCall map[int]struct {
-		result1 *statedb.VersionedValue
+		result1 *state.VersionedValue
 		result2 error
 	}
-	GetStateRangeScanIteratorStub        func(string, string, string) (statedb.ResultsIterator, error)
+	GetStateRangeScanIteratorStub        func(string, string, string) (state.ResultsIterator, error)
 	getStateRangeScanIteratorMutex       sync.RWMutex
 	getStateRangeScanIteratorArgsForCall []struct {
 		arg1 string
@@ -46,18 +46,18 @@ type QueryExecuter struct {
 		arg3 string
 	}
 	getStateRangeScanIteratorReturns struct {
-		result1 statedb.ResultsIterator
+		result1 state.ResultsIterator
 		result2 error
 	}
 	getStateRangeScanIteratorReturnsOnCall map[int]struct {
-		result1 statedb.ResultsIterator
+		result1 state.ResultsIterator
 		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *QueryExecuter) GetPrivateDataHash(arg1 string, arg2 string, arg3 string) (*statedb.VersionedValue, error) {
+func (fake *QueryExecuter) GetPrivateDataHash(arg1 string, arg2 string, arg3 string) (*state.VersionedValue, error) {
 	fake.getPrivateDataHashMutex.Lock()
 	ret, specificReturn := fake.getPrivateDataHashReturnsOnCall[len(fake.getPrivateDataHashArgsForCall)]
 	fake.getPrivateDataHashArgsForCall = append(fake.getPrivateDataHashArgsForCall, struct {
@@ -83,7 +83,7 @@ func (fake *QueryExecuter) GetPrivateDataHashCallCount() int {
 	return len(fake.getPrivateDataHashArgsForCall)
 }
 
-func (fake *QueryExecuter) GetPrivateDataHashCalls(stub func(string, string, string) (*statedb.VersionedValue, error)) {
+func (fake *QueryExecuter) GetPrivateDataHashCalls(stub func(string, string, string) (*state.VersionedValue, error)) {
 	fake.getPrivateDataHashMutex.Lock()
 	defer fake.getPrivateDataHashMutex.Unlock()
 	fake.GetPrivateDataHashStub = stub
@@ -96,33 +96,33 @@ func (fake *QueryExecuter) GetPrivateDataHashArgsForCall(i int) (string, string,
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *QueryExecuter) GetPrivateDataHashReturns(result1 *statedb.VersionedValue, result2 error) {
+func (fake *QueryExecuter) GetPrivateDataHashReturns(result1 *state.VersionedValue, result2 error) {
 	fake.getPrivateDataHashMutex.Lock()
 	defer fake.getPrivateDataHashMutex.Unlock()
 	fake.GetPrivateDataHashStub = nil
 	fake.getPrivateDataHashReturns = struct {
-		result1 *statedb.VersionedValue
+		result1 *state.VersionedValue
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *QueryExecuter) GetPrivateDataHashReturnsOnCall(i int, result1 *statedb.VersionedValue, result2 error) {
+func (fake *QueryExecuter) GetPrivateDataHashReturnsOnCall(i int, result1 *state.VersionedValue, result2 error) {
 	fake.getPrivateDataHashMutex.Lock()
 	defer fake.getPrivateDataHashMutex.Unlock()
 	fake.GetPrivateDataHashStub = nil
 	if fake.getPrivateDataHashReturnsOnCall == nil {
 		fake.getPrivateDataHashReturnsOnCall = make(map[int]struct {
-			result1 *statedb.VersionedValue
+			result1 *state.VersionedValue
 			result2 error
 		})
 	}
 	fake.getPrivateDataHashReturnsOnCall[i] = struct {
-		result1 *statedb.VersionedValue
+		result1 *state.VersionedValue
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *QueryExecuter) GetState(arg1 string, arg2 string) (*statedb.VersionedValue, error) {
+func (fake *QueryExecuter) GetState(arg1 string, arg2 string) (*state.VersionedValue, error) {
 	fake.getStateMutex.Lock()
 	ret, specificReturn := fake.getStateReturnsOnCall[len(fake.getStateArgsForCall)]
 	fake.getStateArgsForCall = append(fake.getStateArgsForCall, struct {
@@ -147,7 +147,7 @@ func (fake *QueryExecuter) GetStateCallCount() int {
 	return len(fake.getStateArgsForCall)
 }
 
-func (fake *QueryExecuter) GetStateCalls(stub func(string, string) (*statedb.VersionedValue, error)) {
+func (fake *QueryExecuter) GetStateCalls(stub func(string, string) (*state.VersionedValue, error)) {
 	fake.getStateMutex.Lock()
 	defer fake.getStateMutex.Unlock()
 	fake.GetStateStub = stub
@@ -160,33 +160,33 @@ func (fake *QueryExecuter) GetStateArgsForCall(i int) (string, string) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *QueryExecuter) GetStateReturns(result1 *statedb.VersionedValue, result2 error) {
+func (fake *QueryExecuter) GetStateReturns(result1 *state.VersionedValue, result2 error) {
 	fake.getStateMutex.Lock()
 	defer fake.getStateMutex.Unlock()
 	fake.GetStateStub = nil
 	fake.getStateReturns = struct {
-		result1 *statedb.VersionedValue
+		result1 *state.VersionedValue
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *QueryExecuter) GetStateReturnsOnCall(i int, result1 *statedb.VersionedValue, result2 error) {
+func (fake *QueryExecuter) GetStateReturnsOnCall(i int, result1 *state.VersionedValue, result2 error) {
 	fake.getStateMutex.Lock()
 	defer fake.getStateMutex.Unlock()
 	fake.GetStateStub = nil
 	if fake.getStateReturnsOnCall == nil {
 		fake.getStateReturnsOnCall = make(map[int]struct {
-			result1 *statedb.VersionedValue
+			result1 *state.VersionedValue
 			result2 error
 		})
 	}
 	fake.getStateReturnsOnCall[i] = struct {
-		result1 *statedb.VersionedValue
+		result1 *state.VersionedValue
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *QueryExecuter) GetStateRangeScanIterator(arg1 string, arg2 string, arg3 string) (statedb.ResultsIterator, error) {
+func (fake *QueryExecuter) GetStateRangeScanIterator(arg1 string, arg2 string, arg3 string) (state.ResultsIterator, error) {
 	fake.getStateRangeScanIteratorMutex.Lock()
 	ret, specificReturn := fake.getStateRangeScanIteratorReturnsOnCall[len(fake.getStateRangeScanIteratorArgsForCall)]
 	fake.getStateRangeScanIteratorArgsForCall = append(fake.getStateRangeScanIteratorArgsForCall, struct {
@@ -212,7 +212,7 @@ func (fake *QueryExecuter) GetStateRangeScanIteratorCallCount() int {
 	return len(fake.getStateRangeScanIteratorArgsForCall)
 }
 
-func (fake *QueryExecuter) GetStateRangeScanIteratorCalls(stub func(string, string, string) (statedb.ResultsIterator, error)) {
+func (fake *QueryExecuter) GetStateRangeScanIteratorCalls(stub func(string, string, string) (state.ResultsIterator, error)) {
 	fake.getStateRangeScanIteratorMutex.Lock()
 	defer fake.getStateRangeScanIteratorMutex.Unlock()
 	fake.GetStateRangeScanIteratorStub = stub
@@ -225,28 +225,28 @@ func (fake *QueryExecuter) GetStateRangeScanIteratorArgsForCall(i int) (string, 
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *QueryExecuter) GetStateRangeScanIteratorReturns(result1 statedb.ResultsIterator, result2 error) {
+func (fake *QueryExecuter) GetStateRangeScanIteratorReturns(result1 state.ResultsIterator, result2 error) {
 	fake.getStateRangeScanIteratorMutex.Lock()
 	defer fake.getStateRangeScanIteratorMutex.Unlock()
 	fake.GetStateRangeScanIteratorStub = nil
 	fake.getStateRangeScanIteratorReturns = struct {
-		result1 statedb.ResultsIterator
+		result1 state.ResultsIterator
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *QueryExecuter) GetStateRangeScanIteratorReturnsOnCall(i int, result1 statedb.ResultsIterator, result2 error) {
+func (fake *QueryExecuter) GetStateRangeScanIteratorReturnsOnCall(i int, result1 state.ResultsIterator, result2 error) {
 	fake.getStateRangeScanIteratorMutex.Lock()
 	defer fake.getStateRangeScanIteratorMutex.Unlock()
 	fake.GetStateRangeScanIteratorStub = nil
 	if fake.getStateRangeScanIteratorReturnsOnCall == nil {
 		fake.getStateRangeScanIteratorReturnsOnCall = make(map[int]struct {
-			result1 statedb.ResultsIterator
+			result1 state.ResultsIterator
 			result2 error
 		})
 	}
 	fake.getStateRangeScanIteratorReturnsOnCall[i] = struct {
-		result1 statedb.ResultsIterator
+		result1 state.ResultsIterator
 		result2 error
 	}{result1, result2}
 }

--- a/core/ledger/kvledger/txmgmt/statedb/commontests/test_common.go
+++ b/core/ledger/kvledger/txmgmt/statedb/commontests/test_common.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/stretchr/testify/assert"
@@ -25,14 +26,14 @@ func TestGetStateMultipleKeys(t *testing.T, dbProvider statedb.VersionedDBProvid
 	assert.NoError(t, err, "Error upon GetLatestSavePoint()")
 	assert.Nil(t, sp)
 
-	batch := statedb.NewUpdateBatch()
-	expectedValues := make([]*statedb.VersionedValue, 2)
-	vv1 := statedb.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}
+	batch := state.NewUpdateBatch()
+	expectedValues := make([]*state.VersionedValue, 2)
+	vv1 := state.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}
 	expectedValues[0] = &vv1
-	vv2 := statedb.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 2)}
+	vv2 := state.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 2)}
 	expectedValues[1] = &vv2
-	vv3 := statedb.VersionedValue{Value: []byte("value3"), Version: version.NewHeight(1, 3)}
-	vv4 := statedb.VersionedValue{Value: []byte{}, Version: version.NewHeight(1, 4)}
+	vv3 := state.VersionedValue{Value: []byte("value3"), Version: version.NewHeight(1, 3)}
+	vv4 := state.VersionedValue{Value: []byte{}, Version: version.NewHeight(1, 4)}
 	batch.Put("ns1", "key1", vv1.Value, vv1.Version)
 	batch.Put("ns1", "key2", vv2.Value, vv2.Version)
 	batch.Put("ns2", "key3", vv3.Value, vv3.Version)
@@ -60,12 +61,12 @@ func TestBasicRW(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	assert.NoError(t, err, "Should receive nil rather than error upon reading non existent key")
 	assert.Nil(t, val)
 
-	batch := statedb.NewUpdateBatch()
-	vv1 := statedb.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}
-	vv2 := statedb.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 2)}
-	vv3 := statedb.VersionedValue{Value: []byte("value3"), Version: version.NewHeight(1, 3)}
-	vv4 := statedb.VersionedValue{Value: []byte{}, Version: version.NewHeight(1, 4)}
-	vv5 := statedb.VersionedValue{Value: []byte("null"), Version: version.NewHeight(1, 5)}
+	batch := state.NewUpdateBatch()
+	vv1 := state.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}
+	vv2 := state.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 2)}
+	vv3 := state.VersionedValue{Value: []byte("value3"), Version: version.NewHeight(1, 3)}
+	vv4 := state.VersionedValue{Value: []byte{}, Version: version.NewHeight(1, 4)}
+	vv5 := state.VersionedValue{Value: []byte("null"), Version: version.NewHeight(1, 5)}
 	batch.Put("ns1", "key1", vv1.Value, vv1.Version)
 	batch.Put("ns1", "key2", vv2.Value, vv2.Version)
 	batch.Put("ns2", "key3", vv3.Value, vv3.Version)
@@ -97,17 +98,17 @@ func TestMultiDBBasicRW(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	db2, err := dbProvider.GetDBHandle("testmultidbbasicrw2")
 	assert.NoError(t, err)
 
-	batch1 := statedb.NewUpdateBatch()
-	vv1 := statedb.VersionedValue{Value: []byte("value1_db1"), Version: version.NewHeight(1, 1)}
-	vv2 := statedb.VersionedValue{Value: []byte("value2_db1"), Version: version.NewHeight(1, 2)}
+	batch1 := state.NewUpdateBatch()
+	vv1 := state.VersionedValue{Value: []byte("value1_db1"), Version: version.NewHeight(1, 1)}
+	vv2 := state.VersionedValue{Value: []byte("value2_db1"), Version: version.NewHeight(1, 2)}
 	batch1.Put("ns1", "key1", vv1.Value, vv1.Version)
 	batch1.Put("ns1", "key2", vv2.Value, vv2.Version)
 	savePoint1 := version.NewHeight(1, 2)
 	db1.ApplyUpdates(batch1, savePoint1)
 
-	batch2 := statedb.NewUpdateBatch()
-	vv3 := statedb.VersionedValue{Value: []byte("value1_db2"), Version: version.NewHeight(1, 4)}
-	vv4 := statedb.VersionedValue{Value: []byte("value2_db2"), Version: version.NewHeight(1, 5)}
+	batch2 := state.NewUpdateBatch()
+	vv3 := state.VersionedValue{Value: []byte("value1_db2"), Version: version.NewHeight(1, 4)}
+	vv4 := state.VersionedValue{Value: []byte("value2_db2"), Version: version.NewHeight(1, 5)}
 	batch2.Put("ns1", "key1", vv3.Value, vv3.Version)
 	batch2.Put("ns1", "key2", vv4.Value, vv4.Version)
 	savePoint2 := version.NewHeight(1, 5)
@@ -133,11 +134,11 @@ func TestDeletes(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	db, err := dbProvider.GetDBHandle("testdeletes")
 	assert.NoError(t, err)
 
-	batch := statedb.NewUpdateBatch()
-	vv1 := statedb.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}
-	vv2 := statedb.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 2)}
-	vv3 := statedb.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 3)}
-	vv4 := statedb.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 4)}
+	batch := state.NewUpdateBatch()
+	vv1 := state.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}
+	vv2 := state.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 2)}
+	vv3 := state.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 3)}
+	vv4 := state.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 4)}
 
 	batch.Put("ns", "key1", vv1.Value, vv1.Version)
 	batch.Put("ns", "key2", vv2.Value, vv2.Version)
@@ -154,7 +155,7 @@ func TestDeletes(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	assert.NoError(t, err)
 	assert.Nil(t, vv)
 
-	batch = statedb.NewUpdateBatch()
+	batch = state.NewUpdateBatch()
 	batch.Delete("ns", "key2", version.NewHeight(1, 6))
 	err = db.ApplyUpdates(batch, savePoint)
 	assert.NoError(t, err)
@@ -169,7 +170,7 @@ func TestIterator(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	assert.NoError(t, err)
 	db.Open()
 	defer db.Close()
-	batch := statedb.NewUpdateBatch()
+	batch := state.NewUpdateBatch()
 	batch.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 1))
 	batch.Put("ns1", "key2", []byte("value2"), version.NewHeight(1, 2))
 	batch.Put("ns1", "key3", []byte("value3"), version.NewHeight(1, 3))
@@ -193,11 +194,11 @@ func TestIterator(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 
 }
 
-func testItr(t *testing.T, itr statedb.ResultsIterator, expectedKeys []string) {
+func testItr(t *testing.T, itr state.ResultsIterator, expectedKeys []string) {
 	defer itr.Close()
 	for _, expectedKey := range expectedKeys {
 		queryResult, _ := itr.Next()
-		vkv := queryResult.(*statedb.VersionedKV)
+		vkv := queryResult.(*state.VersionedKV)
 		key := vkv.Key
 		assert.Equal(t, expectedKey, key)
 	}
@@ -211,7 +212,7 @@ func TestQuery(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	assert.NoError(t, err)
 	db.Open()
 	defer db.Close()
-	batch := statedb.NewUpdateBatch()
+	batch := state.NewUpdateBatch()
 	jsonValue1 := `{"asset_name": "marble1","color": "blue","size": 1,"owner": "tom"}`
 	batch.Put("ns1", "key1", []byte(jsonValue1), version.NewHeight(1, 1))
 	jsonValue2 := `{"asset_name": "marble2","color": "blue","size": 2,"owner": "jerry"}`
@@ -258,7 +259,7 @@ func TestQuery(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	queryResult1, err := itr.Next()
 	assert.NoError(t, err)
 	assert.NotNil(t, queryResult1)
-	versionedQueryRecord := queryResult1.(*statedb.VersionedKV)
+	versionedQueryRecord := queryResult1.(*state.VersionedKV)
 	stringRecord := string(versionedQueryRecord.Value)
 	bFoundRecord := strings.Contains(stringRecord, "jerry")
 	assert.True(t, bFoundRecord)
@@ -276,7 +277,7 @@ func TestQuery(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	queryResult1, err = itr.Next()
 	assert.NoError(t, err)
 	assert.NotNil(t, queryResult1)
-	versionedQueryRecord = queryResult1.(*statedb.VersionedKV)
+	versionedQueryRecord = queryResult1.(*state.VersionedKV)
 	stringRecord = string(versionedQueryRecord.Value)
 	bFoundRecord = strings.Contains(stringRecord, "jerry")
 	assert.True(t, bFoundRecord)
@@ -316,7 +317,7 @@ func TestQuery(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	queryResult1, err = itr.Next()
 	assert.NoError(t, err)
 	assert.NotNil(t, queryResult1)
-	versionedQueryRecord = queryResult1.(*statedb.VersionedKV)
+	versionedQueryRecord = queryResult1.(*state.VersionedKV)
 	stringRecord = string(versionedQueryRecord.Value)
 	bFoundRecord = strings.Contains(stringRecord, "jerry")
 	assert.True(t, bFoundRecord)
@@ -334,7 +335,7 @@ func TestQuery(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	queryResult1, err = itr.Next()
 	assert.NoError(t, err)
 	assert.NotNil(t, queryResult1)
-	versionedQueryRecord = queryResult1.(*statedb.VersionedKV)
+	versionedQueryRecord = queryResult1.(*state.VersionedKV)
 	stringRecord = string(versionedQueryRecord.Value)
 	bFoundRecord = strings.Contains(stringRecord, "jerry")
 	assert.True(t, bFoundRecord)
@@ -361,7 +362,7 @@ func TestQuery(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	queryResult1, err = itr.Next()
 	assert.NoError(t, err)
 	assert.NotNil(t, queryResult1)
-	versionedQueryRecord = queryResult1.(*statedb.VersionedKV)
+	versionedQueryRecord = queryResult1.(*state.VersionedKV)
 	stringRecord = string(versionedQueryRecord.Value)
 	bFoundRecord = strings.Contains(stringRecord, "fred")
 	assert.True(t, bFoundRecord)
@@ -379,7 +380,7 @@ func TestQuery(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	queryResult1, err = itr.Next()
 	assert.NoError(t, err)
 	assert.NotNil(t, queryResult1)
-	versionedQueryRecord = queryResult1.(*statedb.VersionedKV)
+	versionedQueryRecord = queryResult1.(*state.VersionedKV)
 	stringRecord = string(versionedQueryRecord.Value)
 	bFoundRecord = strings.Contains(stringRecord, "fred")
 	assert.True(t, bFoundRecord)
@@ -406,7 +407,7 @@ func TestQuery(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	queryResult1, err = itr.Next()
 	assert.NoError(t, err)
 	assert.NotNil(t, queryResult1)
-	versionedQueryRecord = queryResult1.(*statedb.VersionedKV)
+	versionedQueryRecord = queryResult1.(*state.VersionedKV)
 	stringRecord = string(versionedQueryRecord.Value)
 	bFoundRecord = strings.Contains(stringRecord, "green")
 	assert.True(t, bFoundRecord)
@@ -415,7 +416,7 @@ func TestQuery(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	queryResult2, err = itr.Next()
 	assert.NoError(t, err)
 	assert.NotNil(t, queryResult2)
-	versionedQueryRecord = queryResult2.(*statedb.VersionedKV)
+	versionedQueryRecord = queryResult2.(*state.VersionedKV)
 	stringRecord = string(versionedQueryRecord.Value)
 	bFoundRecord = strings.Contains(stringRecord, "green")
 	assert.True(t, bFoundRecord)
@@ -433,7 +434,7 @@ func TestQuery(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	queryResult1, err = itr.Next()
 	assert.NoError(t, err)
 	assert.NotNil(t, queryResult1)
-	versionedQueryRecord = queryResult1.(*statedb.VersionedKV)
+	versionedQueryRecord = queryResult1.(*state.VersionedKV)
 	stringRecord = string(versionedQueryRecord.Value)
 	bFoundRecord = strings.Contains(stringRecord, "green")
 	assert.True(t, bFoundRecord)
@@ -442,7 +443,7 @@ func TestQuery(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	queryResult2, err = itr.Next()
 	assert.NoError(t, err)
 	assert.NotNil(t, queryResult2)
-	versionedQueryRecord = queryResult2.(*statedb.VersionedKV)
+	versionedQueryRecord = queryResult2.(*state.VersionedKV)
 	stringRecord = string(versionedQueryRecord.Value)
 	bFoundRecord = strings.Contains(stringRecord, "green")
 	assert.True(t, bFoundRecord)
@@ -470,7 +471,7 @@ func TestQuery(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	queryResult1, err = itr.Next()
 	assert.NoError(t, err)
 	assert.NotNil(t, queryResult1)
-	versionedQueryRecord = queryResult1.(*statedb.VersionedKV)
+	versionedQueryRecord = queryResult1.(*state.VersionedKV)
 	stringRecord = string(versionedQueryRecord.Value)
 	bFoundRecord = strings.Contains(stringRecord, "joe")
 	assert.True(t, bFoundRecord)
@@ -490,11 +491,11 @@ func TestGetVersion(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	db, err := dbProvider.GetDBHandle("testgetversion")
 	assert.NoError(t, err)
 
-	batch := statedb.NewUpdateBatch()
-	vv1 := statedb.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}
-	vv2 := statedb.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 2)}
-	vv3 := statedb.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 3)}
-	vv4 := statedb.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 4)}
+	batch := state.NewUpdateBatch()
+	vv1 := state.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}
+	vv2 := state.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 2)}
+	vv3 := state.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 3)}
+	vv4 := state.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 4)}
 
 	batch.Put("ns", "key1", vv1.Value, vv1.Version)
 	batch.Put("ns", "key2", vv2.Value, vv2.Version)
@@ -527,9 +528,9 @@ func TestGetVersion(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 		bulkdb.ClearCachedVersions()
 
 		// initialize a key list
-		loadKeys := []*statedb.CompositeKey{}
+		loadKeys := []*state.CompositeKey{}
 		//create a composite key and add to the key list
-		compositeKey := statedb.CompositeKey{Namespace: "ns", Key: "key3"}
+		compositeKey := state.CompositeKey{Namespace: "ns", Key: "key3"}
 		loadKeys = append(loadKeys, &compositeKey)
 		//load the committed versions
 		bulkdb.LoadCommittedVersions(loadKeys)
@@ -548,7 +549,7 @@ func TestSmallBatchSize(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	assert.NoError(t, err)
 	db.Open()
 	defer db.Close()
-	batch := statedb.NewUpdateBatch()
+	batch := state.NewUpdateBatch()
 	jsonValue1 := []byte(`{"asset_name": "marble1","color": "blue","size": 1,"owner": "tom"}`)
 	batch.Put("ns1", "key1", jsonValue1, version.NewHeight(1, 1))
 	jsonValue2 := []byte(`{"asset_name": "marble2","color": "blue","size": 2,"owner": "jerry"}`)
@@ -617,11 +618,11 @@ func TestBatchWithIndividualRetry(t *testing.T, dbProvider statedb.VersionedDBPr
 	db, err := dbProvider.GetDBHandle("testbatchretry")
 	assert.NoError(t, err)
 
-	batch := statedb.NewUpdateBatch()
-	vv1 := statedb.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}
-	vv2 := statedb.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 2)}
-	vv3 := statedb.VersionedValue{Value: []byte("value3"), Version: version.NewHeight(1, 3)}
-	vv4 := statedb.VersionedValue{Value: []byte("value4"), Version: version.NewHeight(1, 4)}
+	batch := state.NewUpdateBatch()
+	vv1 := state.VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}
+	vv2 := state.VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 2)}
+	vv3 := state.VersionedValue{Value: []byte("value3"), Version: version.NewHeight(1, 3)}
+	vv4 := state.VersionedValue{Value: []byte("value4"), Version: version.NewHeight(1, 4)}
 
 	batch.Put("ns", "key1", vv1.Value, vv1.Version)
 	batch.Put("ns", "key2", vv2.Value, vv2.Version)
@@ -637,7 +638,7 @@ func TestBatchWithIndividualRetry(t *testing.T, dbProvider statedb.VersionedDBPr
 		bulkdb.ClearCachedVersions()
 	}
 
-	batch = statedb.NewUpdateBatch()
+	batch = state.NewUpdateBatch()
 	batch.Put("ns", "key1", vv1.Value, vv1.Version)
 	batch.Put("ns", "key2", vv2.Value, vv2.Version)
 	batch.Put("ns", "key3", vv3.Value, vv3.Version)
@@ -647,7 +648,7 @@ func TestBatchWithIndividualRetry(t *testing.T, dbProvider statedb.VersionedDBPr
 	assert.NoError(t, err)
 
 	// Update document key3
-	batch = statedb.NewUpdateBatch()
+	batch = state.NewUpdateBatch()
 	batch.Delete("ns", "key2", vv2.Version)
 	batch.Put("ns", "key3", vv3.Value, vv3.Version)
 	savePoint = version.NewHeight(1, 7)
@@ -656,7 +657,7 @@ func TestBatchWithIndividualRetry(t *testing.T, dbProvider statedb.VersionedDBPr
 
 	// This should force a retry for couchdb revision conflict for both delete and update
 	// Retry logic should correct the update and prevent delete from throwing an error
-	batch = statedb.NewUpdateBatch()
+	batch = state.NewUpdateBatch()
 	batch.Delete("ns", "key2", vv2.Version)
 	batch.Put("ns", "key3", vv3.Value, vv3.Version)
 	savePoint = version.NewHeight(1, 8)
@@ -675,7 +676,7 @@ func TestBatchWithIndividualRetry(t *testing.T, dbProvider statedb.VersionedDBPr
 		bulkdb.ClearCachedVersions()
 	}
 
-	batch = statedb.NewUpdateBatch()
+	batch = state.NewUpdateBatch()
 	batch.Put("ns1", "key5", jsonValue5, version.NewHeight(1, 9))
 	batch.Put("ns1", "key6", jsonValue6, version.NewHeight(1, 10))
 	batch.Put("ns1", "key7", jsonValue7, version.NewHeight(1, 11))
@@ -691,7 +692,7 @@ func TestBatchWithIndividualRetry(t *testing.T, dbProvider statedb.VersionedDBPr
 	}
 
 	//Send the batch through again to test updates
-	batch = statedb.NewUpdateBatch()
+	batch = state.NewUpdateBatch()
 	batch.Put("ns1", "key5", jsonValue5, version.NewHeight(1, 9))
 	batch.Put("ns1", "key6", jsonValue6, version.NewHeight(1, 10))
 	batch.Put("ns1", "key7", jsonValue7, version.NewHeight(1, 11))
@@ -702,7 +703,7 @@ func TestBatchWithIndividualRetry(t *testing.T, dbProvider statedb.VersionedDBPr
 
 	// Update document key3
 	// this will cause an inconsistent cache entry for connection db2
-	batch = statedb.NewUpdateBatch()
+	batch = state.NewUpdateBatch()
 	batch.Delete("ns1", "key6", version.NewHeight(1, 13))
 	batch.Put("ns1", "key7", jsonValue7, version.NewHeight(1, 14))
 	savePoint = version.NewHeight(1, 15)
@@ -711,7 +712,7 @@ func TestBatchWithIndividualRetry(t *testing.T, dbProvider statedb.VersionedDBPr
 
 	// This should force a retry for couchdb revision conflict for both delete and update
 	// Retry logic should correct the update and prevent delete from throwing an error
-	batch = statedb.NewUpdateBatch()
+	batch = state.NewUpdateBatch()
 	batch.Delete("ns1", "key6", version.NewHeight(1, 16))
 	batch.Put("ns1", "key7", jsonValue7, version.NewHeight(1, 17))
 	savePoint = version.NewHeight(1, 18)
@@ -724,12 +725,12 @@ func TestBatchWithIndividualRetry(t *testing.T, dbProvider statedb.VersionedDBPr
 func TestValueAndMetadataWrites(t *testing.T, dbProvider statedb.VersionedDBProvider) {
 	db, err := dbProvider.GetDBHandle("testvalueandmetadata")
 	assert.NoError(t, err)
-	batch := statedb.NewUpdateBatch()
+	batch := state.NewUpdateBatch()
 
-	vv1 := statedb.VersionedValue{Value: []byte("value1"), Metadata: []byte("metadata1"), Version: version.NewHeight(1, 1)}
-	vv2 := statedb.VersionedValue{Value: []byte("value2"), Metadata: []byte("metadata2"), Version: version.NewHeight(1, 2)}
-	vv3 := statedb.VersionedValue{Value: []byte("value3"), Version: version.NewHeight(1, 3)}
-	vv4 := statedb.VersionedValue{Value: []byte{}, Metadata: []byte("metadata4"), Version: version.NewHeight(1, 4)}
+	vv1 := state.VersionedValue{Value: []byte("value1"), Metadata: []byte("metadata1"), Version: version.NewHeight(1, 1)}
+	vv2 := state.VersionedValue{Value: []byte("value2"), Metadata: []byte("metadata2"), Version: version.NewHeight(1, 2)}
+	vv3 := state.VersionedValue{Value: []byte("value3"), Version: version.NewHeight(1, 3)}
+	vv4 := state.VersionedValue{Value: []byte{}, Metadata: []byte("metadata4"), Version: version.NewHeight(1, 4)}
 
 	batch.PutValAndMetadata("ns1", "key1", vv1.Value, vv1.Metadata, vv1.Version)
 	batch.PutValAndMetadata("ns1", "key2", vv2.Value, vv2.Metadata, vv2.Version)
@@ -756,7 +757,7 @@ func TestPaginatedRangeQuery(t *testing.T, dbProvider statedb.VersionedDBProvide
 	assert.NoError(t, err)
 	db.Open()
 	defer db.Close()
-	batch := statedb.NewUpdateBatch()
+	batch := state.NewUpdateBatch()
 	jsonValue1 := `{"asset_name": "marble1","color": "blue","size": 1,"owner": "tom"}`
 	batch.Put("ns1", "key1", []byte(jsonValue1), version.NewHeight(1, 1))
 	jsonValue2 := `{"asset_name": "marble2","color": "red","size": 2,"owner": "jerry"}`
@@ -884,7 +885,7 @@ func TestRangeQuerySpecialCharacters(t *testing.T, dbProvider statedb.VersionedD
 	db.Open()
 	defer db.Close()
 
-	batch := statedb.NewUpdateBatch()
+	batch := state.NewUpdateBatch()
 	jsonValue1 := `{"asset_name": "marble1","color": "blue","size": 1,"owner": "tom"}`
 	batch.Put("ns1", "key1", []byte(jsonValue1), version.NewHeight(1, 1))
 	jsonValue2 := `{"asset_name": "marble2","color": "red","size": 2,"owner": "jerry"}`
@@ -920,7 +921,7 @@ func TestRangeQuerySpecialCharacters(t *testing.T, dbProvider statedb.VersionedD
 
 func executeRangeQuery(t *testing.T, db statedb.VersionedDB, namespace, startKey, endKey string, limit int32, returnKeys []string) (string, error) {
 
-	var itr statedb.ResultsIterator
+	var itr state.ResultsIterator
 	var err error
 
 	if limit == 0 {
@@ -950,7 +951,7 @@ func executeRangeQuery(t *testing.T, db statedb.VersionedDB, namespace, startKey
 
 	returnBookmark := ""
 	if limit > 0 {
-		if queryResultItr, ok := itr.(statedb.QueryResultsIterator); ok {
+		if queryResultItr, ok := itr.(state.QueryResultsIterator); ok {
 			returnBookmark = queryResultItr.GetBookmarkAndClose()
 		}
 	}
@@ -959,11 +960,11 @@ func executeRangeQuery(t *testing.T, db statedb.VersionedDB, namespace, startKey
 }
 
 // TestItrWithoutClose verifies an iterator contains expected keys
-func TestItrWithoutClose(t *testing.T, itr statedb.ResultsIterator, expectedKeys []string) {
+func TestItrWithoutClose(t *testing.T, itr state.ResultsIterator, expectedKeys []string) {
 	for _, expectedKey := range expectedKeys {
 		queryResult, err := itr.Next()
 		assert.NoError(t, err, "An unexpected error was thrown during iterator Next()")
-		vkv := queryResult.(*statedb.VersionedKV)
+		vkv := queryResult.(*state.VersionedKV)
 		key := vkv.Key
 		assert.Equal(t, expectedKey, key)
 	}
@@ -976,12 +977,12 @@ func TestApplyUpdatesWithNilHeight(t *testing.T, dbProvider statedb.VersionedDBP
 	db, err := dbProvider.GetDBHandle("test-apply-updates-with-nil-height")
 	assert.NoError(t, err)
 
-	batch1 := statedb.NewUpdateBatch()
+	batch1 := state.NewUpdateBatch()
 	batch1.Put("ns", "key1", []byte("value1"), version.NewHeight(1, 4))
 	savePoint := version.NewHeight(1, 5)
 	assert.NoError(t, db.ApplyUpdates(batch1, savePoint))
 
-	batch2 := statedb.NewUpdateBatch()
+	batch2 := state.NewUpdateBatch()
 	batch2.Put("ns", "key1", []byte("value2"), version.NewHeight(1, 1))
 	assert.NoError(t, db.ApplyUpdates(batch2, nil))
 

--- a/core/ledger/kvledger/txmgmt/statedb/mock/versioned_db.go
+++ b/core/ledger/kvledger/txmgmt/statedb/mock/versioned_db.go
@@ -4,15 +4,16 @@ package mock
 import (
 	"sync"
 
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 )
 
 type VersionedDB struct {
-	ApplyUpdatesStub        func(*statedb.UpdateBatch, *version.Height) error
+	ApplyUpdatesStub        func(*state.UpdateBatch, *version.Height) error
 	applyUpdatesMutex       sync.RWMutex
 	applyUpdatesArgsForCall []struct {
-		arg1 *statedb.UpdateBatch
+		arg1 *state.UpdateBatch
 		arg2 *version.Height
 	}
 	applyUpdatesReturns struct {
@@ -35,21 +36,21 @@ type VersionedDB struct {
 	closeMutex       sync.RWMutex
 	closeArgsForCall []struct {
 	}
-	ExecuteQueryStub        func(string, string) (statedb.ResultsIterator, error)
+	ExecuteQueryStub        func(string, string) (state.ResultsIterator, error)
 	executeQueryMutex       sync.RWMutex
 	executeQueryArgsForCall []struct {
 		arg1 string
 		arg2 string
 	}
 	executeQueryReturns struct {
-		result1 statedb.ResultsIterator
+		result1 state.ResultsIterator
 		result2 error
 	}
 	executeQueryReturnsOnCall map[int]struct {
-		result1 statedb.ResultsIterator
+		result1 state.ResultsIterator
 		result2 error
 	}
-	ExecuteQueryWithMetadataStub        func(string, string, map[string]interface{}) (statedb.QueryResultsIterator, error)
+	ExecuteQueryWithMetadataStub        func(string, string, map[string]interface{}) (state.QueryResultsIterator, error)
 	executeQueryWithMetadataMutex       sync.RWMutex
 	executeQueryWithMetadataArgsForCall []struct {
 		arg1 string
@@ -57,11 +58,11 @@ type VersionedDB struct {
 		arg3 map[string]interface{}
 	}
 	executeQueryWithMetadataReturns struct {
-		result1 statedb.QueryResultsIterator
+		result1 state.QueryResultsIterator
 		result2 error
 	}
 	executeQueryWithMetadataReturnsOnCall map[int]struct {
-		result1 statedb.QueryResultsIterator
+		result1 state.QueryResultsIterator
 		result2 error
 	}
 	GetLatestSavePointStub        func() (*version.Height, error)
@@ -76,35 +77,35 @@ type VersionedDB struct {
 		result1 *version.Height
 		result2 error
 	}
-	GetStateStub        func(string, string) (*statedb.VersionedValue, error)
+	GetStateStub        func(string, string) (*state.VersionedValue, error)
 	getStateMutex       sync.RWMutex
 	getStateArgsForCall []struct {
 		arg1 string
 		arg2 string
 	}
 	getStateReturns struct {
-		result1 *statedb.VersionedValue
+		result1 *state.VersionedValue
 		result2 error
 	}
 	getStateReturnsOnCall map[int]struct {
-		result1 *statedb.VersionedValue
+		result1 *state.VersionedValue
 		result2 error
 	}
-	GetStateMultipleKeysStub        func(string, []string) ([]*statedb.VersionedValue, error)
+	GetStateMultipleKeysStub        func(string, []string) ([]*state.VersionedValue, error)
 	getStateMultipleKeysMutex       sync.RWMutex
 	getStateMultipleKeysArgsForCall []struct {
 		arg1 string
 		arg2 []string
 	}
 	getStateMultipleKeysReturns struct {
-		result1 []*statedb.VersionedValue
+		result1 []*state.VersionedValue
 		result2 error
 	}
 	getStateMultipleKeysReturnsOnCall map[int]struct {
-		result1 []*statedb.VersionedValue
+		result1 []*state.VersionedValue
 		result2 error
 	}
-	GetStateRangeScanIteratorStub        func(string, string, string) (statedb.ResultsIterator, error)
+	GetStateRangeScanIteratorStub        func(string, string, string) (state.ResultsIterator, error)
 	getStateRangeScanIteratorMutex       sync.RWMutex
 	getStateRangeScanIteratorArgsForCall []struct {
 		arg1 string
@@ -112,14 +113,14 @@ type VersionedDB struct {
 		arg3 string
 	}
 	getStateRangeScanIteratorReturns struct {
-		result1 statedb.ResultsIterator
+		result1 state.ResultsIterator
 		result2 error
 	}
 	getStateRangeScanIteratorReturnsOnCall map[int]struct {
-		result1 statedb.ResultsIterator
+		result1 state.ResultsIterator
 		result2 error
 	}
-	GetStateRangeScanIteratorWithMetadataStub        func(string, string, string, map[string]interface{}) (statedb.QueryResultsIterator, error)
+	GetStateRangeScanIteratorWithMetadataStub        func(string, string, string, map[string]interface{}) (state.QueryResultsIterator, error)
 	getStateRangeScanIteratorWithMetadataMutex       sync.RWMutex
 	getStateRangeScanIteratorWithMetadataArgsForCall []struct {
 		arg1 string
@@ -128,11 +129,11 @@ type VersionedDB struct {
 		arg4 map[string]interface{}
 	}
 	getStateRangeScanIteratorWithMetadataReturns struct {
-		result1 statedb.QueryResultsIterator
+		result1 state.QueryResultsIterator
 		result2 error
 	}
 	getStateRangeScanIteratorWithMetadataReturnsOnCall map[int]struct {
-		result1 statedb.QueryResultsIterator
+		result1 state.QueryResultsIterator
 		result2 error
 	}
 	GetVersionStub        func(string, string) (*version.Height, error)
@@ -175,11 +176,11 @@ type VersionedDB struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *VersionedDB) ApplyUpdates(arg1 *statedb.UpdateBatch, arg2 *version.Height) error {
+func (fake *VersionedDB) ApplyUpdates(arg1 *state.UpdateBatch, arg2 *version.Height) error {
 	fake.applyUpdatesMutex.Lock()
 	ret, specificReturn := fake.applyUpdatesReturnsOnCall[len(fake.applyUpdatesArgsForCall)]
 	fake.applyUpdatesArgsForCall = append(fake.applyUpdatesArgsForCall, struct {
-		arg1 *statedb.UpdateBatch
+		arg1 *state.UpdateBatch
 		arg2 *version.Height
 	}{arg1, arg2})
 	fake.recordInvocation("ApplyUpdates", []interface{}{arg1, arg2})
@@ -200,13 +201,13 @@ func (fake *VersionedDB) ApplyUpdatesCallCount() int {
 	return len(fake.applyUpdatesArgsForCall)
 }
 
-func (fake *VersionedDB) ApplyUpdatesCalls(stub func(*statedb.UpdateBatch, *version.Height) error) {
+func (fake *VersionedDB) ApplyUpdatesCalls(stub func(*state.UpdateBatch, *version.Height) error) {
 	fake.applyUpdatesMutex.Lock()
 	defer fake.applyUpdatesMutex.Unlock()
 	fake.ApplyUpdatesStub = stub
 }
 
-func (fake *VersionedDB) ApplyUpdatesArgsForCall(i int) (*statedb.UpdateBatch, *version.Height) {
+func (fake *VersionedDB) ApplyUpdatesArgsForCall(i int) (*state.UpdateBatch, *version.Height) {
 	fake.applyUpdatesMutex.RLock()
 	defer fake.applyUpdatesMutex.RUnlock()
 	argsForCall := fake.applyUpdatesArgsForCall[i]
@@ -311,7 +312,7 @@ func (fake *VersionedDB) CloseCalls(stub func()) {
 	fake.CloseStub = stub
 }
 
-func (fake *VersionedDB) ExecuteQuery(arg1 string, arg2 string) (statedb.ResultsIterator, error) {
+func (fake *VersionedDB) ExecuteQuery(arg1 string, arg2 string) (state.ResultsIterator, error) {
 	fake.executeQueryMutex.Lock()
 	ret, specificReturn := fake.executeQueryReturnsOnCall[len(fake.executeQueryArgsForCall)]
 	fake.executeQueryArgsForCall = append(fake.executeQueryArgsForCall, struct {
@@ -336,7 +337,7 @@ func (fake *VersionedDB) ExecuteQueryCallCount() int {
 	return len(fake.executeQueryArgsForCall)
 }
 
-func (fake *VersionedDB) ExecuteQueryCalls(stub func(string, string) (statedb.ResultsIterator, error)) {
+func (fake *VersionedDB) ExecuteQueryCalls(stub func(string, string) (state.ResultsIterator, error)) {
 	fake.executeQueryMutex.Lock()
 	defer fake.executeQueryMutex.Unlock()
 	fake.ExecuteQueryStub = stub
@@ -349,33 +350,33 @@ func (fake *VersionedDB) ExecuteQueryArgsForCall(i int) (string, string) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *VersionedDB) ExecuteQueryReturns(result1 statedb.ResultsIterator, result2 error) {
+func (fake *VersionedDB) ExecuteQueryReturns(result1 state.ResultsIterator, result2 error) {
 	fake.executeQueryMutex.Lock()
 	defer fake.executeQueryMutex.Unlock()
 	fake.ExecuteQueryStub = nil
 	fake.executeQueryReturns = struct {
-		result1 statedb.ResultsIterator
+		result1 state.ResultsIterator
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *VersionedDB) ExecuteQueryReturnsOnCall(i int, result1 statedb.ResultsIterator, result2 error) {
+func (fake *VersionedDB) ExecuteQueryReturnsOnCall(i int, result1 state.ResultsIterator, result2 error) {
 	fake.executeQueryMutex.Lock()
 	defer fake.executeQueryMutex.Unlock()
 	fake.ExecuteQueryStub = nil
 	if fake.executeQueryReturnsOnCall == nil {
 		fake.executeQueryReturnsOnCall = make(map[int]struct {
-			result1 statedb.ResultsIterator
+			result1 state.ResultsIterator
 			result2 error
 		})
 	}
 	fake.executeQueryReturnsOnCall[i] = struct {
-		result1 statedb.ResultsIterator
+		result1 state.ResultsIterator
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *VersionedDB) ExecuteQueryWithMetadata(arg1 string, arg2 string, arg3 map[string]interface{}) (statedb.QueryResultsIterator, error) {
+func (fake *VersionedDB) ExecuteQueryWithMetadata(arg1 string, arg2 string, arg3 map[string]interface{}) (state.QueryResultsIterator, error) {
 	fake.executeQueryWithMetadataMutex.Lock()
 	ret, specificReturn := fake.executeQueryWithMetadataReturnsOnCall[len(fake.executeQueryWithMetadataArgsForCall)]
 	fake.executeQueryWithMetadataArgsForCall = append(fake.executeQueryWithMetadataArgsForCall, struct {
@@ -401,7 +402,7 @@ func (fake *VersionedDB) ExecuteQueryWithMetadataCallCount() int {
 	return len(fake.executeQueryWithMetadataArgsForCall)
 }
 
-func (fake *VersionedDB) ExecuteQueryWithMetadataCalls(stub func(string, string, map[string]interface{}) (statedb.QueryResultsIterator, error)) {
+func (fake *VersionedDB) ExecuteQueryWithMetadataCalls(stub func(string, string, map[string]interface{}) (state.QueryResultsIterator, error)) {
 	fake.executeQueryWithMetadataMutex.Lock()
 	defer fake.executeQueryWithMetadataMutex.Unlock()
 	fake.ExecuteQueryWithMetadataStub = stub
@@ -414,28 +415,28 @@ func (fake *VersionedDB) ExecuteQueryWithMetadataArgsForCall(i int) (string, str
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *VersionedDB) ExecuteQueryWithMetadataReturns(result1 statedb.QueryResultsIterator, result2 error) {
+func (fake *VersionedDB) ExecuteQueryWithMetadataReturns(result1 state.QueryResultsIterator, result2 error) {
 	fake.executeQueryWithMetadataMutex.Lock()
 	defer fake.executeQueryWithMetadataMutex.Unlock()
 	fake.ExecuteQueryWithMetadataStub = nil
 	fake.executeQueryWithMetadataReturns = struct {
-		result1 statedb.QueryResultsIterator
+		result1 state.QueryResultsIterator
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *VersionedDB) ExecuteQueryWithMetadataReturnsOnCall(i int, result1 statedb.QueryResultsIterator, result2 error) {
+func (fake *VersionedDB) ExecuteQueryWithMetadataReturnsOnCall(i int, result1 state.QueryResultsIterator, result2 error) {
 	fake.executeQueryWithMetadataMutex.Lock()
 	defer fake.executeQueryWithMetadataMutex.Unlock()
 	fake.ExecuteQueryWithMetadataStub = nil
 	if fake.executeQueryWithMetadataReturnsOnCall == nil {
 		fake.executeQueryWithMetadataReturnsOnCall = make(map[int]struct {
-			result1 statedb.QueryResultsIterator
+			result1 state.QueryResultsIterator
 			result2 error
 		})
 	}
 	fake.executeQueryWithMetadataReturnsOnCall[i] = struct {
-		result1 statedb.QueryResultsIterator
+		result1 state.QueryResultsIterator
 		result2 error
 	}{result1, result2}
 }
@@ -495,7 +496,7 @@ func (fake *VersionedDB) GetLatestSavePointReturnsOnCall(i int, result1 *version
 	}{result1, result2}
 }
 
-func (fake *VersionedDB) GetState(arg1 string, arg2 string) (*statedb.VersionedValue, error) {
+func (fake *VersionedDB) GetState(arg1 string, arg2 string) (*state.VersionedValue, error) {
 	fake.getStateMutex.Lock()
 	ret, specificReturn := fake.getStateReturnsOnCall[len(fake.getStateArgsForCall)]
 	fake.getStateArgsForCall = append(fake.getStateArgsForCall, struct {
@@ -520,7 +521,7 @@ func (fake *VersionedDB) GetStateCallCount() int {
 	return len(fake.getStateArgsForCall)
 }
 
-func (fake *VersionedDB) GetStateCalls(stub func(string, string) (*statedb.VersionedValue, error)) {
+func (fake *VersionedDB) GetStateCalls(stub func(string, string) (*state.VersionedValue, error)) {
 	fake.getStateMutex.Lock()
 	defer fake.getStateMutex.Unlock()
 	fake.GetStateStub = stub
@@ -533,33 +534,33 @@ func (fake *VersionedDB) GetStateArgsForCall(i int) (string, string) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *VersionedDB) GetStateReturns(result1 *statedb.VersionedValue, result2 error) {
+func (fake *VersionedDB) GetStateReturns(result1 *state.VersionedValue, result2 error) {
 	fake.getStateMutex.Lock()
 	defer fake.getStateMutex.Unlock()
 	fake.GetStateStub = nil
 	fake.getStateReturns = struct {
-		result1 *statedb.VersionedValue
+		result1 *state.VersionedValue
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *VersionedDB) GetStateReturnsOnCall(i int, result1 *statedb.VersionedValue, result2 error) {
+func (fake *VersionedDB) GetStateReturnsOnCall(i int, result1 *state.VersionedValue, result2 error) {
 	fake.getStateMutex.Lock()
 	defer fake.getStateMutex.Unlock()
 	fake.GetStateStub = nil
 	if fake.getStateReturnsOnCall == nil {
 		fake.getStateReturnsOnCall = make(map[int]struct {
-			result1 *statedb.VersionedValue
+			result1 *state.VersionedValue
 			result2 error
 		})
 	}
 	fake.getStateReturnsOnCall[i] = struct {
-		result1 *statedb.VersionedValue
+		result1 *state.VersionedValue
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *VersionedDB) GetStateMultipleKeys(arg1 string, arg2 []string) ([]*statedb.VersionedValue, error) {
+func (fake *VersionedDB) GetStateMultipleKeys(arg1 string, arg2 []string) ([]*state.VersionedValue, error) {
 	var arg2Copy []string
 	if arg2 != nil {
 		arg2Copy = make([]string, len(arg2))
@@ -589,7 +590,7 @@ func (fake *VersionedDB) GetStateMultipleKeysCallCount() int {
 	return len(fake.getStateMultipleKeysArgsForCall)
 }
 
-func (fake *VersionedDB) GetStateMultipleKeysCalls(stub func(string, []string) ([]*statedb.VersionedValue, error)) {
+func (fake *VersionedDB) GetStateMultipleKeysCalls(stub func(string, []string) ([]*state.VersionedValue, error)) {
 	fake.getStateMultipleKeysMutex.Lock()
 	defer fake.getStateMultipleKeysMutex.Unlock()
 	fake.GetStateMultipleKeysStub = stub
@@ -602,33 +603,33 @@ func (fake *VersionedDB) GetStateMultipleKeysArgsForCall(i int) (string, []strin
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *VersionedDB) GetStateMultipleKeysReturns(result1 []*statedb.VersionedValue, result2 error) {
+func (fake *VersionedDB) GetStateMultipleKeysReturns(result1 []*state.VersionedValue, result2 error) {
 	fake.getStateMultipleKeysMutex.Lock()
 	defer fake.getStateMultipleKeysMutex.Unlock()
 	fake.GetStateMultipleKeysStub = nil
 	fake.getStateMultipleKeysReturns = struct {
-		result1 []*statedb.VersionedValue
+		result1 []*state.VersionedValue
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *VersionedDB) GetStateMultipleKeysReturnsOnCall(i int, result1 []*statedb.VersionedValue, result2 error) {
+func (fake *VersionedDB) GetStateMultipleKeysReturnsOnCall(i int, result1 []*state.VersionedValue, result2 error) {
 	fake.getStateMultipleKeysMutex.Lock()
 	defer fake.getStateMultipleKeysMutex.Unlock()
 	fake.GetStateMultipleKeysStub = nil
 	if fake.getStateMultipleKeysReturnsOnCall == nil {
 		fake.getStateMultipleKeysReturnsOnCall = make(map[int]struct {
-			result1 []*statedb.VersionedValue
+			result1 []*state.VersionedValue
 			result2 error
 		})
 	}
 	fake.getStateMultipleKeysReturnsOnCall[i] = struct {
-		result1 []*statedb.VersionedValue
+		result1 []*state.VersionedValue
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *VersionedDB) GetStateRangeScanIterator(arg1 string, arg2 string, arg3 string) (statedb.ResultsIterator, error) {
+func (fake *VersionedDB) GetStateRangeScanIterator(arg1 string, arg2 string, arg3 string) (state.ResultsIterator, error) {
 	fake.getStateRangeScanIteratorMutex.Lock()
 	ret, specificReturn := fake.getStateRangeScanIteratorReturnsOnCall[len(fake.getStateRangeScanIteratorArgsForCall)]
 	fake.getStateRangeScanIteratorArgsForCall = append(fake.getStateRangeScanIteratorArgsForCall, struct {
@@ -654,7 +655,7 @@ func (fake *VersionedDB) GetStateRangeScanIteratorCallCount() int {
 	return len(fake.getStateRangeScanIteratorArgsForCall)
 }
 
-func (fake *VersionedDB) GetStateRangeScanIteratorCalls(stub func(string, string, string) (statedb.ResultsIterator, error)) {
+func (fake *VersionedDB) GetStateRangeScanIteratorCalls(stub func(string, string, string) (state.ResultsIterator, error)) {
 	fake.getStateRangeScanIteratorMutex.Lock()
 	defer fake.getStateRangeScanIteratorMutex.Unlock()
 	fake.GetStateRangeScanIteratorStub = stub
@@ -667,33 +668,33 @@ func (fake *VersionedDB) GetStateRangeScanIteratorArgsForCall(i int) (string, st
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *VersionedDB) GetStateRangeScanIteratorReturns(result1 statedb.ResultsIterator, result2 error) {
+func (fake *VersionedDB) GetStateRangeScanIteratorReturns(result1 state.ResultsIterator, result2 error) {
 	fake.getStateRangeScanIteratorMutex.Lock()
 	defer fake.getStateRangeScanIteratorMutex.Unlock()
 	fake.GetStateRangeScanIteratorStub = nil
 	fake.getStateRangeScanIteratorReturns = struct {
-		result1 statedb.ResultsIterator
+		result1 state.ResultsIterator
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *VersionedDB) GetStateRangeScanIteratorReturnsOnCall(i int, result1 statedb.ResultsIterator, result2 error) {
+func (fake *VersionedDB) GetStateRangeScanIteratorReturnsOnCall(i int, result1 state.ResultsIterator, result2 error) {
 	fake.getStateRangeScanIteratorMutex.Lock()
 	defer fake.getStateRangeScanIteratorMutex.Unlock()
 	fake.GetStateRangeScanIteratorStub = nil
 	if fake.getStateRangeScanIteratorReturnsOnCall == nil {
 		fake.getStateRangeScanIteratorReturnsOnCall = make(map[int]struct {
-			result1 statedb.ResultsIterator
+			result1 state.ResultsIterator
 			result2 error
 		})
 	}
 	fake.getStateRangeScanIteratorReturnsOnCall[i] = struct {
-		result1 statedb.ResultsIterator
+		result1 state.ResultsIterator
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *VersionedDB) GetStateRangeScanIteratorWithMetadata(arg1 string, arg2 string, arg3 string, arg4 map[string]interface{}) (statedb.QueryResultsIterator, error) {
+func (fake *VersionedDB) GetStateRangeScanIteratorWithMetadata(arg1 string, arg2 string, arg3 string, arg4 map[string]interface{}) (state.QueryResultsIterator, error) {
 	fake.getStateRangeScanIteratorWithMetadataMutex.Lock()
 	ret, specificReturn := fake.getStateRangeScanIteratorWithMetadataReturnsOnCall[len(fake.getStateRangeScanIteratorWithMetadataArgsForCall)]
 	fake.getStateRangeScanIteratorWithMetadataArgsForCall = append(fake.getStateRangeScanIteratorWithMetadataArgsForCall, struct {
@@ -720,7 +721,7 @@ func (fake *VersionedDB) GetStateRangeScanIteratorWithMetadataCallCount() int {
 	return len(fake.getStateRangeScanIteratorWithMetadataArgsForCall)
 }
 
-func (fake *VersionedDB) GetStateRangeScanIteratorWithMetadataCalls(stub func(string, string, string, map[string]interface{}) (statedb.QueryResultsIterator, error)) {
+func (fake *VersionedDB) GetStateRangeScanIteratorWithMetadataCalls(stub func(string, string, string, map[string]interface{}) (state.QueryResultsIterator, error)) {
 	fake.getStateRangeScanIteratorWithMetadataMutex.Lock()
 	defer fake.getStateRangeScanIteratorWithMetadataMutex.Unlock()
 	fake.GetStateRangeScanIteratorWithMetadataStub = stub
@@ -733,28 +734,28 @@ func (fake *VersionedDB) GetStateRangeScanIteratorWithMetadataArgsForCall(i int)
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *VersionedDB) GetStateRangeScanIteratorWithMetadataReturns(result1 statedb.QueryResultsIterator, result2 error) {
+func (fake *VersionedDB) GetStateRangeScanIteratorWithMetadataReturns(result1 state.QueryResultsIterator, result2 error) {
 	fake.getStateRangeScanIteratorWithMetadataMutex.Lock()
 	defer fake.getStateRangeScanIteratorWithMetadataMutex.Unlock()
 	fake.GetStateRangeScanIteratorWithMetadataStub = nil
 	fake.getStateRangeScanIteratorWithMetadataReturns = struct {
-		result1 statedb.QueryResultsIterator
+		result1 state.QueryResultsIterator
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *VersionedDB) GetStateRangeScanIteratorWithMetadataReturnsOnCall(i int, result1 statedb.QueryResultsIterator, result2 error) {
+func (fake *VersionedDB) GetStateRangeScanIteratorWithMetadataReturnsOnCall(i int, result1 state.QueryResultsIterator, result2 error) {
 	fake.getStateRangeScanIteratorWithMetadataMutex.Lock()
 	defer fake.getStateRangeScanIteratorWithMetadataMutex.Unlock()
 	fake.GetStateRangeScanIteratorWithMetadataStub = nil
 	if fake.getStateRangeScanIteratorWithMetadataReturnsOnCall == nil {
 		fake.getStateRangeScanIteratorWithMetadataReturnsOnCall = make(map[int]struct {
-			result1 statedb.QueryResultsIterator
+			result1 state.QueryResultsIterator
 			result2 error
 		})
 	}
 	fake.getStateRangeScanIteratorWithMetadataReturnsOnCall[i] = struct {
-		result1 statedb.QueryResultsIterator
+		result1 state.QueryResultsIterator
 		result2 error
 	}{result1, result2}
 }

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/commit_handling.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/commit_handling.go
@@ -11,7 +11,7 @@ import (
 	"math"
 	"sync"
 
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/util/couchdb"
 	"github.com/pkg/errors"
 )
@@ -57,7 +57,7 @@ func (c *committer) updateRevisionInCacheUpdate(key, rev string) {
 
 // buildCommitters builds committers per namespace. Each committer transforms the
 // given batch in the form of underlying db and keep it in memory.
-func (vdb *VersionedDB) buildCommitters(updates *statedb.UpdateBatch) ([]*committer, error) {
+func (vdb *VersionedDB) buildCommitters(updates *state.UpdateBatch) ([]*committer, error) {
 	namespaces := updates.GetUpdatedNamespaces()
 
 	// for each namespace, we build multiple committers (based on maxBatchSize per namespace)
@@ -99,7 +99,7 @@ func (vdb *VersionedDB) buildCommitters(updates *statedb.UpdateBatch) ([]*commit
 	return allCommitters, nil
 }
 
-func (vdb *VersionedDB) buildCommittersForNs(ns string, nsUpdates map[string]*statedb.VersionedValue) ([]*committer, error) {
+func (vdb *VersionedDB) buildCommittersForNs(ns string, nsUpdates map[string]*state.VersionedValue) ([]*committer, error) {
 	db, err := vdb.getNamespaceDBHandle(ns)
 	if err != nil {
 		return nil, err
@@ -232,7 +232,7 @@ func (c *committer) commitUpdates() error {
 	return nil
 }
 
-func (vdb *VersionedDB) getRevisions(ns string, nsUpdates map[string]*statedb.VersionedValue) (map[string]string, error) {
+func (vdb *VersionedDB) getRevisions(ns string, nsUpdates map[string]*state.VersionedValue) (map[string]string, error) {
 	revisions := make(map[string]string)
 	nsRevs := vdb.committedDataCache.revs[ns]
 

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdoc_conv.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdoc_conv.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/hyperledger/fabric/core/ledger/util/couchdb"
 	"github.com/pkg/errors"
 )
@@ -29,7 +29,7 @@ const (
 type keyValue struct {
 	key      string
 	revision string
-	*statedb.VersionedValue
+	*state.VersionedValue
 }
 
 type jsonValue map[string]interface{}
@@ -114,7 +114,7 @@ func couchDocToKeyValue(doc *couchdb.CouchDoc) (*keyValue, error) {
 	}
 	return &keyValue{
 		key, revision,
-		&statedb.VersionedValue{
+		&state.VersionedValue{
 			Value:    returnValue,
 			Metadata: returnMetadata,
 			Version:  returnVersion},

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/redolog.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/redolog.go
@@ -11,8 +11,8 @@ import (
 	"encoding/gob"
 
 	"github.com/hyperledger/fabric/common/ledger/util/leveldbhelper"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 )
 
 var redologKeyPrefix = []byte{byte(0)}
@@ -26,7 +26,7 @@ type redoLogger struct {
 }
 
 type redoRecord struct {
-	UpdateBatch *statedb.UpdateBatch
+	UpdateBatch *state.UpdateBatch
 	Version     *version.Height
 }
 

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/redolog_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/redolog_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,7 +40,7 @@ func TestRedoLogger(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Nil(t, rec)
 		loggers = append(loggers, logger)
-		batch := statedb.NewUpdateBatch()
+		batch := state.NewUpdateBatch()
 		blkNum := uint64(i)
 		batch.Put("ns1", "key1", []byte("value1"), version.NewHeight(blkNum, 1))
 		batch.Put("ns2", string([]byte{0x00, 0xff}), []byte("value3"), version.NewHeight(blkNum, 3))
@@ -56,7 +56,7 @@ func TestRedoLogger(t *testing.T) {
 
 	verifyLogRecords()
 	// overwrite logrecord for one channel
-	records[5].UpdateBatch = statedb.NewUpdateBatch()
+	records[5].UpdateBatch = state.NewUpdateBatch()
 	records[5].Version = version.NewHeight(5, 5)
 	assert.NoError(t, loggers[5].persist(records[5]))
 	verifyLogRecords()
@@ -68,7 +68,7 @@ func TestCouchdbRedoLogger(t *testing.T) {
 
 	// commitToRedologAndRestart - a helper function that commits directly to redologs and restart the statedb
 	commitToRedologAndRestart := func(newVal string, version *version.Height) {
-		batch := statedb.NewUpdateBatch()
+		batch := state.NewUpdateBatch()
 		batch.Put("ns1", "key1", []byte(newVal), version)
 		db, err := testEnv.DBProvider.GetDBHandle("testcouchdbredologger")
 		assert.NoError(t, err)
@@ -102,7 +102,7 @@ func TestCouchdbRedoLogger(t *testing.T) {
 		t.Fatalf("Failed to get database handle: %s", err)
 	}
 	vdb := db.(*VersionedDB)
-	batch1 := statedb.NewUpdateBatch()
+	batch1 := state.NewUpdateBatch()
 	batch1.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 1))
 	vdb.ApplyUpdates(batch1, version.NewHeight(1, 1))
 
@@ -189,7 +189,7 @@ func TestReadExistingRedoRecord(t *testing.T) {
 }
 
 func constructSampleRedoRecord() *redoRecord {
-	batch := statedb.NewUpdateBatch()
+	batch := state.NewUpdateBatch()
 	batch.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 1))
 	batch.Put("ns2", string([]byte{0x00, 0xff}), []byte("value3"), version.NewHeight(3, 3))
 	batch.PutValAndMetadata("ns2", string([]byte{0x00, 0xff}), []byte("value3"), []byte("metadata"), version.NewHeight(4, 4))

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/version_metadata_encoding_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/version_metadata_encoding_test.go
@@ -10,13 +10,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEncodeDecode(t *testing.T) {
-	testdata := []*statedb.VersionedValue{
+	testdata := []*state.VersionedValue{
 		{
 			Version: version.NewHeight(1, 2),
 		},
@@ -36,7 +36,7 @@ func TestEncodeDecode(t *testing.T) {
 	}
 }
 
-func testEncodeDecode(t *testing.T, v *statedb.VersionedValue) {
+func testEncodeDecode(t *testing.T, v *state.VersionedValue) {
 	encodedVerField, err := encodeVersionAndMetadata(v.Version, v.Metadata)
 	assert.NoError(t, err)
 

--- a/core/ledger/kvledger/txmgmt/statedb/statedb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statedb_test.go
@@ -7,127 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package statedb
 
 import (
-	"sort"
 	"testing"
 
-	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPanic(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatalf("Nil value to Put() did not panic\n")
-		}
-	}()
-
-	batch := NewUpdateBatch()
-	// The following call to Put() should result in panic
-	batch.Put("ns1", "key1", nil, nil)
-}
-
-//Test Put(), Get(), and Delete()
-func TestPutGetDeleteExistsGetUpdates(t *testing.T) {
-	batch := NewUpdateBatch()
-	batch.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 1))
-
-	//Get() should return above inserted <k,v> pair
-	actualVersionedValue := batch.Get("ns1", "key1")
-	assert.Equal(t, &VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}, actualVersionedValue)
-	//Exists() should return false as key2 does not exist
-	actualResult := batch.Exists("ns1", "key2")
-	expectedResult := false
-	assert.Equal(t, expectedResult, actualResult)
-
-	//Exists() should return false as ns3 does not exist
-	actualResult = batch.Exists("ns3", "key2")
-	expectedResult = false
-	assert.Equal(t, expectedResult, actualResult)
-
-	//Get() should return nil as key2 does not exist
-	actualVersionedValue = batch.Get("ns1", "key2")
-	assert.Nil(t, actualVersionedValue)
-	//Get() should return nil as ns3 does not exist
-	actualVersionedValue = batch.Get("ns3", "key2")
-	assert.Nil(t, actualVersionedValue)
-
-	batch.Put("ns1", "key2", []byte("value2"), version.NewHeight(1, 2))
-	//Exists() should return true as key2 exists
-	actualResult = batch.Exists("ns1", "key2")
-	expectedResult = true
-	assert.Equal(t, expectedResult, actualResult)
-
-	//GetUpdatedNamespaces should return 3 namespaces
-	batch.Put("ns2", "key2", []byte("value2"), version.NewHeight(1, 2))
-	batch.Put("ns3", "key2", []byte("value2"), version.NewHeight(1, 2))
-	actualNamespaces := batch.GetUpdatedNamespaces()
-	sort.Strings(actualNamespaces)
-	expectedNamespaces := []string{"ns1", "ns2", "ns3"}
-	assert.Equal(t, expectedNamespaces, actualNamespaces)
-
-	//GetUpdates should return two VersionedValues for the namespace ns1
-	expectedUpdates := make(map[string]*VersionedValue)
-	expectedUpdates["key1"] = &VersionedValue{Value: []byte("value1"), Version: version.NewHeight(1, 1)}
-	expectedUpdates["key2"] = &VersionedValue{Value: []byte("value2"), Version: version.NewHeight(1, 2)}
-	actualUpdates := batch.GetUpdates("ns1")
-	assert.Equal(t, expectedUpdates, actualUpdates)
-
-	actualUpdates = batch.GetUpdates("ns4")
-	assert.Nil(t, actualUpdates)
-
-	//Delete the above inserted <k,v> pair
-	batch.Delete("ns1", "key2", version.NewHeight(1, 2))
-	//Exists() should return true after deleting key2
-	//Exists() should return true iff the key has action(Put/Delete) in this batch
-	actualResult = batch.Exists("ns1", "key2")
-	expectedResult = true
-	assert.Equal(t, expectedResult, actualResult)
-
-}
-
-func TestUpdateBatchIterator(t *testing.T) {
-	batch := NewUpdateBatch()
-	batch.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 1))
-	batch.Put("ns1", "key2", []byte("value2"), version.NewHeight(1, 2))
-	batch.Put("ns1", "key3", []byte("value3"), version.NewHeight(1, 3))
-
-	batch.Put("ns2", "key6", []byte("value6"), version.NewHeight(2, 3))
-	batch.Put("ns2", "key5", []byte("value5"), version.NewHeight(2, 2))
-	batch.Put("ns2", "key4", []byte("value4"), version.NewHeight(2, 1))
-
-	checkItrResults(t, batch.GetRangeScanIterator("ns1", "key2", "key3"), []*VersionedKV{
-		{CompositeKey{"ns1", "key2"}, VersionedValue{[]byte("value2"), nil, version.NewHeight(1, 2)}},
-	})
-
-	checkItrResults(t, batch.GetRangeScanIterator("ns2", "key0", "key8"), []*VersionedKV{
-		{CompositeKey{"ns2", "key4"}, VersionedValue{[]byte("value4"), nil, version.NewHeight(2, 1)}},
-		{CompositeKey{"ns2", "key5"}, VersionedValue{[]byte("value5"), nil, version.NewHeight(2, 2)}},
-		{CompositeKey{"ns2", "key6"}, VersionedValue{[]byte("value6"), nil, version.NewHeight(2, 3)}},
-	})
-
-	checkItrResults(t, batch.GetRangeScanIterator("ns2", "", ""), []*VersionedKV{
-		{CompositeKey{"ns2", "key4"}, VersionedValue{[]byte("value4"), nil, version.NewHeight(2, 1)}},
-		{CompositeKey{"ns2", "key5"}, VersionedValue{[]byte("value5"), nil, version.NewHeight(2, 2)}},
-		{CompositeKey{"ns2", "key6"}, VersionedValue{[]byte("value6"), nil, version.NewHeight(2, 3)}},
-	})
-
-	checkItrResults(t, batch.GetRangeScanIterator("non-existing-ns", "", ""), nil)
-}
-
-func checkItrResults(t *testing.T, itr QueryResultsIterator, expectedResults []*VersionedKV) {
-	for i := 0; i < len(expectedResults); i++ {
-		res, _ := itr.Next()
-		assert.Equal(t, expectedResults[i], res)
-	}
-	lastRes, err := itr.Next()
-	assert.NoError(t, err)
-	assert.Nil(t, lastRes)
-	itr.Close()
-}
-
 // TestPaginatedRangeValidation tests queries with pagination
 func TestPaginatedRangeValidation(t *testing.T) {
-
 	queryOptions := make(map[string]interface{})
 	queryOptions["limit"] = int32(10)
 
@@ -151,35 +37,4 @@ func TestPaginatedRangeValidation(t *testing.T) {
 
 	err = ValidateRangeMetadata(queryOptions)
 	assert.Error(t, err, "An should have been thrown for an invalid option")
-
-}
-
-func TestMergeUpdateBatch(t *testing.T) {
-	batch1 := NewUpdateBatch()
-	batch1.Put("ns1", "key1", []byte("batch1_value1"), version.NewHeight(1, 1))
-	batch1.Put("ns1", "key2", []byte("batch1_value2"), version.NewHeight(2, 2))
-	batch1.Put("ns1", "key3", []byte("batch1_value3"), version.NewHeight(3, 3))
-
-	batch2 := NewUpdateBatch()
-	batch2.ContainsPostOrderWrites = true
-	batch2.Put("ns1", "key1", []byte("batch2_value1"), version.NewHeight(4, 4)) // overwrite key1 with new value
-	batch2.Delete("ns1", "key2", version.NewHeight(5, 5))                       // overwrite key2 with deletion
-	batch2.Put("ns1", "key4", []byte("batch2_value4"), version.NewHeight(6, 6)) // new key only in batch2
-	batch2.Delete("ns1", "key5", version.NewHeight(7, 7))                       // delete key only in batch2
-	batch2.Put("ns2", "key6", []byte("batch2_value6"), version.NewHeight(8, 8)) // namespace only in batch2
-
-	batch1.Merge(batch2)
-
-	// prepare final expected batch by writing all updates in the above order
-	expectedBatch := NewUpdateBatch()
-	expectedBatch.ContainsPostOrderWrites = true
-	expectedBatch.Put("ns1", "key1", []byte("batch1_value1"), version.NewHeight(1, 1))
-	expectedBatch.Put("ns1", "key2", []byte("batch1_value2"), version.NewHeight(2, 2))
-	expectedBatch.Put("ns1", "key3", []byte("batch1_value3"), version.NewHeight(3, 3))
-	expectedBatch.Put("ns1", "key1", []byte("batch2_value1"), version.NewHeight(4, 4))
-	expectedBatch.Delete("ns1", "key2", version.NewHeight(5, 5))
-	expectedBatch.Put("ns1", "key4", []byte("batch2_value4"), version.NewHeight(6, 6))
-	expectedBatch.Delete("ns1", "key5", version.NewHeight(7, 7))
-	expectedBatch.Put("ns2", "key6", []byte("batch2_value6"), version.NewHeight(8, 8))
-	assert.Equal(t, expectedBatch, batch1)
 }

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb_test.go
@@ -9,8 +9,8 @@ package stateleveldb
 import (
 	"testing"
 
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/commontests"
 	"github.com/stretchr/testify/assert"
 )
@@ -60,7 +60,7 @@ func TestQueryOnLevelDB(t *testing.T) {
 	assert.NoError(t, err)
 	db.Open()
 	defer db.Close()
-	batch := statedb.NewUpdateBatch()
+	batch := state.NewUpdateBatch()
 	jsonValue1 := `{"asset_name": "marble1","color": "blue","size": 1,"owner": "tom"}`
 	batch.Put("ns1", "key1", []byte(jsonValue1), version.NewHeight(1, 1))
 

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/value_encoding.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/value_encoding.go
@@ -8,12 +8,12 @@ package stateleveldb
 
 import (
 	proto "github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 )
 
 // encodeValue encodes the value, version, and metadata
-func encodeValue(v *statedb.VersionedValue) ([]byte, error) {
+func encodeValue(v *state.VersionedValue) ([]byte, error) {
 	return proto.Marshal(
 		&DBValue{
 			Version:  v.Version.ToBytes(),
@@ -24,7 +24,7 @@ func encodeValue(v *statedb.VersionedValue) ([]byte, error) {
 }
 
 // decodeValue decodes the statedb value bytes
-func decodeValue(encodedValue []byte) (*statedb.VersionedValue, error) {
+func decodeValue(encodedValue []byte) (*state.VersionedValue, error) {
 	dbValue := &DBValue{}
 	err := proto.Unmarshal(encodedValue, dbValue)
 	if err != nil {
@@ -40,5 +40,5 @@ func decodeValue(encodedValue []byte) (*statedb.VersionedValue, error) {
 	if val == nil {
 		val = []byte{}
 	}
-	return &statedb.VersionedValue{Version: ver, Value: val, Metadata: metadata}, nil
+	return &state.VersionedValue{Version: ver, Value: val, Metadata: metadata}, nil
 }

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/value_encoding_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/value_encoding_test.go
@@ -10,13 +10,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEncodeDecodeVersionedValues(t *testing.T) {
-	testdata := []*statedb.VersionedValue{
+	testdata := []*state.VersionedValue{
 		{
 			Value:   []byte("value0"),
 			Version: version.NewHeight(0, 0),
@@ -44,7 +44,7 @@ func TestEncodeDecodeVersionedValues(t *testing.T) {
 	}
 }
 
-func testEncodeDecodeVersionedValues(t *testing.T, v *statedb.VersionedValue) {
+func testEncodeDecodeVersionedValues(t *testing.T, v *state.VersionedValue) {
 	encodedVal, err := encodeValue(v)
 	assert.NoError(t, err)
 	decodedVal, err := decodeValue(encodedVal)

--- a/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/helper.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/helper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
 	commonledger "github.com/hyperledger/fabric/common/ledger"
 	ledger "github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
@@ -158,7 +159,7 @@ func (h *queryHelper) getPrivateData(ns, coll, key string) ([]byte, error) {
 
 	var err error
 	var hashVersion *version.Height
-	var versionedValue *statedb.VersionedValue
+	var versionedValue *state.VersionedValue
 
 	if versionedValue, err = h.txmgr.db.GetPrivateData(ns, coll, key); err != nil {
 		return nil, err
@@ -189,7 +190,7 @@ func (h *queryHelper) getPrivateDataValueHash(ns, coll, key string) (valueHash, 
 	if err := h.checkDone(); err != nil {
 		return nil, nil, err
 	}
-	var versionedValue *statedb.VersionedValue
+	var versionedValue *state.VersionedValue
 	if versionedValue, err = h.txmgr.db.GetPrivateDataHash(ns, coll, key); err != nil {
 		return nil, nil, err
 	}
@@ -356,7 +357,7 @@ func (h *queryHelper) validateCollName(ns, coll string) error {
 type resultsItr struct {
 	ns                      string
 	endKey                  string
-	dbItr                   statedb.ResultsIterator
+	dbItr                   state.ResultsIterator
 	rwSetBuilder            *rwsetutil.RWSetBuilder
 	rangeQueryInfo          *kvrwset.RangeQueryInfo
 	rangeQueryResultsHelper *rwsetutil.RangeQueryResultsHelper
@@ -365,7 +366,7 @@ type resultsItr struct {
 func newResultsItr(ns string, startKey string, endKey string, metadata map[string]interface{},
 	db statedb.VersionedDB, rwsetBuilder *rwsetutil.RWSetBuilder, enableHashing bool, maxDegree uint32, hasher ledger.Hasher) (*resultsItr, error) {
 	var err error
-	var dbItr statedb.ResultsIterator
+	var dbItr state.ResultsIterator
 	if metadata == nil {
 		dbItr, err = db.GetStateRangeScanIterator(ns, startKey, endKey)
 	} else {
@@ -406,14 +407,14 @@ func (itr *resultsItr) Next() (commonledger.QueryResult, error) {
 	if queryResult == nil {
 		return nil, nil
 	}
-	versionedKV := queryResult.(*statedb.VersionedKV)
+	versionedKV := queryResult.(*state.VersionedKV)
 	return &queryresult.KV{Namespace: versionedKV.Namespace, Key: versionedKV.Key, Value: versionedKV.Value}, nil
 }
 
 // GetBookmarkAndClose implements method in interface ledger.ResultsIterator
 func (itr *resultsItr) GetBookmarkAndClose() string {
 	returnBookmark := ""
-	if queryResultIterator, ok := itr.dbItr.(statedb.QueryResultsIterator); ok {
+	if queryResultIterator, ok := itr.dbItr.(state.QueryResultsIterator); ok {
 		returnBookmark = queryResultIterator.GetBookmarkAndClose()
 	}
 	return returnBookmark
@@ -424,7 +425,7 @@ func (itr *resultsItr) GetBookmarkAndClose() string {
 //                                  because, we do not know if the caller is again going to invoke Next() or not.
 //                            or b) the last key that was supplied in the original query (if the iterator is exhausted)
 // 2) The ItrExhausted - set to true if the iterator is going to return nil as a result of the Next() call
-func (itr *resultsItr) updateRangeQueryInfo(queryResult statedb.QueryResult) {
+func (itr *resultsItr) updateRangeQueryInfo(queryResult state.QueryResult) {
 	if itr.rwSetBuilder == nil {
 		return
 	}
@@ -436,7 +437,7 @@ func (itr *resultsItr) updateRangeQueryInfo(queryResult statedb.QueryResult) {
 		itr.rangeQueryInfo.EndKey = itr.endKey
 		return
 	}
-	versionedKV := queryResult.(*statedb.VersionedKV)
+	versionedKV := queryResult.(*state.VersionedKV)
 	itr.rangeQueryResultsHelper.AddResult(rwsetutil.NewKVRead(versionedKV.Key, versionedKV.Version))
 	// Set the end key to the latest key retrieved by the caller.
 	// Because, the caller may actually not invoke the Next() function again
@@ -449,7 +450,7 @@ func (itr *resultsItr) Close() {
 }
 
 type queryResultsItr struct {
-	DBItr        statedb.ResultsIterator
+	DBItr        state.ResultsIterator
 	RWSetBuilder *rwsetutil.RWSetBuilder
 }
 
@@ -463,7 +464,7 @@ func (itr *queryResultsItr) Next() (commonledger.QueryResult, error) {
 	if queryResult == nil {
 		return nil, nil
 	}
-	versionedQueryRecord := queryResult.(*statedb.VersionedKV)
+	versionedQueryRecord := queryResult.(*state.VersionedKV)
 	logger.Debugf("queryResultsItr.Next() returned a record:%s", string(versionedQueryRecord.Value))
 
 	if itr.RWSetBuilder != nil {
@@ -479,13 +480,13 @@ func (itr *queryResultsItr) Close() {
 
 func (itr *queryResultsItr) GetBookmarkAndClose() string {
 	returnBookmark := ""
-	if queryResultIterator, ok := itr.DBItr.(statedb.QueryResultsIterator); ok {
+	if queryResultIterator, ok := itr.DBItr.(state.QueryResultsIterator); ok {
 		returnBookmark = queryResultIterator.GetBookmarkAndClose()
 	}
 	return returnBookmark
 }
 
-func decomposeVersionedValue(versionedValue *statedb.VersionedValue) ([]byte, []byte, *version.Height) {
+func decomposeVersionedValue(versionedValue *state.VersionedValue) ([]byte, []byte, *version.Height) {
 	var value []byte
 	var metadata []byte
 	var ver *version.Height
@@ -501,7 +502,7 @@ func decomposeVersionedValue(versionedValue *statedb.VersionedValue) ([]byte, []
 type pvtdataResultsItr struct {
 	ns    string
 	coll  string
-	dbItr statedb.ResultsIterator
+	dbItr state.ResultsIterator
 }
 
 // Next implements method in interface ledger.ResultsIterator
@@ -513,7 +514,7 @@ func (itr *pvtdataResultsItr) Next() (commonledger.QueryResult, error) {
 	if queryResult == nil {
 		return nil, nil
 	}
-	versionedQueryRecord := queryResult.(*statedb.VersionedKV)
+	versionedQueryRecord := queryResult.(*state.VersionedKV)
 	return &queryresult.KV{
 		Namespace: itr.ns,
 		Key:       versionedQueryRecord.Key,

--- a/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/helper_test.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/helper_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hyperledger/fabric/bccsp/sw"
 	commonledger "github.com/hyperledger/fabric/common/ledger"
 	"github.com/hyperledger/fabric/common/ledger/testutil"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
 	btltestutil "github.com/hyperledger/fabric/core/ledger/pvtdatapolicy/testutil"
 	"github.com/hyperledger/fabric/core/ledger/util"
@@ -40,7 +40,7 @@ func TestPvtdataResultsItr(t *testing.T) {
 		version.NewHeight(1, 0),
 	)
 
-	updates := privacyenabledstate.NewUpdateBatch()
+	updates := state.NewPubHashPvtUpdateBatch()
 	putPvtUpdates(t, updates, "ns1", "coll1", "key1", []byte("pvt_value1"), version.NewHeight(1, 1))
 	putPvtUpdates(t, updates, "ns1", "coll1", "key2", []byte("pvt_value2"), version.NewHeight(1, 2))
 	putPvtUpdates(t, updates, "ns1", "coll1", "key3", []byte("pvt_value3"), version.NewHeight(1, 3))
@@ -144,7 +144,7 @@ func testGetPvtdataHash(t *testing.T, env testEnv) {
 	txMgr := env.getTxMgr().(*LockBasedTxMgr)
 	populateCollConfigForTest(t, txMgr, []collConfigkey{{"ns", "coll"}}, version.NewHeight(1, 1))
 
-	batch := privacyenabledstate.NewUpdateBatch()
+	batch := state.NewPubHashPvtUpdateBatch()
 	batch.HashUpdates.Put(
 		"ns", "coll",
 		util.ComputeStringHash("existing-key"),
@@ -197,7 +197,7 @@ func testGetPvtdataHash(t *testing.T, env testEnv) {
 	assert.Equal(t, expectedRwSet, txrwset)
 }
 
-func putPvtUpdates(t *testing.T, updates *privacyenabledstate.UpdateBatch, ns, coll, key string, value []byte, ver *version.Height) {
+func putPvtUpdates(t *testing.T, updates *state.PubHashPvtUpdateBatch, ns, coll, key string, value []byte, ver *version.Height) {
 	updates.PvtUpdates.Put(ns, coll, key, value, ver)
 	updates.HashUpdates.Put(ns, coll, util.ComputeStringHash(key), util.ComputeHash(value), ver)
 }

--- a/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/pkg_test.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/pkg_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/common/ledger/testutil"
 	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/bookkeeping"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
@@ -209,7 +210,7 @@ func testutilPopulateDB(
 	data []*queryresult.KV, pvtdataHashes []*testutilPvtdata,
 	version *version.Height,
 ) {
-	updates := privacyenabledstate.NewUpdateBatch()
+	updates := state.NewPubHashPvtUpdateBatch()
 	for _, kv := range data {
 		updates.PubUpdates.Put(ns, kv.Key, kv.Value, version)
 	}

--- a/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/state_listener_test.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/state_listener_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
 	"github.com/hyperledger/fabric/common/ledger/testutil"
 	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	"github.com/hyperledger/fabric/core/ledger/mock"
 	"github.com/hyperledger/fabric/core/ledger/util"
 	"github.com/hyperledger/fabric/protoutil"
@@ -40,7 +40,7 @@ func TestStateListener(t *testing.T) {
 
 	// Mimic commit of block 1 with updates in namespaces ns1, ns2, and ns3
 	// This should cause callback to ml1 and ml2 but not to ml3
-	sampleBatch := privacyenabledstate.NewUpdateBatch()
+	sampleBatch := state.NewPubHashPvtUpdateBatch()
 	sampleBatch.PubUpdates.Put("ns1", "key1_1", []byte("value1_1"), version.NewHeight(1, 1))
 	sampleBatch.PubUpdates.Put("ns1", "key1_2", []byte("value1_2"), version.NewHeight(1, 2))
 	sampleBatch.PubUpdates.Put("ns2", "key2_1", []byte("value2_1"), version.NewHeight(1, 3))
@@ -91,7 +91,7 @@ func TestStateListener(t *testing.T) {
 
 	// Mimic commit of block 2 with updates only in ns4 namespace
 	// This should cause callback only to ml3
-	sampleBatch = privacyenabledstate.NewUpdateBatch()
+	sampleBatch = state.NewPubHashPvtUpdateBatch()
 	sampleBatch.PubUpdates.Put("ns4", "key4_1", []byte("value4_1"), version.NewHeight(2, 1))
 	sampleBatch.HashUpdates.Put("ns4", "coll1", []byte("key-hash-1"), []byte("value-hash-1"), version.NewHeight(2, 2))
 	sampleBatch.HashUpdates.Put("ns4", "coll1", []byte("key-hash-2"), []byte("value-hash-2"), version.NewHeight(2, 2))

--- a/core/ledger/kvledger/txmgmt/validator/internal/tx_ops_preparation.go
+++ b/core/ledger/kvledger/txmgmt/validator/internal/tx_ops_preparation.go
@@ -8,10 +8,10 @@ package internal
 
 import (
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/storageutil"
 )
 
@@ -120,8 +120,8 @@ func (txops txOps) applyMetadata(ns, coll string, metadataWrite *kvrwset.KVMetad
 // Further, all the keys that gets written will be required to pull from statedb by vscc for endorsement policy check (in the case of key level
 // endorsement) and hence, the bulkload should be combined
 func retrieveLatestState(ns, coll, key string,
-	precedingUpdates *PubAndHashUpdates, db privacyenabledstate.DB) (*statedb.VersionedValue, error) {
-	var vv *statedb.VersionedValue
+	precedingUpdates *PubAndHashUpdates, db privacyenabledstate.DB) (*state.VersionedValue, error) {
+	var vv *state.VersionedValue
 	var err error
 	if coll == "" {
 		vv := precedingUpdates.PubUpdates.Get(ns, key)

--- a/core/ledger/kvledger/txmgmt/validator/internal/tx_ops_preparation_test.go
+++ b/core/ledger/kvledger/txmgmt/validator/internal/tx_ops_preparation_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
 	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
@@ -64,7 +65,7 @@ func TestTxOpsPreparationValueUpdate(t *testing.T) {
 		compositeKey{ns: "ns1", key: "key2"},
 		compositeKey{ns: "ns1", key: "key3"}
 
-	updateBatch := privacyenabledstate.NewUpdateBatch()
+	updateBatch := state.NewPubHashPvtUpdateBatch()
 	updateBatch.PubUpdates.Put(ck1.ns, ck1.key, []byte("value1"), version.NewHeight(1, 1)) // write key1 with only value
 	updateBatch.PubUpdates.PutValAndMetadata(                                              // write key2 with value and metadata
 		ck2.ns, ck2.key,
@@ -121,7 +122,7 @@ func TestTxOpsPreparationMetadataUpdates(t *testing.T) {
 		compositeKey{ns: "ns1", key: "key2"},
 		compositeKey{ns: "ns1", key: "key3"}
 
-	updateBatch := privacyenabledstate.NewUpdateBatch()
+	updateBatch := state.NewPubHashPvtUpdateBatch()
 	updateBatch.PubUpdates.Put(ck1.ns, ck1.key, []byte("value1"), version.NewHeight(1, 1)) // write key1 with only value
 	updateBatch.PubUpdates.PutValAndMetadata(                                              // write key2 with value and metadata
 		ck2.ns, ck2.key,
@@ -173,7 +174,7 @@ func TestTxOpsPreparationMetadataDelete(t *testing.T) {
 		compositeKey{ns: "ns1", key: "key2"},
 		compositeKey{ns: "ns1", key: "key3"}
 
-	updateBatch := privacyenabledstate.NewUpdateBatch()
+	updateBatch := state.NewPubHashPvtUpdateBatch()
 	updateBatch.PubUpdates.Put(ck1.ns, ck1.key, []byte("value1"), version.NewHeight(1, 1)) // write key1 with only value
 	updateBatch.PubUpdates.PutValAndMetadata(                                              // write key2 with value and metadata
 		ck2.ns, ck2.key,
@@ -224,7 +225,7 @@ func TestTxOpsPreparationMixedUpdates(t *testing.T) {
 		compositeKey{ns: "ns1", key: "key3"},
 		compositeKey{ns: "ns1", key: "key4"}
 
-	updateBatch := privacyenabledstate.NewUpdateBatch()
+	updateBatch := state.NewPubHashPvtUpdateBatch()
 	updateBatch.PubUpdates.Put(ck1.ns, ck1.key, []byte("value1"), version.NewHeight(1, 1)) // write key1 with only value
 	updateBatch.PubUpdates.Put(ck2.ns, ck2.key, []byte("value2"), version.NewHeight(1, 2)) // write key2 with only value
 	updateBatch.PubUpdates.PutValAndMetadata(                                              // write key3 with value and metadata
@@ -306,7 +307,7 @@ func TestTxOpsPreparationPvtdataHashes(t *testing.T) {
 		compositeKey{ns: "ns1", coll: "coll1", key: string(util.ComputeStringHash("key3"))},
 		compositeKey{ns: "ns1", coll: "coll1", key: string(util.ComputeStringHash("key4"))}
 
-	updateBatch := privacyenabledstate.NewUpdateBatch()
+	updateBatch := state.NewPubHashPvtUpdateBatch()
 
 	updateBatch.HashUpdates.Put(ck1.ns, ck1.coll, util.ComputeStringHash(ck1.key),
 		util.ComputeStringHash("value1"), version.NewHeight(1, 1)) // write key1 with only value

--- a/core/ledger/kvledger/txmgmt/validator/internal/val.go
+++ b/core/ledger/kvledger/txmgmt/validator/internal/val.go
@@ -9,6 +9,7 @@ package internal
 import (
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
@@ -42,15 +43,15 @@ type Transaction struct {
 // PubAndHashUpdates encapsulates public and hash updates. The intended use of this to hold the updates
 // that are to be applied to the statedb  as a result of the block commit
 type PubAndHashUpdates struct {
-	PubUpdates  *privacyenabledstate.PubUpdateBatch
-	HashUpdates *privacyenabledstate.HashedUpdateBatch
+	PubUpdates  *state.PubUpdateBatch
+	HashUpdates *state.HashedUpdateBatch
 }
 
 // NewPubAndHashUpdates constructs an empty PubAndHashUpdates
 func NewPubAndHashUpdates() *PubAndHashUpdates {
 	return &PubAndHashUpdates{
-		privacyenabledstate.NewPubUpdateBatch(),
-		privacyenabledstate.NewHashedUpdateBatch(),
+		state.NewPubUpdateBatch(),
+		state.NewHashedUpdateBatch(),
 	}
 }
 

--- a/core/ledger/kvledger/txmgmt/validator/internal/val_test.go
+++ b/core/ledger/kvledger/txmgmt/validator/internal/val_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
@@ -18,8 +19,8 @@ import (
 
 func TestNewPubAndHashUpdates(t *testing.T) {
 	expected := &PubAndHashUpdates{
-		privacyenabledstate.NewPubUpdateBatch(),
-		privacyenabledstate.NewHashedUpdateBatch(),
+		state.NewPubUpdateBatch(),
+		state.NewHashedUpdateBatch(),
 	}
 
 	actual := NewPubAndHashUpdates()

--- a/core/ledger/kvledger/txmgmt/validator/statebasedval/range_query_validator_test.go
+++ b/core/ledger/kvledger/txmgmt/validator/statebasedval/range_query_validator_test.go
@@ -20,15 +20,15 @@ import (
 	"testing"
 
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/stateleveldb"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRangeQueryBoundaryConditions(t *testing.T) {
-	batch := statedb.NewUpdateBatch()
+	batch := state.NewUpdateBatch()
 	batch.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 0))
 	batch.Put("ns1", "key2", []byte("value2"), version.NewHeight(1, 1))
 	batch.Put("ns1", "key3", []byte("value3"), version.NewHeight(1, 2))
@@ -62,7 +62,7 @@ func TestRangeQueryBoundaryConditions(t *testing.T) {
 	testRangeQuery(t, testcase4, batch, version.NewHeight(1, 4), "ns1", rqi4, false)
 }
 
-func testRangeQuery(t *testing.T, testcase string, stateData *statedb.UpdateBatch, savepoint *version.Height,
+func testRangeQuery(t *testing.T, testcase string, stateData *state.UpdateBatch, savepoint *version.Height,
 	ns string, rqi *kvrwset.RangeQueryInfo, expectedResult bool) {
 	t.Run(testcase, func(t *testing.T) {
 		testDBEnv := stateleveldb.NewTestVDBEnv(t)

--- a/core/ledger/kvledger/txmgmt/validator/statebasedval/state_based_validator_test.go
+++ b/core/ledger/kvledger/txmgmt/validator/statebasedval/state_based_validator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/bccsp/sw"
 	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
@@ -76,7 +77,7 @@ func TestValidatorBulkLoadingOfCache(t *testing.T) {
 	validator := &Validator{DB: db, Hasher: cryptoProvider}
 
 	//populate db with initial data
-	batch := privacyenabledstate.NewUpdateBatch()
+	batch := state.NewPubHashPvtUpdateBatch()
 
 	// Create two public KV pairs
 	pubKV1 := keyValue{namespace: "ns1", key: "key1", value: []byte("value1"), version: version.NewHeight(1, 0)}
@@ -201,7 +202,7 @@ func TestValidator(t *testing.T) {
 	db := testDBEnv.GetDBHandle("TestDB")
 
 	//populate db with initial data
-	batch := privacyenabledstate.NewUpdateBatch()
+	batch := state.NewPubHashPvtUpdateBatch()
 	batch.PubUpdates.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 0))
 	batch.PubUpdates.Put("ns1", "key2", []byte("value2"), version.NewHeight(1, 1))
 	batch.PubUpdates.Put("ns1", "key3", []byte("value3"), version.NewHeight(1, 2))
@@ -246,7 +247,7 @@ func TestPhantomValidation(t *testing.T) {
 	db := testDBEnv.GetDBHandle("TestDB")
 
 	//populate db with initial data
-	batch := privacyenabledstate.NewUpdateBatch()
+	batch := state.NewPubHashPvtUpdateBatch()
 	batch.PubUpdates.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 0))
 	batch.PubUpdates.Put("ns1", "key2", []byte("value2"), version.NewHeight(1, 1))
 	batch.PubUpdates.Put("ns1", "key3", []byte("value3"), version.NewHeight(1, 2))
@@ -319,7 +320,7 @@ func TestPhantomHashBasedValidation(t *testing.T) {
 	db := testDBEnv.GetDBHandle("TestDB")
 
 	//populate db with initial data
-	batch := privacyenabledstate.NewUpdateBatch()
+	batch := state.NewPubHashPvtUpdateBatch()
 	batch.PubUpdates.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 0))
 	batch.PubUpdates.Put("ns1", "key2", []byte("value2"), version.NewHeight(1, 1))
 	batch.PubUpdates.Put("ns1", "key3", []byte("value3"), version.NewHeight(1, 2))

--- a/core/ledger/kvledger/txmgmt/validator/validator.go
+++ b/core/ledger/kvledger/txmgmt/validator/validator.go
@@ -18,14 +18,14 @@ package validator
 
 import (
 	"github.com/hyperledger/fabric/core/ledger"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/txmgr"
 )
 
 // Validator validates the transactions present in a block and returns a batch that should be used to update the state
 type Validator interface {
 	ValidateAndPrepareBatch(blockAndPvtdata *ledger.BlockAndPvtData, doMVCCValidation bool) (
-		*privacyenabledstate.UpdateBatch, []*txmgr.TxStatInfo, error,
+		*state.PubHashPvtUpdateBatch, []*txmgr.TxStatInfo, error,
 	)
 }
 

--- a/core/ledger/kvledger/txmgmt/validator/valimpl/default_impl.go
+++ b/core/ledger/kvledger/txmgmt/validator/valimpl/default_impl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/ledger/internal/state"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/txmgr"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/validator"
@@ -52,13 +53,13 @@ func NewStatebasedValidator(
 
 // ValidateAndPrepareBatch implements the function in interface validator.Validator
 func (impl *DefaultImpl) ValidateAndPrepareBatch(blockAndPvtdata *ledger.BlockAndPvtData,
-	doMVCCValidation bool) (*privacyenabledstate.UpdateBatch, []*txmgr.TxStatInfo, error) {
+	doMVCCValidation bool) (*state.PubHashPvtUpdateBatch, []*txmgr.TxStatInfo, error) {
 	block := blockAndPvtdata.Block
 	logger.Debugf("ValidateAndPrepareBatch() for block number = [%d]", block.Header.Number)
 	var internalBlock *internal.Block
 	var txsStatInfo []*txmgr.TxStatInfo
 	var pubAndHashUpdates *internal.PubAndHashUpdates
-	var pvtUpdates *privacyenabledstate.PvtUpdateBatch
+	var pvtUpdates *state.PvtUpdateBatch
 	var err error
 
 	logger.Debug("preprocessing ProtoBlock...")
@@ -93,7 +94,7 @@ func (impl *DefaultImpl) ValidateAndPrepareBatch(blockAndPvtdata *ledger.BlockAn
 	for i := range txsFilter {
 		txsStatInfo[i].ValidationCode = txsFilter.Flag(i)
 	}
-	return &privacyenabledstate.UpdateBatch{
+	return &state.PubHashPvtUpdateBatch{
 		PubUpdates:  pubAndHashUpdates.PubUpdates,
 		HashUpdates: pubAndHashUpdates.HashUpdates,
 		PvtUpdates:  pvtUpdates,


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code structure)
- Test Updates

#### Description

In the ledger package, we have 

1. a bunch of composite keys. 
2. an update batch to hold block's public, hashed, and private states (holds only the valid tx's write-set after the tx is validated by both vscc and serializability check). 
3. an update batch to hold these states combined to update the state database (uses actual key format used at the statedb side).

These `structs`/`methods` are used throughout the ledger package. Hence, we move these structs and related methods to `core/ledger/internal/state`

Add UT to improve the test coverage. Removed some dead-code too. 

#### Related issues

[FAB-17708](https://jira.hyperledger.org/browse/FAB-17688)
