### PR TITLE
Retire dormant Fabric maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,6 @@ Maintainers
 |------|--------|------|----------------------
 | Alessandro Sorniotti | ale-linux | aso | <ale.linux@sopit.net>
 | Artem Barger | c0rwin | c0rwin | <bartem@il.ibm.com>
-| Binh Nguyen | binhn | binhn | <binh1010010110@gmail.com>
 | Brett Logan | btl5037 | btl5037 | <brett.t.logan@ibm.com>
 | Chris Ferris | christo4ferris | cbf | <chris.ferris@gmail.com>
 | Danny Cao | caod123 | caod | <dcao@us.ibm.com>
@@ -16,7 +15,6 @@ Maintainers
 | Jason Yellick | jyellick | jyellick | <jyellick@us.ibm.com>
 | Jay Guo | guoger | guoger | <guojiannan1101@gmail.com>
 | Jonathan Levi | hacera | JonathanLevi | <jonathan@hacera.com>
-| Kostas Christidis | kchristidis | kostas | <kostas@gmail.com>
 | Manish Sethi | manish-sethi | manish-sethi | <manish.sethi@gmail.com>
 | Matthew Sykes | sykesm | sykesm | <sykesmat@us.ibm.com>
 | Srinivasan Muralidharan | muralisrini | muralisr | <srinivasan.muralidharan99@gmail.com>
@@ -52,3 +50,5 @@ Maintainers
 | Yaoguo Jiang | jiangyaoguo | jiangyaoguo | <jiangyaoguo@gmail.com>
 | Greg Haskins | ghaskins | ghaskins | <gregory.haskins@gmail.com>
 | Keith Smith | smithbk | smithbk | <bksmith@us.ibm.com>
+| Binh Nguyen | binhn | binhn | <binh1010010110@gmail.com>
+| Kostas Christidis | kchristidis | kostas | <kostas@gmail.com>


### PR DESCRIPTION
Retire maintainers that have been inactive for the last 3 months:
Binh Nguyen
Kostas Christidis

Note:
"A maintainer removed for inactivity should be restored following a
sustained resumption of contributions and reviews (a month or more)
demonstrating a renewed commitment to the project."

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
