### PR TITLE
[FAB-17804] The variable peerAddress is misspelled as "preeAddress" when config is loading

### DIFF
--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -215,14 +215,14 @@ func GlobalConfig() (*Config, error) {
 }
 
 func (c *Config) load() error {
-	preeAddress, err := getLocalAddress()
+	peerAddress, err := getLocalAddress()
 	if err != nil {
 		return err
 	}
 
 	configDir := filepath.Dir(viper.ConfigFileUsed())
 
-	c.PeerAddress = preeAddress
+	c.PeerAddress = peerAddress
 	c.PeerID = viper.GetString("peer.id")
 	c.LocalMSPID = viper.GetString("peer.localMspId")
 	c.ListenAddress = viper.GetString("peer.listenAddress")


### PR DESCRIPTION
#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description

- The variable peerAddress is misspelled as "preeAddress" when config is loading

#### Related issues
- https://jira.hyperledger.org/browse/FAB-17804

