### PR TITLE
Omit go.{mod,sum} from pkg when not in module mode

### DIFF
--- a/core/chaincode/platforms/golang/platform_test.go
+++ b/core/chaincode/platforms/golang/platform_test.go
@@ -177,14 +177,17 @@ func getGopath() (string, error) {
 func Test_findSource(t *testing.T) {
 	t.Run("Gopath", func(t *testing.T) {
 		source, err := findSource(&CodeDescriptor{
+			Module:       false,
 			Source:       filepath.FromSlash("testdata/src/chaincodes/noop"),
 			MetadataRoot: filepath.FromSlash("testdata/src/chaincodes/noop/META-INF"),
 			Path:         "chaincodes/noop",
 		})
 		require.NoError(t, err, "failed to find source")
-		assert.Len(t, source, 2)
 		assert.Contains(t, source, "src/chaincodes/noop/chaincode.go")
 		assert.Contains(t, source, "META-INF/statedb/couchdb/indexes/indexOwner.json")
+		assert.NotContains(t, source, "src/chaincodes/noop/go.mod")
+		assert.NotContains(t, source, "src/chaincodes/noop/go.sum")
+		assert.Len(t, source, 2)
 	})
 
 	t.Run("Module", func(t *testing.T) {
@@ -460,6 +463,24 @@ func TestDescribeCode(t *testing.T) {
 			Module:       true,
 		}
 		assert.Equal(t, expected, cd)
+	})
+}
+
+func TestRegularFileExists(t *testing.T) {
+	t.Run("RegularFile", func(t *testing.T) {
+		ok, err := regularFileExists("testdata/ccmodule/go.mod")
+		assert.NoError(t, err)
+		assert.True(t, ok)
+	})
+	t.Run("MissingFile", func(t *testing.T) {
+		ok, err := regularFileExists("testdata/missing.file")
+		assert.NoError(t, err)
+		assert.False(t, ok)
+	})
+	t.Run("Directory", func(t *testing.T) {
+		ok, err := regularFileExists("testdata")
+		assert.NoError(t, err)
+		assert.False(t, ok)
 	})
 }
 

--- a/core/chaincode/platforms/golang/testdata/src/chaincodes/noop/go.mod
+++ b/core/chaincode/platforms/golang/testdata/src/chaincodes/noop/go.mod
@@ -1,0 +1,5 @@
+module github.com/hyperledger/fabric/core/chaincode/platforms/golang/testdata/src/chaincodes/noop
+
+go 1.13
+
+// This should not get included in packages that were created from a GOPATH

--- a/core/chaincode/platforms/golang/testdata/src/chaincodes/noop/go.sum
+++ b/core/chaincode/platforms/golang/testdata/src/chaincodes/noop/go.sum
@@ -1,0 +1,2 @@
+ignore/me v0.0.1 h1:0badc0de0badcode
+ignore/me v0.0.1/go.mod


### PR DESCRIPTION
In certain environments, it's possible to package chaincode that structured as a module from an active GOPATH. This often happens when the path provided to the package command is an import path resolvable from the GOPATH instead of a file system path.

If the package could be successfully built in the packaging environment using the import path, the chaincode dependencies would be calculated and packaged from the GOPATH for compilation as a traditional go package.

In this scenario, the `go.mod` would be included in the chaincode package as packaging always includes all non-hidden files in the top level folder of the import path.

On the server, the presence of the `go.mod` implies that the build process should execute in module mode. When the dependencies have been vendored in the module, the build uses `-mod=vendor` flag to indicate the module requirements should be satisfied from the vendor folder.
Unfortunately, since the chaincode dependencies were packaged using GOPATH mode instead of module mode, there are some metadata files missing from the vendor folder that are expected by the module mode build process.

To help prevent this from occurring, we will explicitly omit go.mod and go.sum from top level folder of chaincode that is not packaged in module mode.

Bug fix - FAB-17725