### PR TITLE
Stop modifying curve held in crypto package var

### DIFF
--- a/bccsp/sw/ecdsa_test.go
+++ b/bccsp/sw/ecdsa_test.go
@@ -35,11 +35,11 @@ func TestSignECDSABadParameter(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Induce an error on the underlying ecdsa algorithm
-	msg := []byte("hello world")
-	oldN := lowLevelKey.Params().N
-	defer func() { lowLevelKey.Params().N = oldN }()
-	lowLevelKey.Params().N = big.NewInt(0)
-	_, err = signECDSA(lowLevelKey, msg, nil)
+	curve := *elliptic.P256().Params()
+	curve.N = big.NewInt(0)
+	lowLevelKey.Curve = &curve
+
+	_, err = signECDSA(lowLevelKey, []byte("hello world"), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "zero parameter")
 }


### PR DESCRIPTION
When TestSignECDSABadParameter modified the N parameter of the generated private key, it was actually modifying the copy of the curve maintained by the standard library. Since it modified the standard library, it would restore the original value out of a defer.

Simply copying the curve would prevent any modification to the package level state from the standard library and remove the need to save and restore the original N value of the curve.