### PR TITLE
Improve lifecycle error message for committed sequence

### DIFF
--- a/core/chaincode/lifecycle/lifecycle.go
+++ b/core/chaincode/lifecycle/lifecycle.go
@@ -114,15 +114,15 @@ type ChaincodeParameters struct {
 func (cp *ChaincodeParameters) Equal(ocp *ChaincodeParameters) error {
 	switch {
 	case cp.EndorsementInfo.Version != ocp.EndorsementInfo.Version:
-		return errors.Errorf("Version '%s' != '%s'", cp.EndorsementInfo.Version, ocp.EndorsementInfo.Version)
+		return errors.Errorf("expected Version '%s' does not match passed Version '%s'", cp.EndorsementInfo.Version, ocp.EndorsementInfo.Version)
 	case cp.EndorsementInfo.EndorsementPlugin != ocp.EndorsementInfo.EndorsementPlugin:
-		return errors.Errorf("EndorsementPlugin '%s' != '%s'", cp.EndorsementInfo.EndorsementPlugin, ocp.EndorsementInfo.EndorsementPlugin)
+		return errors.Errorf("expected EndorsementPlugin '%s' does not match passed EndorsementPlugin '%s'", cp.EndorsementInfo.EndorsementPlugin, ocp.EndorsementInfo.EndorsementPlugin)
 	case cp.EndorsementInfo.InitRequired != ocp.EndorsementInfo.InitRequired:
-		return errors.Errorf("InitRequired '%t' != '%t'", cp.EndorsementInfo.InitRequired, ocp.EndorsementInfo.InitRequired)
+		return errors.Errorf("expected InitRequired '%t' does not match passed InitRequired '%t'", cp.EndorsementInfo.InitRequired, ocp.EndorsementInfo.InitRequired)
 	case cp.ValidationInfo.ValidationPlugin != ocp.ValidationInfo.ValidationPlugin:
-		return errors.Errorf("ValidationPlugin '%s' != '%s'", cp.ValidationInfo.ValidationPlugin, ocp.ValidationInfo.ValidationPlugin)
+		return errors.Errorf("expected ValidationPlugin '%s' does not match passed ValidationPlugin '%s'", cp.ValidationInfo.ValidationPlugin, ocp.ValidationInfo.ValidationPlugin)
 	case !bytes.Equal(cp.ValidationInfo.ValidationParameter, ocp.ValidationInfo.ValidationParameter):
-		return errors.Errorf("ValidationParameter '%x' != '%x'", cp.ValidationInfo.ValidationParameter, ocp.ValidationInfo.ValidationParameter)
+		return errors.Errorf("expected ValidationParameter '%x' does not match passed ValidationParameter '%x'", cp.ValidationInfo.ValidationParameter, ocp.ValidationInfo.ValidationParameter)
 	case !proto.Equal(cp.Collections, ocp.Collections):
 		return errors.Errorf("Collections do not match")
 	default:
@@ -432,7 +432,7 @@ func (ef *ExternalFunctions) ApproveChaincodeDefinitionForOrg(chname, ccname str
 		}
 
 		if err := definedChaincode.Parameters().Equal(cd.Parameters()); err != nil {
-			return errors.WithMessagef(err, "attempted to define the current sequence (%d) for namespace %s, but", currentSequence, ccname)
+			return errors.WithMessagef(err, "attempted to redefine the current committed sequence (%d) for namespace %s with different parameters", currentSequence, ccname)
 		}
 	}
 

--- a/core/chaincode/lifecycle/lifecycle_test.go
+++ b/core/chaincode/lifecycle/lifecycle_test.go
@@ -56,7 +56,7 @@ var _ = Describe("ChaincodeParameters", func() {
 			})
 
 			It("returns an error", func() {
-				Expect(lhs.Equal(rhs)).To(MatchError("EndorsementPlugin '' != 'different'"))
+				Expect(lhs.Equal(rhs)).To(MatchError("expected EndorsementPlugin '' does not match passed EndorsementPlugin 'different'"))
 			})
 		})
 
@@ -66,7 +66,7 @@ var _ = Describe("ChaincodeParameters", func() {
 			})
 
 			It("returns an error", func() {
-				Expect(lhs.Equal(rhs)).To(MatchError("InitRequired 'false' != 'true'"))
+				Expect(lhs.Equal(rhs)).To(MatchError("expected InitRequired 'false' does not match passed InitRequired 'true'"))
 			})
 		})
 
@@ -76,7 +76,7 @@ var _ = Describe("ChaincodeParameters", func() {
 			})
 
 			It("returns an error", func() {
-				Expect(lhs.Equal(rhs)).To(MatchError("ValidationPlugin '' != 'different'"))
+				Expect(lhs.Equal(rhs)).To(MatchError("expected ValidationPlugin '' does not match passed ValidationPlugin 'different'"))
 			})
 		})
 
@@ -86,7 +86,7 @@ var _ = Describe("ChaincodeParameters", func() {
 			})
 
 			It("returns an error", func() {
-				Expect(lhs.Equal(rhs)).To(MatchError("ValidationParameter '' != '646966666572656e74'"))
+				Expect(lhs.Equal(rhs)).To(MatchError("expected ValidationParameter '' does not match passed ValidationParameter '646966666572656e74'"))
 			})
 		})
 
@@ -817,7 +817,7 @@ var _ = Describe("ExternalFunctions", func() {
 
 				It("returns an error", func() {
 					err := ef.ApproveChaincodeDefinitionForOrg("my-channel", "cc-name", testDefinition, "hash", fakePublicState, fakeOrgState)
-					Expect(err).To(MatchError("attempted to define the current sequence (5) for namespace cc-name, but: Version 'other-version' != 'version'"))
+					Expect(err).To(MatchError("attempted to redefine the current committed sequence (5) for namespace cc-name with different parameters: expected Version 'other-version' does not match passed Version 'version'"))
 				})
 			})
 		})


### PR DESCRIPTION
#### Type of change

- Improvement to error message

#### Description

If you attempt to approveformyorg again for a committed chaincode definition sequence,
for example to update chaincode package on a peer, but you pass the incorrect
chaincode definition parameters, the error message was not clear.

This change updates the error message to something that the admin can likely
troubleshoot themselves.

Old message:
Error: proposal failed with status: 500 - failed to invoke backing implementation
of 'ApproveChaincodeDefinitionForMyOrg': attempted to define the current sequence
(2) for namespace marbles5, but: Version '3' != '4'

New message:
Error: proposal failed with status: 500 - failed to invoke backing implementation
of 'ApproveChaincodeDefinitionForMyOrg': attempted to redefine the current
committed sequence (3) for namespace marbles5 with different parameters:
expected Version '3' does not match passed Version '4'

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
