### PR TITLE
Remove t.Parallel() from gossip tests

### DIFF
--- a/gossip/comm/ack_test.go
+++ b/gossip/comm/ack_test.go
@@ -61,8 +61,6 @@ func TestInterceptAcks(t *testing.T) {
 }
 
 func TestAck(t *testing.T) {
-	t.Parallel()
-
 	comm1, _ := newCommInstance(t, naiveSec)
 	comm2, port2 := newCommInstance(t, naiveSec)
 	defer comm2.Stop()

--- a/gossip/comm/comm_test.go
+++ b/gossip/comm/comm_test.go
@@ -241,8 +241,6 @@ func handshaker(port int, endpoint string, comm Comm, t *testing.T, connMutator 
 }
 
 func TestMutualParallelSendWithAck(t *testing.T) {
-	t.Parallel()
-
 	// This test tests concurrent and parallel sending of many (1000) messages
 	// from 2 instances to one another at the same time.
 
@@ -297,7 +295,6 @@ func getAvailablePort(t *testing.T) (port int, endpoint string, ll net.Listener)
 }
 
 func TestHandshake(t *testing.T) {
-	t.Parallel()
 	signer := func(msg []byte) ([]byte, error) {
 		mac := hmac.New(sha256.New, hmacKey)
 		mac.Write(msg)
@@ -443,7 +440,6 @@ func TestHandshake(t *testing.T) {
 }
 
 func TestConnectUnexpectedPeer(t *testing.T) {
-	t.Parallel()
 	// Scenarios: In both scenarios, comm1 connects to comm2 or comm3.
 	// and expects to see a PKI-ID which is equal to comm4's PKI-ID.
 	// The connection attempt would succeed or fail based on whether comm2 or comm3
@@ -512,7 +508,6 @@ func TestConnectUnexpectedPeer(t *testing.T) {
 }
 
 func TestGetConnectionInfo(t *testing.T) {
-	t.Parallel()
 	comm1, port1 := newCommInstance(t, naiveSec)
 	comm2, _ := newCommInstance(t, naiveSec)
 	defer comm1.Stop()
@@ -529,7 +524,6 @@ func TestGetConnectionInfo(t *testing.T) {
 }
 
 func TestCloseConn(t *testing.T) {
-	t.Parallel()
 	comm1, port1 := newCommInstance(t, naiveSec)
 	defer comm1.Stop()
 	acceptChan := comm1.Accept(acceptAll)
@@ -586,7 +580,6 @@ func TestCloseConn(t *testing.T) {
 // case assumes some will fail, but that eventually enough messages will get
 // through that the test will end.
 func TestCommSend(t *testing.T) {
-	t.Parallel()
 	comm1, port1 := newCommInstance(t, naiveSec)
 	comm2, port2 := newCommInstance(t, naiveSec)
 	defer comm1.Stop()
@@ -684,7 +677,6 @@ func (bp *nonResponsivePeer) stop() {
 }
 
 func TestNonResponsivePing(t *testing.T) {
-	t.Parallel()
 	c, _ := newCommInstance(t, naiveSec)
 	defer c.Stop()
 	nonRespPeer := newNonResponsivePeer(t)
@@ -703,7 +695,6 @@ func TestNonResponsivePing(t *testing.T) {
 }
 
 func TestResponses(t *testing.T) {
-	t.Parallel()
 	comm1, port1 := newCommInstance(t, naiveSec)
 	comm2, _ := newCommInstance(t, naiveSec)
 
@@ -744,7 +735,6 @@ func TestResponses(t *testing.T) {
 // TestAccept makes sure that accept filters work. The probability of the parity
 // of all nonces being 0 or 1 is very low.
 func TestAccept(t *testing.T) {
-	t.Parallel()
 	comm1, port1 := newCommInstance(t, naiveSec)
 	comm2, _ := newCommInstance(t, naiveSec)
 
@@ -817,7 +807,6 @@ func TestAccept(t *testing.T) {
 }
 
 func TestReConnections(t *testing.T) {
-	t.Parallel()
 	comm1, port1 := newCommInstance(t, naiveSec)
 	comm2, port2 := newCommInstance(t, naiveSec)
 
@@ -855,7 +844,6 @@ func TestReConnections(t *testing.T) {
 }
 
 func TestProbe(t *testing.T) {
-	t.Parallel()
 	comm1, port1 := newCommInstance(t, naiveSec)
 	defer comm1.Stop()
 	comm2, port2 := newCommInstance(t, naiveSec)
@@ -899,7 +887,6 @@ func TestProbe(t *testing.T) {
 }
 
 func TestPresumedDead(t *testing.T) {
-	t.Parallel()
 	comm1, _ := newCommInstance(t, naiveSec)
 	comm2, port2 := newCommInstance(t, naiveSec)
 
@@ -974,7 +961,6 @@ func waitForMessages(t *testing.T, msgChan chan uint64, count int, errMsg string
 }
 
 func TestConcurrentCloseSend(t *testing.T) {
-	t.Parallel()
 	var stopping int32
 
 	comm1, _ := newCommInstance(t, naiveSec)

--- a/gossip/comm/metrics_test.go
+++ b/gossip/comm/metrics_test.go
@@ -24,8 +24,6 @@ func newCommInstanceWithMetrics(t *testing.T, sec *naiveSecProvider, metrics *me
 }
 
 func TestMetrics(t *testing.T) {
-	t.Parallel()
-
 	testMetricProvider := mocks.TestUtilConstructMetricProvider()
 
 	var overflown uint32
@@ -83,5 +81,4 @@ func TestMetrics(t *testing.T) {
 	)
 
 	assert.Equal(t, uint32(1), atomic.LoadUint32(&overflown))
-
 }

--- a/gossip/discovery/discovery_test.go
+++ b/gossip/discovery/discovery_test.go
@@ -513,7 +513,6 @@ func TestBadInput(t *testing.T) {
 }
 
 func TestConnect(t *testing.T) {
-	t.Parallel()
 	nodeNum := 10
 	instances := []*gossipInstance{}
 	firstSentMemReqMsgs := make(chan *protoext.SignedGossipMessage, nodeNum)
@@ -566,8 +565,6 @@ func TestConnect(t *testing.T) {
 }
 
 func TestValidation(t *testing.T) {
-	t.Parallel()
-
 	// Scenarios: This test contains the following sub-tests:
 	// 1) alive message validation: a message is validated <==> it entered the message store
 	// 2) request/response message validation:
@@ -660,7 +657,6 @@ func TestValidation(t *testing.T) {
 	assert.NotNil(t, membershipRequest.Load())
 
 	t.Run("alive message", func(t *testing.T) {
-		t.Parallel()
 		// Spawn a new peer - p4
 		p4 := createDiscoveryInstance(4678, "p1", nil)
 		defer p4.Stop()
@@ -718,7 +714,6 @@ func TestValidation(t *testing.T) {
 	} {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
 			p := createDiscoveryInstance(testCase.port, "p", nil)
 			defer p.Stop()
 			// Record messages validated
@@ -756,7 +751,6 @@ func TestValidation(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	t.Parallel()
 	nodeNum := 5
 	bootPeers := []string{bootPeer(6611), bootPeer(6612)}
 	instances := []*gossipInstance{}
@@ -806,7 +800,6 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestInitiateSync(t *testing.T) {
-	t.Parallel()
 	nodeNum := 10
 	bootPeers := []string{bootPeer(3611), bootPeer(3612)}
 	instances := []*gossipInstance{}
@@ -833,7 +826,6 @@ func TestInitiateSync(t *testing.T) {
 }
 
 func TestSelf(t *testing.T) {
-	t.Parallel()
 	inst := createDiscoveryInstance(13463, "d1", []string{})
 	defer inst.Stop()
 	env := inst.Self().Envelope
@@ -848,7 +840,6 @@ func TestSelf(t *testing.T) {
 }
 
 func TestExpiration(t *testing.T) {
-	t.Parallel()
 	nodeNum := 5
 	bootPeers := []string{bootPeer(2611), bootPeer(2612)}
 	instances := []*gossipInstance{}
@@ -888,7 +879,6 @@ func TestExpiration(t *testing.T) {
 }
 
 func TestGetFullMembership(t *testing.T) {
-	t.Parallel()
 	nodeNum := 15
 	bootPeers := []string{bootPeer(5511), bootPeer(5512)}
 	instances := []*gossipInstance{}
@@ -930,14 +920,12 @@ func TestGetFullMembership(t *testing.T) {
 }
 
 func TestGossipDiscoveryStopping(t *testing.T) {
-	t.Parallel()
 	inst := createDiscoveryInstance(9611, "d1", []string{bootPeer(9611)})
 	time.Sleep(time.Second)
 	waitUntilOrFailBlocking(t, inst.Stop)
 }
 
 func TestGossipDiscoverySkipConnectingToLocalhostBootstrap(t *testing.T) {
-	t.Parallel()
 	inst := createDiscoveryInstance(11611, "d1", []string{"localhost:11611", "127.0.0.1:11611"})
 	inst.comm.lock.Lock()
 	inst.comm.mock = &mock.Mock{}
@@ -953,7 +941,6 @@ func TestGossipDiscoverySkipConnectingToLocalhostBootstrap(t *testing.T) {
 }
 
 func TestConvergence(t *testing.T) {
-	t.Parallel()
 	// scenario:
 	// {boot peer: [peer list]}
 	// {d1: d2, d3, d4}
@@ -986,7 +973,6 @@ func TestConvergence(t *testing.T) {
 }
 
 func TestDisclosurePolicyWithPull(t *testing.T) {
-	t.Parallel()
 	// Scenario: run 2 groups of peers that simulate 2 organizations:
 	// {p0, p1, p2, p3, p4}
 	// {p5, p6, p7, p8, p9}
@@ -1131,8 +1117,6 @@ func discPolForPeer(selfPort int) DisclosurePolicy {
 }
 
 func TestCertificateChange(t *testing.T) {
-	t.Parallel()
-
 	bootPeers := []string{bootPeer(42611), bootPeer(42612), bootPeer(42613)}
 	p1 := createDiscoveryInstance(42611, "d1", bootPeers)
 	p2 := createDiscoveryInstance(42612, "d2", bootPeers)
@@ -1201,7 +1185,6 @@ func TestMsgStoreExpiration(t *testing.T) {
 	// Starts 4 instances, wait for membership to build, stop 2 instances
 	// Check that membership in 2 running instances become 2
 	// Wait for expiration and check that alive messages and related entities in maps are removed in running instances
-	t.Parallel()
 	nodeNum := 4
 	bootPeers := []string{bootPeer(12611), bootPeer(12612)}
 	instances := []*gossipInstance{}
@@ -1271,8 +1254,6 @@ func TestMsgStoreExpiration(t *testing.T) {
 }
 
 func TestExpirationNoSecretEnvelope(t *testing.T) {
-	t.Parallel()
-
 	l, err := zap.NewDevelopment()
 	assert.NoError(t, err)
 
@@ -1323,8 +1304,6 @@ func TestMsgStoreExpirationWithMembershipMessages(t *testing.T) {
 	// Waits for expiration and checks msgStore and related maps
 	// Processes stored MembershipRequest msg and checks msgStore and related maps
 	// Processes stored MembershipResponse msg and checks msgStore and related maps
-
-	t.Parallel()
 	bootPeers := []string{}
 	peersNum := 3
 	instances := []*gossipInstance{}
@@ -1535,8 +1514,6 @@ func TestMsgStoreExpirationWithMembershipMessages(t *testing.T) {
 }
 
 func TestAliveMsgStore(t *testing.T) {
-	t.Parallel()
-
 	bootPeers := []string{}
 	peersNum := 2
 	instances := []*gossipInstance{}
@@ -1584,7 +1561,6 @@ func TestAliveMsgStore(t *testing.T) {
 }
 
 func TestMemRespDisclosurePol(t *testing.T) {
-	t.Parallel()
 	pol := func(remotePeer *NetworkMember) (Sieve, EnvelopeFilter) {
 		return func(_ *protoext.SignedGossipMessage) bool {
 				return remotePeer.Endpoint == "localhost:7880"
@@ -1669,8 +1645,6 @@ func TestMembersIntersect(t *testing.T) {
 }
 
 func TestPeerIsolation(t *testing.T) {
-	t.Parallel()
-
 	// Scenario:
 	// Start 3 peers (peer0, peer1, peer2). Set peer1 as the bootstrap peer for all.
 	// Stop peer0 and peer1 for a while, start them again and test if peer2 still gets full membership

--- a/gossip/election/election_test.go
+++ b/gossip/election/election_test.go
@@ -204,7 +204,6 @@ func waitForLeaderElection(t *testing.T, peers []*peer) []string {
 }
 
 func TestMetrics(t *testing.T) {
-	t.Parallel()
 	// Scenario: spawn a single peer and ensure it reports being a leader after some time.
 	// Then, make it relinquish its leadership and then ensure it reports not being a leader.
 	var wgLeader sync.WaitGroup
@@ -243,7 +242,6 @@ func TestMetrics(t *testing.T) {
 }
 
 func TestInitPeersAtSameTime(t *testing.T) {
-	t.Parallel()
 	// Scenario: Peers are spawned at the same time
 	// expected outcome: the peer that has the lowest ID is the leader
 	peers := createPeers(0, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
@@ -256,7 +254,6 @@ func TestInitPeersAtSameTime(t *testing.T) {
 }
 
 func TestInitPeersStartAtIntervals(t *testing.T) {
-	t.Parallel()
 	// Scenario: Peers are spawned one by one in a slow rate
 	// expected outcome: the first peer is the leader although its ID is highest
 	peers := createPeers(testStartupGracePeriod+testLeadershipDeclarationInterval, 3, 2, 1, 0)
@@ -265,7 +262,6 @@ func TestInitPeersStartAtIntervals(t *testing.T) {
 }
 
 func TestStop(t *testing.T) {
-	t.Parallel()
 	// Scenario: peers are spawned at the same time
 	// and then are stopped. We count the number of Gossip() invocations they invoke
 	// after they stop, and it should not increase after they are stopped
@@ -297,7 +293,6 @@ func TestConvergence(t *testing.T) {
 	// Scenario: 2 peer group converge their views
 	// expected outcome: only 1 leader is left out of the 2
 	// and that leader is the leader with the lowest ID
-	t.Parallel()
 	peers1 := createPeers(0, 3, 2, 1, 0)
 	peers2 := createPeers(0, 4, 5, 6, 7)
 	leaders1 := waitForLeaderElection(t, peers1)
@@ -345,7 +340,6 @@ func TestConvergence(t *testing.T) {
 }
 
 func TestLeadershipTakeover(t *testing.T) {
-	t.Parallel()
 	// Scenario: Peers spawn one by one in descending order.
 	// After a while, the leader peer stops.
 	// expected outcome: the peer that takes over is the peer with lowest ID
@@ -361,7 +355,6 @@ func TestLeadershipTakeover(t *testing.T) {
 }
 
 func TestYield(t *testing.T) {
-	t.Parallel()
 	// Scenario: Peers spawn and a leader is elected.
 	// After a while, the leader yields.
 	// (Call yield twice to ensure only one callback is called)
@@ -396,7 +389,6 @@ func TestYield(t *testing.T) {
 }
 
 func TestYieldSinglePeer(t *testing.T) {
-	t.Parallel()
 	// Scenario: spawn a single peer and have it yield.
 	// Ensure it recovers its leadership after a while.
 	peers := createPeers(0, 0)
@@ -407,7 +399,6 @@ func TestYieldSinglePeer(t *testing.T) {
 }
 
 func TestYieldAllPeers(t *testing.T) {
-	t.Parallel()
 	// Scenario: spawn 2 peers and have them all yield after regaining leadership.
 	// Ensure the first peer is the leader in the end after both peers yield
 	peers := createPeers(0, 0, 1)
@@ -425,7 +416,6 @@ func TestYieldAllPeers(t *testing.T) {
 }
 
 func TestPartition(t *testing.T) {
-	t.Parallel()
 	// Scenario: peers spawn together, and then after a while a network partition occurs
 	// and no peer can communicate with another peer
 	// Expected outcome 1: each peer is a leader

--- a/gossip/gossip/algo/pull_test.go
+++ b/gossip/gossip/algo/pull_test.go
@@ -159,7 +159,6 @@ func (p *pullTestInstance) SendRes(items []string, context interface{}, nonce ui
 }
 
 func TestPullEngine_Add(t *testing.T) {
-	t.Parallel()
 	peers := make(map[string]*pullTestInstance)
 	inst1 := newPushPullTestInstance("p1", peers)
 	defer inst1.Stop()
@@ -169,7 +168,6 @@ func TestPullEngine_Add(t *testing.T) {
 }
 
 func TestPullEngine_Remove(t *testing.T) {
-	t.Parallel()
 	peers := make(map[string]*pullTestInstance)
 	inst1 := newPushPullTestInstance("p1", peers)
 	defer inst1.Stop()
@@ -182,7 +180,6 @@ func TestPullEngine_Remove(t *testing.T) {
 }
 
 func TestPullEngine_Stop(t *testing.T) {
-	t.Parallel()
 	peers := make(map[string]*pullTestInstance)
 	inst1 := newPushPullTestInstance("p1", peers)
 	inst2 := newPushPullTestInstance("p2", peers)
@@ -204,7 +201,6 @@ func TestPullEngine_Stop(t *testing.T) {
 }
 
 func TestPullEngineAll2AllWithIncrementalSpawning(t *testing.T) {
-	t.Parallel()
 	// Scenario: spawn 10 nodes, each 50 ms after the other
 	// and have them transfer data between themselves.
 	// Expected outcome: obviously, everything should succeed.
@@ -230,7 +226,6 @@ func TestPullEngineAll2AllWithIncrementalSpawning(t *testing.T) {
 }
 
 func TestPullEngineSelectiveUpdates(t *testing.T) {
-	t.Parallel()
 	// Scenario: inst1 has {1, 3} and inst2 has {0,1,2,3}.
 	// inst1 initiates to inst2
 	// Expected outcome: inst1 asks for 0,2 and inst2 sends 0,2 only
@@ -282,7 +277,6 @@ func TestPullEngineSelectiveUpdates(t *testing.T) {
 }
 
 func TestByzantineResponder(t *testing.T) {
-	t.Parallel()
 	// Scenario: inst1 sends hello to inst2 but inst3 is byzantine so it attempts to send a digest and a response to inst1.
 	// expected outcome is for inst1 not to process updates from inst3.
 	peers := make(map[string]*pullTestInstance)
@@ -340,7 +334,6 @@ func TestByzantineResponder(t *testing.T) {
 }
 
 func TestMultipleInitiators(t *testing.T) {
-	t.Parallel()
 	// Scenario: inst1, inst2 and inst3 both start protocol with inst4 at the same time.
 	// Expected outcome: inst4 successfully transfers state to all of them
 	peers := make(map[string]*pullTestInstance)
@@ -370,7 +363,6 @@ func TestMultipleInitiators(t *testing.T) {
 }
 
 func TestLatePeers(t *testing.T) {
-	t.Parallel()
 	// Scenario: inst1 initiates to inst2 (items: {1,2,3,4}) and inst3 (items: {5,6,7,8}),
 	// but inst2 is too slow to respond, and all items
 	// should be received from inst3.
@@ -403,7 +395,6 @@ func TestLatePeers(t *testing.T) {
 }
 
 func TestBiDiUpdates(t *testing.T) {
-	t.Parallel()
 	// Scenario: inst1 has {1, 3} and inst2 has {0,2} and both initiate to the other at the same time.
 	// Expected outcome: both have {0,1,2,3} in the end
 	peers := make(map[string]*pullTestInstance)
@@ -433,7 +424,6 @@ func TestBiDiUpdates(t *testing.T) {
 }
 
 func TestSpread(t *testing.T) {
-	t.Parallel()
 	// Scenario: inst1 initiates to inst2, inst3 inst4 and each have items 0-100. inst5 also has the same items but isn't selected
 	// Expected outcome: each responder (inst2, inst3 and inst4) is chosen at least once (the probability for not choosing each of them is slim)
 	// inst5 isn't selected at all
@@ -495,7 +485,6 @@ func TestSpread(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
-	t.Parallel()
 	// Scenario: 3 instances, items [0-5] are found only in the first instance, the other 2 have none.
 	//           and also the first instance only gives the 2nd instance even items, and odd items to the 3rd.
 	//           also, instances 2 and 3 don't know each other.

--- a/gossip/gossip/anchor_test.go
+++ b/gossip/gossip/anchor_test.go
@@ -159,7 +159,6 @@ func memResp(nonce uint64, endpoint string) *protoext.SignedGossipMessage {
 type msgInspection func(t *testing.T, index int, m *receivedMsg)
 
 func TestAnchorPeer(t *testing.T) {
-	t.Parallel()
 	// Actors:
 	// OrgA: {
 	// 	p:   a real gossip instance
@@ -267,7 +266,6 @@ func TestAnchorPeer(t *testing.T) {
 }
 
 func TestBootstrapPeerMisConfiguration(t *testing.T) {
-	t.Parallel()
 	// Scenario:
 	// The peer 'p' is a peer in orgA
 	// Peers bs1 and bs2 are bootstrap peers.

--- a/gossip/gossip/channel/channel_test.go
+++ b/gossip/gossip/channel/channel_test.go
@@ -307,8 +307,6 @@ func TestBadInput(t *testing.T) {
 }
 
 func TestSelf(t *testing.T) {
-	t.Parallel()
-
 	cs := &cryptoService{}
 	pkiID1 := common.PKIidType("1")
 	jcm := &joinChanMsg{
@@ -330,8 +328,6 @@ func TestSelf(t *testing.T) {
 }
 
 func TestMsgStoreNotExpire(t *testing.T) {
-	t.Parallel()
-
 	cs := &cryptoService{}
 
 	pkiID1 := common.PKIidType("1")
@@ -431,8 +427,6 @@ func TestLeaveChannel(t *testing.T) {
 	// 1) It doesn't return any members of the channel when queried
 	// 2) It doesn't send anymore pull for blocks
 	// 3) When asked for pull for blocks, it ignores the request
-	t.Parallel()
-
 	jcm := &joinChanMsg{
 		members2AnchorPeers: map[string][]api.AnchorPeer{
 			"ORG1": {},
@@ -500,7 +494,6 @@ func TestLeaveChannel(t *testing.T) {
 }
 
 func TestChannelPeriodicalPublishStateInfo(t *testing.T) {
-	t.Parallel()
 	ledgerHeight := 5
 	receivedMsg := int32(0)
 	stateInfoReceptionChan := make(chan *protoext.SignedGossipMessage, 1)
@@ -537,7 +530,6 @@ func TestChannelPeriodicalPublishStateInfo(t *testing.T) {
 }
 
 func TestChannelMsgStoreEviction(t *testing.T) {
-	t.Parallel()
 	// Scenario: Create 4 phases in which the pull mediator of the channel would receive blocks
 	// via pull.
 	// The total amount of blocks should be restricted by the capacity of the message store.
@@ -635,7 +627,6 @@ func TestChannelMsgStoreEviction(t *testing.T) {
 }
 
 func TestChannelPull(t *testing.T) {
-	t.Parallel()
 	cs := &cryptoService{}
 	cs.On("VerifyBlock", mock.Anything).Return(nil)
 	receivedBlocksChan := make(chan *protoext.SignedGossipMessage, 2)
@@ -672,7 +663,6 @@ func TestChannelPull(t *testing.T) {
 }
 
 func TestChannelPullAccessControl(t *testing.T) {
-	t.Parallel()
 	// Scenario: We have 2 organizations in the channel: ORG1, ORG2
 	// The "acting peer" is from ORG1 and peers "1", "2", "3" are from
 	// the following organizations:
@@ -764,8 +754,6 @@ func TestChannelPullAccessControl(t *testing.T) {
 }
 
 func TestChannelPeerNotInChannel(t *testing.T) {
-	t.Parallel()
-
 	cs := &cryptoService{}
 	cs.On("VerifyBlock", mock.Anything).Return(nil)
 	gossipMessagesSentFromChannel := make(chan *proto.GossipMessage, 1)
@@ -878,8 +866,6 @@ func TestChannelPeerNotInChannel(t *testing.T) {
 }
 
 func TestChannelIsInChannel(t *testing.T) {
-	t.Parallel()
-
 	cs := &cryptoService{}
 	cs.On("VerifyBlock", mock.Anything).Return(nil)
 	adapter := new(gossipAdapterMock)
@@ -897,8 +883,6 @@ func TestChannelIsInChannel(t *testing.T) {
 }
 
 func TestChannelIsSubscribed(t *testing.T) {
-	t.Parallel()
-
 	cs := &cryptoService{}
 	cs.On("VerifyBlock", mock.Anything).Return(nil)
 	adapter := new(gossipAdapterMock)
@@ -913,8 +897,6 @@ func TestChannelIsSubscribed(t *testing.T) {
 }
 
 func TestChannelAddToMessageStore(t *testing.T) {
-	t.Parallel()
-
 	cs := &cryptoService{}
 	cs.On("VerifyBlock", mock.Anything).Return(nil)
 	demuxedMsgs := make(chan *protoext.SignedGossipMessage, 1)
@@ -966,8 +948,6 @@ func TestChannelAddToMessageStore(t *testing.T) {
 }
 
 func TestChannelBlockExpiration(t *testing.T) {
-	t.Parallel()
-
 	cs := &cryptoService{}
 	cs.On("VerifyBlock", mock.Anything).Return(nil)
 	demuxedMsgs := make(chan *protoext.SignedGossipMessage, 1)
@@ -1059,7 +1039,6 @@ func TestChannelBlockExpiration(t *testing.T) {
 }
 
 func TestChannelBadBlocks(t *testing.T) {
-	t.Parallel()
 	receivedMessages := make(chan *protoext.SignedGossipMessage, 1)
 	cs := &cryptoService{}
 	cs.On("VerifyBlock", mock.Anything).Return(nil)
@@ -1096,8 +1075,6 @@ func TestChannelBadBlocks(t *testing.T) {
 }
 
 func TestChannelPulledBadBlocks(t *testing.T) {
-	t.Parallel()
-
 	// Test a pull with a block of a bad channel
 	cs := &cryptoService{}
 	cs.On("VerifyBlock", mock.Anything).Return(nil)
@@ -1198,8 +1175,6 @@ func TestChannelPulledBadBlocks(t *testing.T) {
 }
 
 func TestChannelStateInfoSnapshot(t *testing.T) {
-	t.Parallel()
-
 	cs := &cryptoService{}
 	cs.On("VerifyBlock", mock.Anything).Return(nil)
 	adapter := new(gossipAdapterMock)
@@ -1307,7 +1282,6 @@ func TestChannelStateInfoSnapshot(t *testing.T) {
 }
 
 func TestInterOrgExternalEndpointDisclosure(t *testing.T) {
-	t.Parallel()
 	cs := &cryptoService{}
 	adapter := new(gossipAdapterMock)
 	pkiID1 := common.PKIidType("withExternalEndpoint")
@@ -1404,8 +1378,6 @@ func TestInterOrgExternalEndpointDisclosure(t *testing.T) {
 }
 
 func TestChannelStop(t *testing.T) {
-	t.Parallel()
-
 	cs := &cryptoService{}
 	cs.On("VerifyBlock", mock.Anything).Return(nil)
 	adapter := new(gossipAdapterMock)
@@ -1433,8 +1405,6 @@ func TestChannelStop(t *testing.T) {
 }
 
 func TestChannelReconfigureChannel(t *testing.T) {
-	t.Parallel()
-
 	// Scenario: We test the following things:
 	// Updating a channel with an outdated JoinChannel message doesn't work
 	// Removing an organization from a channel is indeed reflected in that
@@ -1530,8 +1500,6 @@ func TestChannelReconfigureChannel(t *testing.T) {
 }
 
 func TestChannelNoAnchorPeers(t *testing.T) {
-	t.Parallel()
-
 	// Scenario: We got a join channel message with no anchor peers
 	// In this case, we should be in the channel
 
@@ -1557,8 +1525,6 @@ func TestChannelNoAnchorPeers(t *testing.T) {
 }
 
 func TestGossipChannelEligibility(t *testing.T) {
-	t.Parallel()
-
 	// Scenario: We have a peer in an org that joins a channel with org1 and org2.
 	// and it receives StateInfo messages of other peers and the eligibility
 	// of these peers of being in the channel is checked.
@@ -1684,8 +1650,6 @@ func TestGossipChannelEligibility(t *testing.T) {
 }
 
 func TestChannelGetPeers(t *testing.T) {
-	t.Parallel()
-
 	// Scenario: We have a peer in an org, and the peer is notified that several peers
 	// exist, and some of them:
 	// (1) Join its channel, and are eligible for receiving blocks.
@@ -1732,8 +1696,6 @@ func TestChannelGetPeers(t *testing.T) {
 }
 
 func TestOnDemandGossip(t *testing.T) {
-	t.Parallel()
-
 	// Scenario: update the metadata and ensure only 1 dissemination
 	// takes place when membership is not empty
 
@@ -1809,7 +1771,6 @@ func TestOnDemandGossip(t *testing.T) {
 }
 
 func TestChannelPullWithDigestsFilter(t *testing.T) {
-	t.Parallel()
 	cs := &cryptoService{}
 	cs.On("VerifyBlock", mock.Anything).Return(nil)
 	receivedBlocksChan := make(chan *protoext.SignedGossipMessage, 2)
@@ -1848,8 +1809,6 @@ func TestChannelPullWithDigestsFilter(t *testing.T) {
 }
 
 func TestFilterForeignOrgLeadershipMessages(t *testing.T) {
-	t.Parallel()
-
 	org1 := api.OrgIdentityType("org1")
 	org2 := api.OrgIdentityType("org2")
 
@@ -2179,7 +2138,6 @@ func TestChangesInPeers(t *testing.T) {
 	for _, test := range cases {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 
 			//channel for holding the output of report
 			chForString := make(chan string, 1)
@@ -2267,7 +2225,6 @@ func TestMembershiptrackerStopWhenGCStops(t *testing.T) {
 	// membershipTracker, as long as gossip channel was not stopped, has printed the right thing
 	// membershipTracker does not print after gossip channel was stopped
 	// membershipTracker stops running after gossip channel was stopped
-	t.Parallel()
 	membershipReported := make(chan struct{}, 1)
 	cs := &cryptoService{}
 	pkiID1 := common.PKIidType("1")

--- a/gossip/gossip/gossip_test.go
+++ b/gossip/gossip/gossip_test.go
@@ -340,7 +340,6 @@ func (g *gossipGRPC) Stop() {
 }
 
 func TestLeaveChannel(t *testing.T) {
-	t.Parallel()
 	// Scenario: Have 3 peers in a channel and make one of them leave it.
 	// Ensure the peers don't recognize the other peer when it left the channel
 
@@ -386,7 +385,6 @@ func TestLeaveChannel(t *testing.T) {
 }
 
 func TestPull(t *testing.T) {
-	t.Parallel()
 	t1 := time.Now()
 	// Scenario: Turn off forwarding and use only pull-based gossip.
 	// First phase: Ensure full membership view for all nodes
@@ -477,7 +475,6 @@ func TestPull(t *testing.T) {
 }
 
 func TestConnectToAnchorPeers(t *testing.T) {
-	t.Parallel()
 	// Scenario: spawn 10 peers, and have them join a channel
 	// of 3 anchor peers that don't exist yet.
 	// Wait 5 seconds, and then spawn a random anchor peer out of the 3.
@@ -554,7 +551,6 @@ func TestConnectToAnchorPeers(t *testing.T) {
 }
 
 func TestMembership(t *testing.T) {
-	t.Parallel()
 	t1 := time.Now()
 	// Scenario: spawn 20 nodes and a single bootstrap node and then:
 	// 1) Check full membership views for all nodes but the bootstrap node.
@@ -642,8 +638,6 @@ func TestMembership(t *testing.T) {
 }
 
 func TestNoMessagesSelfLoop(t *testing.T) {
-	t.Parallel()
-
 	port0, grpc0, certs0, secDialOpts0, _ := util.CreateGRPCLayer()
 	boot := newGossipInstanceWithGRPC(0, port0, grpc0, certs0, secDialOpts0, 100)
 	boot.JoinChan(&joinChanMsg{}, common.ChannelID("A"))
@@ -703,7 +697,6 @@ func TestNoMessagesSelfLoop(t *testing.T) {
 }
 
 func TestDissemination(t *testing.T) {
-	t.Parallel()
 	t1 := time.Now()
 	// Scenario: 20 nodes and a bootstrap node.
 	// The bootstrap node sends 10 messages and we count
@@ -835,7 +828,6 @@ func TestDissemination(t *testing.T) {
 }
 
 func TestMembershipConvergence(t *testing.T) {
-	t.Parallel()
 	// Scenario: Spawn 12 nodes and 3 bootstrap peers
 	// but assign each node to its bootstrap peer group modulo 3.
 	// Then:
@@ -940,7 +932,6 @@ func TestMembershipConvergence(t *testing.T) {
 }
 
 func TestMembershipRequestSpoofing(t *testing.T) {
-	t.Parallel()
 	// Scenario: g1, g2, g3 are peers, and g2 is malicious, and wants
 	// to impersonate g3 when sending a membership request to g1.
 	// Expected output: g1 should *NOT* respond to g2,
@@ -1015,7 +1006,6 @@ func TestMembershipRequestSpoofing(t *testing.T) {
 }
 
 func TestDataLeakage(t *testing.T) {
-	t.Parallel()
 	// Scenario: spawn some nodes and let them all
 	// establish full membership.
 	// Then, have half be in channel A and half be in channel B.
@@ -1153,12 +1143,12 @@ func TestDataLeakage(t *testing.T) {
 }
 
 func TestDisseminateAll2All(t *testing.T) {
+	t.Skip()
+
 	// Scenario: spawn some nodes, have each node
 	// disseminate a block to all nodes.
 	// Ensure all blocks are received
 
-	t.Skip()
-	t.Parallel()
 	stopped := int32(0)
 	go waitForTestCompletion(&stopped, t)
 
@@ -1235,8 +1225,6 @@ func TestDisseminateAll2All(t *testing.T) {
 }
 
 func TestSendByCriteria(t *testing.T) {
-	t.Parallel()
-
 	port0, grpc0, certs0, secDialOpts0, _ := util.CreateGRPCLayer()
 	g1 := newGossipInstanceWithGRPC(0, port0, grpc0, certs0, secDialOpts0, 100)
 	port1, grpc1, certs1, secDialOpts1, _ := util.CreateGRPCLayer()
@@ -1393,7 +1381,6 @@ func TestSendByCriteria(t *testing.T) {
 }
 
 func TestIdentityExpiration(t *testing.T) {
-	t.Parallel()
 	// Scenario: spawn 5 peers and make the MessageCryptoService revoke one of the first 4.
 	// The last peer's certificate expires after a few seconds.
 	// Eventually, the rest of the peers should not be able to communicate with
@@ -1600,8 +1587,6 @@ func checkPeersMembership(t *testing.T, peers []*gossipGRPC, n int) func() bool 
 }
 
 func TestMembershipMetrics(t *testing.T) {
-	t.Parallel()
-
 	wg0 := sync.WaitGroup{}
 	wg0.Add(1)
 	once0 := sync.Once{}
@@ -1662,5 +1647,4 @@ func TestMembershipMetrics(t *testing.T) {
 	pI1.Stop()
 	waitUntilOrFail(t, waitForMembership(0), "waiting for metrics membership of 0")
 	pI0.Stop()
-
 }

--- a/gossip/gossip/msgstore/msgs_test.go
+++ b/gossip/gossip/msgstore/msgs_test.go
@@ -107,7 +107,6 @@ func TestNewMessagesInvalidated(t *testing.T) {
 }
 
 func TestConcurrency(t *testing.T) {
-	t.Parallel()
 	stopFlag := int32(0)
 	msgStore := NewMessageStore(compareInts, Noop)
 	looper := func(f func()) func() {
@@ -143,7 +142,6 @@ func TestConcurrency(t *testing.T) {
 }
 
 func TestExpiration(t *testing.T) {
-	t.Parallel()
 	expired := make(chan int, 50)
 	msgTTL := time.Second * 3
 
@@ -196,7 +194,6 @@ func TestExpiration(t *testing.T) {
 }
 
 func TestExpirationConcurrency(t *testing.T) {
-	t.Parallel()
 	expired := make([]int, 0)
 	msgTTL := time.Second * 3
 	lock := &sync.RWMutex{}
@@ -246,7 +243,6 @@ func TestExpirationConcurrency(t *testing.T) {
 }
 
 func TestStop(t *testing.T) {
-	t.Parallel()
 	expired := make([]int, 0)
 	msgTTL := time.Second * 3
 
@@ -271,7 +267,6 @@ func TestStop(t *testing.T) {
 }
 
 func TestPurge(t *testing.T) {
-	t.Parallel()
 	purged := make(chan int, 5)
 	msgStore := NewMessageStore(alwaysNoAction, func(o interface{}) {
 		purged <- o.(int)

--- a/gossip/gossip/orgs_test.go
+++ b/gossip/gossip/orgs_test.go
@@ -143,7 +143,6 @@ func newGossipInstanceWithGRPCWithExternalEndpoint(id int, port int, gRPCServer 
 }
 
 func TestMultipleOrgEndpointLeakage(t *testing.T) {
-	t.Parallel()
 	// Scenario: create 2 organizations, each with 5 peers.
 	// Both organizations will have an anchor peer each
 	// The first 2 peers of each org would have an external endpoint, the rest won't.
@@ -271,7 +270,6 @@ func TestMultipleOrgEndpointLeakage(t *testing.T) {
 }
 
 func TestConfidentiality(t *testing.T) {
-	t.Parallel()
 	// Scenario: create 4 organizations: {A, B, C, D}, each with 3 peers.
 	// Make only the first 2 peers have an external endpoint.
 	// Also, add the peers to the following channels:

--- a/gossip/gossip/pull/pullstore_test.go
+++ b/gossip/gossip/pull/pullstore_test.go
@@ -179,14 +179,12 @@ func createPullInstanceWithFilters(endpoint string, peer2PullInst map[string]*pu
 }
 
 func TestCreateAndStop(t *testing.T) {
-	t.Parallel()
 	pullInst := createPullInstance("localhost:2000", make(map[string]*pullInstance))
 	pullInst.start()
 	pullInst.stop()
 }
 
 func TestRegisterMsgHook(t *testing.T) {
-	t.Parallel()
 	peer2pullInst := make(map[string]*pullInstance)
 	inst1 := createPullInstance("localhost:5611", peer2pullInst)
 	inst2 := createPullInstance("localhost:5612", peer2pullInst)
@@ -213,7 +211,6 @@ func TestRegisterMsgHook(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
-	t.Parallel()
 	peer2pullInst := make(map[string]*pullInstance)
 
 	eq := func(a interface{}, b interface{}) bool {
@@ -250,7 +247,6 @@ func TestFilter(t *testing.T) {
 }
 
 func TestAddAndRemove(t *testing.T) {
-	t.Parallel()
 	peer2pullInst := make(map[string]*pullInstance)
 	inst1 := createPullInstance("localhost:5611", peer2pullInst)
 	inst2 := createPullInstance("localhost:5612", peer2pullInst)
@@ -320,7 +316,6 @@ func TestAddAndRemove(t *testing.T) {
 }
 
 func TestDigestsFilters(t *testing.T) {
-	t.Parallel()
 	df1 := createDigestsFilter(2)
 	inst1 := createPullInstanceWithFilters("localhost:5611", make(map[string]*pullInstance), nil, df1)
 	inst2 := createPullInstance("localhost:5612", make(map[string]*pullInstance))
@@ -359,8 +354,6 @@ func TestDigestsFilters(t *testing.T) {
 }
 
 func TestHandleMessage(t *testing.T) {
-	t.Parallel()
-
 	inst1 := createPullInstance("localhost:5611", make(map[string]*pullInstance))
 	inst2 := createPullInstance("localhost:5612", make(map[string]*pullInstance))
 	inst1.start()

--- a/gossip/privdata/dataretriever_test.go
+++ b/gossip/privdata/dataretriever_test.go
@@ -27,7 +27,6 @@ import (
 	hence data should be looked up directly from transient store
 */
 func TestNewDataRetriever_GetDataFromTransientStore(t *testing.T) {
-	t.Parallel()
 	committer := &mocks.Committer{}
 
 	store := newTransientStore(t)
@@ -102,7 +101,6 @@ func TestNewDataRetriever_GetDataFromTransientStore(t *testing.T) {
 	from the ledger rather than transient store as data being committed
 */
 func TestNewDataRetriever_GetDataFromLedger(t *testing.T) {
-	t.Parallel()
 	committer := &mocks.Committer{}
 
 	store := newTransientStore(t)
@@ -163,7 +161,6 @@ func TestNewDataRetriever_GetDataFromLedger(t *testing.T) {
 }
 
 func TestNewDataRetriever_FailGetPvtDataFromLedger(t *testing.T) {
-	t.Parallel()
 	committer := &mocks.Committer{}
 
 	store := newTransientStore(t)
@@ -194,7 +191,6 @@ func TestNewDataRetriever_FailGetPvtDataFromLedger(t *testing.T) {
 }
 
 func TestNewDataRetriever_GetOnlyRelevantPvtData(t *testing.T) {
-	t.Parallel()
 	committer := &mocks.Committer{}
 
 	store := newTransientStore(t)
@@ -256,7 +252,6 @@ func TestNewDataRetriever_GetOnlyRelevantPvtData(t *testing.T) {
 }
 
 func TestNewDataRetriever_GetMultipleDigests(t *testing.T) {
-	t.Parallel()
 	committer := &mocks.Committer{}
 
 	store := newTransientStore(t)
@@ -366,7 +361,6 @@ func TestNewDataRetriever_GetMultipleDigests(t *testing.T) {
 }
 
 func TestNewDataRetriever_EmptyWriteSet(t *testing.T) {
-	t.Parallel()
 	committer := &mocks.Committer{}
 
 	store := newTransientStore(t)
@@ -414,7 +408,6 @@ func TestNewDataRetriever_EmptyWriteSet(t *testing.T) {
 }
 
 func TestNewDataRetriever_FailedObtainConfigHistoryRetriever(t *testing.T) {
-	t.Parallel()
 	committer := &mocks.Committer{}
 
 	store := newTransientStore(t)
@@ -455,7 +448,6 @@ func TestNewDataRetriever_FailedObtainConfigHistoryRetriever(t *testing.T) {
 }
 
 func TestNewDataRetriever_NoCollectionConfig(t *testing.T) {
-	t.Parallel()
 	committer := &mocks.Committer{}
 
 	store := newTransientStore(t)
@@ -521,7 +513,6 @@ func TestNewDataRetriever_NoCollectionConfig(t *testing.T) {
 }
 
 func TestNewDataRetriever_FailedGetLedgerHeight(t *testing.T) {
-	t.Parallel()
 	committer := &mocks.Committer{}
 
 	store := newTransientStore(t)
@@ -547,7 +538,6 @@ func TestNewDataRetriever_FailedGetLedgerHeight(t *testing.T) {
 }
 
 func TestNewDataRetriever_EmptyPvtRWSetInTransientStore(t *testing.T) {
-	t.Parallel()
 	committer := &mocks.Committer{}
 
 	store := newTransientStore(t)

--- a/gossip/privdata/pull_test.go
+++ b/gossip/privdata/pull_test.go
@@ -311,7 +311,6 @@ func newPRWSet() []util.PrivateRWSet {
 }
 
 func TestPullerFromOnly1Peer(t *testing.T) {
-	t.Parallel()
 	// Scenario: p1 pulls from p2 and not from p3
 	// and succeeds - p1 asks from p2 (and not from p3!) for the
 	// expected digest
@@ -383,7 +382,6 @@ func TestPullerFromOnly1Peer(t *testing.T) {
 }
 
 func TestPullerDataNotAvailable(t *testing.T) {
-	t.Parallel()
 	// Scenario: p1 pulls from p2 and not from p3
 	// but the data in p2 doesn't exist
 	gn := &gossipNetwork{}
@@ -425,7 +423,6 @@ func TestPullerDataNotAvailable(t *testing.T) {
 }
 
 func TestPullerNoPeersKnown(t *testing.T) {
-	t.Parallel()
 	// Scenario: p1 doesn't know any peer and therefore fails fetching
 	gn := &gossipNetwork{}
 	policyStore := newCollectionStore().withPolicy("col1", uint64(100)).thatMapsTo("p2", "p3")
@@ -442,7 +439,6 @@ func TestPullerNoPeersKnown(t *testing.T) {
 }
 
 func TestPullPeerFilterError(t *testing.T) {
-	t.Parallel()
 	// Scenario: p1 attempts to fetch for the wrong channel
 	gn := &gossipNetwork{}
 	policyStore := newCollectionStore().withPolicy("col1", uint64(100)).thatMapsTo("p2")
@@ -460,7 +456,6 @@ func TestPullPeerFilterError(t *testing.T) {
 }
 
 func TestPullerPeerNotEligible(t *testing.T) {
-	t.Parallel()
 	// Scenario: p1 pulls from p2 or from p3
 	// but it's not eligible for pulling data from p2 or from p3
 	gn := &gossipNetwork{}
@@ -527,7 +522,6 @@ func TestPullerPeerNotEligible(t *testing.T) {
 }
 
 func TestPullerDifferentPeersDifferentCollections(t *testing.T) {
-	t.Parallel()
 	// Scenario: p1 pulls from p2 and from p3
 	// and each has different collections
 	gn := &gossipNetwork{}
@@ -627,7 +621,6 @@ func TestPullerDifferentPeersDifferentCollections(t *testing.T) {
 }
 
 func TestPullerRetries(t *testing.T) {
-	t.Parallel()
 	// Scenario: p1 pulls from p2, p3, p4 and p5.
 	// Only p3 considers p1 to be eligible to receive the data.
 	// The rest consider p1 as not eligible.
@@ -732,7 +725,6 @@ func TestPullerRetries(t *testing.T) {
 }
 
 func TestPullerPreferEndorsers(t *testing.T) {
-	t.Parallel()
 	// Scenario: p1 pulls from p2, p3, p4, p5
 	// and the only endorser for col1 is p3, so it should be selected
 	// at the top priority for col1.
@@ -829,7 +821,6 @@ func TestPullerPreferEndorsers(t *testing.T) {
 }
 
 func TestPullerFetchReconciledItemsPreferPeersFromOriginalConfig(t *testing.T) {
-	t.Parallel()
 	// Scenario: p1 pulls from p2, p3, p4, p5
 	// the only peer that was in the collection config while data was created for col1 is p3, so it should be selected
 	// at the top priority for col1.
@@ -950,8 +941,6 @@ func TestPullerAvoidPullingPurgedData(t *testing.T) {
 	// p2 and p3 is suppose to have it, while p3 has more advanced
 	// ledger and based on BTL already purged data for, so p1
 	// suppose to fetch data only from p2
-
-	t.Parallel()
 	gn := &gossipNetwork{}
 	factoryMock := &mocks.CollectionAccessFactory{}
 	accessPolicyMock := &mocks.CollectionAccessPolicy{}
@@ -1060,7 +1049,6 @@ func (c *counterDataRetreiver) getNumberOfCalls() int {
 }
 
 func TestPullerIntegratedWithDataRetreiver(t *testing.T) {
-	t.Parallel()
 	gn := &gossipNetwork{}
 
 	ns1, ns2 := "testChaincodeName1", "testChaincodeName2"
@@ -1168,7 +1156,6 @@ func toDigKey(dig *proto.PvtDataDigest) *privdatacommon.DigKey {
 }
 
 func TestPullerMetrics(t *testing.T) {
-	t.Parallel()
 	// Scenario: p1 pulls from p2 and sends metric reports
 	gn := &gossipNetwork{}
 	policyStore := newCollectionStore().withPolicy("col1", uint64(100)).thatMapsTo("p2")

--- a/gossip/service/gossip_service_test.go
+++ b/gossip/service/gossip_service_test.go
@@ -151,11 +151,9 @@ func TestInitGossipService(t *testing.T) {
 // Make sure *joinChannelMessage implements the api.JoinChannelMessage
 func TestJCMInterface(t *testing.T) {
 	_ = api.JoinChannelMessage(&joinChannelMessage{})
-	t.Parallel()
 }
 
 func TestLeaderElectionWithDeliverClient(t *testing.T) {
-	t.Parallel()
 	//Test check if leader election works with mock deliver service instance
 	//Configuration set to use dynamic leader election
 	//10 peers started, added to channel and at the end we check if only for one peer
@@ -453,7 +451,6 @@ func (li *mockLedgerInfo) Close() {
 }
 
 func TestLeaderElectionWithRealGossip(t *testing.T) {
-	t.Parallel()
 	// Spawn 10 gossip instances with single channel and inside same organization
 	// Run leader election on top of each gossip instance and check that only one leader chosen
 	// Create another channel includes sub-set of peers over same gossip instances {1,3,5,7}

--- a/gossip/state/metrics_test.go
+++ b/gossip/state/metrics_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	t.Parallel()
 	mc := &mockCommitter{Mock: &mock.Mock{}}
 	mc.On("CommitLegacy", mock.Anything).Return(nil)
 	mc.On("LedgerHeight", mock.Anything).Return(uint64(100), nil).Twice()

--- a/gossip/state/state_test.go
+++ b/gossip/state/state_test.go
@@ -477,7 +477,6 @@ func newBootNode(id int, committer committer.Committer, acceptor peerIdentityAcc
 }
 
 func TestNilDirectMsg(t *testing.T) {
-	t.Parallel()
 	mc := &mockCommitter{Mock: &mock.Mock{}}
 	mc.On("LedgerHeight", mock.Anything).Return(uint64(1), nil)
 	g := &mocks.GossipMock{}
@@ -495,7 +494,6 @@ func TestNilDirectMsg(t *testing.T) {
 }
 
 func TestNilAddPayload(t *testing.T) {
-	t.Parallel()
 	mc := &mockCommitter{Mock: &mock.Mock{}}
 	mc.On("LedgerHeight", mock.Anything).Return(uint64(1), nil)
 	g := &mocks.GossipMock{}
@@ -509,7 +507,6 @@ func TestNilAddPayload(t *testing.T) {
 }
 
 func TestAddPayloadLedgerUnavailable(t *testing.T) {
-	t.Parallel()
 	mc := &mockCommitter{Mock: &mock.Mock{}}
 	mc.On("LedgerHeight", mock.Anything).Return(uint64(1), nil)
 	g := &mocks.GossipMock{}
@@ -540,7 +537,6 @@ func TestLargeBlockGap(t *testing.T) {
 	// than itself (500 blocks higher).
 	// The peer needs to ask blocks in a way such that the size of the payload buffer
 	// never rises above a certain threshold.
-	t.Parallel()
 	mc := &mockCommitter{Mock: &mock.Mock{}}
 	blocksPassedToLedger := make(chan uint64, 200)
 	mc.On("CommitLegacy", mock.Anything).Run(func(arg mock.Arguments) {
@@ -612,7 +608,6 @@ func TestOverPopulation(t *testing.T) {
 	// with a gap in between, and ensure that the payload buffer
 	// rejects blocks starting if the distance between the ledger height to the latest
 	// block it contains is bigger than defMaxBlockDistance.
-	t.Parallel()
 	mc := &mockCommitter{Mock: &mock.Mock{}}
 	blocksPassedToLedger := make(chan uint64, 10)
 	mc.On("CommitLegacy", mock.Anything).Run(func(arg mock.Arguments) {
@@ -676,7 +671,6 @@ func TestBlockingEnqueue(t *testing.T) {
 	// Scenario: In parallel, get blocks from gossip and from the orderer.
 	// The blocks from the orderer we get are X2 times the amount of blocks from gossip.
 	// The blocks we get from gossip are random indices, to maximize disruption.
-	t.Parallel()
 	mc := &mockCommitter{Mock: &mock.Mock{}}
 	blocksPassedToLedger := make(chan uint64, 10)
 	mc.On("CommitLegacy", mock.Anything).Run(func(arg mock.Arguments) {
@@ -809,7 +803,6 @@ func TestHaltChainProcessing(t *testing.T) {
 }
 
 func TestFailures(t *testing.T) {
-	t.Parallel()
 	mc := &mockCommitter{Mock: &mock.Mock{}}
 	mc.On("LedgerHeight", mock.Anything).Return(uint64(0), nil)
 	g := &mocks.GossipMock{}
@@ -826,7 +819,6 @@ func TestFailures(t *testing.T) {
 }
 
 func TestGossipReception(t *testing.T) {
-	t.Parallel()
 	signalChan := make(chan struct{})
 	rawblock := &pcomm.Block{
 		Header: &pcomm.BlockHeader{
@@ -904,7 +896,6 @@ func TestLedgerHeightFromProperties(t *testing.T) {
 	// either set both metadata properly, or only the properties, or none, or both.
 	// Ensure the logic handles all of the 4 possible cases as needed
 
-	t.Parallel()
 	// Returns whether the given networkMember was selected or not
 	wasNetworkMemberSelected := func(t *testing.T, networkMember discovery.NetworkMember) bool {
 		var wasGivenNetworkMemberSelected int32
@@ -971,7 +962,6 @@ func TestLedgerHeightFromProperties(t *testing.T) {
 }
 
 func TestAccessControl(t *testing.T) {
-	t.Parallel()
 	bootstrapSetSize := 5
 	bootstrapSet := make([]*peerNode, 0)
 
@@ -1084,7 +1074,6 @@ func TestAccessControl(t *testing.T) {
 }
 
 func TestNewGossipStateProvider_SendingManyMessages(t *testing.T) {
-	t.Parallel()
 	bootstrapSetSize := 5
 	bootstrapSet := make([]*peerNode, 0)
 
@@ -1162,7 +1151,6 @@ func TestNewGossipStateProvider_SendingManyMessages(t *testing.T) {
 // complete missing blocks. Since state transfer messages now batched, it is expected
 // to see _exactly_ two messages with state transfer response.
 func TestNewGossipStateProvider_BatchingOfStateRequest(t *testing.T) {
-	t.Parallel()
 	bootPeer, bootPort := newBootNode(0, newCommitter(), noopPeerIdentityAcceptor)
 	defer bootPeer.shutdown()
 
@@ -1301,7 +1289,6 @@ type testData struct {
 }
 
 func TestTransferOfPrivateRWSet(t *testing.T) {
-	t.Parallel()
 	chainID := "testChainID"
 
 	// First gossip instance
@@ -1537,7 +1524,6 @@ func TestTransferOfPvtDataBetweenPeers(t *testing.T) {
 	   Test going to check that block from one peer will be replicated into second one and
 	   have identical content.
 	*/
-	t.Parallel()
 	chainID := "testChainID"
 
 	// Initialize peer


### PR DESCRIPTION
This is the result of a discussion with @yacovm in FAB-17608.