### PR TITLE
Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation

### DIFF
--- a/core/chaincode/platforms/golang/platform.go
+++ b/core/chaincode/platforms/golang/platform.go
@@ -171,7 +171,7 @@ func (p *Platform) GetDeploymentPayload(codepath string) ([]byte, error) {
 	for _, file := range fileMap.Sources() {
 		err = util.WriteFileToPackage(file.Path, file.Name, tw)
 		if err != nil {
-			return nil, fmt.Errorf("Error writing %s to tar: %s", file.Name, err)
+			return nil, fmt.Errorf("failed writing %s to tar: %s", file.Name, err)
 		}
 	}
 

--- a/internal/peer/packaging/platforms.go
+++ b/internal/peer/packaging/platforms.go
@@ -59,7 +59,7 @@ func NewRegistry(platformTypes ...Platform) *Registry {
 func (r *Registry) ValidateSpec(ccType, path string) error {
 	platform, ok := r.Platforms[ccType]
 	if !ok {
-		return fmt.Errorf("Unknown chaincodeType: %s", ccType)
+		return fmt.Errorf("unknown chaincodeType: %s", ccType)
 	}
 	return platform.ValidatePath(path)
 }
@@ -78,7 +78,7 @@ func (r *Registry) NormalizePath(ccType, path string) (string, error) {
 func (r *Registry) ValidateDeploymentSpec(ccType string, codePackage []byte) error {
 	platform, ok := r.Platforms[ccType]
 	if !ok {
-		return fmt.Errorf("Unknown chaincodeType: %s", ccType)
+		return fmt.Errorf("unknown chaincodeType: %s", ccType)
 	}
 
 	// ignore empty packages
@@ -92,7 +92,7 @@ func (r *Registry) ValidateDeploymentSpec(ccType string, codePackage []byte) err
 func (r *Registry) GetDeploymentPayload(ccType, path string) ([]byte, error) {
 	platform, ok := r.Platforms[ccType]
 	if !ok {
-		return nil, fmt.Errorf("Unknown chaincodeType: %s", ccType)
+		return nil, fmt.Errorf("unknown chaincodeType: %s", ccType)
 	}
 
 	return platform.GetDeploymentPayload(path)


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)


#### Description

- Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation

