### PR TITLE
build: disable race for gossip and use failfast

### DIFF
--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -152,7 +152,7 @@ run_tests() {
         local -a serial
         while IFS= read -r pkg; do serial+=("$pkg"); done < <(serial_test_packages "$@")
         if [ "${#serial[@]}" -ne 0 ]; then
-            go test "${flags[@]}" "${race_flags[@]}" -tags "$GO_TAGS" "${serial[@]}" -short -p 1 -timeout=20m
+            go test "${flags[@]}" -failfast -tags "$GO_TAGS" "${serial[@]}" -short -p 1 -timeout=20m
         fi
 
         local -a parallel


### PR DESCRIPTION
Turn off race detection for gossip (again) and enable the `-failfast` option to terminate the gossip tests immediately after the first failure.