### PR TITLE
Return Error From PKCS11 CreateSession

### DIFF
--- a/bccsp/pkcs11/pkcs11.go
+++ b/bccsp/pkcs11/pkcs11.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/miekg/pkcs11"
+	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -51,46 +52,37 @@ func loadLib(lib, pin, label string) (*pkcs11.Ctx, uint, *pkcs11.SessionHandle, 
 		}
 	}
 	if !found {
-		return nil, slot, nil, fmt.Errorf("Could not find token with label %s", label)
+		return nil, slot, nil, fmt.Errorf("could not find token with label %s", label)
 	}
 
-	session := createSession(ctx, slot, pin)
-
-	logger.Debugf("Created new pkcs11 session %+v on slot %d\n", session, slot)
-
-	if pin == "" {
-		return nil, slot, nil, fmt.Errorf("No PIN set")
-	}
-	err = ctx.Login(session, pkcs11.CKU_USER, pin)
+	session, err := createSession(ctx, slot, pin)
 	if err != nil {
-		if err != pkcs11.Error(pkcs11.CKR_USER_ALREADY_LOGGED_IN) {
-			return nil, slot, nil, fmt.Errorf("Login failed [%s]", err)
-		}
+		return nil, slot, nil, err
 	}
 
 	return ctx, slot, &session, nil
 }
 
