### PR TITLE
validation got fixed in input of cli

### DIFF
--- a/internal/peer/lifecycle/chaincode/approveformyorg.go
+++ b/internal/peer/lifecycle/chaincode/approveformyorg.go
@@ -60,15 +60,15 @@ type ApproveForMyOrgInput struct {
 
 // Validate the input for an ApproveChaincodeDefinitionForMyOrg proposal
 func (a *ApproveForMyOrgInput) Validate() error {
-	if a.ChannelID == "" {
+	if a.ChannelID == "" || nil {
 		return errors.New("The required parameter 'channelID' is empty. Rerun the command with -C flag")
 	}
 
-	if a.Name == "" {
+	if a.Name == "" || nil{
 		return errors.New("The required parameter 'name' is empty. Rerun the command with -n flag")
 	}
 
-	if a.Version == "" {
+	if a.Version == "" || nil{
 		return errors.New("The required parameter 'version' is empty. Rerun the command with -v flag")
 	}
 


### PR DESCRIPTION


add an extra OR for validating against nil too

#### Type of change
- Bug fix
#### Description
I was passing values dynamically in shell (just like first network example) so flags was pre-written 
and values are figured in run time but when forever reason a value is missed but the flag is still there WRONG error message showes up and drove me crazy like full three minutes

this was the command:
peer lifecycle chaincode checkcommitreadiness --channelID $CHANNEL_NAME --name $PEER_CONN_PARMS --version ${VERSION} --sequence ${VERSION} --output json --init-required

as you can see no value for --name flag
but this is the error returned 

Error: The required parameter 'version' is empty. Rerun the command with -v flag
Usage:
  peer lifecycle chaincode checkcommitreadiness [flags]

#### Additional details

hope this was the only place which handles error checking if not let me know

#### Related issues

nothing that I'm aware of
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.

enginestart2@gmail.com