### PR TITLE
Simplify test assets and setup for go chaincode

### DIFF
--- a/core/chaincode/platforms/golang/testdata/ccmodule/chaincode.go
+++ b/core/chaincode/platforms/golang/testdata/ccmodule/chaincode.go
@@ -8,25 +8,8 @@ package main
 
 import (
 	"ccmodule/customlogger"
-
-	"github.com/hyperledger/fabric-chaincode-go/shim"
-	pb "github.com/hyperledger/fabric-protos-go/peer"
 )
 
-// No-op test chaincode
-type TestChaincode struct{}
-
-func (t *TestChaincode) Init(stub shim.ChaincodeStubInterface) pb.Response {
-	return shim.Success(nil)
-}
-
-func (t *TestChaincode) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
-	return shim.Success(nil)
-}
-
 func main() {
-	err := shim.Start(new(TestChaincode))
-	if err != nil {
-		customlogger.Logf("Error starting TestChaincode: %s", err)
-	}
+	customlogger.Logf("I'm not really chaincode.")
 }

--- a/core/chaincode/platforms/golang/testdata/ccmodule/go.mod
+++ b/core/chaincode/platforms/golang/testdata/ccmodule/go.mod
@@ -1,8 +1,3 @@
 module ccmodule
 
 go 1.12
-
-require (
-	github.com/hyperledger/fabric-chaincode-go v0.0.0-20190823162523-04390e015b85
-	github.com/hyperledger/fabric-protos-go v0.0.0-20190823190507-26c33c998676
-)

--- a/core/chaincode/platforms/golang/testdata/ccmodule/nested/chaincode.go
+++ b/core/chaincode/platforms/golang/testdata/ccmodule/nested/chaincode.go
@@ -8,25 +8,8 @@ package main
 
 import (
 	"ccmodule/customlogger"
-
-	"github.com/hyperledger/fabric-chaincode-go/shim"
-	pb "github.com/hyperledger/fabric-protos-go/peer"
 )
 
-// No-op test chaincode
-type TestChaincode struct{}
-
-func (t *TestChaincode) Init(stub shim.ChaincodeStubInterface) pb.Response {
-	return shim.Success(nil)
-}
-
-func (t *TestChaincode) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
-	return shim.Success(nil)
-}
-
 func main() {
-	err := shim.Start(new(TestChaincode))
-	if err != nil {
-		customlogger.Logf("Error starting TestChaincode: %s", err)
-	}
+	customlogger.Logf("I'm not really chaincode.")
 }

--- a/core/chaincode/platforms/golang/testdata/src/chaincodes/BadImport/main.go
+++ b/core/chaincode/platforms/golang/testdata/src/chaincodes/BadImport/main.go
@@ -1,26 +1,14 @@
 /*
- * Copyright Greg Haskins All Rights Reserved
- *
- * SPDX-License-Identifier: Apache-2.0
- *
- */
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
 
 package main
 
 import (
 	"bogus/package"
-	"fmt"
-
-	"github.com/hyperledger/fabric-chaincode-go/shim"
 )
 
-// SimpleChaincode example simple Chaincode implementation
-type SimpleChaincode struct {
-}
-
 func main() {
-	err := shim.Start(new(SimpleChaincode))
-	if err != nil {
-		fmt.Printf("Error starting Simple chaincode: %s", err)
-	}
 }

--- a/core/chaincode/platforms/golang/testdata/src/chaincodes/BadMetadataIgnoreHiddenFile/main.go
+++ b/core/chaincode/platforms/golang/testdata/src/chaincodes/BadMetadataIgnoreHiddenFile/main.go
@@ -1,25 +1,11 @@
 /*
- * Copyright Greg Haskins All Rights Reserved
- *
- * SPDX-License-Identifier: Apache-2.0
- *
- */
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
 
 package main
 
-import (
-	"fmt"
-
-	"github.com/hyperledger/fabric-chaincode-go/shim"
-)
-
-// SimpleChaincode example simple Chaincode implementation
-type SimpleChaincode struct {
-}
-
 func main() {
-	err := shim.Start(new(SimpleChaincode))
-	if err != nil {
-		fmt.Printf("Error starting Simple chaincode: %s", err)
-	}
+	//  Empty shell with no dependencies
 }

--- a/core/chaincode/platforms/golang/testdata/src/chaincodes/BadMetadataInvalidIndex/main.go
+++ b/core/chaincode/platforms/golang/testdata/src/chaincodes/BadMetadataInvalidIndex/main.go
@@ -1,25 +1,11 @@
 /*
- * Copyright Greg Haskins All Rights Reserved
- *
- * SPDX-License-Identifier: Apache-2.0
- *
- */
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
 
 package main
 
-import (
-	"fmt"
-
-	"github.com/hyperledger/fabric-chaincode-go/shim"
-)
-
-// SimpleChaincode example simple Chaincode implementation
-type SimpleChaincode struct {
-}
-
 func main() {
-	err := shim.Start(new(SimpleChaincode))
-	if err != nil {
-		fmt.Printf("Error starting Simple chaincode: %s", err)
-	}
+	//  Empty shell with no dependencies
 }

--- a/core/chaincode/platforms/golang/testdata/src/chaincodes/BadMetadataUnexpectedFolderContent/main.go
+++ b/core/chaincode/platforms/golang/testdata/src/chaincodes/BadMetadataUnexpectedFolderContent/main.go
@@ -1,25 +1,11 @@
 /*
- * Copyright Greg Haskins All Rights Reserved
- *
- * SPDX-License-Identifier: Apache-2.0
- *
- */
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
 
 package main
 
-import (
-	"fmt"
-
-	"github.com/hyperledger/fabric-chaincode-go/shim"
-)
-
-// SimpleChaincode example simple Chaincode implementation
-type SimpleChaincode struct {
-}
-
 func main() {
-	err := shim.Start(new(SimpleChaincode))
-	if err != nil {
-		fmt.Printf("Error starting Simple chaincode: %s", err)
-	}
+	//  Empty shell with no dependencies
 }

--- a/core/chaincode/platforms/golang/testdata/src/chaincodes/noop/chaincode.go
+++ b/core/chaincode/platforms/golang/testdata/src/chaincodes/noop/chaincode.go
@@ -6,27 +6,6 @@ SPDX-License-Identifier: Apache-2.0
 
 package main
 
-import (
-	"fmt"
-
-	"github.com/hyperledger/fabric-chaincode-go/shim"
-	pb "github.com/hyperledger/fabric-protos-go/peer"
-)
-
-// No-op test chaincode
-type TestChaincode struct{}
-
-func (t *TestChaincode) Init(stub shim.ChaincodeStubInterface) pb.Response {
-	return shim.Success(nil)
-}
-
-func (t *TestChaincode) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
-	return shim.Success(nil)
-}
-
 func main() {
-	err := shim.Start(new(TestChaincode))
-	if err != nil {
-		fmt.Printf("Error starting Simple chaincode: %s", err)
-	}
+	//  Empty shell with no dependencies
 }


### PR DESCRIPTION
In preparation for modules, explicitly setup a GOPATH based environment for unit tests that require it.

With go 1.14, the presence of a `go.mod` breaks some go chaincode packaging tests. These changes explicitly disable module mode and setup a GOPATH for testdata. To prevent vendoring another copy of the chaincode requirements with the tests, the chaincode imports were removed from the programs. These imports were not required to execute the production code paths and our integration tests have sufficient coverage to ensure end-to-end functionality.

Since the packaging tests don't really need functional chaincode to exercise the code, reduce the tests to simple main modules with no out-of-tree dependencies. Our integration tests already cover packaging and installation of go chaincode.