### PR TITLE
Update Prereqs for Fabric users

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -98,7 +98,7 @@ You can then access the html files at `http://localhost/index.html`.
 Updating content in the [Commands Reference](https://hyperledger-fabric.readthedocs.io/en/latest/command_ref.html) topic requires additional steps. Because the information in the Commands Reference topic is generated content, you cannot simply update the associated markdown files.
 - Instead you need to update the `_preamble.md` or `_postscript.md` files under `src/github.com/hyperledger/fabric/docs/wrappers` for the command.
 - To update the command help text, you need to edit the associated `.go` file for the command that is located under `/fabric/internal/peer`.
-- Then you need to run the command `make help-docs` which generates the updated markdown files under `docs/source/commands`. **Tip:** Before running `make help-docs`, ensure that you have the [Go Programming language](/source/prereqs.html#go-programming-language) installed.
+- Then, from the `fabric` folder, you need to run the command `make help-docs` which generates the updated markdown files under `docs/source/commands`. 
 
 Remember that when you push the changes to GitHub, you need to include the `_preamble.md`, `_postscript.md` or `_.go` file that was modified as well as the generated markdown file.
 

--- a/docs/source/dev-setup/devenv.rst
+++ b/docs/source/dev-setup/devenv.rst
@@ -36,6 +36,36 @@ the application after installing it:
 
     open /Applications/Docker.app
 
+Developing on Windows
+~~~~~~~~~~~~~~~~~~~~~
+
+On Windows 10 you should use the native Docker distribution and you
+may use the Windows PowerShell. However, for the ``binaries``
+command to succeed you will still need to have the ``uname`` command
+available. You can get it as part of Git but beware that only the
+64bit version is supported.
+
+Before running any ``git clone`` commands, run the following commands:
+
+::
+
+    git config --global core.autocrlf false
+    git config --global core.longpaths true
+
+You can check the setting of these parameters with the following commands:
+
+::
+
+    git config --get core.autocrlf
+    git config --get core.longpaths
+
+These need to be ``false`` and ``true`` respectively.
+
+The ``curl`` command that comes with Git and Docker Toolbox is old and
+does not handle properly the redirect used in
+:doc:`getting_started`. Make sure you have and use a newer version
+which can be downloaded from the `cURL downloads page
+<https://curl.haxx.se/download.html>`__
 
 Clone the Hyperledger Fabric source
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -122,6 +152,8 @@ few commands.
     ginkgo -r ./integration/nwo
 
 If those commands completely successfully, you're ready to Go!
+
+If you plan to use the Hyperledger Fabric application SDKs then be sure to check out their prerequisites in the Node.js SDK `README <https://github.com/hyperledger/fabric-sdk-node#build-and-test>`__ and Java SDK `README <https://github.com/hyperledger/fabric-gateway-java/blob/master/README.md>`__.
 
 .. Licensed under Creative Commons Attribution 4.0 International License
    https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -36,11 +36,12 @@ in various programming languages. Smart contract APIs are available for Go, Node
 Hyperledger Fabric application SDKs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Hyperledger Fabric offers a number of SDKs to support developing applications
-in various programming languages. SDKs are available for Node.js and Java:
+Hyperledger Fabric offers a number of SDKs to support developing applications in various programming languages. SDKs are available for Node.js and Java:
 
   * `Node.js SDK <https://github.com/hyperledger/fabric-sdk-node>`__ and `Node.js SDK documentation <https://hyperledger.github.io/fabric-sdk-node/>`__.
   * `Java SDK <https://github.com/hyperledger/fabric-gateway-java>`__ and `Java SDK documentation <https://hyperledger.github.io/fabric-gateway-java/>`__.
+
+  Prerequisites for developing with the SDKs can be found in the Node.js SDK `README <https://github.com/hyperledger/fabric-sdk-node#build-and-test>`__ and Java SDK `README <https://github.com/hyperledger/fabric-gateway-java/blob/master/README.md>`__.
 
 In addition, there are two more application SDKs that have not yet been officially released
 (for Python and Go), but they are still available for downloading and testing:
@@ -48,8 +49,7 @@ In addition, there are two more application SDKs that have not yet been official
   * `Python SDK <https://github.com/hyperledger/fabric-sdk-py>`__.
   * `Go SDK <https://github.com/hyperledger/fabric-sdk-go>`__.
 
-Currently, Node.js and Java support the new application programming model delivered in
-Hyperledger Fabric v1.4. Support for Go is planned to be delivered in a later release.
+Currently, Node.js and Java support the new application programming model delivered in Hyperledger Fabric v1.4. Support for Go is planned to be delivered in a later release.
 
 Hyperledger Fabric CA
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -13,9 +13,8 @@ Hyperledger Fabric.
           Please visit the :doc:`prereqs` if you haven't previously installed
           it.
 
-          If you are using Docker Toolbox on Windows 7 or macOS, you
-          will need to use a location under ``C:\Users`` (Windows 7) or
-          ``/Users`` (macOS) when installing and running the samples.
+          If you are using Docker Toolbox or macOS, you
+          will need to use a location under ``/Users`` (macOS) when installing and running the samples.
 
           If you are using Docker for Mac, you will need to use a location
           under ``/Users``, ``/Volumes``, ``/private``, or ``/tmp``.  To use a different

--- a/docs/source/prereqs.rst
+++ b/docs/source/prereqs.rst
@@ -1,10 +1,9 @@
 Prerequisites
 =============
 
-Before we begin, if you haven't already done so, you may wish to check that
-you have all the prerequisites below installed on the platform(s)
-on which you'll be developing blockchain applications and/or operating
-Hyperledger Fabric.
+Before you begin, you should confirm that you have installed all the prerequisites below on the platform where you will be running Hyperledger Fabric.
+
+.. note:: These prerequisites are recommended for Fabric users. If you are a Fabric developer you should refer to the instructions for :doc:`dev-setup/devenv`.
 
 Install Git
 -----------
@@ -75,125 +74,10 @@ following command from a terminal prompt:
 
   docker-compose --version
 
-.. _Go:
-
-Go Programming Language
------------------------
-
-Hyperledger Fabric uses the Go Programming Language for many of its
-components.
-
-  - `Go <https://golang.org/dl/>`__ version 1.14.x is required.
-
-Given that we will be writing chaincode programs in Go, there are two
-environment variables you will need to set properly; you can make these
-settings permanent by placing them in the appropriate startup file, such
-as your personal ``~/.bashrc`` file if you are using the ``bash`` shell
-under Linux.
-
-First, you must set the environment variable ``GOPATH`` to point at the
-Go workspace containing the downloaded Fabric code base, with something like:
-
-.. code:: bash
-
-  export GOPATH=$HOME/go
-
-.. note:: You **must** set the GOPATH variable
-
-  Even though, in Linux, Go's ``GOPATH`` variable can be a colon-separated list
-  of directories, and will use a default value of ``$HOME/go`` if it is unset,
-  the current Fabric build framework still requires you to set and export that
-  variable, and it must contain **only** the single directory name for your Go
-  workspace. (This restriction might be removed in a future release.)
-
-Second, you should (again, in the appropriate startup file) extend your
-command search path to include the Go ``bin`` directory, such as the following
-example for ``bash`` under Linux:
-
-.. code:: bash
-
-  export PATH=$PATH:$GOPATH/bin
-
-While this directory may not exist in a new Go workspace installation, it is
-populated later by the Fabric build system with a small number of Go executables
-used by other parts of the build system. So even if you currently have no such
-directory yet, extend your shell search path as above.
-
-Node.js Runtime and NPM
------------------------
-
-If you will be developing applications for Hyperledger Fabric leveraging the
-Hyperledger Fabric SDK for Node.js, version 8 is supported from 8.9.4 and higher.
-Node.js version 10 is supported from 10.15.3 and higher.
-
-  - `Node.js <https://nodejs.org/en/download/>`__ download
-
-.. note:: Installing Node.js will also install NPM, however it is recommended
-          that you confirm the version of NPM installed. You can upgrade
-          the ``npm`` tool with the following command:
-
-.. code:: bash
-
-  npm install npm@5.6.0 -g
-
-Python
-^^^^^^
-
-.. note:: The following applies to Ubuntu 16.04 users only.
-
-By default Ubuntu 16.04 comes with Python 3.5.1 installed as the ``python3`` binary.
-The Fabric Node.js SDK requires an iteration of Python 2.7 in order for ``npm install``
-operations to complete successfully.  Retrieve the 2.7 version with the following command:
-
-.. code:: bash
-
-  sudo apt-get install python
-
-Check your version(s):
-
-.. code:: bash
-
-  python --version
-
 .. _windows-extras:
 
 Windows extras
 --------------
-
-If you are developing on Windows 7, you will want to work within the
-Docker Quickstart Terminal. However, by default it uses an old `Git
-Bash <https://git-scm.com/downloads>`__ and experience has shown this
-to be a poor development environment with limited functionality. It is
-suitable to run Docker based scenarios, such as
-:doc:`getting_started`, but you will have difficulties with operations
-involving the ``make`` and ``docker`` commands.
-
-Instead, it is recommended to use the MSYS2 environment and run make
-and docker from the MSYS2 command shell. To do so, `install
-MSYS2 <https://github.com/msys2/msys2/wiki/MSYS2-installation>`__
-(along with the base developer toolchain and gcc packages using
-pacman) and launch Docker Toolbox from the MSYS2 shell with the
-following command:
-
-::
-
-   /c/Program\ Files/Docker\ Toolbox/start.sh
-
-Alternatively, you can change the Docker Quickstart Terminal command
-to use MSYS2 bash by changing the target of the Windows shortcut from:
-
-::
-
-   "C:\Program Files\Git\bin\bash.exe" --login -i "C:\Program Files\Docker Toolbox\start.sh"
-
-to:
-
-::
-
-   "C:\msys64\usr\bin\bash.exe" --login -i "C:\Program Files\Docker Toolbox\start.sh"
-
-With the above change, you can now simply launch the Docker Quickstart
-Terminal and get a suitable environment.
 
 On Windows 10 you should use the native Docker distribution and you
 may use the Windows PowerShell. However, for the ``binaries``
@@ -222,28 +106,6 @@ does not handle properly the redirect used in
 :doc:`getting_started`. Make sure you have and use a newer version
 which can be downloaded from the `cURL downloads page
 <https://curl.haxx.se/download.html>`__
-
-For Node.js you also need the necessary Visual Studio C++ Build Tools
-which are freely available and can be installed with the following
-command:
-
-.. code:: bash
-
-	  npm install --global windows-build-tools
-
-See the `NPM windows-build-tools page
-<https://www.npmjs.com/package/windows-build-tools>`__ for more
-details.
-
-Once this is done, you should also install the NPM GRPC module with the
-following command:
-
-.. code:: bash
-
-	  npm install --global grpc
-
-Your environment should now be ready to go through the
-:doc:`getting_started` samples and tutorials.
 
 .. note:: If you have questions not addressed by this documentation, or run into
           issues with any of the tutorials, please visit the :doc:`questions`

--- a/docs/source/tutorial/commercial_paper.md
+++ b/docs/source/tutorial/commercial_paper.md
@@ -48,18 +48,8 @@ tutorial. We've kept these to a minimum so that you can get going quickly.
 
 You **must** have the following technologies installed:
 
-  * [**Node**](https://nodejs.org/en/about/) version 8.9.0, or higher. Node is
-    a JavaScript runtime that you can use to run applications and smart
-    contracts. You are recommended to use the LTS (Long Term Support) version
-    of node. Install node [here](https://nodejs.org/en/).
-
-
-  * [**Docker**](https://www.docker.com/get-started) version 18.06, or higher.
-    Docker help developers and administrators create standard environments for
-    building and running applications and smart contracts. Hyperledger Fabric is
-    provided as a set of Docker images, and the PaperNet smart contract will run
-    in a Docker container. Install Docker
-    [here](https://www.docker.com/get-started).
+  * [**Node**](https://github.com/hyperledger/fabric-sdk-node#build-and-test)
+    The Node.js SDK README contains the up to date list of prerequisites.
 
 You **will** find it helpful to install the following technologies:
 

--- a/docs/source/write_first_app.rst
+++ b/docs/source/write_first_app.rst
@@ -43,6 +43,30 @@ After completing this tutorial you should have a basic understanding of how Fabr
 applications and smart contracts work together to manage data on the distributed
 ledger of a blockchain network.
 
+Before you begin
+----------------
+
+In addition to the standard :doc:`prereqs` for Fabric, this tutorial leverages the Hyperledger Fabric SDK for Node.js. See the Node.js SDK `README <https://github.com/hyperledger/fabric-sdk-node#build-and-test>`__ for a up to date list of prerequisites.
+
+- If you are using macOS, complete the following steps:
+
+  1. Install `Homebrew <https://brew.sh/>`_.
+  2. Check the Node SDK `prerequisties <https://github.com/hyperledger/fabric-sdk-node#build-and-test>`_ to find out what level of Node to install.
+  3. Run ``brew install node`` to download the latest version of node or choose a specific version, for example: ``brew install node@10`` according to what is supported in the prerequisites.
+  4. Run ``npm install``.
+
+- If you are on Windows,  you can install the `windows-build-tools <https://github.com/felixrieseberg/windows-build-tools#readme>`_ with npm which installs all required compilers and tooling by running the following command:
+
+  .. code:: bash
+
+    npm install --global windows-build-tools
+
+- If you are on Linux, you need to install `Python v2.7 <https://www.python.org/download/releases/2.7/>`_, `make <https://www.gnu.org/software/make/>`_, and a C/C++ compiler toolchain such as `GCC <https://gcc.gnu.org/>`_. You can run the following command to install the other tools:
+
+  .. code:: bash
+
+    sudo apt install build-essentials
+
 Set up the blockchain network
 -----------------------------
 
@@ -50,8 +74,6 @@ If you've already run through :doc:`test_network` tutorial and have a network up
 and running, this tutorial will bring down your running network network before
 bringing up a new one.
 
-If you are using Mac OS and running Mojave, you will need to `install Xcode
-<./tutorial/installxcode.html>`_.
 
 Launch the network
 ^^^^^^^^^^^^^^^^^^
@@ -128,9 +150,6 @@ You should see the following:
 There are files for other program languages, for example in the
 ``fabcar/java`` directory. You can read these once you've used the
 JavaScript example -- the principles are the same.
-
-If you are using Mac OS and running Mojave, you will need to `install Xcode
-<./tutorial/installxcode.html>`_.
 
 Enrolling the admin user
 ------------------------


### PR DESCRIPTION
Signed-off-by: pama-ibm <pama@ibm.com>

Per Matt Sykes request, clarify that the list of prereqs in this Getting started topic is for Fabric users and not Fabric developers. I provided a link to the Fabric developers topic.

#### Type of change

- Documentation update

#### Description

- [x]  Remove node.js and python info from core Fabric prereq doc section 

- [x] Remove GOPATH requirement to developers contributing guide.

-  [x] In the Windows extras section, remove the language around developing Fabric and 'make', and instead in the [developer contribution guide](https://hyperledger-fabric.readthedocs.io/en/latest/dev-setup/devenv.html) mention that the same Windows guidance would apply.

- [x] Remove node.js and python info. Guidance should be in the API docs and git repos for the chaincode and client SDKs.  Improvements can be made there. There are sections for both Chaincode and Client SDKs in the Getting Started- these could be good places to add pre-reqs for the development. 

#### Additional details
