### PR TITLE
[LEDGER] fix couchDB UT flakes: increase waitFor and add statecouchdb to serial package list (in UT)

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
@@ -608,7 +608,7 @@ func TestHandleChaincodeDeploy(t *testing.T) {
 		}
 		return true
 	}
-	assert.Eventually(t, queryUsingIndex, 2*time.Second, 100*time.Millisecond, "error executing query with sort")
+	assert.Eventually(t, queryUsingIndex, 6*time.Second, 1*time.Second, "error executing query with sort")
 
 	//Query namespace "ns2", index is only created in "ns1".  This should return an error.
 	_, err = db.ExecuteQuery("ns2", queryString)
@@ -662,7 +662,7 @@ func TestHandleChaincodeDeployErroneousIndexFile(t *testing.T) {
 		}
 		return true
 	}
-	assert.Eventually(t, queryUsingIndex, 2*time.Second, 100*time.Millisecond, "error executing query with sort")
+	assert.Eventually(t, queryUsingIndex, 6*time.Second, 1*time.Second, "error executing query with sort")
 }
 
 func TestIsBulkOptimizable(t *testing.T) {

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -16,6 +16,7 @@ excluded_packages=(
 # packages that must be run serially
 serial_packages=(
     "github.com/hyperledger/fabric/gossip/..."
+    "github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/statecouchdb"
 )
 
 # packages which need to be tested with build tag pkcs11


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

The CouchDB creates an index in the background and responds to the REST API immediately.
Currently, we wait only for 2 seconds before failing the test. Within the 2 seconds, every 100 milliseconds, CouchDB is queried to ensure that the passed index is being built and can be used for the query. On a first success, the test is passed.

As we have only 2 vCPUs, 4 GB of RAM to run CI, it may not be sufficient enough for CouchDB to build an index within the 2 seconds. Further, if we run tests in parallel, the CouchDB could face CPU contention too. Note that the CouchDB consumes 3x higher CPU utilization as compared to the goleveldb.

Hence, we increase the wait time to 6 seconds and the query time to 1 second.

#### Additional details

It is bad to do the fix with trail and error. However, these errors are quite hard to regenerate at the local development environment as the resource allocations varies significantly (like 8 vCPUs, 32 GB ram, SSD vs 2 vCPU, 4 GB ram, SDD).

#### Related issues

[FAB-17755](https://jira.hyperledger.org/browse/FAB-17755)