### PR TITLE
[FAB-9629] support for building multi-arch docker images

### DIFF
--- a/docker-env.mk
+++ b/docker-env.mk
@@ -21,7 +21,7 @@ ifneq ($(NO_PROXY),)
 DOCKER_BUILD_FLAGS+=--build-arg 'NO_PROXY=$(NO_PROXY)'
 endif
 
-DBUILD = docker build --force-rm $(DOCKER_BUILD_FLAGS)
+DBUILD = docker buildx build --force-rm --output type=docker $(DOCKER_BUILD_FLAGS)
 
 DOCKER_NS ?= hyperledger
 DOCKER_TAG=$(ARCH)-$(PROJECT_VERSION)
@@ -53,4 +53,4 @@ BASE_DOCKER_LABEL=org.hyperledger.fabric
 # As an aside, also note that we incorporate the version number in the .dummy
 # file to differentiate different tags to fix FAB-1145
 #
-DUMMY = .dummy-$(DOCKER_TAG)
+DUMMY = .dummy-$(PROJECT_VERSION)

--- a/images/orderer/Dockerfile
+++ b/images/orderer/Dockerfile
@@ -7,7 +7,7 @@ ARG ALPINE_VER
 FROM alpine:${ALPINE_VER} as base
 RUN apk add --no-cache tzdata
 
-FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
+FROM --platform=$BUILDPLATFORM golang:${GO_VER}-alpine${ALPINE_VER} as golang
 RUN apk add --no-cache \
 	gcc \
 	musl-dev \
@@ -18,14 +18,17 @@ ADD . $GOPATH/src/github.com/hyperledger/fabric
 WORKDIR $GOPATH/src/github.com/hyperledger/fabric
 
 FROM golang as orderer
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 ARG GO_TAGS
-RUN make orderer GO_TAGS=${GO_TAGS}
+RUN export MAKETARGET=$(echo $TARGETPLATFORM | sed -e 's|/|-|g') && \
+	make release/${MAKETARGET}/bin/orderer GO_TAGS=${GO_TAGS}
 
 FROM base
 ENV FABRIC_CFG_PATH /etc/hyperledger/fabric
 VOLUME /etc/hyperledger/fabric
 VOLUME /var/hyperledger
-COPY --from=orderer /go/src/github.com/hyperledger/fabric/build/bin /usr/local/bin
+COPY --from=orderer /go/src/github.com/hyperledger/fabric/release/*/bin /usr/local/bin
 COPY --from=orderer /go/src/github.com/hyperledger/fabric/sampleconfig/msp ${FABRIC_CFG_PATH}/msp
 COPY --from=orderer /go/src/github.com/hyperledger/fabric/sampleconfig/orderer.yaml ${FABRIC_CFG_PATH}
 COPY --from=orderer /go/src/github.com/hyperledger/fabric/sampleconfig/configtx.yaml ${FABRIC_CFG_PATH}

--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -8,7 +8,7 @@ ARG ALPINE_VER
 FROM alpine:${ALPINE_VER} as peer-base
 RUN apk add --no-cache tzdata
 
-FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
+FROM --platform=$BUILDPLATFORM golang:${GO_VER}-alpine${ALPINE_VER} as golang
 RUN apk add --no-cache \
 	bash \
 	gcc \
@@ -19,14 +19,17 @@ ADD . $GOPATH/src/github.com/hyperledger/fabric
 WORKDIR $GOPATH/src/github.com/hyperledger/fabric
 
 FROM golang as peer
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 ARG GO_TAGS
-RUN make peer GO_TAGS=${GO_TAGS}
+RUN export MAKETARGET=$(echo $TARGETPLATFORM | sed -e 's|/|-|g') && \
+	make release/${MAKETARGET}/bin/peer GO_TAGS=${GO_TAGS}
 
 FROM peer-base
 ENV FABRIC_CFG_PATH /etc/hyperledger/fabric
 VOLUME /etc/hyperledger/fabric
 VOLUME /var/hyperledger
-COPY --from=peer /go/src/github.com/hyperledger/fabric/build/bin /usr/local/bin
+COPY --from=peer /go/src/github.com/hyperledger/fabric/release/*/bin /usr/local/bin
 COPY --from=peer /go/src/github.com/hyperledger/fabric/sampleconfig/msp ${FABRIC_CFG_PATH}/msp
 COPY --from=peer /go/src/github.com/hyperledger/fabric/sampleconfig/core.yaml ${FABRIC_CFG_PATH}
 EXPOSE 7051

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -4,7 +4,7 @@
 
 ARG GO_VER
 ARG ALPINE_VER
-FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
+FROM --platform=$BUILDPLATFORM golang:${GO_VER}-alpine${ALPINE_VER} as golang
 
 RUN apk add --no-cache \
 	bash \
@@ -17,7 +17,15 @@ ADD . $GOPATH/src/github.com/hyperledger/fabric
 WORKDIR $GOPATH/src/github.com/hyperledger/fabric
 
 FROM golang as tools
-RUN make configtxgen configtxlator cryptogen peer discover idemixgen
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+RUN export MAKETARGET=$(echo $TARGETPLATFORM | sed -e 's|/|-|g') && \
+	make release/${MAKETARGET}/bin/configtxgen \
+		release/${MAKETARGET}/bin/configtxlator \
+		release/${MAKETARGET}/bin/cryptogen \
+		release/${MAKETARGET}/bin/peer \
+		release/${MAKETARGET}/bin/discover \
+		release/${MAKETARGET}/bin/idemixgen
 
 FROM golang:${GO_VER}-alpine
 # git is required to support `go list -m`
@@ -28,5 +36,5 @@ RUN apk add --no-cache \
 	tzdata;
 ENV FABRIC_CFG_PATH /etc/hyperledger/fabric
 VOLUME /etc/hyperledger/fabric
-COPY --from=tools /go/src/github.com/hyperledger/fabric/build/bin /usr/local/bin
+COPY --from=tools /go/src/github.com/hyperledger/fabric/release/*/bin /usr/local/bin
 COPY --from=tools /go/src/github.com/hyperledger/fabric/sampleconfig ${FABRIC_CFG_PATH}


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

I want to be able to use Hyperledger Fabric on various architectures, including `arm64`.  Since HLF is written in Go I figured this should be straightforward to support.

Sadly the Docker Hub images are `x86_64` only.  However, using Docker's new [buildx](https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images) makes building multi-arch images easy.

I've modified the HLF makefiles so that the various `xxx-docker` targets build for multiple architectures.  So that building the images doesn't take forever, cross-compilation on the host arch is used.

#### Additional details

Building images is much the same as it currently is, with some additional setup:

<!--- Additional implementation details or comments to reviewers. -->

* Setup qemu and buildx:
  ```
  $ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
  $ docker buildx create --name mybuilder
  $ docker buildx use mybuilder
   ```
* Build peer images:
   ```
   $ make peer-docker
   ...

   $ docker images --format "{{.Repository}}:{{.Tag}}" | grep peer
   hyperledger/fabric-peer:2.1
   hyperledger/fabric-peer:2.1.0
   hyperledger/fabric-peer:amd64-2.1.0-snapshot-67a821897
   hyperledger/fabric-peer:latest
   hyperledger/fabric-peer:s390x-2.1.0-snapshot-67a821897
   hyperledger/fabric-peer:ppc64le-2.1.0-snapshot-67a821897
   hyperledger/fabric-peer:arm64-2.1.0-snapshot-67a821897
   ```
* Publish peer multi-arch manifest:
   ```
   make peer-publish-images
   ```

The orderer, tools and ccenv images are built similarly.

<!--- Summarize how the pull request was tested (if not obvious from commit). -->

I've published these multi-arch images to my own repo and have been using them.  I can't find how the makefiles are invoked by CI, so I can't test this any further.  However, I'm willing to work on integrating these changes into any CI scripts.

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

HLF Jira has issue [FAB-9629](https://jira.hyperledger.org/browse/FAB-9629), but it seems to be closed as "Won't Do" without any comments.  Hopefully it was closed due to no one wanting to work on it and not for some other reason.

While this PR is on master, I've also implemented this on the `release-2.0` and `release-2.1` branches.