### PR TITLE
[FAB-13460] Add Support for TLS1.3

### DIFF
--- a/internal/pkg/comm/client.go
+++ b/internal/pkg/comm/client.go
@@ -71,7 +71,9 @@ func (client *GRPCClient) parseSecureOptions(opts SecureOptions) error {
 
 	client.tlsConfig = &tls.Config{
 		VerifyPeerCertificate: opts.VerifyCertificate,
-		MinVersion:            tls.VersionTLS12} // TLS 1.2 only
+		MinVersion:            tls.VersionTLS12,
+		MaxVersion:            tls.VersionTLS13,
+	}
 	if len(opts.ServerRootCAs) > 0 {
 		client.tlsConfig.RootCAs = x509.NewCertPool()
 		for _, certBytes := range opts.ServerRootCAs {

--- a/internal/pkg/comm/client_test.go
+++ b/internal/pkg/comm/client_test.go
@@ -253,10 +253,9 @@ func TestNewConnection(t *testing.T) {
 			serverTLS: &tls.Config{
 				Certificates: []tls.Certificate{testCerts.serverCert},
 				ClientAuth:   tls.RequireAndVerifyClientCert,
-				MaxVersion:   tls.VersionTLS12, // https://github.com/golang/go/issues/33368
 			},
 			success:  false,
-			errorMsg: "tls: bad certificate",
+			errorMsg: "failed to create new connection: context deadline exceeded",
 		},
 		{
 			name: "client TLS / server TLS client cert",

--- a/internal/pkg/comm/creds.go
+++ b/internal/pkg/comm/creds.go
@@ -35,9 +35,9 @@ func NewServerTransportCredentials(
 	// NOTE: unlike the default grpc/credentials implementation, we do not
 	// clone the tls.Config which allows us to update it dynamically
 	serverConfig.config.NextProtos = alpnProtoStr
-	// override TLS version and ensure it is 1.2
+	// override TLS version and ensure it is 1.2 or 1.3
 	serverConfig.config.MinVersion = tls.VersionTLS12
-	serverConfig.config.MaxVersion = tls.VersionTLS12
+	serverConfig.config.MaxVersion = tls.VersionTLS13
 	return &serverCreds{
 		serverConfig: serverConfig,
 		logger:       logger}

--- a/orderer/consensus/kafka/config.go
+++ b/orderer/consensus/kafka/config.go
@@ -57,7 +57,7 @@ func newBrokerConfig(
 			Certificates: []tls.Certificate{keyPair},
 			RootCAs:      rootCAs,
 			MinVersion:   tls.VersionTLS12,
-			MaxVersion:   0, // Latest supported TLS version
+			MaxVersion:   tls.VersionTLS13,
 		}
 	}
 	brokerConfig.Net.SASL.Enable = saslPlain.Enabled

--- a/orderer/consensus/kafka/config_test.go
+++ b/orderer/consensus/kafka/config_test.go
@@ -99,8 +99,8 @@ func TestBrokerConfigTLSConfigEnabled(t *testing.T) {
 		assert.NotNil(t, testBrokerConfig.Net.TLS.Config)
 		assert.Len(t, testBrokerConfig.Net.TLS.Config.Certificates, 1)
 		assert.Len(t, testBrokerConfig.Net.TLS.Config.RootCAs.Subjects(), 1)
-		assert.Equal(t, uint16(0), testBrokerConfig.Net.TLS.Config.MaxVersion)
 		assert.Equal(t, uint16(tls.VersionTLS12), testBrokerConfig.Net.TLS.Config.MinVersion)
+		assert.Equal(t, uint16(tls.VersionTLS13), testBrokerConfig.Net.TLS.Config.MaxVersion)
 	})
 
 	t.Run("Disabled", func(t *testing.T) {


### PR DESCRIPTION
Add support for TLS1.3 and adds a tests to ensure these versions work on the comm stack.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
