### PR TITLE
Bump golang.org/x/tools to release-branch.go1.14

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -904,8 +904,8 @@
   version = "v0.3.2"
 
 [[projects]]
-  branch = "release-branch.go1.13"
-  digest = "1:b3e64b43fe77039813b4f33100e4ef2e17960309f3c6c9ab120f5c55de747992"
+  branch = "release-branch.go1.14"
+  digest = "1:e48760fc099273347f411f9def6122238a06afe0f5b5d242db0e66cf0de94948"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
@@ -917,9 +917,10 @@
     "internal/fastwalk",
     "internal/gopathwalk",
     "internal/semver",
+    "internal/span",
   ]
   pruneopts = "NUT"
-  revision = "65e3620a7ae7ac25e8494a60f0e5ef4e4fba03b3"
+  revision = "575de47986ce07f39826bf8d5e365d5ebf51ee63"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,7 @@ noverify = [
 
 [[constraint]]
   name = "golang.org/x/tools"
-  branch = "release-branch.go1.13"
+  branch = "release-branch.go1.14"
 
 [[constraint]]
   name = "google.golang.org/grpc"

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -13,5 +13,5 @@ require (
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
-	golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4
+	golang.org/x/tools v0.0.0-20200131233409-575de47986ce
 )

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -46,13 +46,10 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5 h1:Xim2mBRFdXzXmKRO8DJg/FJtn/8Fj9NOEpO6+WuMPmk=
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f h1:J5lckAjkw6qYlOZNj90mLYNTEKDvWeuc1yieZ8qUzUE=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
-golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8j4DQRpdYMnGn/bJUEU=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -60,7 +57,6 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb h1:fgwFCsaw9buMuxNd6+DQfAuSFqbNiQZpcgJQAgJsK6k=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -71,10 +67,9 @@ golang.org/x/tools v0.0.0-20181112210238-4b1f3b6b1646/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4 h1:Toz2IK7k8rbltAXwNAxKcn9OzqyNfMUhUNjz3sL0NMk=
-golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200131233409-575de47986ce h1:Uglradbb4KfUWaYasZhlsDsGRwHHvRsHoNAEONef0W8=
+golang.org/x/tools v0.0.0-20200131233409-575de47986ce/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/vendor/golang.org/x/tools/go/gcexportdata/gcexportdata.go
+++ b/vendor/golang.org/x/tools/go/gcexportdata/gcexportdata.go
@@ -100,7 +100,7 @@ func Read(in io.Reader, fset *token.FileSet, imports map[string]*types.Package, 
 // Write writes encoded type information for the specified package to out.
 // The FileSet provides file position information for named objects.
 func Write(out io.Writer, fset *token.FileSet, pkg *types.Package) error {
-	b, err := gcimporter.BExportData(fset, pkg)
+	b, err := gcimporter.IExportData(fset, pkg)
 	if err != nil {
 		return err
 	}

--- a/vendor/golang.org/x/tools/go/internal/gcimporter/bimport.go
+++ b/vendor/golang.org/x/tools/go/internal/gcimporter/bimport.go
@@ -332,7 +332,7 @@ func (p *importer) pos() token.Pos {
 	p.prevFile = file
 	p.prevLine = line
 
-	return p.fake.pos(file, line)
+	return p.fake.pos(file, line, 0)
 }
 
 // Synthesize a token.Pos
@@ -341,7 +341,9 @@ type fakeFileSet struct {
 	files map[string]*token.File
 }
 
-func (s *fakeFileSet) pos(file string, line int) token.Pos {
+func (s *fakeFileSet) pos(file string, line, column int) token.Pos {
+	// TODO(mdempsky): Make use of column.
+
 	// Since we don't know the set of needed file positions, we
 	// reserve maxlines positions per file.
 	const maxlines = 64 * 1024
@@ -976,10 +978,11 @@ const (
 	aliasTag
 )
 
+var predeclOnce sync.Once
 var predecl []types.Type // initialized lazily
 
 func predeclared() []types.Type {
-	if predecl == nil {
+	predeclOnce.Do(func() {
 		// initialize lazily to be sure that all
 		// elements have been initialized before
 		predecl = []types.Type{ // basic types
@@ -1026,7 +1029,7 @@ func predeclared() []types.Type {
 			// used internally by gc; never used by this package or in .a files
 			anyType{},
 		}
-	}
+	})
 	return predecl
 }
 

--- a/vendor/golang.org/x/tools/go/internal/gcimporter/iexport.go
+++ b/vendor/golang.org/x/tools/go/internal/gcimporter/iexport.go
@@ -6,8 +6,6 @@
 // This file was derived from $GOROOT/src/cmd/compile/internal/gc/iexport.go;
 // see that file for specification of the format.
 
-// +build go1.11
-
 package gcimporter
 
 import (
@@ -28,7 +26,10 @@ import (
 const iexportVersion = 0
 
 // IExportData returns the binary export data for pkg.
+//
 // If no file set is provided, position info will be missing.
+// The package path of the top-level package will not be recorded,
+// so that calls to IImportData can override with a provided package path.
 func IExportData(fset *token.FileSet, pkg *types.Package) (b []byte, err error) {
 	defer func() {
 		if e := recover(); e != nil {
@@ -48,6 +49,7 @@ func IExportData(fset *token.FileSet, pkg *types.Package) (b []byte, err error) 
 		stringIndex: map[string]uint64{},
 		declIndex:   map[types.Object]uint64{},
 		typIndex:    map[types.Type]uint64{},
+		localpkg:    pkg,
 	}
 
 	for i, pt := range predeclared() {
@@ -73,7 +75,7 @@ func IExportData(fset *token.FileSet, pkg *types.Package) (b []byte, err error) 
 	// Append indices to data0 section.
 	dataLen := uint64(p.data0.Len())
 	w := p.newWriter()
-	w.writeIndex(p.declIndex, pkg)
+	w.writeIndex(p.declIndex)
 	w.flush()
 
 	// Assemble header.
@@ -95,14 +97,14 @@ func IExportData(fset *token.FileSet, pkg *types.Package) (b []byte, err error) 
 // we're writing out the main index, which is also read by
 // non-compiler tools and includes a complete package description
 // (i.e., name and height).
-func (w *exportWriter) writeIndex(index map[types.Object]uint64, localpkg *types.Package) {
+func (w *exportWriter) writeIndex(index map[types.Object]uint64) {
 	// Build a map from packages to objects from that package.
 	pkgObjs := map[*types.Package][]types.Object{}
 
 	// For the main index, make sure to include every package that
 	// we reference, even if we're not exporting (or reexporting)
 	// any symbols from it.
-	pkgObjs[localpkg] = nil
+	pkgObjs[w.p.localpkg] = nil
 	for pkg := range w.p.allPkgs {
 		pkgObjs[pkg] = nil
 	}
@@ -121,12 +123,12 @@ func (w *exportWriter) writeIndex(index map[types.Object]uint64, localpkg *types
 	}
 
 	sort.Slice(pkgs, func(i, j int) bool {
-		return pkgs[i].Path() < pkgs[j].Path()
+		return w.exportPath(pkgs[i]) < w.exportPath(pkgs[j])
 	})
 
 	w.uint64(uint64(len(pkgs)))
 	for _, pkg := range pkgs {
-		w.string(pkg.Path())
+		w.string(w.exportPath(pkg))
 		w.string(pkg.Name())
 		w.uint64(uint64(0)) // package height is not needed for go/types
 
@@ -142,6 +144,8 @@ func (w *exportWriter) writeIndex(index map[types.Object]uint64, localpkg *types
 type iexporter struct {
 	fset *token.FileSet
 	out  *bytes.Buffer
+
+	localpkg *types.Package
 
 	// allPkgs tracks all packages that have been referenced by
 	// the export data, so we can ensure to include them in the
@@ -193,6 +197,13 @@ type exportWriter struct {
 	currPkg  *types.Package
 	prevFile string
 	prevLine int64
+}
+
+func (w *exportWriter) exportPath(pkg *types.Package) string {
+	if pkg == w.p.localpkg {
+		return ""
+	}
+	return pkg.Path()
 }
 
 func (p *iexporter) doDecl(obj types.Object) {
@@ -267,6 +278,11 @@ func (w *exportWriter) tag(tag byte) {
 }
 
 func (w *exportWriter) pos(pos token.Pos) {
+	if w.p.fset == nil {
+		w.int64(0)
+		return
+	}
+
 	p := w.p.fset.Position(pos)
 	file := p.Filename
 	line := int64(p.Line)
@@ -299,7 +315,7 @@ func (w *exportWriter) pkg(pkg *types.Package) {
 	// Ensure any referenced packages are declared in the main index.
 	w.p.allPkgs[pkg] = true
 
-	w.string(pkg.Path())
+	w.string(w.exportPath(pkg))
 }
 
 func (w *exportWriter) qualifiedIdent(obj types.Object) {
@@ -394,7 +410,7 @@ func (w *exportWriter) doTyp(t types.Type, pkg *types.Package) {
 			w.pos(f.Pos())
 			w.string(f.Name())
 			w.typ(f.Type(), pkg)
-			w.bool(f.Embedded())
+			w.bool(f.Anonymous())
 			w.string(t.Tag(i)) // note (or tag)
 		}
 

--- a/vendor/golang.org/x/tools/go/packages/external.go
+++ b/vendor/golang.org/x/tools/go/packages/external.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -76,12 +77,17 @@ func findExternalDriver(cfg *Config) driver {
 		}
 
 		buf := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
 		cmd := exec.CommandContext(cfg.Context, tool, words...)
 		cmd.Dir = cfg.Dir
 		cmd.Env = cfg.Env
 		cmd.Stdin = bytes.NewReader(req)
 		cmd.Stdout = buf
-		cmd.Stderr = new(bytes.Buffer)
+		cmd.Stderr = stderr
+		if len(stderr.Bytes()) != 0 && os.Getenv("GOPACKAGESPRINTDRIVERERRORS") != "" {
+			fmt.Fprintf(os.Stderr, "%s stderr: <<%s>>\n", cmdDebugStr(cmd, words...), stderr)
+		}
+
 		if err := cmd.Run(); err != nil {
 			return nil, fmt.Errorf("%v: %v: %s", tool, err, cmd.Stderr)
 		}

--- a/vendor/golang.org/x/tools/go/packages/golist.go
+++ b/vendor/golang.org/x/tools/go/packages/golist.go
@@ -21,10 +21,12 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"golang.org/x/tools/go/internal/packagesdriver"
 	"golang.org/x/tools/internal/gopathwalk"
 	"golang.org/x/tools/internal/semver"
+	"golang.org/x/tools/internal/span"
 )
 
 // debug controls verbose logging.
@@ -108,6 +110,7 @@ func goListDriver(cfg *Config, patterns ...string) (*driverResponse, error) {
 			sizeswg.Done()
 		}()
 	}
+	defer sizeswg.Wait()
 
 	// start fetching rootDirs
 	var info goInfo
@@ -125,6 +128,10 @@ func goListDriver(cfg *Config, patterns ...string) (*driverResponse, error) {
 		<-envReady
 		return &info
 	}
+
+	// Ensure that we don't leak goroutines: Load is synchronous, so callers will
+	// not expect it to access the fields of cfg after the call returns.
+	defer getGoInfo()
 
 	// always pass getGoInfo to golistDriver
 	golistDriver := func(cfg *Config, patterns ...string) (*driverResponse, error) {
@@ -263,10 +270,7 @@ func addNeededOverlayPackages(cfg *Config, driver driver, response *responseDedu
 	if err != nil {
 		return err
 	}
-	if err := addNeededOverlayPackages(cfg, driver, response, needPkgs, getGoInfo); err != nil {
-		return err
-	}
-	return nil
+	return addNeededOverlayPackages(cfg, driver, response, needPkgs, getGoInfo)
 }
 
 func runContainsQueries(cfg *Config, driver driver, response *responseDeduper, queries []string, goInfo func() *goInfo) error {
@@ -280,30 +284,42 @@ func runContainsQueries(cfg *Config, driver driver, response *responseDeduper, q
 			return fmt.Errorf("could not determine absolute path of file= query path %q: %v", query, err)
 		}
 		dirResponse, err := driver(cfg, pattern)
-		if err != nil || (len(dirResponse.Packages) == 1 && len(dirResponse.Packages[0].Errors) == 1) {
-			// There was an error loading the package. Try to load the file as an ad-hoc package.
-			// Usually the error will appear in a returned package, but may not if we're in modules mode
-			// and the ad-hoc is located outside a module.
+		if err != nil {
 			var queryErr error
-			dirResponse, queryErr = driver(cfg, query)
-			if queryErr != nil {
-				// Return the original error if the attempt to fall back failed.
-				return err
+			if dirResponse, queryErr = adHocPackage(cfg, driver, pattern, query); queryErr != nil {
+				return err // return the original error
 			}
-			// Special case to handle issue #33482:
-			// If this is a file= query for ad-hoc packages where the file only exists on an overlay,
-			// and exists outside of a module, add the file in for the package.
-			if len(dirResponse.Packages) == 1 && len(dirResponse.Packages) == 1 &&
-				dirResponse.Packages[0].ID == "command-line-arguments" && len(dirResponse.Packages[0].GoFiles) == 0 {
-				filename := filepath.Join(pattern, filepath.Base(query)) // avoid recomputing abspath
-				// TODO(matloob): check if the file is outside of a root dir?
-				for path := range cfg.Overlay {
-					if path == filename {
-						dirResponse.Packages[0].Errors = nil
-						dirResponse.Packages[0].GoFiles = []string{path}
-						dirResponse.Packages[0].CompiledGoFiles = []string{path}
-					}
+		}
+		// `go list` can report errors for files that are not listed as part of a package's GoFiles.
+		// In the case of an invalid Go file, we should assume that it is part of package if only
+		// one package is in the response. The file may have valid contents in an overlay.
+		if len(dirResponse.Packages) == 1 {
+			pkg := dirResponse.Packages[0]
+			for i, err := range pkg.Errors {
+				s := errorSpan(err)
+				if !s.IsValid() {
+					break
 				}
+				if len(pkg.CompiledGoFiles) == 0 {
+					break
+				}
+				dir := filepath.Dir(pkg.CompiledGoFiles[0])
+				filename := filepath.Join(dir, filepath.Base(s.URI().Filename()))
+				if info, err := os.Stat(filename); err != nil || info.IsDir() {
+					break
+				}
+				if !contains(pkg.CompiledGoFiles, filename) {
+					pkg.CompiledGoFiles = append(pkg.CompiledGoFiles, filename)
+					pkg.GoFiles = append(pkg.GoFiles, filename)
+					pkg.Errors = append(pkg.Errors[:i], pkg.Errors[i+1:]...)
+				}
+			}
+		}
+		// A final attempt to construct an ad-hoc package.
+		if len(dirResponse.Packages) == 1 && len(dirResponse.Packages[0].Errors) == 1 {
+			var queryErr error
+			if dirResponse, queryErr = adHocPackage(cfg, driver, pattern, query); queryErr != nil {
+				return err // return the original error
 			}
 		}
 		isRoot := make(map[string]bool, len(dirResponse.Roots))
@@ -329,6 +345,75 @@ func runContainsQueries(cfg *Config, driver driver, response *responseDeduper, q
 		}
 	}
 	return nil
+}
+
+// adHocPackage attempts to construct an ad-hoc package given a query that failed.
+func adHocPackage(cfg *Config, driver driver, pattern, query string) (*driverResponse, error) {
+	// There was an error loading the package. Try to load the file as an ad-hoc package.
+	// Usually the error will appear in a returned package, but may not if we're in modules mode
+	// and the ad-hoc is located outside a module.
+	dirResponse, err := driver(cfg, query)
+	if err != nil {
+		return nil, err
+	}
+	// If we get nothing back from `go list`, try to make this file into its own ad-hoc package.
+	if len(dirResponse.Packages) == 0 && err == nil {
+		dirResponse.Packages = append(dirResponse.Packages, &Package{
+			ID:              "command-line-arguments",
+			PkgPath:         query,
+			GoFiles:         []string{query},
+			CompiledGoFiles: []string{query},
+			Imports:         make(map[string]*Package),
+		})
+		dirResponse.Roots = append(dirResponse.Roots, "command-line-arguments")
+	}
+	// Special case to handle issue #33482:
+	// If this is a file= query for ad-hoc packages where the file only exists on an overlay,
+	// and exists outside of a module, add the file in for the package.
+	if len(dirResponse.Packages) == 1 && (dirResponse.Packages[0].ID == "command-line-arguments" ||
+		filepath.ToSlash(dirResponse.Packages[0].PkgPath) == filepath.ToSlash(query)) {
+		if len(dirResponse.Packages[0].GoFiles) == 0 {
+			filename := filepath.Join(pattern, filepath.Base(query)) // avoid recomputing abspath
+			// TODO(matloob): check if the file is outside of a root dir?
+			for path := range cfg.Overlay {
+				if path == filename {
+					dirResponse.Packages[0].Errors = nil
+					dirResponse.Packages[0].GoFiles = []string{path}
+					dirResponse.Packages[0].CompiledGoFiles = []string{path}
+				}
+			}
+		}
+	}
+	return dirResponse, nil
+}
+
+func contains(files []string, filename string) bool {
+	for _, f := range files {
+		if f == filename {
+			return true
+		}
+	}
+	return false
+}
+
+// errorSpan attempts to parse a standard `go list` error message
+// by stripping off the trailing error message.
+//
+// It works only on errors whose message is prefixed by colon,
+// followed by a space (": "). For example:
+//
+//   attributes.go:13:1: expected 'package', found 'type'
+//
+func errorSpan(err Error) span.Span {
+	if err.Pos == "" {
+		input := strings.TrimSpace(err.Msg)
+		msgIndex := strings.Index(input, ": ")
+		if msgIndex < 0 {
+			return span.Parse(input)
+		}
+		return span.Parse(input[:msgIndex])
+	}
+	return span.Parse(err.Pos)
 }
 
 // modCacheRegexp splits a path in a module cache into module, module version, and package.
@@ -394,6 +479,10 @@ func runNamedQueries(cfg *Config, driver driver, response *responseDeduper, quer
 		}
 
 		files, err := ioutil.ReadDir(modRoot)
+		if err != nil {
+			panic(err) // See above.
+		}
+
 		for _, f := range files {
 			if strings.HasSuffix(f.Name(), ".go") {
 				simpleMatches = append(simpleMatches, rel)
@@ -461,7 +550,7 @@ func runNamedQueries(cfg *Config, driver driver, response *responseDeduper, quer
 		// We're only trying to look at stuff in the module cache, so
 		// disable the network. This should speed things up, and has
 		// prevented errors in at least one case, #28518.
-		tmpCfg.Env = append(append([]string{"GOPROXY=off"}, cfg.Env...))
+		tmpCfg.Env = append([]string{"GOPROXY=off"}, cfg.Env...)
 
 		var err error
 		tmpCfg.Dir, err = ioutil.TempDir("", "gopackages-modquery")
@@ -509,17 +598,29 @@ func roots(cfg *Config) ([]gopathwalk.Root, string, error) {
 
 	var roots []gopathwalk.Root
 	// Always add GOROOT.
-	roots = append(roots, gopathwalk.Root{filepath.Join(goroot, "/src"), gopathwalk.RootGOROOT})
+	roots = append(roots, gopathwalk.Root{
+		Path: filepath.Join(goroot, "/src"),
+		Type: gopathwalk.RootGOROOT,
+	})
 	// If modules are enabled, scan the module dir.
 	if modDir != "" {
-		roots = append(roots, gopathwalk.Root{modDir, gopathwalk.RootCurrentModule})
+		roots = append(roots, gopathwalk.Root{
+			Path: modDir,
+			Type: gopathwalk.RootCurrentModule,
+		})
 	}
 	// Add either GOPATH/src or GOPATH/pkg/mod, depending on module mode.
 	for _, p := range gopath {
 		if modDir != "" {
-			roots = append(roots, gopathwalk.Root{filepath.Join(p, "/pkg/mod"), gopathwalk.RootModuleCache})
+			roots = append(roots, gopathwalk.Root{
+				Path: filepath.Join(p, "/pkg/mod"),
+				Type: gopathwalk.RootModuleCache,
+			})
 		} else {
-			roots = append(roots, gopathwalk.Root{filepath.Join(p, "/src"), gopathwalk.RootGOPATH})
+			roots = append(roots, gopathwalk.Root{
+				Path: filepath.Join(p, "/src"),
+				Type: gopathwalk.RootGOPATH,
+			})
 		}
 	}
 
@@ -636,9 +737,9 @@ func golistDriver(cfg *Config, rootsDirs func() *goInfo, words ...string) (*driv
 	// go list uses the following identifiers in ImportPath and Imports:
 	//
 	// 	"p"			-- importable package or main (command)
-	//      "q.test"		-- q's test executable
+	// 	"q.test"		-- q's test executable
 	// 	"p [q.test]"		-- variant of p as built for q's test executable
-	//	"q_test [q.test]"	-- q's external test package
+	// 	"q_test [q.test]"	-- q's external test package
 	//
 	// The packages p that are built differently for a test q.test
 	// are q itself, plus any helpers used by the external test q_test,
@@ -677,11 +778,11 @@ func golistDriver(cfg *Config, rootsDirs func() *goInfo, words ...string) (*driv
 		// go list -e, when given an absolute path, will find the package contained at
 		// that directory. But when no package exists there, it will return a fake package
 		// with an error and the ImportPath set to the absolute path provided to go list.
-		// Try toto convert that absolute path to what its package path would be if it's
+		// Try to convert that absolute path to what its package path would be if it's
 		// contained in a known module or GOPATH entry. This will allow the package to be
 		// properly "reclaimed" when overlays are processed.
 		if filepath.IsAbs(p.ImportPath) && p.Error != nil {
-			pkgPath, ok := getPkgPath(p.ImportPath, rootsDirs)
+			pkgPath, ok := getPkgPath(cfg, p.ImportPath, rootsDirs)
 			if ok {
 				p.ImportPath = pkgPath
 			}
@@ -791,15 +892,31 @@ func golistDriver(cfg *Config, rootsDirs func() *goInfo, words ...string) (*driv
 }
 
 // getPkgPath finds the package path of a directory if it's relative to a root directory.
-func getPkgPath(dir string, goInfo func() *goInfo) (string, bool) {
+func getPkgPath(cfg *Config, dir string, goInfo func() *goInfo) (string, bool) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		cfg.Logf("error getting absolute path of %s: %v", dir, err)
+		return "", false
+	}
 	for rdir, rpath := range goInfo().rootDirs {
+		absRdir, err := filepath.Abs(rdir)
+		if err != nil {
+			cfg.Logf("error getting absolute path of %s: %v", rdir, err)
+			continue
+		}
+		// Make sure that the directory is in the module,
+		// to avoid creating a path relative to another module.
+		if !strings.HasPrefix(absDir, absRdir) {
+			cfg.Logf("%s does not have prefix %s", absDir, absRdir)
+			continue
+		}
 		// TODO(matloob): This doesn't properly handle symlinks.
 		r, err := filepath.Rel(rdir, dir)
 		if err != nil {
 			continue
 		}
 		if rpath != "" {
-			// We choose only ore root even though the directory even it can belong in multiple modules
+			// We choose only one root even though the directory even it can belong in multiple modules
 			// or GOPATH entries. This is okay because we only need to work with absolute dirs when a
 			// file is missing from disk, for instance when gopls calls go/packages in an overlay.
 			// Once the file is saved, gopls, or the next invocation of the tool will get the correct
@@ -807,6 +924,7 @@ func getPkgPath(dir string, goInfo func() *goInfo) (string, bool) {
 			// TODO(matloob): Implement module tiebreaking?
 			return path.Join(rpath, filepath.ToSlash(r)), true
 		}
+		return filepath.ToSlash(r), true
 	}
 	return "", false
 }
@@ -831,7 +949,7 @@ func golistargs(cfg *Config, words []string) []string {
 		fmt.Sprintf("-compiled=%t", cfg.Mode&(NeedCompiledGoFiles|NeedSyntax|NeedTypesInfo|NeedTypesSizes) != 0),
 		fmt.Sprintf("-test=%t", cfg.Tests),
 		fmt.Sprintf("-export=%t", usesExportData(cfg)),
-		fmt.Sprintf("-deps=%t", cfg.Mode&NeedDeps != 0),
+		fmt.Sprintf("-deps=%t", cfg.Mode&NeedImports != 0),
 		// go list doesn't let you pass -test and -find together,
 		// probably because you'd just get the TestMain.
 		fmt.Sprintf("-find=%t", !cfg.Tests && cfg.Mode&findFlags == 0),
@@ -858,7 +976,7 @@ func invokeGo(cfg *Config, args ...string) (*bytes.Buffer, error) {
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	defer func(start time.Time) {
-		cfg.Logf("%s for %v, stderr: <<%s>>\n", time.Since(start), cmdDebugStr(cmd, args...), stderr)
+		cfg.Logf("%s for %v, stderr: <<%s>> stdout: <<%s>>\n", time.Since(start), cmdDebugStr(cmd, args...), stderr, stdout)
 	}(time.Now())
 
 	if err := cmd.Run(); err != nil {
@@ -886,8 +1004,21 @@ func invokeGo(cfg *Config, args ...string) (*bytes.Buffer, error) {
 
 		// Is there an error running the C compiler in cgo? This will be reported in the "Error" field
 		// and should be suppressed by go list -e.
-		if len(stderr.String()) > 0 && strings.HasPrefix(stderr.String(), "# runtime/cgo\n") && strings.Count(stderr.String(), "\n") == 2 {
-			return stdout, nil
+		//
+		// This condition is not perfect yet because the error message can include other error messages than runtime/cgo.
+		isPkgPathRune := func(r rune) bool {
+			// From https://golang.org/ref/spec#Import_declarations:
+			//    Implementation restriction: A compiler may restrict ImportPaths to non-empty strings
+			//    using only characters belonging to Unicode's L, M, N, P, and S general categories
+			//    (the Graphic characters without spaces) and may also exclude the
+			//    characters !"#$%&'()*,:;<=>?[\]^`{|} and the Unicode replacement character U+FFFD.
+			return unicode.IsOneOf([]*unicode.RangeTable{unicode.L, unicode.M, unicode.N, unicode.P, unicode.S}, r) &&
+				!strings.ContainsRune("!\"#$%&'()*,:;<=>?[\\]^`{|}\uFFFD", r)
+		}
+		if len(stderr.String()) > 0 && strings.HasPrefix(stderr.String(), "# ") {
+			if strings.HasPrefix(strings.TrimLeftFunc(stderr.String()[len("# "):], isPkgPathRune), "\n") {
+				return stdout, nil
+			}
 		}
 
 		// This error only appears in stderr. See golang.org/cl/166398 for a fix in go list to show
@@ -926,10 +1057,31 @@ func invokeGo(cfg *Config, args ...string) (*bytes.Buffer, error) {
 			return bytes.NewBufferString(output), nil
 		}
 
+		// Workaround for #34273. go list -e with GO111MODULE=on has incorrect behavior when listing a
+		// directory outside any module.
+		if len(stderr.String()) > 0 && strings.Contains(stderr.String(), "outside available modules") {
+			output := fmt.Sprintf(`{"ImportPath": %q,"Incomplete": true,"Error": {"Pos": "","Err": %q}}`,
+				// TODO(matloob): command-line-arguments isn't correct here.
+				"command-line-arguments", strings.Trim(stderr.String(), "\n"))
+			return bytes.NewBufferString(output), nil
+		}
+
+		// Another variation of the previous error
+		if len(stderr.String()) > 0 && strings.Contains(stderr.String(), "outside module root") {
+			output := fmt.Sprintf(`{"ImportPath": %q,"Incomplete": true,"Error": {"Pos": "","Err": %q}}`,
+				// TODO(matloob): command-line-arguments isn't correct here.
+				"command-line-arguments", strings.Trim(stderr.String(), "\n"))
+			return bytes.NewBufferString(output), nil
+		}
+
 		// Workaround for an instance of golang.org/issue/26755: go list -e  will return a non-zero exit
 		// status if there's a dependency on a package that doesn't exist. But it should return
 		// a zero exit status and set an error on that package.
 		if len(stderr.String()) > 0 && strings.Contains(stderr.String(), "no Go files in") {
+			// Don't clobber stdout if `go list` actually returned something.
+			if len(stdout.String()) > 0 {
+				return stdout, nil
+			}
 			// try to extract package name from string
 			stderrStr := stderr.String()
 			var importPath string
@@ -963,12 +1115,6 @@ func invokeGo(cfg *Config, args ...string) (*bytes.Buffer, error) {
 	if len(stderr.Bytes()) != 0 && os.Getenv("GOPACKAGESPRINTGOLISTERRORS") != "" {
 		fmt.Fprintf(os.Stderr, "%s stderr: <<%s>>\n", cmdDebugStr(cmd, args...), stderr)
 	}
-
-	// debugging
-	if false {
-		fmt.Fprintf(os.Stderr, "%s stdout: <<%s>>\n", cmdDebugStr(cmd, args...), stdout)
-	}
-
 	return stdout, nil
 }
 

--- a/vendor/golang.org/x/tools/go/packages/loadmode_string.go
+++ b/vendor/golang.org/x/tools/go/packages/loadmode_string.go
@@ -1,0 +1,57 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package packages
+
+import (
+	"fmt"
+	"strings"
+)
+
+var allModes = []LoadMode{
+	NeedName,
+	NeedFiles,
+	NeedCompiledGoFiles,
+	NeedImports,
+	NeedDeps,
+	NeedExportsFile,
+	NeedTypes,
+	NeedSyntax,
+	NeedTypesInfo,
+	NeedTypesSizes,
+}
+
+var modeStrings = []string{
+	"NeedName",
+	"NeedFiles",
+	"NeedCompiledGoFiles",
+	"NeedImports",
+	"NeedDeps",
+	"NeedExportsFile",
+	"NeedTypes",
+	"NeedSyntax",
+	"NeedTypesInfo",
+	"NeedTypesSizes",
+}
+
+func (mod LoadMode) String() string {
+	m := mod
+	if m == 0 {
+		return fmt.Sprintf("LoadMode(0)")
+	}
+	var out []string
+	for i, x := range allModes {
+		if x > m {
+			break
+		}
+		if (m & x) != 0 {
+			out = append(out, modeStrings[i])
+			m = m ^ x
+		}
+	}
+	if m != 0 {
+		out = append(out, "Unknown")
+	}
+	return fmt.Sprintf("LoadMode(%s)", strings.Join(out, "|"))
+}

--- a/vendor/golang.org/x/tools/go/packages/packages.go
+++ b/vendor/golang.org/x/tools/go/packages/packages.go
@@ -48,8 +48,7 @@ const (
 	// "placeholder" Packages with only the ID set.
 	NeedImports
 
-	// NeedDeps adds the fields requested by the LoadMode in the packages in Imports. If NeedImports
-	// is not set NeedDeps has no effect.
+	// NeedDeps adds the fields requested by the LoadMode in the packages in Imports.
 	NeedDeps
 
 	// NeedExportsFile adds ExportsFile.
@@ -75,7 +74,7 @@ const (
 
 	// Deprecated: LoadImports exists for historical compatibility
 	// and should not be used. Please directly specify the needed fields using the Need values.
-	LoadImports = LoadFiles | NeedImports | NeedDeps
+	LoadImports = LoadFiles | NeedImports
 
 	// Deprecated: LoadTypes exists for historical compatibility
 	// and should not be used. Please directly specify the needed fields using the Need values.
@@ -87,7 +86,7 @@ const (
 
 	// Deprecated: LoadAllSyntax exists for historical compatibility
 	// and should not be used. Please directly specify the needed fields using the Need values.
-	LoadAllSyntax = LoadSyntax
+	LoadAllSyntax = LoadSyntax | NeedDeps
 )
 
 // A Config specifies details about how packages should be loaded.
@@ -416,11 +415,13 @@ type loader struct {
 	parseCacheMu sync.Mutex
 	exportMu     sync.Mutex // enforces mutual exclusion of exportdata operations
 
-	// TODO(matloob): Add an implied mode here and use that instead of mode.
-	// Implied mode would contain all the fields we need the data for so we can
-	// get the actually requested fields. We'll zero them out before returning
-	// packages to the user. This will make it easier for us to get the conditions
-	// where we need certain modes right.
+	// Config.Mode contains the implied mode (see impliedLoadMode).
+	// Implied mode contains all the fields we need the data for.
+	// In requestedMode there are the actually requested fields.
+	// We'll zero them out before returning packages to the user.
+	// This makes it easier for us to get the conditions where
+	// we need certain modes right.
+	requestedMode LoadMode
 }
 
 type parseValue struct {
@@ -462,7 +463,11 @@ func newLoader(cfg *Config) *loader {
 		}
 	}
 
-	if ld.Mode&NeedTypes != 0 {
+	// Save the actually requested fields. We'll zero them out before returning packages to the user.
+	ld.requestedMode = ld.Mode
+	ld.Mode = impliedLoadMode(ld.Mode)
+
+	if ld.Mode&NeedTypes != 0 || ld.Mode&NeedSyntax != 0 {
 		if ld.Fset == nil {
 			ld.Fset = token.NewFileSet()
 		}
@@ -476,6 +481,7 @@ func newLoader(cfg *Config) *loader {
 			}
 		}
 	}
+
 	return ld
 }
 
@@ -496,8 +502,8 @@ func (ld *loader) refine(roots []string, list ...*Package) ([]*Package, error) {
 		}
 		lpkg := &loaderPackage{
 			Package:   pkg,
-			needtypes: (ld.Mode&(NeedTypes|NeedTypesInfo) != 0 && rootIndex < 0) || rootIndex >= 0,
-			needsrc: (ld.Mode&(NeedSyntax|NeedTypesInfo) != 0 && rootIndex < 0) || rootIndex >= 0 ||
+			needtypes: (ld.Mode&(NeedTypes|NeedTypesInfo) != 0 && ld.Mode&NeedDeps != 0 && rootIndex < 0) || rootIndex >= 0,
+			needsrc: (ld.Mode&(NeedSyntax|NeedTypesInfo) != 0 && ld.Mode&NeedDeps != 0 && rootIndex < 0) || rootIndex >= 0 ||
 				len(ld.Overlay) > 0 || // Overlays can invalidate export data. TODO(matloob): make this check fine-grained based on dependencies on overlaid files
 				pkg.ExportFile == "" && pkg.PkgPath != "unsafe",
 		}
@@ -545,8 +551,7 @@ func (ld *loader) refine(roots []string, list ...*Package) ([]*Package, error) {
 		stack = append(stack, lpkg) // push
 		stubs := lpkg.Imports       // the structure form has only stubs with the ID in the Imports
 		// If NeedImports isn't set, the imports fields will all be zeroed out.
-		// If NeedDeps isn't also set we want to keep the stubs.
-		if ld.Mode&NeedImports != 0 && ld.Mode&NeedDeps != 0 {
+		if ld.Mode&NeedImports != 0 {
 			lpkg.Imports = make(map[string]*Package, len(stubs))
 			for importPath, ipkg := range stubs {
 				var importErr error
@@ -583,7 +588,7 @@ func (ld *loader) refine(roots []string, list ...*Package) ([]*Package, error) {
 		return lpkg.needsrc
 	}
 
-	if ld.Mode&(NeedImports|NeedDeps) == 0 {
+	if ld.Mode&NeedImports == 0 {
 		// We do this to drop the stub import packages that we are not even going to try to resolve.
 		for _, lpkg := range initial {
 			lpkg.Imports = nil
@@ -594,7 +599,7 @@ func (ld *loader) refine(roots []string, list ...*Package) ([]*Package, error) {
 			visit(lpkg)
 		}
 	}
-	if ld.Mode&NeedDeps != 0 { // TODO(matloob): This is only the case if NeedTypes is also set, right?
+	if ld.Mode&NeedImports != 0 && ld.Mode&NeedTypes != 0 {
 		for _, lpkg := range srcPkgs {
 			// Complete type information is required for the
 			// immediate dependencies of each source package.
@@ -604,9 +609,9 @@ func (ld *loader) refine(roots []string, list ...*Package) ([]*Package, error) {
 			}
 		}
 	}
-	// Load type data if needed, starting at
+	// Load type data and syntax if needed, starting at
 	// the initial packages (roots of the import DAG).
-	if ld.Mode&NeedTypes != 0 {
+	if ld.Mode&NeedTypes != 0 || ld.Mode&NeedSyntax != 0 {
 		var wg sync.WaitGroup
 		for _, lpkg := range initial {
 			wg.Add(1)
@@ -619,54 +624,44 @@ func (ld *loader) refine(roots []string, list ...*Package) ([]*Package, error) {
 	}
 
 	result := make([]*Package, len(initial))
-	importPlaceholders := make(map[string]*Package)
 	for i, lpkg := range initial {
 		result[i] = lpkg.Package
 	}
 	for i := range ld.pkgs {
 		// Clear all unrequested fields, for extra de-Hyrum-ization.
-		if ld.Mode&NeedName == 0 {
+		if ld.requestedMode&NeedName == 0 {
 			ld.pkgs[i].Name = ""
 			ld.pkgs[i].PkgPath = ""
 		}
-		if ld.Mode&NeedFiles == 0 {
+		if ld.requestedMode&NeedFiles == 0 {
 			ld.pkgs[i].GoFiles = nil
 			ld.pkgs[i].OtherFiles = nil
 		}
-		if ld.Mode&NeedCompiledGoFiles == 0 {
+		if ld.requestedMode&NeedCompiledGoFiles == 0 {
 			ld.pkgs[i].CompiledGoFiles = nil
 		}
-		if ld.Mode&NeedImports == 0 {
+		if ld.requestedMode&NeedImports == 0 {
 			ld.pkgs[i].Imports = nil
 		}
-		if ld.Mode&NeedExportsFile == 0 {
+		if ld.requestedMode&NeedExportsFile == 0 {
 			ld.pkgs[i].ExportFile = ""
 		}
-		if ld.Mode&NeedTypes == 0 {
+		if ld.requestedMode&NeedTypes == 0 {
 			ld.pkgs[i].Types = nil
 			ld.pkgs[i].Fset = nil
 			ld.pkgs[i].IllTyped = false
 		}
-		if ld.Mode&NeedSyntax == 0 {
+		if ld.requestedMode&NeedSyntax == 0 {
 			ld.pkgs[i].Syntax = nil
 		}
-		if ld.Mode&NeedTypesInfo == 0 {
+		if ld.requestedMode&NeedTypesInfo == 0 {
 			ld.pkgs[i].TypesInfo = nil
 		}
-		if ld.Mode&NeedTypesSizes == 0 {
+		if ld.requestedMode&NeedTypesSizes == 0 {
 			ld.pkgs[i].TypesSizes = nil
 		}
-		if ld.Mode&NeedDeps == 0 {
-			for j, pkg := range ld.pkgs[i].Imports {
-				ph, ok := importPlaceholders[pkg.ID]
-				if !ok {
-					ph = &Package{ID: pkg.ID}
-					importPlaceholders[pkg.ID] = ph
-				}
-				ld.pkgs[i].Imports[j] = ph
-			}
-		}
 	}
+
 	return result, nil
 }
 
@@ -687,7 +682,6 @@ func (ld *loader) loadRecursive(lpkg *loaderPackage) {
 			}(imp)
 		}
 		wg.Wait()
-
 		ld.loadPackage(lpkg)
 	})
 }
@@ -776,12 +770,23 @@ func (ld *loader) loadPackage(lpkg *loaderPackage) {
 		lpkg.Errors = append(lpkg.Errors, errs...)
 	}
 
+	if ld.Config.Mode&NeedTypes != 0 && len(lpkg.CompiledGoFiles) == 0 && lpkg.ExportFile != "" {
+		// The config requested loading sources and types, but sources are missing.
+		// Add an error to the package and fall back to loading from export data.
+		appendError(Error{"-", fmt.Sprintf("sources missing for package %s", lpkg.ID), ParseError})
+		ld.loadFromExportData(lpkg)
+		return // can't get syntax trees for this package
+	}
+
 	files, errs := ld.parseFiles(lpkg.CompiledGoFiles)
 	for _, err := range errs {
 		appendError(err)
 	}
 
 	lpkg.Syntax = files
+	if ld.Config.Mode&NeedTypes == 0 {
+		return
+	}
 
 	lpkg.TypesInfo = &types.Info{
 		Types:      make(map[ast.Expr]types.TypeAndValue),
@@ -814,7 +819,7 @@ func (ld *loader) loadPackage(lpkg *loaderPackage) {
 		if ipkg.Types != nil && ipkg.Types.Complete() {
 			return ipkg.Types, nil
 		}
-		log.Fatalf("internal error: nil Pkg importing %q from %q", path, lpkg)
+		log.Fatalf("internal error: package %q without types was imported from %q", path, lpkg)
 		panic("unreachable")
 	})
 
@@ -825,7 +830,7 @@ func (ld *loader) loadPackage(lpkg *loaderPackage) {
 		// Type-check bodies of functions only in non-initial packages.
 		// Example: for import graph A->B->C and initial packages {A,C},
 		// we can ignore function bodies in B.
-		IgnoreFuncBodies: (ld.Mode&(NeedDeps|NeedTypesInfo) == 0) && !lpkg.initial,
+		IgnoreFuncBodies: ld.Mode&NeedDeps == 0 && !lpkg.initial,
 
 		Error: appendError,
 		Sizes: ld.sizes,
@@ -1087,6 +1092,25 @@ func (ld *loader) loadFromExportData(lpkg *loaderPackage) (*types.Package, error
 	return tpkg, nil
 }
 
+// impliedLoadMode returns loadMode with its dependencies.
+func impliedLoadMode(loadMode LoadMode) LoadMode {
+	if loadMode&NeedTypesInfo != 0 && loadMode&NeedImports == 0 {
+		// If NeedTypesInfo, go/packages needs to do typechecking itself so it can
+		// associate type info with the AST. To do so, we need the export data
+		// for dependencies, which means we need to ask for the direct dependencies.
+		// NeedImports is used to ask for the direct dependencies.
+		loadMode |= NeedImports
+	}
+
+	if loadMode&NeedDeps != 0 && loadMode&NeedImports == 0 {
+		// With NeedDeps we need to load at least direct dependencies.
+		// NeedImports is used to ask for the direct dependencies.
+		loadMode |= NeedImports
+	}
+
+	return loadMode
+}
+
 func usesExportData(cfg *Config) bool {
-	return cfg.Mode&NeedExportsFile != 0 || cfg.Mode&NeedTypes != 0 && cfg.Mode&NeedTypesInfo == 0
+	return cfg.Mode&NeedExportsFile != 0 || cfg.Mode&NeedTypes != 0 && cfg.Mode&NeedDeps == 0
 }

--- a/vendor/golang.org/x/tools/internal/gopathwalk/walk.go
+++ b/vendor/golang.org/x/tools/internal/gopathwalk/walk.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"golang.org/x/tools/internal/fastwalk"
 )
@@ -59,24 +60,38 @@ func SrcDirsRoots(ctx *build.Context) []Root {
 // paths of the containing source directory and the package directory.
 // add will be called concurrently.
 func Walk(roots []Root, add func(root Root, dir string), opts Options) {
+	WalkSkip(roots, add, func(Root, string) bool { return false }, opts)
+}
+
+// WalkSkip walks Go source directories ($GOROOT, $GOPATH, etc) to find packages.
+// For each package found, add will be called (concurrently) with the absolute
+// paths of the containing source directory and the package directory.
+// For each directory that will be scanned, skip will be called (concurrently)
+// with the absolute paths of the containing source directory and the directory.
+// If skip returns false on a directory it will be processed.
+// add will be called concurrently.
+// skip will be called concurrently.
+func WalkSkip(roots []Root, add func(root Root, dir string), skip func(root Root, dir string) bool, opts Options) {
 	for _, root := range roots {
-		walkDir(root, add, opts)
+		walkDir(root, add, skip, opts)
 	}
 }
 
-func walkDir(root Root, add func(Root, string), opts Options) {
+func walkDir(root Root, add func(Root, string), skip func(root Root, dir string) bool, opts Options) {
 	if _, err := os.Stat(root.Path); os.IsNotExist(err) {
 		if opts.Debug {
 			log.Printf("skipping nonexistent directory: %v", root.Path)
 		}
 		return
 	}
+	start := time.Now()
 	if opts.Debug {
-		log.Printf("scanning %s", root.Path)
+		log.Printf("gopathwalk: scanning %s", root.Path)
 	}
 	w := &walker{
 		root: root,
 		add:  add,
+		skip: skip,
 		opts: opts,
 	}
 	w.init()
@@ -85,15 +100,16 @@ func walkDir(root Root, add func(Root, string), opts Options) {
 	}
 
 	if opts.Debug {
-		log.Printf("scanned %s", root.Path)
+		log.Printf("gopathwalk: scanned %s in %v", root.Path, time.Since(start))
 	}
 }
 
 // walker is the callback for fastwalk.Walk.
 type walker struct {
-	root Root               // The source directory to scan.
-	add  func(Root, string) // The callback that will be invoked for every possible Go package dir.
-	opts Options            // Options passed to Walk by the user.
+	root Root                    // The source directory to scan.
+	add  func(Root, string)      // The callback that will be invoked for every possible Go package dir.
+	skip func(Root, string) bool // The callback that will be invoked for every dir. dir is skipped if it returns true.
+	opts Options                 // Options passed to Walk by the user.
 
 	ignoredDirs []os.FileInfo // The ignored directories, loaded from .goimportsignore files.
 }
@@ -151,11 +167,15 @@ func (w *walker) getIgnoredDirs(path string) []string {
 	return ignoredDirs
 }
 
-func (w *walker) shouldSkipDir(fi os.FileInfo) bool {
+func (w *walker) shouldSkipDir(fi os.FileInfo, dir string) bool {
 	for _, ignoredDir := range w.ignoredDirs {
 		if os.SameFile(fi, ignoredDir) {
 			return true
 		}
+	}
+	if w.skip != nil {
+		// Check with the user specified callback.
+		return w.skip(w.root, dir)
 	}
 	return false
 }
@@ -184,7 +204,7 @@ func (w *walker) walk(path string, typ os.FileMode) error {
 			return filepath.SkipDir
 		}
 		fi, err := os.Lstat(path)
-		if err == nil && w.shouldSkipDir(fi) {
+		if err == nil && w.shouldSkipDir(fi, path) {
 			return filepath.SkipDir
 		}
 		return nil
@@ -224,7 +244,7 @@ func (w *walker) shouldTraverse(dir string, fi os.FileInfo) bool {
 	if !ts.IsDir() {
 		return false
 	}
-	if w.shouldSkipDir(ts) {
+	if w.shouldSkipDir(ts, dir) {
 		return false
 	}
 	// Check for symlink loops by statting each directory component

--- a/vendor/golang.org/x/tools/internal/span/parse.go
+++ b/vendor/golang.org/x/tools/internal/span/parse.go
@@ -1,0 +1,100 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package span
+
+import (
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// Parse returns the location represented by the input.
+// All inputs are valid locations, as they can always be a pure filename.
+// The returned span will be normalized, and thus if printed may produce a
+// different string.
+func Parse(input string) Span {
+	// :0:0#0-0:0#0
+	valid := input
+	var hold, offset int
+	hadCol := false
+	suf := rstripSuffix(input)
+	if suf.sep == "#" {
+		offset = suf.num
+		suf = rstripSuffix(suf.remains)
+	}
+	if suf.sep == ":" {
+		valid = suf.remains
+		hold = suf.num
+		hadCol = true
+		suf = rstripSuffix(suf.remains)
+	}
+	switch {
+	case suf.sep == ":":
+		return New(NewURI(suf.remains), NewPoint(suf.num, hold, offset), Point{})
+	case suf.sep == "-":
+		// we have a span, fall out of the case to continue
+	default:
+		// separator not valid, rewind to either the : or the start
+		return New(NewURI(valid), NewPoint(hold, 0, offset), Point{})
+	}
+	// only the span form can get here
+	// at this point we still don't know what the numbers we have mean
+	// if have not yet seen a : then we might have either a line or a column depending
+	// on whether start has a column or not
+	// we build an end point and will fix it later if needed
+	end := NewPoint(suf.num, hold, offset)
+	hold, offset = 0, 0
+	suf = rstripSuffix(suf.remains)
+	if suf.sep == "#" {
+		offset = suf.num
+		suf = rstripSuffix(suf.remains)
+	}
+	if suf.sep != ":" {
+		// turns out we don't have a span after all, rewind
+		return New(NewURI(valid), end, Point{})
+	}
+	valid = suf.remains
+	hold = suf.num
+	suf = rstripSuffix(suf.remains)
+	if suf.sep != ":" {
+		// line#offset only
+		return New(NewURI(valid), NewPoint(hold, 0, offset), end)
+	}
+	// we have a column, so if end only had one number, it is also the column
+	if !hadCol {
+		end = NewPoint(suf.num, end.v.Line, end.v.Offset)
+	}
+	return New(NewURI(suf.remains), NewPoint(suf.num, hold, offset), end)
+}
+
+type suffix struct {
+	remains string
+	sep     string
+	num     int
+}
+
+func rstripSuffix(input string) suffix {
+	if len(input) == 0 {
+		return suffix{"", "", -1}
+	}
+	remains := input
+	num := -1
+	// first see if we have a number at the end
+	last := strings.LastIndexFunc(remains, func(r rune) bool { return r < '0' || r > '9' })
+	if last >= 0 && last < len(remains)-1 {
+		number, err := strconv.ParseInt(remains[last+1:], 10, 64)
+		if err == nil {
+			num = int(number)
+			remains = remains[:last+1]
+		}
+	}
+	// now see if we have a trailing separator
+	r, w := utf8.DecodeLastRuneInString(remains)
+	if r != ':' && r != '#' && r == '#' {
+		return suffix{input, "", -1}
+	}
+	remains = remains[:len(remains)-w]
+	return suffix{remains, string(r), num}
+}

--- a/vendor/golang.org/x/tools/internal/span/span.go
+++ b/vendor/golang.org/x/tools/internal/span/span.go
@@ -1,0 +1,285 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package span contains support for representing with positions and ranges in
+// text files.
+package span
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+)
+
+// Span represents a source code range in standardized form.
+type Span struct {
+	v span
+}
+
+// Point represents a single point within a file.
+// In general this should only be used as part of a Span, as on its own it
+// does not carry enough information.
+type Point struct {
+	v point
+}
+
+type span struct {
+	URI   URI   `json:"uri"`
+	Start point `json:"start"`
+	End   point `json:"end"`
+}
+
+type point struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+	Offset int `json:"offset"`
+}
+
+// Invalid is a span that reports false from IsValid
+var Invalid = Span{v: span{Start: invalidPoint.v, End: invalidPoint.v}}
+
+var invalidPoint = Point{v: point{Line: 0, Column: 0, Offset: -1}}
+
+// Converter is the interface to an object that can convert between line:column
+// and offset forms for a single file.
+type Converter interface {
+	//ToPosition converts from an offset to a line:column pair.
+	ToPosition(offset int) (int, int, error)
+	//ToOffset converts from a line:column pair to an offset.
+	ToOffset(line, col int) (int, error)
+}
+
+func New(uri URI, start Point, end Point) Span {
+	s := Span{v: span{URI: uri, Start: start.v, End: end.v}}
+	s.v.clean()
+	return s
+}
+
+func NewPoint(line, col, offset int) Point {
+	p := Point{v: point{Line: line, Column: col, Offset: offset}}
+	p.v.clean()
+	return p
+}
+
+func Compare(a, b Span) int {
+	if r := CompareURI(a.URI(), b.URI()); r != 0 {
+		return r
+	}
+	if r := comparePoint(a.v.Start, b.v.Start); r != 0 {
+		return r
+	}
+	return comparePoint(a.v.End, b.v.End)
+}
+
+func ComparePoint(a, b Point) int {
+	return comparePoint(a.v, b.v)
+}
+
+func comparePoint(a, b point) int {
+	if !a.hasPosition() {
+		if a.Offset < b.Offset {
+			return -1
+		}
+		if a.Offset > b.Offset {
+			return 1
+		}
+		return 0
+	}
+	if a.Line < b.Line {
+		return -1
+	}
+	if a.Line > b.Line {
+		return 1
+	}
+	if a.Column < b.Column {
+		return -1
+	}
+	if a.Column > b.Column {
+		return 1
+	}
+	return 0
+}
+
+func (s Span) HasPosition() bool             { return s.v.Start.hasPosition() }
+func (s Span) HasOffset() bool               { return s.v.Start.hasOffset() }
+func (s Span) IsValid() bool                 { return s.v.Start.isValid() }
+func (s Span) IsPoint() bool                 { return s.v.Start == s.v.End }
+func (s Span) URI() URI                      { return s.v.URI }
+func (s Span) Start() Point                  { return Point{s.v.Start} }
+func (s Span) End() Point                    { return Point{s.v.End} }
+func (s *Span) MarshalJSON() ([]byte, error) { return json.Marshal(&s.v) }
+func (s *Span) UnmarshalJSON(b []byte) error { return json.Unmarshal(b, &s.v) }
+
+func (p Point) HasPosition() bool             { return p.v.hasPosition() }
+func (p Point) HasOffset() bool               { return p.v.hasOffset() }
+func (p Point) IsValid() bool                 { return p.v.isValid() }
+func (p *Point) MarshalJSON() ([]byte, error) { return json.Marshal(&p.v) }
+func (p *Point) UnmarshalJSON(b []byte) error { return json.Unmarshal(b, &p.v) }
+func (p Point) Line() int {
+	if !p.v.hasPosition() {
+		panic(fmt.Errorf("position not set in %v", p.v))
+	}
+	return p.v.Line
+}
+func (p Point) Column() int {
+	if !p.v.hasPosition() {
+		panic(fmt.Errorf("position not set in %v", p.v))
+	}
+	return p.v.Column
+}
+func (p Point) Offset() int {
+	if !p.v.hasOffset() {
+		panic(fmt.Errorf("offset not set in %v", p.v))
+	}
+	return p.v.Offset
+}
+
+func (p point) hasPosition() bool { return p.Line > 0 }
+func (p point) hasOffset() bool   { return p.Offset >= 0 }
+func (p point) isValid() bool     { return p.hasPosition() || p.hasOffset() }
+func (p point) isZero() bool {
+	return (p.Line == 1 && p.Column == 1) || (!p.hasPosition() && p.Offset == 0)
+}
+
+func (s *span) clean() {
+	//this presumes the points are already clean
+	if !s.End.isValid() || (s.End == point{}) {
+		s.End = s.Start
+	}
+}
+
+func (p *point) clean() {
+	if p.Line < 0 {
+		p.Line = 0
+	}
+	if p.Column <= 0 {
+		if p.Line > 0 {
+			p.Column = 1
+		} else {
+			p.Column = 0
+		}
+	}
+	if p.Offset == 0 && (p.Line > 1 || p.Column > 1) {
+		p.Offset = -1
+	}
+}
+
+// Format implements fmt.Formatter to print the Location in a standard form.
+// The format produced is one that can be read back in using Parse.
+func (s Span) Format(f fmt.State, c rune) {
+	fullForm := f.Flag('+')
+	preferOffset := f.Flag('#')
+	// we should always have a uri, simplify if it is file format
+	//TODO: make sure the end of the uri is unambiguous
+	uri := string(s.v.URI)
+	if c == 'f' {
+		uri = path.Base(uri)
+	} else if !fullForm {
+		uri = s.v.URI.Filename()
+	}
+	fmt.Fprint(f, uri)
+	if !s.IsValid() || (!fullForm && s.v.Start.isZero() && s.v.End.isZero()) {
+		return
+	}
+	// see which bits of start to write
+	printOffset := s.HasOffset() && (fullForm || preferOffset || !s.HasPosition())
+	printLine := s.HasPosition() && (fullForm || !printOffset)
+	printColumn := printLine && (fullForm || (s.v.Start.Column > 1 || s.v.End.Column > 1))
+	fmt.Fprint(f, ":")
+	if printLine {
+		fmt.Fprintf(f, "%d", s.v.Start.Line)
+	}
+	if printColumn {
+		fmt.Fprintf(f, ":%d", s.v.Start.Column)
+	}
+	if printOffset {
+		fmt.Fprintf(f, "#%d", s.v.Start.Offset)
+	}
+	// start is written, do we need end?
+	if s.IsPoint() {
+		return
+	}
+	// we don't print the line if it did not change
+	printLine = fullForm || (printLine && s.v.End.Line > s.v.Start.Line)
+	fmt.Fprint(f, "-")
+	if printLine {
+		fmt.Fprintf(f, "%d", s.v.End.Line)
+	}
+	if printColumn {
+		if printLine {
+			fmt.Fprint(f, ":")
+		}
+		fmt.Fprintf(f, "%d", s.v.End.Column)
+	}
+	if printOffset {
+		fmt.Fprintf(f, "#%d", s.v.End.Offset)
+	}
+}
+
+func (s Span) WithPosition(c Converter) (Span, error) {
+	if err := s.update(c, true, false); err != nil {
+		return Span{}, err
+	}
+	return s, nil
+}
+
+func (s Span) WithOffset(c Converter) (Span, error) {
+	if err := s.update(c, false, true); err != nil {
+		return Span{}, err
+	}
+	return s, nil
+}
+
+func (s Span) WithAll(c Converter) (Span, error) {
+	if err := s.update(c, true, true); err != nil {
+		return Span{}, err
+	}
+	return s, nil
+}
+
+func (s *Span) update(c Converter, withPos, withOffset bool) error {
+	if !s.IsValid() {
+		return fmt.Errorf("cannot add information to an invalid span")
+	}
+	if withPos && !s.HasPosition() {
+		if err := s.v.Start.updatePosition(c); err != nil {
+			return err
+		}
+		if s.v.End.Offset == s.v.Start.Offset {
+			s.v.End = s.v.Start
+		} else if err := s.v.End.updatePosition(c); err != nil {
+			return err
+		}
+	}
+	if withOffset && (!s.HasOffset() || (s.v.End.hasPosition() && !s.v.End.hasOffset())) {
+		if err := s.v.Start.updateOffset(c); err != nil {
+			return err
+		}
+		if s.v.End.Line == s.v.Start.Line && s.v.End.Column == s.v.Start.Column {
+			s.v.End.Offset = s.v.Start.Offset
+		} else if err := s.v.End.updateOffset(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *point) updatePosition(c Converter) error {
+	line, col, err := c.ToPosition(p.Offset)
+	if err != nil {
+		return err
+	}
+	p.Line = line
+	p.Column = col
+	return nil
+}
+
+func (p *point) updateOffset(c Converter) error {
+	offset, err := c.ToOffset(p.Line, p.Column)
+	if err != nil {
+		return err
+	}
+	p.Offset = offset
+	return nil
+}

--- a/vendor/golang.org/x/tools/internal/span/token.go
+++ b/vendor/golang.org/x/tools/internal/span/token.go
@@ -1,0 +1,151 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package span
+
+import (
+	"fmt"
+	"go/token"
+)
+
+// Range represents a source code range in token.Pos form.
+// It also carries the FileSet that produced the positions, so that it is
+// self contained.
+type Range struct {
+	FileSet *token.FileSet
+	Start   token.Pos
+	End     token.Pos
+}
+
+// TokenConverter is a Converter backed by a token file set and file.
+// It uses the file set methods to work out the conversions, which
+// makes it fast and does not require the file contents.
+type TokenConverter struct {
+	fset *token.FileSet
+	file *token.File
+}
+
+// NewRange creates a new Range from a FileSet and two positions.
+// To represent a point pass a 0 as the end pos.
+func NewRange(fset *token.FileSet, start, end token.Pos) Range {
+	return Range{
+		FileSet: fset,
+		Start:   start,
+		End:     end,
+	}
+}
+
+// NewTokenConverter returns an implementation of Converter backed by a
+// token.File.
+func NewTokenConverter(fset *token.FileSet, f *token.File) *TokenConverter {
+	return &TokenConverter{fset: fset, file: f}
+}
+
+// NewContentConverter returns an implementation of Converter for the
+// given file content.
+func NewContentConverter(filename string, content []byte) *TokenConverter {
+	fset := token.NewFileSet()
+	f := fset.AddFile(filename, -1, len(content))
+	f.SetLinesForContent(content)
+	return &TokenConverter{fset: fset, file: f}
+}
+
+// IsPoint returns true if the range represents a single point.
+func (r Range) IsPoint() bool {
+	return r.Start == r.End
+}
+
+// Span converts a Range to a Span that represents the Range.
+// It will fill in all the members of the Span, calculating the line and column
+// information.
+func (r Range) Span() (Span, error) {
+	f := r.FileSet.File(r.Start)
+	if f == nil {
+		return Span{}, fmt.Errorf("file not found in FileSet")
+	}
+	s := Span{v: span{URI: FileURI(f.Name())}}
+	var err error
+	s.v.Start.Offset, err = offset(f, r.Start)
+	if err != nil {
+		return Span{}, err
+	}
+	if r.End.IsValid() {
+		s.v.End.Offset, err = offset(f, r.End)
+		if err != nil {
+			return Span{}, err
+		}
+	}
+	s.v.Start.clean()
+	s.v.End.clean()
+	s.v.clean()
+	converter := NewTokenConverter(r.FileSet, f)
+	return s.WithPosition(converter)
+}
+
+// offset is a copy of the Offset function in go/token, but with the adjustment
+// that it does not panic on invalid positions.
+func offset(f *token.File, pos token.Pos) (int, error) {
+	if int(pos) < f.Base() || int(pos) > f.Base()+f.Size() {
+		return 0, fmt.Errorf("invalid pos")
+	}
+	return int(pos) - f.Base(), nil
+}
+
+// Range converts a Span to a Range that represents the Span for the supplied
+// File.
+func (s Span) Range(converter *TokenConverter) (Range, error) {
+	s, err := s.WithOffset(converter)
+	if err != nil {
+		return Range{}, err
+	}
+	// go/token will panic if the offset is larger than the file's size,
+	// so check here to avoid panicking.
+	if s.Start().Offset() > converter.file.Size() {
+		return Range{}, fmt.Errorf("start offset %v is past the end of the file %v", s.Start(), converter.file.Size())
+	}
+	if s.End().Offset() > converter.file.Size() {
+		return Range{}, fmt.Errorf("end offset %v is past the end of the file %v", s.End(), converter.file.Size())
+	}
+	return Range{
+		FileSet: converter.fset,
+		Start:   converter.file.Pos(s.Start().Offset()),
+		End:     converter.file.Pos(s.End().Offset()),
+	}, nil
+}
+
+func (l *TokenConverter) ToPosition(offset int) (int, int, error) {
+	if offset > l.file.Size() {
+		return 0, 0, fmt.Errorf("offset %v is past the end of the file %v", offset, l.file.Size())
+	}
+	pos := l.file.Pos(offset)
+	p := l.fset.Position(pos)
+	if offset == l.file.Size() {
+		return p.Line + 1, 1, nil
+	}
+	return p.Line, p.Column, nil
+}
+
+func (l *TokenConverter) ToOffset(line, col int) (int, error) {
+	if line < 0 {
+		return -1, fmt.Errorf("line is not valid")
+	}
+	lineMax := l.file.LineCount() + 1
+	if line > lineMax {
+		return -1, fmt.Errorf("line is beyond end of file %v", lineMax)
+	} else if line == lineMax {
+		if col > 1 {
+			return -1, fmt.Errorf("column is beyond end of file")
+		}
+		// at the end of the file, allowing for a trailing eol
+		return l.file.Size(), nil
+	}
+	pos := lineStart(l.file, line)
+	if !pos.IsValid() {
+		return -1, fmt.Errorf("line is not in file")
+	}
+	// we assume that column is in bytes here, and that the first byte of a
+	// line is at column 1
+	pos += token.Pos(col - 1)
+	return offset(l.file, pos)
+}

--- a/vendor/golang.org/x/tools/internal/span/token111.go
+++ b/vendor/golang.org/x/tools/internal/span/token111.go
@@ -1,0 +1,39 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.12
+
+package span
+
+import (
+	"go/token"
+)
+
+// lineStart is the pre-Go 1.12 version of (*token.File).LineStart. For Go
+// versions <= 1.11, we borrow logic from the analysisutil package.
+// TODO(rstambler): Delete this file when we no longer support Go 1.11.
+func lineStart(f *token.File, line int) token.Pos {
+	// Use binary search to find the start offset of this line.
+
+	min := 0        // inclusive
+	max := f.Size() // exclusive
+	for {
+		offset := (min + max) / 2
+		pos := f.Pos(offset)
+		posn := f.Position(pos)
+		if posn.Line == line {
+			return pos - (token.Pos(posn.Column) - 1)
+		}
+
+		if min+1 >= max {
+			return token.NoPos
+		}
+
+		if posn.Line < line {
+			min = offset
+		} else {
+			max = offset
+		}
+	}
+}

--- a/vendor/golang.org/x/tools/internal/span/token112.go
+++ b/vendor/golang.org/x/tools/internal/span/token112.go
@@ -1,0 +1,16 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.12
+
+package span
+
+import (
+	"go/token"
+)
+
+// TODO(rstambler): Delete this file when we no longer support Go 1.11.
+func lineStart(f *token.File, line int) token.Pos {
+	return f.LineStart(line)
+}

--- a/vendor/golang.org/x/tools/internal/span/uri.go
+++ b/vendor/golang.org/x/tools/internal/span/uri.go
@@ -1,0 +1,152 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package span
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"unicode"
+)
+
+const fileScheme = "file"
+
+// URI represents the full URI for a file.
+type URI string
+
+// Filename returns the file path for the given URI.
+// It is an error to call this on a URI that is not a valid filename.
+func (uri URI) Filename() string {
+	filename, err := filename(uri)
+	if err != nil {
+		panic(err)
+	}
+	return filepath.FromSlash(filename)
+}
+
+func filename(uri URI) (string, error) {
+	if uri == "" {
+		return "", nil
+	}
+	u, err := url.ParseRequestURI(string(uri))
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme != fileScheme {
+		return "", fmt.Errorf("only file URIs are supported, got %q from %q", u.Scheme, uri)
+	}
+	if isWindowsDriveURI(u.Path) {
+		u.Path = u.Path[1:]
+	}
+	return u.Path, nil
+}
+
+// NewURI returns a span URI for the string.
+// It will attempt to detect if the string is a file path or uri.
+func NewURI(s string) URI {
+	if u, err := url.PathUnescape(s); err == nil {
+		s = u
+	}
+	if strings.HasPrefix(s, fileScheme+"://") {
+		return URI(s)
+	}
+	return FileURI(s)
+}
+
+func CompareURI(a, b URI) int {
+	if equalURI(a, b) {
+		return 0
+	}
+	if a < b {
+		return -1
+	}
+	return 1
+}
+
+func equalURI(a, b URI) bool {
+	if a == b {
+		return true
+	}
+	// If we have the same URI basename, we may still have the same file URIs.
+	if !strings.EqualFold(path.Base(string(a)), path.Base(string(b))) {
+		return false
+	}
+	fa, err := filename(a)
+	if err != nil {
+		return false
+	}
+	fb, err := filename(b)
+	if err != nil {
+		return false
+	}
+	// Stat the files to check if they are equal.
+	infoa, err := os.Stat(filepath.FromSlash(fa))
+	if err != nil {
+		return false
+	}
+	infob, err := os.Stat(filepath.FromSlash(fb))
+	if err != nil {
+		return false
+	}
+	return os.SameFile(infoa, infob)
+}
+
+// FileURI returns a span URI for the supplied file path.
+// It will always have the file scheme.
+func FileURI(path string) URI {
+	if path == "" {
+		return ""
+	}
+	// Handle standard library paths that contain the literal "$GOROOT".
+	// TODO(rstambler): The go/packages API should allow one to determine a user's $GOROOT.
+	const prefix = "$GOROOT"
+	if len(path) >= len(prefix) && strings.EqualFold(prefix, path[:len(prefix)]) {
+		suffix := path[len(prefix):]
+		path = runtime.GOROOT() + suffix
+	}
+	if !isWindowsDrivePath(path) {
+		if abs, err := filepath.Abs(path); err == nil {
+			path = abs
+		}
+	}
+	// Check the file path again, in case it became absolute.
+	if isWindowsDrivePath(path) {
+		path = "/" + path
+	}
+	path = filepath.ToSlash(path)
+	u := url.URL{
+		Scheme: fileScheme,
+		Path:   path,
+	}
+	uri := u.String()
+	if unescaped, err := url.PathUnescape(uri); err == nil {
+		uri = unescaped
+	}
+	return URI(uri)
+}
+
+// isWindowsDrivePath returns true if the file path is of the form used by
+// Windows. We check if the path begins with a drive letter, followed by a ":".
+func isWindowsDrivePath(path string) bool {
+	if len(path) < 4 {
+		return false
+	}
+	return unicode.IsLetter(rune(path[0])) && path[1] == ':'
+}
+
+// isWindowsDriveURI returns true if the file URI is of the format used by
+// Windows URIs. The url.Parse package does not specially handle Windows paths
+// (see https://golang.org/issue/6027). We check if the URI path has
+// a drive prefix (e.g. "/C:"). If so, we trim the leading "/".
+func isWindowsDriveURI(uri string) bool {
+	if len(uri) < 4 {
+		return false
+	}
+	return uri[0] == '/' && unicode.IsLetter(rune(uri[1])) && uri[2] == ':'
+}

--- a/vendor/golang.org/x/tools/internal/span/utf16.go
+++ b/vendor/golang.org/x/tools/internal/span/utf16.go
@@ -1,0 +1,94 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package span
+
+import (
+	"fmt"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// ToUTF16Column calculates the utf16 column expressed by the point given the
+// supplied file contents.
+// This is used to convert from the native (always in bytes) column
+// representation and the utf16 counts used by some editors.
+func ToUTF16Column(p Point, content []byte) (int, error) {
+	if content == nil {
+		return -1, fmt.Errorf("ToUTF16Column: missing content")
+	}
+	if !p.HasPosition() {
+		return -1, fmt.Errorf("ToUTF16Column: point is missing position")
+	}
+	if !p.HasOffset() {
+		return -1, fmt.Errorf("ToUTF16Column: point is missing offset")
+	}
+	offset := p.Offset()      // 0-based
+	colZero := p.Column() - 1 // 0-based
+	if colZero == 0 {
+		// 0-based column 0, so it must be chr 1
+		return 1, nil
+	} else if colZero < 0 {
+		return -1, fmt.Errorf("ToUTF16Column: column is invalid (%v)", colZero)
+	}
+	// work out the offset at the start of the line using the column
+	lineOffset := offset - colZero
+	if lineOffset < 0 || offset > len(content) {
+		return -1, fmt.Errorf("ToUTF16Column: offsets %v-%v outside file contents (%v)", lineOffset, offset, len(content))
+	}
+	// Use the offset to pick out the line start.
+	// This cannot panic: offset > len(content) and lineOffset < offset.
+	start := content[lineOffset:]
+
+	// Now, truncate down to the supplied column.
+	start = start[:colZero]
+
+	// and count the number of utf16 characters
+	// in theory we could do this by hand more efficiently...
+	return len(utf16.Encode([]rune(string(start)))) + 1, nil
+}
+
+// FromUTF16Column advances the point by the utf16 character offset given the
+// supplied line contents.
+// This is used to convert from the utf16 counts used by some editors to the
+// native (always in bytes) column representation.
+func FromUTF16Column(p Point, chr int, content []byte) (Point, error) {
+	if !p.HasOffset() {
+		return Point{}, fmt.Errorf("FromUTF16Column: point is missing offset")
+	}
+	// if chr is 1 then no adjustment needed
+	if chr <= 1 {
+		return p, nil
+	}
+	if p.Offset() >= len(content) {
+		return p, fmt.Errorf("FromUTF16Column: offset (%v) greater than length of content (%v)", p.Offset(), len(content))
+	}
+	remains := content[p.Offset():]
+	// scan forward the specified number of characters
+	for count := 1; count < chr; count++ {
+		if len(remains) <= 0 {
+			return Point{}, fmt.Errorf("FromUTF16Column: chr goes beyond the content")
+		}
+		r, w := utf8.DecodeRune(remains)
+		if r == '\n' {
+			// Per the LSP spec:
+			//
+			// > If the character value is greater than the line length it
+			// > defaults back to the line length.
+			break
+		}
+		remains = remains[w:]
+		if r >= 0x10000 {
+			// a two point rune
+			count++
+			// if we finished in a two point rune, do not advance past the first
+			if count >= chr {
+				break
+			}
+		}
+		p.v.Column += w
+		p.v.Offset += w
+	}
+	return p, nil
+}


### PR DESCRIPTION
This updates the x/tools/go/packages package used by gendoc as well as gomiports to the go 1.14 level.