### PR TITLE
Update pkg/configtx tests to use New to create ConfigTx

### DIFF
--- a/pkg/configtx/application.go
+++ b/pkg/configtx/application.go
@@ -77,7 +77,7 @@ func (c *ConfigTx) AddAnchorPeer(orgName string, newAnchorPeer Address) error {
 		// Unmarshal existing anchor peers if the config value exists
 		err := proto.Unmarshal(anchorPeerConfigValue.Value, anchorPeersProto)
 		if err != nil {
-			return fmt.Errorf("failed unmarshaling %s's anchor peer endpoints: %v", orgName, err)
+			return fmt.Errorf("failed unmarshaling anchor peer endpoints for org %s: %v", orgName, err)
 		}
 	}
 
@@ -118,7 +118,7 @@ func (c *ConfigTx) RemoveAnchorPeer(orgName string, anchorPeerToRemove Address) 
 		// Unmarshal existing anchor peers if the config value exists
 		err := proto.Unmarshal(anchorPeerConfigValue.Value, anchorPeersProto)
 		if err != nil {
-			return fmt.Errorf("failed unmarshaling %s's anchor peer endpoints: %v", orgName, err)
+			return fmt.Errorf("failed unmarshaling anchor peer endpoints for org %s: %v", orgName, err)
 		}
 	}
 

--- a/pkg/configtx/config.go
+++ b/pkg/configtx/config.go
@@ -317,6 +317,10 @@ func setValue(cg *cb.ConfigGroup, value *standardConfigValue, modPolicy string) 
 		return fmt.Errorf("marshaling standard config value '%s': %v", value.key, err)
 	}
 
