### PR TITLE
Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation

### DIFF
--- a/internal/peer/packaging/platforms.go
+++ b/internal/peer/packaging/platforms.go
@@ -59,7 +59,7 @@ func NewRegistry(platformTypes ...Platform) *Registry {
 func (r *Registry) ValidateSpec(ccType, path string) error {
 	platform, ok := r.Platforms[ccType]
 	if !ok {
-		return fmt.Errorf("Unknown chaincodeType: %s", ccType)
+		return fmt.Errorf("unknown chaincodeType: %s", ccType)
 	}
 	return platform.ValidatePath(path)
 }
@@ -78,7 +78,7 @@ func (r *Registry) NormalizePath(ccType, path string) (string, error) {
 func (r *Registry) ValidateDeploymentSpec(ccType string, codePackage []byte) error {
 	platform, ok := r.Platforms[ccType]
 	if !ok {
-		return fmt.Errorf("Unknown chaincodeType: %s", ccType)
+		return fmt.Errorf("unknown chaincodeType: %s", ccType)
 	}
 
 	// ignore empty packages
@@ -92,7 +92,7 @@ func (r *Registry) ValidateDeploymentSpec(ccType string, codePackage []byte) err
 func (r *Registry) GetDeploymentPayload(ccType, path string) ([]byte, error) {
 	platform, ok := r.Platforms[ccType]
 	if !ok {
-		return nil, fmt.Errorf("Unknown chaincodeType: %s", ccType)
+		return nil, fmt.Errorf("unknown chaincodeType: %s", ccType)
 	}
 
 	return platform.GetDeploymentPayload(path)

--- a/internal/peer/packaging/platforms_test.go
+++ b/internal/peer/packaging/platforms_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Platforms", func() {
 			Context("when the platform is unknown", func() {
 				It("returns an error", func() {
 					err := registry.ValidateSpec("badType", "")
-					Expect(err).To(MatchError("Unknown chaincodeType: badType"))
+					Expect(err).To(MatchError("unknown chaincodeType: badType"))
 				})
 			})
 		})
@@ -73,7 +73,7 @@ var _ = Describe("Platforms", func() {
 			Context("when the platform is unknown", func() {
 				It("returns an error", func() {
 					err := registry.ValidateDeploymentSpec("badType", nil)
-					Expect(err).To(MatchError("Unknown chaincodeType: badType"))
+					Expect(err).To(MatchError("unknown chaincodeType: badType"))
 				})
 			})
 		})
@@ -92,7 +92,7 @@ var _ = Describe("Platforms", func() {
 				It("returns an error", func() {
 					payload, err := registry.GetDeploymentPayload("badType", "")
 					Expect(payload).To(BeNil())
-					Expect(err).To(MatchError("Unknown chaincodeType: badType"))
+					Expect(err).To(MatchError("unknown chaincodeType: badType"))
 				})
 			})
 		})


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
- Test update

#### Description

Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation