### PR TITLE
Fix run-unit-tests to allow successful execution when the serial packages list is empty

### DIFF
--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -4,8 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
-set -o pipefail
+set -eo pipefail
 
 base_dir="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -129,8 +128,6 @@ serial_test_packages() {
     filter=$(package_filter "${serial_packages[@]}")
     if [ -n "$filter" ]; then
         join_by $'\n' "$@" | grep -E "$filter" || true
-    else
-        join_by $'\n' "$@"
     fi
 }
 


### PR DESCRIPTION
When the serial_packages array is empty, serial_test_packages should return without doing anything.

This was included in a change that removed gossip from the serial package list that was reverted.