### PR TITLE
FAB-17752: return errors when creating keystore

### DIFF
--- a/bccsp/sw/fileks.go
+++ b/bccsp/sw/fileks.go
@@ -398,11 +398,7 @@ func (ks *fileBasedKeyStore) createKeyStoreIfNotExists() error {
 	if missing {
 		logger.Debugf("KeyStore path [%s] missing [%t]: [%s]", ksPath, missing, utils.ErrToString(err))
 
-		err := ks.createKeyStore()
-		if err != nil {
-			logger.Errorf("Failed creating KeyStore At [%s]: [%s]", ksPath, err.Error())
-			return nil
-		}
+		return ks.createKeyStore()
 	}
 
 	return nil
@@ -411,12 +407,16 @@ func (ks *fileBasedKeyStore) createKeyStoreIfNotExists() error {
 func (ks *fileBasedKeyStore) createKeyStore() error {
 	// Create keystore directory root if it doesn't exist yet
 	ksPath := ks.path
-	logger.Debugf("Creating KeyStore at [%s]...", ksPath)
+	logger.Debugf("Creating KeyStore at [%s]", ksPath)
 
-	os.MkdirAll(ksPath, 0755)
+	err := os.MkdirAll(ksPath, 0755)
+	if err == nil {
+		logger.Debugf("KeyStore created at [%s]", ksPath)
+	} else {
+		logger.Errorf("Failed creating KeyStore at [%s]: [%s]", ksPath, err.Error())
+	}
 
-	logger.Debugf("KeyStore created at [%s].", ksPath)
-	return nil
+	return err
 }
 
 func (ks *fileBasedKeyStore) openKeyStore() error {
@@ -424,7 +424,7 @@ func (ks *fileBasedKeyStore) openKeyStore() error {
 		return nil
 	}
 	ks.isOpen = true
-	logger.Debugf("KeyStore opened at [%s]...done", ks.path)
+	logger.Debugf("KeyStore opened at [%s]", ks.path)
 
 	return nil
 }

--- a/bccsp/sw/fileks.go
+++ b/bccsp/sw/fileks.go
@@ -409,14 +409,13 @@ func (ks *fileBasedKeyStore) createKeyStore() error {
 	ksPath := ks.path
 	logger.Debugf("Creating KeyStore at [%s]", ksPath)
 
-	err := os.MkdirAll(ksPath, 0755)
-	if err == nil {
-		logger.Debugf("KeyStore created at [%s]", ksPath)
-	} else {
+	if err := os.MkdirAll(ksPath, 0755); err != nil {
 		logger.Errorf("Failed creating KeyStore at [%s]: [%s]", ksPath, err.Error())
+		return err
 	}
 
-	return err
+	logger.Debugf("KeyStore created at [%s]", ksPath)
+	return nil
 }
 
 func (ks *fileBasedKeyStore) openKeyStore() error {

--- a/bccsp/sw/fileks_test.go
+++ b/bccsp/sw/fileks_test.go
@@ -130,3 +130,29 @@ func TestReInitKeyStore(t *testing.T) {
 	err = fbKs.Init(nil, ksPath, false)
 	assert.EqualError(t, err, "KeyStore already initilized.")
 }
+
+func TestCreateKeyStoreFailed(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "bccspks")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+	validpath := filepath.Join(tempDir, "keystore")
+
+	cs := []struct {
+		valid bool
+		path  string
+	}{
+		{false, "/invalid/keystore"},
+		{true, validpath},
+	}
+
+	for i, c := range cs {
+		cid := fmt.Sprintf("case %d", i)
+
+		_, err := NewFileBasedKeyStore(nil, c.path, false)
+		if c.valid {
+			assert.NoError(t, err, cid)
+		} else {
+			assert.Error(t, err, cid)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Shitaibin <hz_stb@163.com>
Change-Id: I9e68f2c79eb38e7c38e5903080309c762f6cb6bf


#### Type of change


- Bug fix


#### Description

FAB-17752: https://jira.hyperledger.org/browse/FAB-17752?filter=-1

#### Additional details

Has been tested by lint, tests and byfn.

logs:

```
2020-04-14 01:40:21.591 UTC [bccsp_sw] createKeyStore -> DEBU 01c Creating KeyStore at [/etc/hyperledger/fabric/msp/keystore]
2020-04-14 01:40:21.592 UTC [bccsp_sw] createKeyStore -> DEBU 01d KeyStore created at [/etc/hyperledger/fabric/msp/keystore]
```


#### Related issues

FAB-17752


