### PR TITLE
[FAB-17716] Fix test flake due to too many requests for /protos.Deliver

### DIFF
--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -140,7 +140,7 @@ peer:
   limits:
     concurrency:
       endorserService: 100
-      deliverService: 1
+      deliverService: 100
 
 vm:
   endpoint: unix:///var/run/docker.sock

--- a/integration/nwo/fabricconfig/core.go
+++ b/integration/nwo/fabricconfig/core.go
@@ -50,6 +50,7 @@ type Peer struct {
 	Handlers               *Handlers       `yaml:"handlers,omitempty"`
 	ValidatorPoolSize      int             `yaml:"validatorPoolSize,omitempty"`
 	Discovery              *Discovery      `yaml:"discovery,omitempty"`
+	Limits                 *Limits         `yaml:"limits,omitempty"`
 
 	ExtraProperties map[string]interface{} `yaml:",inline,omitempty"`
 }
@@ -210,6 +211,15 @@ type Discovery struct {
 	AuthCacheMaxSize             int     `yaml:"authCacheMaxSize,omitempty"`
 	AuthCachePurgeRetentionRatio float64 `yaml:"authCachePurgeRetentionRatio"`
 	OrgMembersAllowedAccess      bool    `yaml:"orgMembersAllowedAccess"`
+}
+
+type Limits struct {
+	Concurrency *Concurrency `yaml:"concurrency,omitempty"`
+}
+
+type Concurrency struct {
+	EndorserService int `yaml:"endorserService,omitempty"`
+	DeliverService  int `yaml:"deliverService,omitempty"`
 }
 
 type VM struct {


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Test update

#### Description
Currently peer.limits.concurrency.deliverService value is set to 1
in IT core_template.go. This value is too low and may cause test flakes
because some tests have multiple goroutines sending requests to DeliverService.

This PR sets a higher value for all tests in IT. Meanwhile, it overwrites
the value to 1 in pvtdata_test.go where maximum 1 goroutine sends requests
to DeliverService.

#### Related issues
https://jira.hyperledger.org/browse/FAB-17716
