### PR TITLE
Backport FAB-17725 to release-2.1

### DIFF
--- a/core/chaincode/platforms/golang/platform_test.go
+++ b/core/chaincode/platforms/golang/platform_test.go
@@ -177,14 +177,17 @@ func getGopath() (string, error) {
 func Test_findSource(t *testing.T) {
 	t.Run("Gopath", func(t *testing.T) {
 		source, err := findSource(&CodeDescriptor{
+			Module:       false,
 			Source:       filepath.FromSlash("testdata/src/chaincodes/noop"),
 			MetadataRoot: filepath.FromSlash("testdata/src/chaincodes/noop/META-INF"),
 			Path:         "chaincodes/noop",
 		})
 		require.NoError(t, err, "failed to find source")
-		assert.Len(t, source, 2)
 		assert.Contains(t, source, "src/chaincodes/noop/chaincode.go")
 		assert.Contains(t, source, "META-INF/statedb/couchdb/indexes/indexOwner.json")
+		assert.NotContains(t, source, "src/chaincodes/noop/go.mod")
+		assert.NotContains(t, source, "src/chaincodes/noop/go.sum")
+		assert.Len(t, source, 2)
 	})
 
 	t.Run("Module", func(t *testing.T) {
@@ -460,6 +463,24 @@ func TestDescribeCode(t *testing.T) {
 			Module:       true,
 		}
 		assert.Equal(t, expected, cd)
+	})
+}
+
+func TestRegularFileExists(t *testing.T) {
+	t.Run("RegularFile", func(t *testing.T) {
+		ok, err := regularFileExists("testdata/ccmodule/go.mod")
+		assert.NoError(t, err)
+		assert.True(t, ok)
+	})
+	t.Run("MissingFile", func(t *testing.T) {
+		ok, err := regularFileExists("testdata/missing.file")
+		assert.NoError(t, err)
+		assert.False(t, ok)
+	})
+	t.Run("Directory", func(t *testing.T) {
+		ok, err := regularFileExists("testdata")
+		assert.NoError(t, err)
+		assert.False(t, ok)
 	})
 }
 

--- a/core/chaincode/platforms/golang/testdata/src/chaincodes/noop/go.mod
+++ b/core/chaincode/platforms/golang/testdata/src/chaincodes/noop/go.mod
@@ -1,0 +1,5 @@
+module github.com/hyperledger/fabric/core/chaincode/platforms/golang/testdata/src/chaincodes/noop
+
+go 1.13
+
+// This should not get included in packages that were created from a GOPATH

--- a/core/chaincode/platforms/golang/testdata/src/chaincodes/noop/go.sum
+++ b/core/chaincode/platforms/golang/testdata/src/chaincodes/noop/go.sum
@@ -1,0 +1,2 @@
+ignore/me v0.0.1 h1:0badc0de0badcode
+ignore/me v0.0.1/go.mod

--- a/core/chaincode/platforms/util/writer.go
+++ b/core/chaincode/platforms/util/writer.go
@@ -133,6 +133,8 @@ func WriteFileToPackage(localpath string, packagepath string, tw *tar.Writer) er
 	header.Mode = 0100644
 	header.Uid = 500
 	header.Gid = 500
+	header.Uname = ""
+	header.Gname = ""
 
 	err = tw.WriteHeader(header)
 	if err != nil {

--- a/core/chaincode/platforms/util/writer_test.go
+++ b/core/chaincode/platforms/util/writer_test.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,6 +55,14 @@ func TestWriteFileToPackage(t *testing.T) {
 	header, err := tr.Next()
 	require.NoError(t, err, "Error getting the file from the tar")
 	assert.Equal(t, filename, header.Name, "filename read from archive does not match what was added")
+	assert.Equal(t, time.Time{}, header.AccessTime, "expected zero access time")
+	assert.Equal(t, time.Unix(0, 0), header.ModTime, "expected zero modification time")
+	assert.Equal(t, time.Time{}, header.ChangeTime, "expected zero change time")
+	assert.Equal(t, int64(0100644), header.Mode, "expected regular file mode")
+	assert.Equal(t, 500, header.Uid, "expected 500 uid")
+	assert.Equal(t, 500, header.Gid, "expected 500 gid")
+	assert.Equal(t, "", header.Uname, "expected empty user name")
+	assert.Equal(t, "", header.Gname, "expected empty group name")
 
 	b := make([]byte, 5)
 	n, err := tr.Read(b)

--- a/release_notes/v2.1.0.md
+++ b/release_notes/v2.1.0.md
@@ -1,0 +1,29 @@
+
+Fixes
+-----
+
+**FAB-17725: Omit go.mod and go.sum from package when not in module mode**
+
+In certain environments, it's possible to package chaincode that is structured
+as a module from an active GOPATH. This often happens when the path provided
+to the package command is an import path resolvable from the GOPATH instead of
+a file system path.
+
+If the package can successfully build in the packaging environment from the
+import path, the chaincode dependencies are calculated and packaged from the
+GOPATH for compilation as a traditional go package.
+
+In this scenario where the code at the import path is structured as a module,
+the go.mod would be included in the chaincode package as packaging always
+includes all non-hidden files in the top level folder of the import path.
+
+On the server, the presence of the go.mod implies that the build process
+should execute in module mode. When the dependencies have been vendored in the
+module, the build uses -mod=vendor flag to indicate the module requirements
+should be satisfied from the vendor folder.  Unfortunately, since the
+chaincode dependencies were packaged using GOPATH mode instead of module mode,
+there are some metadata files missing from the vendor folder that are expected
+by the module mode build process.
+
+To help prevent this from occurring, we will explicitly omit go.mod and go.sum
+from top level folder of chaincode that is not packaged in module mode.


### PR DESCRIPTION
- Release note for FAB-17725
- #1043 / FAB-17725 to release-2.1 to prevent packaging of go.mod and go.sum 
- #1040 to release-2.1 