### PR TITLE
[FAB-17720] improve MSP certificates validation.

### DIFF
--- a/pkg/configtx/msp.go
+++ b/pkg/configtx/msp.go
@@ -670,6 +670,20 @@ func (m *MSP) validateCACerts() error {
 	if err != nil {
 		return fmt.Errorf("invalid intermediate cert: %v", err)
 	}
+	//TODO: follow the workaround that msp code use to incorporate cert.Verify()
+	for _, ic := range m.IntermediateCerts {
+		validIntermediateCert := false
+		for _, rc := range m.RootCerts {
+			err := ic.CheckSignatureFrom(rc)
+			if err == nil {
+				validIntermediateCert = true
+				break
+			}
+		}
+		if !validIntermediateCert {
+			return fmt.Errorf("intermediate cert not signed by any root certs of this MSP. serial number: %d", ic.SerialNumber)
+		}
+	}
 
 	err = validateCACerts(m.TLSRootCerts)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Chongxin Luo <Chongxin.Luo@ibm.com>
FAB-17720 #done

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description
* Added intermediate cert validation for MSP, which it must be issued
by one of the root certs.

#### Related issues
[FAB-17720](https://jira.hyperledger.org/browse/FAB-17720)
