### PR TITLE
build: fix dependencies for spelling make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ help-docs: native
 	@scripts/generateHelpDocs.sh
 
 .PHONY: spelling
-spelling:
+spelling: gotools
 	@scripts/check_spelling.sh
 
 .PHONY: references


### PR DESCRIPTION
bug: The spelling target relies on the "misspell" command from gotools but does not specify it in the dependencies.