### PR TITLE
Remove un-used constant chaincodeAddrKey

### DIFF
--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -101,7 +101,6 @@ import (
 )
 
 const (
-	chaincodeAddrKey       = "peer.chaincodeAddress"
 	chaincodeListenAddrKey = "peer.chaincodeListenAddress"
 	defaultChaincodePort   = 7052
 )


### PR DESCRIPTION
The constant **chaincodeAddrKey** is no longer used.

_Safe to merge ;)_

Change-Id: I8a268012d6bf5b03f88933938eb5c37db57ab161
Signed-off-by: yacovm <yacovm@il.ibm.com>
