### PR TITLE
PKCS11: Validate session and get new if invalid - master

### DIFF
--- a/bccsp/pkcs11/impl.go
+++ b/bccsp/pkcs11/impl.go
@@ -53,7 +53,7 @@ func New(opts PKCS11Opts, keyStore bccsp.KeyStore) (bccsp.BCCSP, error) {
 	}
 
 	sessions := make(chan pkcs11.SessionHandle, sessionCacheSize)
-	csp := &impl{swCSP, conf, ctx, sessions, slot, lib, opts.SoftVerify, opts.Immutable}
+	csp := &impl{swCSP, conf, ctx, sessions, slot, pin, lib, opts.SoftVerify, opts.Immutable}
 	csp.returnSession(*session)
 	return csp, nil
 }
@@ -66,6 +66,7 @@ type impl struct {
 	ctx      *pkcs11.Ctx
 	sessions chan pkcs11.SessionHandle
 	slot     uint
+	pin      string
 
 	lib        string
 	softVerify bool


### PR DESCRIPTION
Signed-off-by: Mihir Shah <mrshah@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

Making the same change from https://github.com/hyperledger/fabric/pull/1022 into master

As described in [JIRA FAB-17722](https://jira.hyperledger.org/browse/FAB-17722):
Currently the pkcs11 code in fabric's bccsp module is set to have a session cache and reuse sessions if available in cache. If a session goes bad (due to connection issues with HSM), the session is not evicted from cache and will be reused. If all sessions go bad, the client will never be able to recover and keep using bad sessions.

#### Additional details

This code change:
- Moves creation of a new session to a new function `CreateSession`
- Validates the existing session by calling `GetSessionInfo`
- If found invalid, creates a new session and expects the old one to be garbage collected.
- The current test in pkcs11_test.go `TestPKCS11GetSession`, will test the new function as well. Let me know if I should add additional test to test `CreateSession` function.

#### Related issues

https://github.com/hyperledger/fabric/pull/1022
https://jira.hyperledger.org/browse/FAB-17722

