### PR TITLE
Improve test coverage for errors

### DIFF
--- a/cmd/configtxgen/main.go
+++ b/cmd/configtxgen/main.go
@@ -47,7 +47,7 @@ func doOutputBlock(config *genesisconfig.Profile, channelID string, outputBlock 
 	logger.Info("Writing genesis block")
 	err = writeFile(outputBlock, protoutil.MarshalOrPanic(genesisBlock), 0640)
 	if err != nil {
-		return fmt.Errorf("Error writing genesis block: %s", err)
+		return fmt.Errorf("error writing genesis block: %s", err)
 	}
 	return nil
 }
@@ -69,7 +69,7 @@ func doOutputChannelCreateTx(conf, baseProfile *genesisconfig.Profile, channelID
 	logger.Info("Writing new channel tx")
 	err = writeFile(outputChannelCreateTx, protoutil.MarshalOrPanic(configtx), 0640)
 	if err != nil {
-		return fmt.Errorf("Error writing channel create tx: %s", err)
+		return fmt.Errorf("error writing channel create tx: %s", err)
 	}
 	return nil
 }
@@ -77,11 +77,11 @@ func doOutputChannelCreateTx(conf, baseProfile *genesisconfig.Profile, channelID
 func doOutputAnchorPeersUpdate(conf *genesisconfig.Profile, channelID string, outputAnchorPeersUpdate string, asOrg string) error {
 	logger.Info("Generating anchor peer update")
 	if asOrg == "" {
-		return fmt.Errorf("Must specify an organization to update the anchor peer for")
+		return fmt.Errorf("must specify an organization to update the anchor peer for")
 	}
 
 	if conf.Application == nil {
-		return fmt.Errorf("Cannot update anchor peers without an application section")
+		return fmt.Errorf("cannot update anchor peers without an application section")
 	}
 
 	original, err := encoder.NewChannelGroup(conf)
@@ -127,7 +127,7 @@ func doInspectBlock(inspectBlock string) error {
 	logger.Info("Inspecting block")
 	data, err := ioutil.ReadFile(inspectBlock)
 	if err != nil {
-		return fmt.Errorf("Could not read block %s", inspectBlock)
+		return fmt.Errorf("could not read block %s", inspectBlock)
 	}
 
 	logger.Info("Parsing genesis block")


### PR DESCRIPTION
Signed-off-by: Svetoslav Blyahov <svetlio.blyahoff@gmail.com>

Improve configtxgen test coverage (for error messages) as @wlahti advised in my previous PR.

#### Type of change
- Test update

#### Description

Start expecting exact error messages.
