### PR TITLE
Revert parallel gossip UT execution

### DIFF
--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -4,7 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set -eo pipefail
+set -e
+set -o pipefail
 
 base_dir="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -15,6 +16,7 @@ excluded_packages=(
 
 # packages that must be run serially
 serial_packages=(
+    "github.com/hyperledger/fabric/gossip/..."
 )
 
 # packages which need to be tested with build tag pkcs11
@@ -127,6 +129,8 @@ serial_test_packages() {
     filter=$(package_filter "${serial_packages[@]}")
     if [ -n "$filter" ]; then
         join_by $'\n' "$@" | grep -E "$filter" || true
+    else
+        join_by $'\n' "$@"
     fi
 }
 


### PR DESCRIPTION
This reverts commit 27e3a6ca2930ddffce14140ece11cb371c8532f0.
    
CI is overwhelmed and it causes flakes.

Change-Id: I2fd7dd1a746ea90e0aa3302aaba2215e0101335b
Signed-off-by: yacovm <yacovm@il.ibm.com>

