### PR TITLE
[FAB-17743] Rename ConfigTx accessors

### DIFF
--- a/integration/configtx/configtx_test.go
+++ b/integration/configtx/configtx_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Config", func() {
 
 			By("ensuring the active channel config matches the submitted config")
 			finalChannelConfig := nwo.GetConfig(network, peer, orderer, "testchannel")
-			Expect(c.Updated()).To(Equal(finalChannelConfig))
+			Expect(c.UpdatedConfig()).To(Equal(finalChannelConfig))
 		}
 	})
 })

--- a/pkg/configtx/application.go
+++ b/pkg/configtx/application.go
@@ -28,7 +28,7 @@ type Application struct {
 // transaction as an Application type. This can be used to retrieve existing values for the application
 // prior to updating the application configuration.
 func (c *ConfigTx) ApplicationConfiguration() (Application, error) {
-	applicationGroup, ok := c.base.ChannelGroup.Groups[ApplicationGroupKey]
+	applicationGroup, ok := c.original.ChannelGroup.Groups[ApplicationGroupKey]
 	if !ok {
 		return Application{}, errors.New("config does not contain application group")
 	}
@@ -196,7 +196,7 @@ func (c *ConfigTx) RemoveACLs(acls []string) error {
 
 // ApplicationACLs returns a map of application acls from a config transaction.
 func (c *ConfigTx) ApplicationACLs() (map[string]string, error) {
-	return getACLs(c.base)
+	return getACLs(c.original)
 }
 
 // getACLs returns a map of ACLS for given config application.
@@ -222,7 +222,7 @@ func getACLs(config *cb.Config) (map[string]string, error) {
 
 // AnchorPeers retrieves existing anchor peers from a application organization.
 func (c *ConfigTx) AnchorPeers(orgName string) ([]Address, error) {
-	applicationOrgGroup, ok := c.base.ChannelGroup.Groups[ApplicationGroupKey].Groups[orgName]
+	applicationOrgGroup, ok := c.original.ChannelGroup.Groups[ApplicationGroupKey].Groups[orgName]
 	if !ok {
 		return nil, fmt.Errorf("application org %s does not exist in channel config", orgName)
 	}

--- a/pkg/configtx/application_test.go
+++ b/pkg/configtx/application_test.go
@@ -222,8 +222,8 @@ func TestAddAnchorPeer(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	newOrg1AnchorPeer := Address{
@@ -429,8 +429,8 @@ func TestAddAnchorPeerFailure(t *testing.T) {
 			}
 
 			c := ConfigTx{
-				base:    config,
-				updated: config,
+				original: config,
+				updated:  config,
 			}
 
 			if tt.configMod != nil {
@@ -464,8 +464,8 @@ func TestRemoveAnchorPeer(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedUpdatedConfigJSON := `
@@ -622,8 +622,8 @@ func TestRemoveAnchorPeerFailure(t *testing.T) {
 			}
 
 			c := ConfigTx{
-				base:    config,
-				updated: config,
+				original: config,
+				updated:  config,
 			}
 
 			err = c.RemoveAnchorPeer(tt.orgName, tt.anchorPeerToRemove)
@@ -649,8 +649,8 @@ func TestAnchorPeer(t *testing.T) {
 
 	expectedAnchorPeer := Address{Host: "host1", Port: 123}
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	err = c.AddAnchorPeer("Org1", expectedAnchorPeer)
@@ -687,8 +687,8 @@ func TestAnchorPeerFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	for _, test := range []struct {
@@ -763,8 +763,8 @@ func TestAddACL(t *testing.T) {
 				tt.configMod(config)
 			}
 			c := ConfigTx{
-				base:    config,
-				updated: config,
+				original: config,
+				updated:  config,
 			}
 
 			err = c.AddACLs(tt.newACL)
@@ -837,8 +837,8 @@ func TestRemoveACL(t *testing.T) {
 				tt.configMod(config)
 			}
 			c := &ConfigTx{
-				base:    config,
-				updated: config,
+				original: config,
+				updated:  config,
 			}
 
 			err = c.RemoveACLs(tt.removeACL)
@@ -871,8 +871,8 @@ func TestAddApplicationOrg(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	org := Organization{
@@ -1058,8 +1058,8 @@ func TestAddApplicationOrgFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	org := Organization{
@@ -1087,8 +1087,8 @@ func TestApplicationConfiguration(t *testing.T) {
 	}
 
 	c := &ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 	for _, org := range baseApplicationConf.Organizations {
 		err = c.AddApplicationOrg(org)
@@ -1114,7 +1114,7 @@ func TestApplicationConfigurationFailure(t *testing.T) {
 		{
 			testName: "When the application group does not exist",
 			configMod: func(ct *ConfigTx, appOrg Application, gt *GomegaWithT) {
-				delete(ct.base.ChannelGroup.Groups, ApplicationGroupKey)
+				delete(ct.original.ChannelGroup.Groups, ApplicationGroupKey)
 			},
 			expectedErr: "config does not contain application group",
 		},
@@ -1152,8 +1152,8 @@ func TestApplicationConfigurationFailure(t *testing.T) {
 			}
 
 			c := &ConfigTx{
-				base:    config,
-				updated: config,
+				original: config,
+				updated:  config,
 			}
 			if tt.configMod != nil {
 				tt.configMod(c, baseApplicationConf, gt)
@@ -1183,7 +1183,7 @@ func TestApplicationACLs(t *testing.T) {
 	}
 
 	c := &ConfigTx{
-		base: config,
+		original: config,
 	}
 
 	applicationACLs, err := c.ApplicationACLs()
@@ -1203,7 +1203,7 @@ func TestApplicationACLsFailure(t *testing.T) {
 	}
 
 	c := &ConfigTx{
-		base: config,
+		original: config,
 	}
 
 	applicationACLs, err := c.ApplicationACLs()

--- a/pkg/configtx/capabilities.go
+++ b/pkg/configtx/capabilities.go
@@ -17,7 +17,7 @@ import (
 // ChannelCapabilities returns a map of enabled channel capabilities
 // from a config transaction.
 func (c *ConfigTx) ChannelCapabilities() ([]string, error) {
-	capabilities, err := getCapabilities(c.base.ChannelGroup)
+	capabilities, err := getCapabilities(c.original.ChannelGroup)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving channel capabilities: %v", err)
 	}
@@ -28,7 +28,7 @@ func (c *ConfigTx) ChannelCapabilities() ([]string, error) {
 // OrdererCapabilities returns a map of enabled orderer capabilities
 // from a config transaction.
 func (c *ConfigTx) OrdererCapabilities() ([]string, error) {
-	orderer, ok := c.base.ChannelGroup.Groups[OrdererGroupKey]
+	orderer, ok := c.original.ChannelGroup.Groups[OrdererGroupKey]
 	if !ok {
 		return nil, errors.New("orderer missing from config")
 	}
@@ -44,7 +44,7 @@ func (c *ConfigTx) OrdererCapabilities() ([]string, error) {
 // ApplicationCapabilities returns a map of enabled application capabilities
 // from a config transaction.
 func (c *ConfigTx) ApplicationCapabilities() ([]string, error) {
-	application, ok := c.base.ChannelGroup.Groups[ApplicationGroupKey]
+	application, ok := c.original.ChannelGroup.Groups[ApplicationGroupKey]
 	if !ok {
 		return nil, errors.New("application missing from config")
 	}

--- a/pkg/configtx/capabilities_test.go
+++ b/pkg/configtx/capabilities_test.go
@@ -33,8 +33,8 @@ func TestChannelCapabilities(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	err := setValue(config.ChannelGroup, capabilitiesValue(expectedCapabilities), AdminsPolicyKey)
@@ -69,8 +69,8 @@ func TestOrdererCapabilities(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	ordererCapabilities, err := c.OrdererCapabilities()
@@ -96,8 +96,8 @@ func TestOrdererCapabilitiesFailure(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	ordererCapabilities, err := c.OrdererCapabilities()
@@ -123,8 +123,8 @@ func TestApplicationCapabilities(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	applicationCapabilities, err := c.ApplicationCapabilities()
@@ -150,8 +150,8 @@ func TestApplicationCapabilitiesFailure(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	applicationCapabilities, err := c.ApplicationCapabilities()

--- a/pkg/configtx/config.go
+++ b/pkg/configtx/config.go
@@ -66,10 +66,10 @@ type standardConfigPolicy struct {
 	value *cb.Policy
 }
 
-// ConfigTx wraps a config transaction
+// ConfigTx wraps a config transaction.
 type ConfigTx struct {
 	// original state of the config
-	base *cb.Config
+	original *cb.Config
 	// modified state of the config
 	updated *cb.Config
 }
@@ -77,19 +77,19 @@ type ConfigTx struct {
 // New returns an config.
 func New(config *cb.Config) ConfigTx {
 	return ConfigTx{
-		base: config,
+		original: config,
 		// Clone the base config for processing updates
 		updated: proto.Clone(config).(*cb.Config),
 	}
 }
 
-// Base returns the base config
-func (c *ConfigTx) Base() *cb.Config {
-	return c.base
+// OriginalConfig returns the original unedited config.
+func (c *ConfigTx) OriginalConfig() *cb.Config {
+	return c.original
 }
 
-// Updated returns the updated config
-func (c *ConfigTx) Updated() *cb.Config {
+// UpdatedConfig returns the modified config.
+func (c *ConfigTx) UpdatedConfig() *cb.Config {
 	return c.updated
 }
 
@@ -99,7 +99,7 @@ func (c *ConfigTx) ComputeUpdate(channelID string) (*cb.ConfigUpdate, error) {
 		return nil, errors.New("channel ID is required")
 	}
 
-	updt, err := computeConfigUpdate(c.base, c.updated)
+	updt, err := computeConfigUpdate(c.original, c.updated)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute update: %v", err)
 	}
@@ -111,7 +111,7 @@ func (c *ConfigTx) ComputeUpdate(channelID string) (*cb.ConfigUpdate, error) {
 
 // ChannelConfiguration returns a channel configuration value from a config transaction.
 func (c *ConfigTx) ChannelConfiguration() (Channel, error) {
-	channelGroup := c.base.ChannelGroup
+	channelGroup := c.original.ChannelGroup
 	var (
 		err          error
 		consortium   string

--- a/pkg/configtx/config_test.go
+++ b/pkg/configtx/config_test.go
@@ -1278,8 +1278,8 @@ func TestComputeUpdate(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    base,
-		updated: updated,
+		original: base,
+		updated:  updated,
 	}
 
 	channelID := "testChannel"
@@ -1314,8 +1314,8 @@ func TestComputeUpdateFailures(t *testing.T) {
 	updated := &cb.Config{}
 
 	c := ConfigTx{
-		base:    base,
-		updated: updated,
+		original: base,
+		updated:  updated,
 	}
 
 	for _, test := range []struct {

--- a/pkg/configtx/consortiums.go
+++ b/pkg/configtx/consortiums.go
@@ -65,7 +65,7 @@ func (c *ConfigTx) AddOrgToConsortium(org Organization, consortium string) error
 // Consortiums returns a list of consortiums for the channel configuration.
 // Consortiums is only defined for the ordering system channel.
 func (c *ConfigTx) Consortiums() ([]Consortium, error) {
-	consortiumsGroup, ok := c.base.ChannelGroup.Groups[ConsortiumsGroupKey]
+	consortiumsGroup, ok := c.original.ChannelGroup.Groups[ConsortiumsGroupKey]
 	if !ok {
 		return nil, errors.New("channel configuration does not have consortiums")
 	}

--- a/pkg/configtx/consortiums_test.go
+++ b/pkg/configtx/consortiums_test.go
@@ -354,8 +354,8 @@ func TestAddOrgToConsortium(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	orgToAdd := Organization{
@@ -850,8 +850,8 @@ func TestAddOrgToConsortiumFailures(t *testing.T) {
 			}
 
 			c := ConfigTx{
-				base:    config,
-				updated: config,
+				original: config,
+				updated:  config,
 			}
 
 			err = c.AddOrgToConsortium(test.org, test.consortium)
@@ -880,8 +880,8 @@ func TestRemoveConsortium(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	err = c.RemoveConsortium("Consortium1")
@@ -911,8 +911,8 @@ func TestRemoveConsortiumFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	err = c.RemoveConsortium("BadConsortium")

--- a/pkg/configtx/example_test.go
+++ b/pkg/configtx/example_test.go
@@ -1414,7 +1414,7 @@ func ExampleConfigTx_AddChannelCapability() {
 		panic(err)
 	}
 
-	err = protolator.DeepMarshalJSON(os.Stdout, c.Updated())
+	err = protolator.DeepMarshalJSON(os.Stdout, c.UpdatedConfig())
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/configtx/msp.go
+++ b/pkg/configtx/msp.go
@@ -152,7 +152,7 @@ type NodeOUs struct {
 // ApplicationMSP returns the MSP configuration for an existing application
 // org in a config transaction.
 func (c *ConfigTx) ApplicationMSP(orgName string) (MSP, error) {
-	applicationOrgGroup, ok := c.base.ChannelGroup.Groups[ApplicationGroupKey].Groups[orgName]
+	applicationOrgGroup, ok := c.original.ChannelGroup.Groups[ApplicationGroupKey].Groups[orgName]
 	if !ok {
 		return MSP{}, fmt.Errorf("application org %s does not exist in config", orgName)
 	}
@@ -163,7 +163,7 @@ func (c *ConfigTx) ApplicationMSP(orgName string) (MSP, error) {
 // OrdererMSP returns the MSP configuration for an existing orderer org
 // in a config transaction.
 func (c *ConfigTx) OrdererMSP(orgName string) (MSP, error) {
-	ordererOrgGroup, ok := c.base.ChannelGroup.Groups[OrdererGroupKey].Groups[orgName]
+	ordererOrgGroup, ok := c.original.ChannelGroup.Groups[OrdererGroupKey].Groups[orgName]
 	if !ok {
 		return MSP{}, fmt.Errorf("orderer org %s does not exist in config", orgName)
 	}
@@ -174,7 +174,7 @@ func (c *ConfigTx) OrdererMSP(orgName string) (MSP, error) {
 // ConsortiumMSP returns the MSP configuration for an existing consortium
 // org in a config transaction.
 func (c *ConfigTx) ConsortiumMSP(consortiumName, orgName string) (MSP, error) {
-	consortiumGroup, ok := c.base.ChannelGroup.Groups[ConsortiumsGroupKey].Groups[consortiumName]
+	consortiumGroup, ok := c.original.ChannelGroup.Groups[ConsortiumsGroupKey].Groups[consortiumName]
 	if !ok {
 		return MSP{}, fmt.Errorf("consortium %s does not exist in config", consortiumName)
 	}
@@ -624,7 +624,7 @@ func (c *ConfigTx) UpdateApplicationMSP(updatedMSP MSP, orgName string) error {
 		return err
 	}
 
-	err = setMSPConfigForOrg(c.Updated(), updatedMSP, orgName)
+	err = setMSPConfigForOrg(c.UpdatedConfig(), updatedMSP, orgName)
 	if err != nil {
 		return err
 	}

--- a/pkg/configtx/msp_test.go
+++ b/pkg/configtx/msp_test.go
@@ -60,8 +60,8 @@ func TestApplicationMSP(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	msp, err := c.ApplicationMSP("Org1")
@@ -89,8 +89,8 @@ func TestOrdererMSP(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	msp, err := c.OrdererMSP("OrdererOrg")
@@ -118,8 +118,8 @@ func TestConsortiumMSP(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	msp, err := c.ConsortiumMSP("Consortium1", "Org1")
@@ -294,8 +294,8 @@ func TestMSPConfigurationFailures(t *testing.T) {
 			}
 
 			c := ConfigTx{
-				base:    config,
-				updated: config,
+				original: config,
+				updated:  config,
 			}
 			if tt.mspMod != nil && tt.orgType != ConsortiumsGroupKey {
 				baseMSP := baseMSP(t)
@@ -807,7 +807,7 @@ func TestUpdateApplicationMSP(t *testing.T) {
 `, org1CertBase64, newIntermediateCertBase64, org1CRLBase64, newCRLBase64, newRootCertBase64, org1PKBase64, org2CertBase64, org2CRLBase64, org2PKBase64)
 
 	buf := bytes.Buffer{}
-	err = protolator.DeepMarshalJSON(&buf, c.Updated())
+	err = protolator.DeepMarshalJSON(&buf, c.UpdatedConfig())
 	gt.Expect(err).NotTo(HaveOccurred())
 
 	gt.Expect(buf.String()).To(MatchJSON(expectedConfigJSON))
@@ -964,7 +964,7 @@ func TestCreateApplicationMSPCRL(t *testing.T) {
 	gt.Expect(err).NotTo(HaveOccurred())
 
 	// create a new ConfigTx with our updated config as the base
-	c := New(originalConfigTx.Updated())
+	c := New(originalConfigTx.UpdatedConfig())
 
 	tests := []struct {
 		spec             string

--- a/pkg/configtx/orderer.go
+++ b/pkg/configtx/orderer.go
@@ -112,7 +112,7 @@ func (c *ConfigTx) UpdateOrdererConfiguration(o Orderer) error {
 // transaction as an Orderer type. This can be used to retrieve existing values for the orderer
 // prior to updating the orderer configuration.
 func (c *ConfigTx) OrdererConfiguration() (Orderer, error) {
-	ordererGroup, ok := c.base.ChannelGroup.Groups[OrdererGroupKey]
+	ordererGroup, ok := c.original.ChannelGroup.Groups[OrdererGroupKey]
 	if !ok {
 		return Orderer{}, errors.New("config does not contain orderer group")
 	}
@@ -155,7 +155,7 @@ func (c *ConfigTx) OrdererConfiguration() (Orderer, error) {
 	}
 
 	// ORDERER ADDRESSES
-	ordererAddresses, err := getOrdererAddresses(c.base)
+	ordererAddresses, err := getOrdererAddresses(c.original)
 	if err != nil {
 		return Orderer{}, err
 	}

--- a/pkg/configtx/orderer_test.go
+++ b/pkg/configtx/orderer_test.go
@@ -957,8 +957,8 @@ func TestUpdateOrdererConfiguration(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 	err = c.UpdateOrdererConfiguration(updatedOrdererConf)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -1293,8 +1293,8 @@ func TestOrdererConfiguration(t *testing.T) {
 			}
 
 			c := ConfigTx{
-				base:    config,
-				updated: config,
+				original: config,
+				updated:  config,
 			}
 
 			ordererConf, err := c.OrdererConfiguration()
@@ -1387,8 +1387,8 @@ func TestOrdererConfigurationFailure(t *testing.T) {
 			}
 
 			c := ConfigTx{
-				base:    config,
-				updated: config,
+				original: config,
+				updated:  config,
 			}
 
 			err = setValue(c.updated.ChannelGroup, ordererAddressesValue(baseOrdererConfig.Addresses), ordererAdminsPolicyName)
@@ -1421,8 +1421,8 @@ func TestAddOrdererOrg(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	org := Organization{
@@ -1591,8 +1591,8 @@ func TestAddOrdererOrgFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	org := Organization{
@@ -1638,8 +1638,8 @@ func TestAddOrdererEndpoint(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedUpdatedConfigJSON := `
@@ -1725,8 +1725,8 @@ func TestAddOrdererEndpointFailure(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	tests := []struct {
@@ -1798,8 +1798,8 @@ func TestRemoveOrdererEndpoint(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedUpdatedConfigJSON := `
@@ -1884,8 +1884,8 @@ func TestRemoveOrdererEndpointFailure(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	tests := []struct {

--- a/pkg/configtx/organization.go
+++ b/pkg/configtx/organization.go
@@ -17,7 +17,7 @@ import (
 
 // ApplicationOrg retrieves an existing org from an application organization config group.
 func (c *ConfigTx) ApplicationOrg(orgName string) (Organization, error) {
-	orgGroup, ok := c.base.ChannelGroup.Groups[ApplicationGroupKey].Groups[orgName]
+	orgGroup, ok := c.original.ChannelGroup.Groups[ApplicationGroupKey].Groups[orgName]
 	if !ok {
 		return Organization{}, fmt.Errorf("application org %s does not exist in channel config", orgName)
 	}
@@ -39,7 +39,7 @@ func (c *ConfigTx) RemoveApplicationOrg(orgName string) error {
 
 // OrdererOrg retrieves an existing org from an orderer organization config group.
 func (c *ConfigTx) OrdererOrg(orgName string) (Organization, error) {
-	orgGroup, ok := c.base.ChannelGroup.Groups[OrdererGroupKey].Groups[orgName]
+	orgGroup, ok := c.original.ChannelGroup.Groups[OrdererGroupKey].Groups[orgName]
 	if !ok {
 		return Organization{}, fmt.Errorf("orderer org %s does not exist in channel config", orgName)
 	}
@@ -81,7 +81,7 @@ func (c *ConfigTx) RemoveOrdererOrg(orgName string) error {
 
 // ConsortiumOrg retrieves an existing org from a consortium organization config group.
 func (c *ConfigTx) ConsortiumOrg(consortiumName, orgName string) (Organization, error) {
-	consortium, ok := c.base.ChannelGroup.Groups[ConsortiumsGroupKey].Groups[consortiumName]
+	consortium, ok := c.original.ChannelGroup.Groups[ConsortiumsGroupKey].Groups[consortiumName]
 	if !ok {
 		return Organization{}, fmt.Errorf("consortium %s does not exist in channel config", consortiumName)
 	}

--- a/pkg/configtx/organization_test.go
+++ b/pkg/configtx/organization_test.go
@@ -52,8 +52,8 @@ func TestApplicationOrg(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedOrg := channel.Application.Organizations[0]
@@ -115,8 +115,8 @@ func TestRemoveApplicationOrg(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	err = c.RemoveApplicationOrg("Org1")
@@ -146,8 +146,8 @@ func TestRemoveApplicationOrgFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	err = c.RemoveApplicationOrg("BadOrg")
@@ -168,8 +168,8 @@ func TestOrdererOrg(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedOrg := channel.Orderer.Organizations[0]
@@ -222,8 +222,8 @@ func TestRemoveOrdererOrg(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	err = c.RemoveOrdererOrg("OrdererOrg")
@@ -244,8 +244,8 @@ func TestRemoveOrdererOrgFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	err = c.RemoveOrdererOrg("BadOrg")
@@ -266,8 +266,8 @@ func TestConsortiumOrg(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedOrg := channel.Consortiums[0].Organizations[0]
@@ -329,8 +329,8 @@ func TestRemoveConsortiumOrg(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	err = c.RemoveConsortiumOrg("Consortium1", "Org1")
@@ -351,8 +351,8 @@ func TestRemoveConsortiumOrgFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	tests := []struct {

--- a/pkg/configtx/policies.go
+++ b/pkg/configtx/policies.go
@@ -45,7 +45,7 @@ func (c *ConfigTx) UpdateConsortiumChannelCreationPolicy(consortiumName string, 
 
 // ConsortiumOrgPolicies returns a map of policies for a specific consortium org.
 func (c *ConfigTx) ConsortiumOrgPolicies(consortiumName, orgName string) (map[string]Policy, error) {
-	consortium, ok := c.base.ChannelGroup.Groups[ConsortiumsGroupKey].Groups[consortiumName]
+	consortium, ok := c.original.ChannelGroup.Groups[ConsortiumsGroupKey].Groups[consortiumName]
 	if !ok {
 		return nil, fmt.Errorf("consortium %s does not exist in channel config", consortiumName)
 	}
@@ -60,7 +60,7 @@ func (c *ConfigTx) ConsortiumOrgPolicies(consortiumName, orgName string) (map[st
 
 // OrdererPolicies returns a map of policies for channel orderer.
 func (c *ConfigTx) OrdererPolicies() (map[string]Policy, error) {
-	orderer, ok := c.base.ChannelGroup.Groups[OrdererGroupKey]
+	orderer, ok := c.original.ChannelGroup.Groups[OrdererGroupKey]
 	if !ok {
 		return nil, errors.New("orderer missing from config")
 	}
@@ -70,7 +70,7 @@ func (c *ConfigTx) OrdererPolicies() (map[string]Policy, error) {
 
 // OrdererOrgPolicies returns a map of policies for a specific org.
 func (c *ConfigTx) OrdererOrgPolicies(orgName string) (map[string]Policy, error) {
-	org, ok := c.base.ChannelGroup.Groups[OrdererGroupKey].Groups[orgName]
+	org, ok := c.original.ChannelGroup.Groups[OrdererGroupKey].Groups[orgName]
 	if !ok {
 		return nil, fmt.Errorf("orderer org %s does not exist in channel config", orgName)
 	}
@@ -80,7 +80,7 @@ func (c *ConfigTx) OrdererOrgPolicies(orgName string) (map[string]Policy, error)
 
 // ApplicationPolicies returns a map of policies for application config group.
 func (c *ConfigTx) ApplicationPolicies() (map[string]Policy, error) {
-	application, ok := c.base.ChannelGroup.Groups[ApplicationGroupKey]
+	application, ok := c.original.ChannelGroup.Groups[ApplicationGroupKey]
 	if !ok {
 		return nil, errors.New("application missing from config")
 	}
@@ -91,7 +91,7 @@ func (c *ConfigTx) ApplicationPolicies() (map[string]Policy, error) {
 // ApplicationOrgPolicies returns a map of policies for specific application
 // organization.
 func (c *ConfigTx) ApplicationOrgPolicies(orgName string) (map[string]Policy, error) {
-	orgGroup, ok := c.base.ChannelGroup.Groups[ApplicationGroupKey].Groups[orgName]
+	orgGroup, ok := c.original.ChannelGroup.Groups[ApplicationGroupKey].Groups[orgName]
 	if !ok {
 		return nil, fmt.Errorf("application org %s does not exist in channel config", orgName)
 	}
@@ -101,7 +101,7 @@ func (c *ConfigTx) ApplicationOrgPolicies(orgName string) (map[string]Policy, er
 
 // ChannelPolicies returns a map of policies for channel configuration.
 func (c *ConfigTx) ChannelPolicies() (map[string]Policy, error) {
-	return getPolicies(c.base.ChannelGroup.Policies)
+	return getPolicies(c.original.ChannelGroup.Policies)
 }
 
 // AddApplicationPolicy modifies an existing application policy configuration.

--- a/pkg/configtx/policies_test.go
+++ b/pkg/configtx/policies_test.go
@@ -76,8 +76,8 @@ func TestRemoveApplicationOrgPolicy(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	application.Organizations[0].Policies = applicationOrgStandardPolicies()
@@ -111,8 +111,8 @@ func TestRemoveApplicationOrgPolicyFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	err := c.RemoveApplicationOrgPolicy("bad-org", "")
@@ -142,8 +142,8 @@ func TestAddApplicationOrgPolicy(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	application.Organizations[0].Policies = applicationOrgStandardPolicies()
@@ -180,8 +180,8 @@ func TestAddApplicationOrgPolicyFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	err := c.AddApplicationOrgPolicy("Org1", AdminsPolicyKey, "TestPolicy", Policy{})
@@ -204,8 +204,8 @@ func TestAddApplicationPolicy(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedPolicies := map[string]Policy{
@@ -251,8 +251,8 @@ func TestAddApplicationPolicyFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedPolicies := application.Policies
@@ -279,8 +279,8 @@ func TestRemoveApplicationPolicy(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedPolicies := map[string]Policy{
@@ -323,8 +323,8 @@ func TestRemoveApplicationPolicyFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	tests := []struct {
@@ -381,8 +381,8 @@ func TestAddConsortiumOrgPolicy(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedPolicies := map[string]Policy{
@@ -436,8 +436,8 @@ func TestAddConsortiumOrgPolicyFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	for _, test := range []struct {
@@ -495,8 +495,8 @@ func TestRemoveConsortiumOrgPolicy(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedPolicies := map[string]Policy{
@@ -546,8 +546,8 @@ func TestRemoveConsortiumOrgPolicyFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	for _, test := range []struct {
@@ -593,8 +593,8 @@ func TestAddOrdererPolicy(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 	expectedPolicies := map[string]Policy{
 		ReadersPolicyKey: {
@@ -647,8 +647,8 @@ func TestAddOrdererPolicyFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	err = c.AddOrdererPolicy(AdminsPolicyKey, "TestPolicy", Policy{})
@@ -675,8 +675,8 @@ func TestRemoveOrdererPolicy(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedPolicies := map[string]Policy{
@@ -727,8 +727,8 @@ func TestRemoveOrdererPolicyFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	tests := []struct {
@@ -801,8 +801,8 @@ func TestAddOrdererOrgPolicy(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedPolicies := map[string]Policy{
@@ -856,8 +856,8 @@ func TestAddOrdererOrgPolicyFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	err = c.AddOrdererOrgPolicy("OrdererOrg", AdminsPolicyKey, "TestPolicy", Policy{})
@@ -884,8 +884,8 @@ func TestRemoveOrdererOrgPolicy(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedPolicies := map[string]Policy{
@@ -935,8 +935,8 @@ func TestRemoveOrdererOrgPolicyFailures(t *testing.T) {
 	}
 
 	c := ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	err = c.RemoveOrdererOrgPolicy("bad-org", "TestPolicy")
@@ -961,8 +961,8 @@ func TestUpdateConsortiumChannelCreationPolicy(t *testing.T) {
 		},
 	}
 	c := &ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	updatedPolicy := Policy{Type: ImplicitMetaPolicyType, Rule: "MAJORITY Admins"}
@@ -1000,8 +1000,8 @@ func TestUpdateConsortiumChannelCreationPolicyFailures(t *testing.T) {
 		},
 	}
 	c := &ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	tests := []struct {
@@ -1057,7 +1057,7 @@ func TestAddChannelPolicy(t *testing.T) {
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(updatedChannelPolicy).To(Equal(expectedPolicies))
 
-	baseChannel := c.base.ChannelGroup
+	baseChannel := c.original.ChannelGroup
 	gt.Expect(baseChannel.Policies).To(HaveLen(0))
 	gt.Expect(baseChannel.Policies["TestPolicy"]).To(BeNil())
 }
@@ -1095,7 +1095,7 @@ func TestRemoveChannelPolicy(t *testing.T) {
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(updatedChannelPolicy).To(Equal(expectedPolicies))
 
-	baseChannel := c.base.ChannelGroup
+	baseChannel := c.original.ChannelGroup
 	gt.Expect(baseChannel.Policies).To(HaveLen(3))
 	gt.Expect(baseChannel.Policies[ReadersPolicyKey]).ToNot(BeNil())
 }
@@ -1118,8 +1118,8 @@ func TestConsortiumOrgPolicies(t *testing.T) {
 		},
 	}
 	c := &ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	expectedPolicies := map[string]Policy{
@@ -1164,8 +1164,8 @@ func TestConsortiumOrgPoliciesFailures(t *testing.T) {
 		},
 	}
 	c := &ConfigTx{
-		base:    config,
-		updated: config,
+		original: config,
+		updated:  config,
 	}
 
 	tests := []struct {


### PR DESCRIPTION
#### Type of change

- Improvement (Rename)

#### Description

Rename ConfigTx.Base() and ConfigTx.Updated() 

#### Related issues
[FAB-17743](https://jira.hyperledger.org/browse/FAB-17743)
