### PR TITLE
Add nsswitch.conf to the orderer and peer docker images

### DIFF
--- a/images/orderer/Dockerfile
+++ b/images/orderer/Dockerfile
@@ -6,6 +6,10 @@ ARG GO_VER
 ARG ALPINE_VER
 FROM alpine:${ALPINE_VER} as base
 RUN apk add --no-cache tzdata
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
 FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
 RUN apk add --no-cache \

--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -7,6 +7,10 @@ ARG ALPINE_VER
 
 FROM alpine:${ALPINE_VER} as peer-base
 RUN apk add --no-cache tzdata
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
 FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
 RUN apk add --no-cache \

--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache tzdata
 # set up nsswitch.conf for Go's "netgo" implementation
 # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 
 FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
 RUN apk add --no-cache \


### PR DESCRIPTION
Go's netgo implementation currently does not respect hostname overrides
defined in /etc/hosts if the /etc/nsswitch.conf does not exists.

Signed-off-by: Frank Felhoffer <frank.felhoffer@securekey.com>

#### Type of change

- Bug fix

#### Description

Golang does not use the content of the /etc/hosts file at all if there is no /etc/nsswitch.conf with some minimal configuration in place. Usually there is one, but at some point of time Alpine Linux decided to remove this file from their distribution and ever since the applications written in Go placed into an alpine based docker image struggle with this.

Users who are using the /etc/hosts file to override hostnames are unable to use the new images unless they add the nsswitch.conf on their own, either by mounting it into the image or creating they own images.

#### Additional details

Endless threads on the Internet suggests the applied solution:
https://github.com/golang/go/issues/22846
https://github.com/golang/go/issues/35305

The pull request has been tested by rebuilding the images and taking the look if the /etc/nsswitch.conf is now present.

#### Related issues

N/A
<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

