### PR TITLE
Delete non existing reference

### DIFF
--- a/docs/source/txflow.rst
+++ b/docs/source/txflow.rst
@@ -122,8 +122,5 @@ transaction was validated or invalidated.
           whether your transaction has actually been ordered, validated, and
           committed to the ledger.
 
-See the :ref:`sequence diagram <swimlane>` to better understand the
-transaction flow.
-
 .. Licensed under Creative Commons Attribution 4.0 International License
 https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
#### Type of change
- Documentation update

#### Description
File [arch-deep-dive.rst](https://github.com/hyperledger/fabric/blob/release-1.4/docs/source/arch-deep-dive.rst) which is referenced does not exists anymore in > release 1.4
This might be a little bit confusing for the reader

Signed-off-by: Stefan Obermeier <obermeier@users.noreply.github.com>