### PR TITLE
Explicitly enumerate the two packages that require the pkcs11 build tag during tests

### DIFF
--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -21,7 +21,8 @@ serial_packages=(
 
 # packages which need to be tested with build tag pkcs11
 pkcs11_packages=(
-    "github.com/hyperledger/fabric/bccsp/..."
+    "github.com/hyperledger/fabric/bccsp/factory"
+    "github.com/hyperledger/fabric/bccsp/pkcs11"
 )
 
 # packages that are only tested when they (or their deps) change


### PR DESCRIPTION
Explicitly enumerate the two packages that require the pkcs11 build tag during tests. This prevents  (cached) re-execution of bccsp packages that do not rely on pkcs11.