### PR TITLE
Capture flogging output in integration tests

### DIFF
--- a/integration/lifecycle/lifecycle_suite_test.go
+++ b/integration/lifecycle/lifecycle_suite_test.go
@@ -20,6 +20,7 @@ import (
 	pcommon "github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/bccsp/sw"
+	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/integration"
 	"github.com/hyperledger/fabric/integration/nwo"
 	"github.com/hyperledger/fabric/integration/nwo/commands"
@@ -58,6 +59,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 }, func(payload []byte) {
 	err := json.Unmarshal(payload, &components)
 	Expect(err).NotTo(HaveOccurred())
+
+	flogging.SetWriter(GinkgoWriter)
 })
 
 var _ = SynchronizedAfterSuite(func() {

--- a/integration/raft/raft_suite_test.go
+++ b/integration/raft/raft_suite_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/integration"
 	"github.com/hyperledger/fabric/integration/nwo"
 	"github.com/hyperledger/fabric/integration/nwo/commands"
@@ -42,6 +43,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 }, func(payload []byte) {
 	err := json.Unmarshal(payload, &components)
 	Expect(err).NotTo(HaveOccurred())
+
+	flogging.SetWriter(GinkgoWriter)
 })
 
 var _ = SynchronizedAfterSuite(func() {


### PR DESCRIPTION
Two suites use fabric packages instead of command line tools to interact with the network. This pattern results in log output going to Stderr instead of to GinkgoWriter. This means two things:

1. There's a bunch of logging that gets printed when running the tests that is intermingled with the test runner output.
2. The log output is not captured in the GinkgoWriter associated with the test. Prevents time-ordered correlation of activities when failures occur.

Address this by setting the GinkgoWriter as the flogging package writer in the test suite processes.