### PR TITLE
Revert #1092: fix couchDB UT flakes

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
@@ -685,7 +685,7 @@ func TestHandleChaincodeDeploy(t *testing.T) {
 		}
 		return true
 	}
-	assert.Eventually(t, queryUsingIndex, 6*time.Second, 1*time.Second, "error executing query with sort")
+	assert.Eventually(t, queryUsingIndex, 2*time.Second, 100*time.Millisecond, "error executing query with sort")
 
 	//Query namespace "ns2", index is only created in "ns1".  This should return an error.
 	_, err = db.ExecuteQuery("ns2", queryString)
@@ -738,7 +738,7 @@ func TestHandleChaincodeDeployErroneousIndexFile(t *testing.T) {
 		}
 		return true
 	}
-	assert.Eventually(t, queryUsingIndex, 6*time.Second, 1*time.Second, "error executing query with sort")
+	assert.Eventually(t, queryUsingIndex, 2*time.Second, 100*time.Millisecond, "error executing query with sort")
 }
 
 func TestIsBulkOptimizable(t *testing.T) {

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -16,7 +16,6 @@ excluded_packages=(
 # packages that must be run serially
 serial_packages=(
     "github.com/hyperledger/fabric/gossip/..."
-    "github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/statecouchdb"
 )
 
 # packages which need to be tested with build tag pkcs11


### PR DESCRIPTION
The changes in #1092 do not appear to address the source of the flake and unnecessarily extend the serial package list in unit tests.

On current master (with the commits from #1092), the failures still occur:
```
--- FAIL: TestHandleChaincodeDeployErroneousIndexFile (6.15s)
    statecouchdb_test.go:39: Initializing TestVDBEnv
    statecouchdb_test.go:741: 
        	Error Trace:	statecouchdb_test.go:741
        	Error:      	Condition never satisfied
        	Test:       	TestHandleChaincodeDeployErroneousIndexFile
        	Messages:   	error executing query with sort
    statecouchdb_test.go:86: Cleaningup TestVDBEnv
```