### PR TITLE
[FAB-16879] Add stack trace to couchdb http errors

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/batch_util.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/batch_util.go
@@ -8,6 +8,8 @@ package statecouchdb
 
 import (
 	"sync"
+
+	"github.com/pkg/errors"
 )
 
 // batch is executed in a separate goroutine.
@@ -42,7 +44,7 @@ func executeBatches(batches []batch) error {
 
 	select {
 	case err := <-errsChan:
-		return err
+		return errors.WithStack(err)
 	default:
 		return nil
 	}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/commit_handling.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/commit_handling.go
@@ -89,7 +89,7 @@ func (vdb *VersionedDB) buildCommitters(updates *statedb.UpdateBatch) ([]*commit
 	var allCommitters []*committer
 	select {
 	case err := <-errsChan:
-		return nil, err
+		return nil, errors.WithStack(err)
 	default:
 		for i := 0; i < len(namespaces); i++ {
 			allCommitters = append(allCommitters, <-nsCommittersChan...)
@@ -165,7 +165,7 @@ func (vdb *VersionedDB) executeCommitter(committers []*committer) error {
 
 	select {
 	case err := <-errsChan:
-		return err
+		return errors.WithStack(err)
 	default:
 		return nil
 	}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
@@ -704,7 +704,7 @@ func (vdb *VersionedDB) postCommitProcessing(committers []*committer, namespaces
 	wg.Wait()
 	select {
 	case err := <-errChan:
-		return err
+		return errors.WithStack(err)
 	default:
 		return nil
 	}
@@ -764,7 +764,7 @@ func (vdb *VersionedDB) ensureFullCommitAndRecordSavepoint(height *version.Heigh
 	select {
 	case err := <-errsChan:
 		logger.Errorf("Failed to perform full commit")
-		return errors.WithMessage(err, "failed to perform full commit")
+		return errors.Wrap(err, "failed to perform full commit")
 	default:
 		logger.Debugf("All changes have been flushed to the disk")
 	}

--- a/core/ledger/util/couchdb/couchdb.go
+++ b/core/ledger/util/couchdb/couchdb.go
@@ -1895,7 +1895,7 @@ func (couchInstance *CouchInstance) handleRequest(ctx context.Context, method, d
 
 	//if a golang http error is still present after retries are exhausted, return the error
 	if errResp != nil {
-		return nil, couchDBReturn, errResp
+		return nil, couchDBReturn, errors.Wrap(errResp, "http error calling couchdb")
 	}
 
 	//This situation should not occur according to the golang spec.


### PR DESCRIPTION
#### Type of change

- Error handling improvement

#### Description

If there is http error calling couchdb, no context was provided
to higher level code that handles the errors.

This change adds stack trace to the http error at the point that the error
is raised, so that admins can identify what was going on upon hitting the error.
In most places, the higher level error handlers are already printing stack
trace, if available, e.g. in the commit path and recommit lost block path.

Also, for each of the points in ledger code where go routines are used,
if stack trace was added in the go routine error, the stack would only
be available from the point the go routine was called and lower. This
is resolved by also adding stack trace to errors that are returned from
go routines.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>

