### PR TITLE
Improve configtxgen test coverage for unhappy paths

### DIFF
--- a/cmd/configtxgen/main_test.go
+++ b/cmd/configtxgen/main_test.go
@@ -46,6 +46,13 @@ func TestInspectBlock(t *testing.T) {
 	assert.NoError(t, doInspectBlock(blockDest), "Good block inspection request")
 }
 
+func TestInspectBlockErr(t *testing.T) {
+	config := genesisconfig.Load(genesisconfig.SampleInsecureSoloProfile, configtest.GetDevConfigDir())
+
+	assert.Error(t, doOutputBlock(config, "foo", ""), "Error writing genesis block:")
+	assert.Error(t, doInspectBlock(""), "Could not read block")
+}
+
 func TestMissingOrdererSection(t *testing.T) {
 	blockDest := filepath.Join(tmpDir, "block")
 


### PR DESCRIPTION
Signed-off-by: Svetoslav Blyahov <svetlio.blyahoff@gmail.com>

Adding a simple test for an unhappy path in configtxgen package to improve test coverage a bit

#### Type of change
- Test update

#### Description

Adding a test for covering the unhappy path of passing an empty string, instead of a config path in:
- configtxgen
  doOutputBlock
  doInspectBlock

Basically following some low-hanging fruits for improving test coverage in this part of the code base I've been researching recently. 

Aim in this PR is to see if such a minor improvements in test coverage have a good reception. If so I will continue with some follow ups in this test file and other test files related to that package. 

Thanks in advance and looking forward to hearing your comments and recommendations.