### PR TITLE
Fix MSP identity validity rules doc typo

### DIFF
--- a/docs/source/msp-identity-validity-rules.rst
+++ b/docs/source/msp-identity-validity-rules.rst
@@ -24,7 +24,7 @@ Here are a few examples::
        |
       id
 
-The default MPS implementation accepts as valid identities X.509 certificates
+The default MSP implementation accepts as valid identities X.509 certificates
 signed by the appropriate authorities. In the diagram above,
 only certificates signed by iCA11, iCA12, iCA2, iCA3, and rCA3
 will be considered valid. Certificates signed by internal nodes will be rejected.


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Fix small typo in MSP identity validity rules doc. 