### PR TITLE
build: explicitly enumerate tool dep in check targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ help-docs: native
 	@scripts/generateHelpDocs.sh
 
 .PHONY: spelling
-spelling: gotools
+spelling: gotool.misspell
 	@scripts/check_spelling.sh
 
 .PHONY: references
@@ -164,27 +164,27 @@ profile: export JOB_TYPE=PROFILE
 profile: unit-test
 
 .PHONY: linter
-linter: check-deps gotools
+linter: check-deps gotool.goimports
 	@echo "LINT: Running code checks.."
 	./scripts/golinter.sh
 
 .PHONY: check-deps
-check-deps: gotools
+check-deps: gotool.dep
 	@echo "DEP: Checking for dependency issues.."
 	./scripts/check_deps.sh
 
 .PHONY: check-metrics-docs
-check-metrics-doc: gotools
+check-metrics-doc:
 	@echo "METRICS: Checking for outdated reference documentation.."
 	./scripts/metrics_doc.sh check
 
 .PHONY: generate-metrics-docs
-generate-metrics-doc: gotools
+generate-metrics-doc:
 	@echo "Generating metrics reference documentation..."
 	./scripts/metrics_doc.sh generate
 
 .PHONY: protos
-protos: gotools
+protos: gotool.protoc-gen-go
 	@echo "Compiling non-API protos..."
 	./scripts/compile_protos.sh
 


### PR DESCRIPTION
By explicitly listing the tools that a target depends on, we can avoid building unnecessary tools.