### PR TITLE
 [FAB-17762] create index in deterministic order to avoid flake

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
@@ -718,15 +718,20 @@ func TestHandleChaincodeDeployErroneousIndexFile(t *testing.T) {
 	batch.Put("ns1", "key1", []byte(`{"asset_name": "marble1","color": "blue","size": 1,"owner": "tom"}`), version.NewHeight(1, 1))
 	batch.Put("ns1", "key2", []byte(`{"asset_name": "marble2","color": "blue","size": 2,"owner": "jerry"}`), version.NewHeight(1, 2))
 
-	badSyntaxFileContent := `{"index":{"fields": This is a bad json}`
-	indexData := map[string][]byte{
-		"META-INF/statedb/couchdb/indexes/indexSizeSortName.json": []byte(`{"index":{"fields":[{"size":"desc"}]},"ddoc":"indexSizeSortName","name":"indexSizeSortName","type":"json"}`),
-		"META-INF/statedb/couchdb/indexes/badSyntax.json":         []byte(badSyntaxFileContent),
-	}
-
 	indexCapable, ok := db.(statedb.IndexCapable)
 	if !ok {
 		t.Fatalf("Couchdb state impl is expected to implement interface `statedb.IndexCapable`")
+	}
+
+	indexData := map[string][]byte{
+		"META-INF/statedb/couchdb/indexes/indexSizeSortName.json": []byte(`{"index":{"fields":[{"size":"desc"}]},"ddoc":"indexSizeSortName","name":"indexSizeSortName","type":"json"}`),
+	}
+
+	assert.NoError(t, indexCapable.ProcessIndexesForChaincodeDeploy("ns1", indexData))
+
+	badSyntaxFileContent := `{"index":{"fields": This is a bad json}`
+	indexData = map[string][]byte{
+		"META-INF/statedb/couchdb/indexes/badSyntax.json": []byte(badSyntaxFileContent),
 	}
 	assert.Error(t, indexCapable.ProcessIndexesForChaincodeDeploy("ns1", indexData))
 


### PR DESCRIPTION
ProcessIndexesForChaincodeDeploy returns an error on the first failure to create an index but, as the indexes are passed in a map, the order of the operations is non-deterministic.

TestHandleChaincodeDeployErroneousIndexFile relies on successful creation of a good index to support the query performed by the test and an error from ProcessIndexesForChaincodeDeploy related to an attempt to create an index from invalid JSON. As both documents were passed to a single call to ProcessIndexesForChaincodeDeploy, there was a 50/50 chance that the "good" index would not be processed.

This change uses two calls to ensure that the "good" index is created before the "bad" one is tested. While this addresses the test flake, there may be future changes to the production implementation of ProcessIndexesForChaincodeDeploy from the ledger team.