### PR TITLE
[FAB-13460] Add Support for TLS1.3

### DIFF
--- a/internal/pkg/comm/client.go
+++ b/internal/pkg/comm/client.go
@@ -71,7 +71,8 @@ func (client *GRPCClient) parseSecureOptions(opts SecureOptions) error {
 
 	client.tlsConfig = &tls.Config{
 		VerifyPeerCertificate: opts.VerifyCertificate,
-		MinVersion:            tls.VersionTLS12} // TLS 1.2 only
+		MinVersion:            tls.VersionTLS12,
+	}
 	if len(opts.ServerRootCAs) > 0 {
 		client.tlsConfig.RootCAs = x509.NewCertPool()
 		for _, certBytes := range opts.ServerRootCAs {

--- a/internal/pkg/comm/creds.go
+++ b/internal/pkg/comm/creds.go
@@ -35,9 +35,7 @@ func NewServerTransportCredentials(
 	// NOTE: unlike the default grpc/credentials implementation, we do not
 	// clone the tls.Config which allows us to update it dynamically
 	serverConfig.config.NextProtos = alpnProtoStr
-	// override TLS version and ensure it is 1.2
 	serverConfig.config.MinVersion = tls.VersionTLS12
-	serverConfig.config.MaxVersion = tls.VersionTLS12
 	return &serverCreds{
 		serverConfig: serverConfig,
 		logger:       logger}


### PR DESCRIPTION
Add support for TLS1.3 and adds a tests to ensure these versions work on the comm stack.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
