### PR TITLE
[FAB-17778] MSP.IsWellFormed: Only allow canonical CA signatures

### DIFF
--- a/msp/msp_test.go
+++ b/msp/msp_test.go
@@ -10,10 +10,12 @@ package msp
 import (
 	"crypto/ecdsa"
 	"crypto/x509"
+	"encoding/asn1"
 	"encoding/hex"
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -315,6 +317,50 @@ func TestIsWellFormed(t *testing.T) {
 	err = mspMgr.IsWellFormed(sId)
 	assert.Error(t, err)
 	assert.Equal(t, "no MSP provider recognizes the identity", err.Error())
+
+	// Restore the identity to what it was
+	sId = &msp.SerializedIdentity{}
+	err = proto.Unmarshal(serializedID, sId)
+	assert.NoError(t, err)
+
+	// Append some trailing junk at the end
+	sId.IdBytes = append(sId.IdBytes, []byte{1, 2, 3}...)
+	// And ensure it is deemed invalid
+	err = localMsp.IsWellFormed(sId)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "for MSP SampleOrg has trailing bytes")
+
+	// Parse the certificate of the identity
+	cert, err := x509.ParseCertificate(bl.Bytes)
+	assert.NoError(t, err)
+	// Obtain the ECDSA signature
+	r, s, err := utils.UnmarshalECDSASignature(cert.Signature)
+	assert.NoError(t, err)
+
+	// Modify it by appending some bytes to its end.
+	modifiedSig, err := asn1.Marshal(rst{
+		R: r,
+		S: s,
+		T: big.NewInt(100),
+	})
+	assert.NoError(t, err)
+	newCert, err := certFromX509Cert(cert)
+	assert.NoError(t, err)
+	newCert.SignatureValue.Bytes = modifiedSig
+	newCert.SignatureValue.BitLength = len(newCert.SignatureValue.Bytes) * 8
+	newCert.Raw = nil
+	// Pour it back into the identity
+	rawCert, err := asn1.Marshal(newCert)
+	assert.NoError(t, err)
+	sId.IdBytes = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rawCert})
+	// Ensure it is invalid now and the signature modification is detected
+	err = localMsp.IsWellFormed(sId)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "for MSP SampleOrg has a non canonical signature")
+}
+
+type rst struct {
+	R, S, T *big.Int
 }
 
 func TestValidateCAIdentity(t *testing.T) {


### PR DESCRIPTION
This change makes MSP.IsWellFormed (not used in transaction validation, only for gossip)
for x509 based identities to check that the signature of the CA over an identity has canonical ASN1 encoding.
It also makes sure that the certificate is encoded in a single and minimal PEM block.

Change-Id: I7ba0db00b3eb58171bb05ee7680721a41ef1c802
Signed-off-by: yacovm <yacovm@il.ibm.com>
