### PR TITLE
Switch from os.Stat to exec.LookPath

### DIFF
--- a/core/container/externalbuilder/externalbuilder.go
+++ b/core/container/externalbuilder/externalbuilder.go
@@ -316,13 +316,10 @@ func (b *Builder) Build(buildContext *BuildContext) error {
 func (b *Builder) Release(buildContext *BuildContext) error {
 	release := filepath.Join(b.Location, "bin", "release")
 
-	_, err := os.Stat(release)
-	if os.IsNotExist(err) {
+	_, err := exec.LookPath(release)
+	if err != nil {
 		b.Logger.Debugf("Skipping release step for '%s' as no release binary found", buildContext.CCID)
 		return nil
-	}
-	if err != nil {
-		return errors.WithMessagef(err, "could not stat release binary '%s'", release)
 	}
 
 	cmd := b.NewCommand(release, buildContext.BldDir, buildContext.ReleaseDir)


### PR DESCRIPTION
Replace call to `os.Stat` to check for the presence of the `bin/release` script with `exec.LookPath`. The `LookPath` function, when provided with a relative path, will look for the presence of the executable and determine if it's executable. On non-unix platforms, it will also handle looking for executable suffixes as appropriate.

This supersedes #1155 and #1162 as it implements the suggested change.