-func (csp *impl) getSession() (session pkcs11.SessionHandle) {
+func (csp *impl) getSession() (session pkcs11.SessionHandle, err error) {
 	select {
 	case session = <-csp.sessions:
-		_, err := csp.ctx.GetSessionInfo(session)
+		_, err = csp.ctx.GetSessionInfo(session)
 		if err != nil {
 			logger.Warningf("Get session info failed [%s], closing existing session and getting a new session\n", err)
 			csp.ctx.CloseSession(session)
-			session = createSession(csp.ctx, csp.slot, csp.pin)
+			session, err = createSession(csp.ctx, csp.slot, csp.pin)
 		} else {
 			logger.Debugf("Reusing existing pkcs11 session %+v on slot %d\n", session, csp.slot)
 		}
 
 	default:
 		// cache is empty (or completely in use), create a new session
-		session = createSession(csp.ctx, csp.slot, csp.pin)
+		session, err = createSession(csp.ctx, csp.slot, csp.pin)
 	}
-	return session
+	return session, err
 }
 
-func createSession(ctx *pkcs11.Ctx, slot uint, pin string) pkcs11.SessionHandle {
+func createSession(ctx *pkcs11.Ctx, slot uint, pin string) (pkcs11.SessionHandle, error) {
 	var s pkcs11.SessionHandle
 	var err error
 	for i := 0; i < 10; i++ {
@@ -102,18 +94,16 @@ func createSession(ctx *pkcs11.Ctx, slot uint, pin string) pkcs11.SessionHandle 
 		}
 	}
 	if err != nil {
-		logger.Fatalf("OpenSession failed [%s]", err)
+		return 0, errors.Wrap(err, "OpenSession failed")
 	}
 	logger.Debugf("Created new pkcs11 session %+v on slot %d\n", s, slot)
 	session := s
 
 	err = ctx.Login(session, pkcs11.CKU_USER, pin)
-	if err != nil {
-		if err != pkcs11.Error(pkcs11.CKR_USER_ALREADY_LOGGED_IN) {
-			logger.Errorf("Login failed [%s]", err)
-		}
+	if err != nil && err != pkcs11.Error(pkcs11.CKR_USER_ALREADY_LOGGED_IN) {
+		return session, errors.Wrap(err, "Login failed")
 	}
-	return session
+	return session, nil
 }
 
 func (csp *impl) returnSession(session pkcs11.SessionHandle) {
@@ -129,7 +119,10 @@ func (csp *impl) returnSession(session pkcs11.SessionHandle) {
 // Look for an EC key by SKI, stored in CKA_ID
 func (csp *impl) getECKey(ski []byte) (pubKey *ecdsa.PublicKey, isPriv bool, err error) {
 	p11lib := csp.ctx
-	session := csp.getSession()
+	session, err := csp.getSession()
+	if err != nil {
+		return nil, false, err
+	}
 	defer csp.returnSession(session)
 	isPriv = true
 	_, err = findKeyPairFromSKI(p11lib, session, ski, privateKeyType)
@@ -205,7 +198,10 @@ func namedCurveFromOID(oid asn1.ObjectIdentifier) elliptic.Curve {
 
 func (csp *impl) generateECKey(curve asn1.ObjectIdentifier, ephemeral bool) (ski []byte, pubKey *ecdsa.PublicKey, err error) {
 	p11lib := csp.ctx
-	session := csp.getSession()
+	session, err := csp.getSession()
+	if err != nil {
+		return nil, nil, err
+	}
 	defer csp.returnSession(session)
 
 	id := nextIDCtr()
@@ -321,7 +317,10 @@ func (csp *impl) generateECKey(curve asn1.ObjectIdentifier, ephemeral bool) (ski
 
 func (csp *impl) signP11ECDSA(ski []byte, msg []byte) (R, S *big.Int, err error) {
 	p11lib := csp.ctx
-	session := csp.getSession()
+	session, err := csp.getSession()
+	if err != nil {
+		return nil, nil, err
+	}
 	defer csp.returnSession(session)
 
 	privateKey, err := findKeyPairFromSKI(p11lib, session, ski, privateKeyType)
@@ -351,7 +350,10 @@ func (csp *impl) signP11ECDSA(ski []byte, msg []byte) (R, S *big.Int, err error)
 
 func (csp *impl) verifyP11ECDSA(ski []byte, msg []byte, R, S *big.Int, byteSize int) (bool, error) {
 	p11lib := csp.ctx
-	session := csp.getSession()
+	session, err := csp.getSession()
+	if err != nil {
+		return false, err
+	}
 	defer csp.returnSession(session)
 
 	logger.Debugf("Verify ECDSA\n")

--- a/bccsp/pkcs11/pkcs11_test.go
+++ b/bccsp/pkcs11/pkcs11_test.go
@@ -90,7 +90,9 @@ func TestPKCS11GetSession(t *testing.T) {
 	}
 	var sessions []pkcs11.SessionHandle
 	for i := 0; i < 3*sessionCacheSize; i++ {
-		sessions = append(sessions, currentBCCSP.(*impl).getSession())
+		session, err := currentBCCSP.(*impl).getSession()
+		assert.NoError(t, err)
+		sessions = append(sessions, session)
 	}
 
 	// Return all sessions, should leave sessionCacheSize cached
@@ -105,13 +107,13 @@ func TestPKCS11GetSession(t *testing.T) {
 
 	// Should be able to get sessionCacheSize cached sessions
 	for i := 0; i < sessionCacheSize; i++ {
-		sessions = append(sessions, currentBCCSP.(*impl).getSession())
+		session, err := currentBCCSP.(*impl).getSession()
+		assert.NoError(t, err)
+		sessions = append(sessions, session)
 	}
 
-	// This one should fail
-	assert.Panics(t, func() {
-		currentBCCSP.(*impl).getSession()
-	}, "Should not been able to create another session")
+	_, err := currentBCCSP.(*impl).getSession()
+	assert.EqualError(t, err, "OpenSession failed: pkcs11: 0x3: CKR_SLOT_ID_INVALID")
 
 	// Cleanup
 	for _, session := range sessions {


### PR DESCRIPTION
The current implementation of BCCSP performs a fatal logging function in the event it cannot open a session with the HSM. This is fine during startup when it's expected an exit might occur, but the createSession function is called during the standard code flow, i.e., when the cryptoServiceProvider's session pool is already completely in use (by default 10 sessions) a new session is created. So it is possible while running post-setup for the fatal log to occur when an expected error occurs, i.e., the HSM has reached its maximum session handles. Instead of issuing a fatal log call, we should return the error as it's probable the error is recoverable, or outside the control of Fabric itself (is a problem with the HSM).

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>

Note: #1047 appears to have broke the tests for these function changes. If you run the PKCS11 tests using `go test -tags pkcs11 ./bccsp/pkcs11/...` the tests fail. When using `make unit-test` the failure doesn't occur (though it should, the test asserts that a panic occurs, but the test no longer panics due to the change Mihir introduced)

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Prevents production environments from issuing a fatal logging call in a recoverable situation
