### PR TITLE
remove external builder bin release binary file Stat

### DIFF
--- a/core/container/externalbuilder/externalbuilder.go
+++ b/core/container/externalbuilder/externalbuilder.go
@@ -316,17 +316,8 @@ func (b *Builder) Build(buildContext *BuildContext) error {
 func (b *Builder) Release(buildContext *BuildContext) error {
 	release := filepath.Join(b.Location, "bin", "release")
 
-	_, err := os.Stat(release)
-	if os.IsNotExist(err) {
-		b.Logger.Debugf("Skipping release step for '%s' as no release binary found", buildContext.CCID)
-		return nil
-	}
-	if err != nil {
-		return errors.WithMessagef(err, "could not stat release binary '%s'", release)
-	}
-
 	cmd := b.NewCommand(release, buildContext.BldDir, buildContext.ReleaseDir)
-	err = b.runCommand(cmd)
+	err := b.runCommand(cmd)
 	if err != nil {
 		return errors.Wrapf(err, "builder '%s' release failed", b.Name)
 	}

--- a/core/container/externalbuilder/externalbuilder_test.go
+++ b/core/container/externalbuilder/externalbuilder_test.go
@@ -279,17 +279,6 @@ var _ = Describe("externalbuilder", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			When("the release binary is not in the builder", func() {
-				BeforeEach(func() {
-					builder.Location = "bad-builder-location"
-				})
-
-				It("returns no error as release is optional", func() {
-					err := builder.Release(buildContext)
-					Expect(err).NotTo(HaveOccurred())
-				})
-			})
-
 			When("the builder exits with a non-zero status", func() {
 				BeforeEach(func() {
 					builder.Location = "testdata/failbuilder"


### PR DESCRIPTION
Signed-off-by: kevinxiong <59443487@qq.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (improvement to code, performance, etc)

#### Description

<!--- Describe your changes in detail, including motivation. -->
In core/container/externalbuilder/externalbuilder.go, we have three other functions: Detect, Build, and Run. They do not perform file bin/detect, bin/build, and bin/run existence detection, and they can safely run on various platforms. I haven't found the need for the Release function to check the file bin/release existence. If these code segments are removed, it can also be safely run on various platforms including windows.

reference: suspend external builder bin release binary file Stat on windows
https://github.com/hyperledger/fabric/pull/1155
