### PR TITLE
[FAB-17805] Remove duplicate codes in file bccsp/sw/ecdsa_test.go

### DIFF
--- a/bccsp/sw/ecdsa_test.go
+++ b/bccsp/sw/ecdsa_test.go
@@ -42,7 +42,6 @@ func TestSignECDSABadParameter(t *testing.T) {
 	_, err = signECDSA(lowLevelKey, msg, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "zero parameter")
-	lowLevelKey.Params().N = oldN
 }
 
 func TestVerifyECDSA(t *testing.T) {
@@ -59,10 +58,6 @@ func TestVerifyECDSA(t *testing.T) {
 	valid, err := verifyECDSA(&lowLevelKey.PublicKey, sigma, msg, nil)
 	assert.NoError(t, err)
 	assert.True(t, valid)
-
-	_, err = verifyECDSA(&lowLevelKey.PublicKey, nil, msg, nil)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Failed unmashalling signature [")
 
 	_, err = verifyECDSA(&lowLevelKey.PublicKey, nil, msg, nil)
 	assert.Error(t, err)


### PR DESCRIPTION
Signed-off-by: xu wu <wuxu1103@163.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Test update

#### Description
In function TestSignECDSABadParameter, (https://github.com/hyperledger/fabric/blob/9fabf569a7f4a0b161a6cbed19b1de6cc81db6af/bccsp/sw/ecdsa_test.go#L45) is meaningless, whose function has been implemented in defer(https://github.com/hyperledger/fabric/blob/9fabf569a7f4a0b161a6cbed19b1de6cc81db6af/bccsp/sw/ecdsa_test.go#L40).

In function TestVerifyECDSA, (https://github.com/hyperledger/fabric/blob/9fabf569a7f4a0b161a6cbed19b1de6cc81db6af/bccsp/sw/ecdsa_test.go#L63~#L65) and (https://github.com/hyperledger/fabric/blob/9fabf569a7f4a0b161a6cbed19b1de6cc81db6af/bccsp/sw/ecdsa_test.go#L67~#L69) are repeated.

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues
https://jira.hyperledger.org/browse/FAB-17805
<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
