### PR TITLE
Enable race detector for gossip packages in unit test

### DIFF
--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -154,7 +154,7 @@ run_tests() {
         local -a serial
         while IFS= read -r pkg; do serial+=("$pkg"); done < <(serial_test_packages "$@")
         if [ "${#serial[@]}" -ne 0 ]; then
-            go test "${flags[@]}" -tags "$GO_TAGS" "${serial[@]}" -short -p 1 -timeout=20m
+            go test "${flags[@]}" "${race_flags[@]}" -tags "$GO_TAGS" "${serial[@]}" -short -p 1 -timeout=20m
         fi
 
         local -a parallel


### PR DESCRIPTION
This is a follow up on #1003 and enables the race detector for gossip packages. This PR should not be merged unless #1003 is.