### PR TITLE
Add test to ensure CRL can be signed by intermediate CA cert

### DIFF
--- a/pkg/config/msp.go
+++ b/pkg/config/msp.go
@@ -697,38 +697,3 @@ func validateCACerts(caCerts []*x509.Certificate) error {
 
 	return nil
 }
-
-func addMSPConfigToOrg(org *cb.ConfigGroup, fabricMSPConfig *mb.FabricMSPConfig) error {
-	configValue, err := getOrgMSPValue(org)
-	if err != nil {
-		return err
-	}
-
-	mspConfig := &mb.MSPConfig{}
-	err = proto.Unmarshal(configValue.Value, mspConfig)
-	if err != nil {
-		return fmt.Errorf("unmarshalling mspConfig: %v", err)
-	}
-
-	serializedMSPConfig, err := proto.Marshal(fabricMSPConfig)
-	if err != nil {
-		return fmt.Errorf("marshalling updated mspConfig: %v", err)
-	}
-
-	mspConfig.Config = serializedMSPConfig
-
-	err = setValue(org, mspValue(mspConfig), AdminsPolicyKey)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func getOrgMSPValue(org *cb.ConfigGroup) (*cb.ConfigValue, error) {
-	configValue, ok := org.Values[MSPKey]
-	if !ok {
-		return nil, errors.New("org doesn't have MSP value")
-	}
-	return configValue, nil
-}

--- a/pkg/config/signer_test.go
+++ b/pkg/config/signer_test.go
@@ -166,6 +166,24 @@ func generateCACertAndPrivateKey(t *testing.T, orgName string) (*x509.Certificat
 	return generateCertAndPrivateKey(t, template, template, nil)
 }
 
+func generateIntermediateCACertAndPrivateKey(t *testing.T, orgName string, rootCACert *x509.Certificate, rootPrivKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey) {
+	serialNumber := generateSerialNumber(t)
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   "intermediateca." + orgName,
+			Organization: []string{orgName},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	return generateCertAndPrivateKey(t, template, rootCACert, rootPrivKey)
+}
+
 // generateCertAndPrivateKeyFromCACert returns a cert and private key signed by the given CACert.
 func generateCertAndPrivateKeyFromCACert(t *testing.T, orgName string, caCert *x509.Certificate, privateKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey) {
 	serialNumber := generateSerialNumber(t)


### PR DESCRIPTION
#### Type of change

- Test update

#### Description

- Added a test to ensure a CRL can be created and signed by an intermediate CA cert. 
- Removed dead code from msp.go

#### Related issues

[FAB-17694](https://jira.hyperledger.org/browse/FAB-17694)
