### PR TITLE
Fix temporary directory cleanup in core/operations

### DIFF
--- a/core/operations/system_test.go
+++ b/core/operations/system_test.go
@@ -44,7 +44,7 @@ var _ = Describe("System", func() {
 
 	BeforeEach(func() {
 		var err error
-		tempDir, err := ioutil.TempDir("", "opssys")
+		tempDir, err = ioutil.TempDir("", "opssys")
 		Expect(err).NotTo(HaveOccurred())
 
 		generateCertificates(tempDir)


### PR DESCRIPTION
Liberate the tempDir assignment so the cleanup runs with an initialized value.