+	if cg.Values == nil {
+		cg.Values = map[string]*cb.ConfigValue{}
+	}
+
 	cg.Values[value.key] = &cb.ConfigValue{
 		Value:     v,
 		ModPolicy: modPolicy,
@@ -487,9 +491,9 @@ func newChannelCreateConfigUpdate(channelID string, channelConfig Channel, templ
 // newConfigGroup creates an empty *cb.ConfigGroup.
 func newConfigGroup() *cb.ConfigGroup {
 	return &cb.ConfigGroup{
-		Groups:   make(map[string]*cb.ConfigGroup),
-		Values:   make(map[string]*cb.ConfigValue),
-		Policies: make(map[string]*cb.ConfigPolicy),
+		Groups:   map[string]*cb.ConfigGroup{},
+		Values:   map[string]*cb.ConfigValue{},
+		Policies: map[string]*cb.ConfigPolicy{},
 	}
 }
 

--- a/pkg/configtx/consortiums_test.go
+++ b/pkg/configtx/consortiums_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/common/tools/protolator"
 	"github.com/hyperledger/fabric/common/tools/protolator/protoext/commonext"
@@ -353,10 +354,7 @@ func TestAddOrgToConsortium(t *testing.T) {
 		},
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	orgToAdd := Organization{
 		Name:     "Org3",
@@ -783,7 +781,7 @@ func TestAddOrgToConsortium(t *testing.T) {
 	err = c.AddOrgToConsortium(orgToAdd, "Consortium1")
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	gt.Expect(config).To(Equal(expectedConfigProto))
+	gt.Expect(proto.Equal(c.UpdatedConfig(), expectedConfigProto)).To(BeTrue())
 }
 
 func TestAddOrgToConsortiumFailures(t *testing.T) {
@@ -849,10 +847,7 @@ func TestAddOrgToConsortiumFailures(t *testing.T) {
 				},
 			}
 
-			c := ConfigTx{
-				original: config,
-				updated:  config,
-			}
+			c := New(config)
 
 			err = c.AddOrgToConsortium(test.org, test.consortium)
 			gt.Expect(err).To(MatchError(test.expectedErr))
@@ -879,14 +874,11 @@ func TestRemoveConsortium(t *testing.T) {
 		},
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	c.RemoveConsortium("Consortium1")
 
-	updatedConsortiumsGroup := c.updated.ChannelGroup.Groups[ConsortiumsGroupKey]
+	updatedConsortiumsGroup := c.UpdatedConfig().ChannelGroup.Groups[ConsortiumsGroupKey]
 	gt.Expect(updatedConsortiumsGroup.Groups["Consortium1"]).To(BeNil())
 }
 

--- a/pkg/configtx/organization_test.go
+++ b/pkg/configtx/organization_test.go
@@ -51,10 +51,7 @@ func TestApplicationOrg(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	expectedOrg := channel.Application.Organizations[0]
 
@@ -114,10 +111,7 @@ func TestRemoveApplicationOrg(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	c.RemoveApplicationOrg("Org1")
 	gt.Expect(c.updated.ChannelGroup.Groups[ApplicationGroupKey].Groups["Org1"]).To(BeNil())
@@ -135,10 +129,7 @@ func TestOrdererOrg(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	expectedOrg := channel.Orderer.Organizations[0]
 
@@ -189,10 +180,7 @@ func TestRemoveOrdererOrg(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	c.RemoveOrdererOrg("OrdererOrg")
 	gt.Expect(c.updated.ChannelGroup.Groups[OrdererGroupKey].Groups["OrdererOrg"]).To(BeNil())
@@ -210,10 +198,7 @@ func TestConsortiumOrg(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	expectedOrg := channel.Consortiums[0].Organizations[0]
 
@@ -273,13 +258,10 @@ func TestRemoveConsortiumOrg(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	c.RemoveConsortiumOrg("Consortium1", "Org1")
-	gt.Expect(c.updated.ChannelGroup.Groups[ConsortiumsGroupKey].Groups["Consortium1"].Groups["Org1"]).To(BeNil())
+	gt.Expect(c.UpdatedConfig().ChannelGroup.Groups[ConsortiumsGroupKey].Groups["Consortium1"].Groups["Org1"]).To(BeNil())
 }
 
 func TestNewOrgConfigGroup(t *testing.T) {

--- a/pkg/configtx/policies_test.go
+++ b/pkg/configtx/policies_test.go
@@ -75,10 +75,7 @@ func TestRemoveApplicationOrgPolicy(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	application.Organizations[0].Policies = applicationOrgStandardPolicies()
 	expectedOrgConfigGroup, _ := newOrgConfigGroup(application.Organizations[0])
@@ -87,7 +84,7 @@ func TestRemoveApplicationOrgPolicy(t *testing.T) {
 	err := c.RemoveApplicationOrgPolicy("Org1", "TestPolicy")
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	actualOrg1Policies := c.updated.ChannelGroup.Groups[ApplicationGroupKey].Groups["Org1"].Policies
+	actualOrg1Policies := c.UpdatedConfig().ChannelGroup.Groups[ApplicationGroupKey].Groups["Org1"].Policies
 	gt.Expect(actualOrg1Policies).To(Equal(expectedPolicies))
 }
 
@@ -116,10 +113,7 @@ func TestRemoveApplicationOrgPolicyFailures(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	err := c.RemoveApplicationOrgPolicy("Org1", "TestPolicy")
 	gt.Expect(err).To(MatchError("unknown policy type: 15"))
@@ -147,10 +141,7 @@ func TestAddApplicationOrgPolicy(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	application.Organizations[0].Policies = applicationOrgStandardPolicies()
 	expectedOrgConfigGroup, _ := newOrgConfigGroup(application.Organizations[0])
@@ -160,7 +151,7 @@ func TestAddApplicationOrgPolicy(t *testing.T) {
 	err := c.AddApplicationOrgPolicy("Org1", AdminsPolicyKey, "TestPolicy", Policy{Type: ImplicitMetaPolicyType, Rule: "MAJORITY Endorsement"})
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	actualOrg1Policies := config.ChannelGroup.Groups[ApplicationGroupKey].Groups["Org1"].Policies
+	actualOrg1Policies := c.UpdatedConfig().ChannelGroup.Groups[ApplicationGroupKey].Groups["Org1"].Policies
 	gt.Expect(actualOrg1Policies).To(Equal(expectedPolicies))
 }
 
@@ -185,10 +176,7 @@ func TestAddApplicationOrgPolicyFailures(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	err := c.AddApplicationOrgPolicy("Org1", AdminsPolicyKey, "TestPolicy", Policy{})
 	gt.Expect(err).To(MatchError("failed to add policy 'TestPolicy': unknown policy type: "))
@@ -209,10 +197,7 @@ func TestAddApplicationPolicy(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	expectedPolicies := map[string]Policy{
 		ReadersPolicyKey: {
@@ -236,7 +221,7 @@ func TestAddApplicationPolicy(t *testing.T) {
 	err = c.AddApplicationPolicy(AdminsPolicyKey, "TestPolicy", Policy{Type: ImplicitMetaPolicyType, Rule: "MAJORITY Endorsement"})
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	updatedPolicies, err := getPolicies(c.updated.ChannelGroup.Groups[ApplicationGroupKey].Policies)
+	updatedPolicies, err := getPolicies(c.UpdatedConfig().ChannelGroup.Groups[ApplicationGroupKey].Policies)
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(updatedPolicies).To(Equal(expectedPolicies))
 }
@@ -256,10 +241,7 @@ func TestAddApplicationPolicyFailures(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	expectedPolicies := application.Policies
 	expectedPolicies["TestPolicy"] = expectedPolicies[EndorsementPolicyKey]
@@ -284,10 +266,7 @@ func TestRemoveApplicationPolicy(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	expectedPolicies := map[string]Policy{
 		ReadersPolicyKey: {
@@ -307,7 +286,7 @@ func TestRemoveApplicationPolicy(t *testing.T) {
 	err = c.RemoveApplicationPolicy("TestPolicy")
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	updatedPolicies, err := getPolicies(c.updated.ChannelGroup.Groups[ApplicationGroupKey].Policies)
+	updatedPolicies, err := getPolicies(c.UpdatedConfig().ChannelGroup.Groups[ApplicationGroupKey].Policies)
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(updatedPolicies).To(Equal(expectedPolicies))
 }
@@ -333,10 +312,7 @@ func TestRemoveApplicationPolicyFailures(t *testing.T) {
 		ChannelGroup: channelGroup,
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	err = c.RemoveApplicationPolicy("TestPolicy")
 	gt.Expect(err).To(MatchError("unknown policy type: 15"))
@@ -360,10 +336,7 @@ func TestAddConsortiumOrgPolicy(t *testing.T) {
 		},
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	expectedPolicies := map[string]Policy{
 		ReadersPolicyKey: {
@@ -415,10 +388,7 @@ func TestAddConsortiumOrgPolicyFailures(t *testing.T) {
 		},
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	for _, test := range []struct {
 		name        string
@@ -474,10 +444,7 @@ func TestRemoveConsortiumOrgPolicy(t *testing.T) {
 		},
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	expectedPolicies := map[string]Policy{
 		ReadersPolicyKey: {
@@ -500,7 +467,7 @@ func TestRemoveConsortiumOrgPolicy(t *testing.T) {
 
 	c.RemoveConsortiumOrgPolicy("Consortium1", "Org1", "TestPolicy")
 
-	consortium1Org1 := c.updated.ChannelGroup.Groups[ConsortiumsGroupKey].Groups["Consortium1"].Groups["Org1"]
+	consortium1Org1 := c.UpdatedConfig().ChannelGroup.Groups[ConsortiumsGroupKey].Groups["Consortium1"].Groups["Org1"]
 	updatedPolicies, err := getPolicies(consortium1Org1.Policies)
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(updatedPolicies).To(Equal(expectedPolicies))
@@ -524,10 +491,8 @@ func TestAddOrdererPolicy(t *testing.T) {
 		},
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
+
 	expectedPolicies := map[string]Policy{
 		ReadersPolicyKey: {
 			Type: ImplicitMetaPolicyType,
@@ -554,7 +519,7 @@ func TestAddOrdererPolicy(t *testing.T) {
 	err = c.AddOrdererPolicy(AdminsPolicyKey, "TestPolicy", Policy{Type: ImplicitMetaPolicyType, Rule: "ANY Endorsement"})
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	ordererConfigGroup := c.updated.ChannelGroup.Groups[OrdererGroupKey]
+	ordererConfigGroup := c.UpdatedConfig().ChannelGroup.Groups[OrdererGroupKey]
 	updatedPolicies, err := getPolicies(ordererConfigGroup.Policies)
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(updatedPolicies).To(Equal(expectedPolicies))
@@ -578,10 +543,7 @@ func TestAddOrdererPolicyFailures(t *testing.T) {
 		},
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	err = c.AddOrdererPolicy(AdminsPolicyKey, "TestPolicy", Policy{})
 	gt.Expect(err).To(MatchError("failed to add policy 'TestPolicy': unknown policy type: "))
@@ -606,10 +568,7 @@ func TestRemoveOrdererPolicy(t *testing.T) {
 		},
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	expectedPolicies := map[string]Policy{
 		ReadersPolicyKey: {
@@ -658,10 +617,7 @@ func TestRemoveOrdererPolicyFailures(t *testing.T) {
 		},
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	tests := []struct {
 		testName      string
@@ -723,10 +679,7 @@ func TestAddOrdererOrgPolicy(t *testing.T) {
 		},
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	expectedPolicies := map[string]Policy{
 		ReadersPolicyKey: {
@@ -754,7 +707,7 @@ func TestAddOrdererOrgPolicy(t *testing.T) {
 	err = c.AddOrdererOrgPolicy("OrdererOrg", AdminsPolicyKey, "TestPolicy", Policy{Type: ImplicitMetaPolicyType, Rule: "ANY Endorsement"})
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	ordererOrgConfigGroup := c.updated.ChannelGroup.Groups[OrdererGroupKey].Groups["OrdererOrg"]
+	ordererOrgConfigGroup := c.UpdatedConfig().ChannelGroup.Groups[OrdererGroupKey].Groups["OrdererOrg"]
 	updatedPolicies, err := getPolicies(ordererOrgConfigGroup.Policies)
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(updatedPolicies).To(Equal(expectedPolicies))
@@ -778,10 +731,7 @@ func TestAddOrdererOrgPolicyFailures(t *testing.T) {
 		},
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	err = c.AddOrdererOrgPolicy("OrdererOrg", AdminsPolicyKey, "TestPolicy", Policy{})
 	gt.Expect(err).To(MatchError("unknown policy type: "))
@@ -806,10 +756,7 @@ func TestRemoveOrdererOrgPolicy(t *testing.T) {
 		},
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	expectedPolicies := map[string]Policy{
 		ReadersPolicyKey: {
@@ -833,7 +780,7 @@ func TestRemoveOrdererOrgPolicy(t *testing.T) {
 	err = c.RemoveOrdererOrgPolicy("OrdererOrg", "TestPolicy")
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	ordererOrgConfigGroup := c.updated.ChannelGroup.Groups[OrdererGroupKey].Groups["OrdererOrg"]
+	ordererOrgConfigGroup := c.UpdatedConfig().ChannelGroup.Groups[OrdererGroupKey].Groups["OrdererOrg"]
 	updatedPolicies, err := getPolicies(ordererOrgConfigGroup.Policies)
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(updatedPolicies).To(Equal(expectedPolicies))
@@ -857,10 +804,7 @@ func TestRemoveOrdererOrgPolicyFailures(t *testing.T) {
 		},
 	}
 
-	c := ConfigTx{
-		original: config,
-		updated:  config,
-	}
+	c := New(config)
 
 	err = c.RemoveOrdererOrgPolicy("bad-org", "TestPolicy")
 	gt.Expect(err).To(MatchError("orderer org bad-org does not exist in channel config"))
@@ -883,17 +827,15 @@ func TestUpdateConsortiumChannelCreationPolicy(t *testing.T) {
 			},
 		},
 	}
-	c := &ConfigTx{
-		original: config,
-		updated:  config,
-	}
+
+	c := New(config)
 
 	updatedPolicy := Policy{Type: ImplicitMetaPolicyType, Rule: "MAJORITY Admins"}
 
 	err = c.UpdateConsortiumChannelCreationPolicy("Consortium1", updatedPolicy)
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	consortium := c.updated.ChannelGroup.Groups[ConsortiumsGroupKey].Groups["Consortium1"]
+	consortium := c.UpdatedConfig().ChannelGroup.Groups[ConsortiumsGroupKey].Groups["Consortium1"]
 	creationPolicy := consortium.Values[ChannelCreationPolicyKey]
 	policy := &cb.Policy{}
 	err = proto.Unmarshal(creationPolicy.Value, policy)
@@ -922,10 +864,8 @@ func TestUpdateConsortiumChannelCreationPolicyFailures(t *testing.T) {
 			},
 		},
 	}
-	c := &ConfigTx{
-		original: config,
-		updated:  config,
-	}
+
+	c := New(config)
 
 	tests := []struct {
 		name           string
@@ -1014,13 +954,13 @@ func TestRemoveChannelPolicy(t *testing.T) {
 	err = c.RemoveChannelPolicy(ReadersPolicyKey)
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	updatedChannelPolicy, err := getPolicies(c.updated.ChannelGroup.Policies)
+	updatedChannelPolicy, err := getPolicies(c.UpdatedConfig().ChannelGroup.Policies)
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Expect(updatedChannelPolicy).To(Equal(expectedPolicies))
 
-	baseChannel := c.original.ChannelGroup
-	gt.Expect(baseChannel.Policies).To(HaveLen(3))
-	gt.Expect(baseChannel.Policies[ReadersPolicyKey]).ToNot(BeNil())
+	originalChannel := c.OriginalConfig().ChannelGroup
+	gt.Expect(originalChannel.Policies).To(HaveLen(3))
+	gt.Expect(originalChannel.Policies[ReadersPolicyKey]).ToNot(BeNil())
 }
 
 func TestRemoveChannelPolicyFailures(t *testing.T) {
@@ -1064,10 +1004,8 @@ func TestConsortiumOrgPolicies(t *testing.T) {
 			},
 		},
 	}
-	c := &ConfigTx{
-		original: config,
-		updated:  config,
-	}
+
+	c := New(config)
 
 	expectedPolicies := map[string]Policy{
 		ReadersPolicyKey: {
@@ -1110,10 +1048,8 @@ func TestConsortiumOrgPoliciesFailures(t *testing.T) {
 			},
 		},
 	}
-	c := &ConfigTx{
-		original: config,
-		updated:  config,
-	}
+
+	c := New(config)
 
 	tests := []struct {
 		testName       string

--- a/pkg/configtx/signer_test.go
+++ b/pkg/configtx/signer_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
+	cb "github.com/hyperledger/fabric-protos-go/common"
 	. "github.com/onsi/gomega"
 )
 
@@ -81,6 +83,121 @@ func TestPublic(t *testing.T) {
 		PrivateKey:  privateKey,
 	}
 	gt.Expect(signingIdentity.Public()).To(Equal(cert.PublicKey))
+}
+
+func TestSignConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	gt := NewGomegaWithT(t)
+
+	cert, privateKey := generateCACertAndPrivateKey(t, "org1.example.com")
+	signingIdentity := SigningIdentity{
+		Certificate: cert,
+		PrivateKey:  privateKey,
+		MSPID:       "test-msp",
+	}
+
+	configSignature, err := signingIdentity.SignConfigUpdate(&cb.ConfigUpdate{})
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	sh, err := signingIdentity.signatureHeader()
+	gt.Expect(err).NotTo(HaveOccurred())
+	expectedCreator := sh.Creator
+	signatureHeader := &cb.SignatureHeader{}
+	err = proto.Unmarshal(configSignature.SignatureHeader, signatureHeader)
+	gt.Expect(err).NotTo(HaveOccurred())
+	gt.Expect(signatureHeader.Creator).To(Equal(expectedCreator))
+}
+
+func TestSignConfigUpdateEnvelope(t *testing.T) {
+	t.Parallel()
+	gt := NewGomegaWithT(t)
+
+	// create signingIdentity
+	cert, privateKey := generateCACertAndPrivateKey(t, "org1.example.com")
+	signingIdentity := SigningIdentity{
+		Certificate: cert,
+		PrivateKey:  privateKey,
+		MSPID:       "test-msp",
+	}
+
+	// create detached config signature
+	configUpdate := &cb.ConfigUpdate{
+		ChannelId: "testchannel",
+	}
+	configSignature, err := signingIdentity.SignConfigUpdate(configUpdate)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	// create signed config envelope
+	signedEnv, err := signingIdentity.SignConfigUpdateEnvelope(configUpdate, configSignature)
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	payload := &cb.Payload{}
+	err = proto.Unmarshal(signedEnv.Payload, payload)
+	gt.Expect(err).NotTo(HaveOccurred())
+	// check header channel ID equal
+	channelHeader := &cb.ChannelHeader{}
+	err = proto.Unmarshal(payload.GetHeader().GetChannelHeader(), channelHeader)
+	gt.Expect(err).NotTo(HaveOccurred())
+	gt.Expect(channelHeader.ChannelId).To(Equal(configUpdate.ChannelId))
+	// check config update envelope signatures are equal
+	configEnv := &cb.ConfigUpdateEnvelope{}
+	err = proto.Unmarshal(payload.Data, configEnv)
+	gt.Expect(err).NotTo(HaveOccurred())
+	gt.Expect(len(configEnv.Signatures)).To(Equal(1))
+	expectedSignatures := configEnv.Signatures[0]
+	gt.Expect(expectedSignatures.SignatureHeader).To(Equal(configSignature.SignatureHeader))
+	gt.Expect(expectedSignatures.Signature).To(Equal(configSignature.Signature))
+}
+
+func TestSignConfigUpdateEnvelopeFailures(t *testing.T) {
+	t.Parallel()
+	gt := NewGomegaWithT(t)
+
+	// create signingIdentity
+	cert, privateKey := generateCACertAndPrivateKey(t, "org1.example.com")
+	signingIdentity := SigningIdentity{
+		Certificate: cert,
+		PrivateKey:  privateKey,
+		MSPID:       "test-msp",
+	}
+
+	// create detached config signature
+	configUpdate := &cb.ConfigUpdate{
+		ChannelId: "testchannel",
+	}
+	configSignature, err := signingIdentity.SignConfigUpdate(configUpdate)
+
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	tests := []struct {
+		spec            string
+		configUpdate    *cb.ConfigUpdate
+		signingIdentity SigningIdentity
+		configSignature []*cb.ConfigSignature
+		expectedErr     string
+	}{
+		{
+			spec:            "when no signatures are provided",
+			configUpdate:    nil,
+			signingIdentity: signingIdentity,
+			configSignature: []*cb.ConfigSignature{configSignature},
+			expectedErr:     "marshaling config update: proto: Marshal called with nil",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.spec, func(t *testing.T) {
+			t.Parallel()
+			gt := NewGomegaWithT(t)
+
+			// create signed config envelope
+			signedEnv, err := tc.signingIdentity.SignConfigUpdateEnvelope(tc.configUpdate, tc.configSignature...)
+			gt.Expect(err).To(MatchError(tc.expectedErr))
+			gt.Expect(signedEnv).To(BeNil())
+		})
+	}
 }
 
 func TestToLowS(t *testing.T) {


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update

#### Description

- Use New() to create ConfigTx in tests to ensure the functionality works as expected (i.e. getters retrieve from OriginalConfig() while setters set in UpdatedConfig() ). 
- Some miscellaneous cleanup.

#### Related issues

[FAB-17775](https://jira.hyperledger.org/browse/FAB-17775)