### PR TITLE
[LEDGER] ensure peer panic does not occur when the index path is wrong

### DIFF
--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/common_storage_db.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/common_storage_db.go
@@ -32,14 +32,6 @@ const (
 	pvtDataPrefix  = "p"
 	hashDataPrefix = "h"
 	couchDB        = "CouchDB"
-	// Example for chaincode indexes:
-	// "META-INF/statedb/couchdb/indexes/indexColorSortName.json"
-	chaincodeIndexDirDepth = 3
-	// Example for collection scoped indexes:
-	// "META-INF/statedb/couchdb/collections/collectionMarbles/indexes/indexCollMarbles.json"
-	collectionDirDepth      = 3
-	collectionNameDepth     = 4
-	collectionIndexDirDepth = 5
 )
 
 // StateDBConfig encapsulates the configuration for stateDB on the ledger.
@@ -399,13 +391,27 @@ type indexInfo struct {
 	collectionName        string
 }
 
+const (
+	// Example for chaincode indexes:
+	// "META-INF/statedb/couchdb/indexes/indexColorSortName.json"
+	chaincodeIndexDirDepth = 3
+	// Example for collection scoped indexes:
+	// "META-INF/statedb/couchdb/collections/collectionMarbles/indexes/indexCollMarbles.json"
+	collectionDirDepth      = 3
+	collectionNameDepth     = 4
+	collectionIndexDirDepth = 5
+)
+
 func getIndexInfo(indexPath string) *indexInfo {
 	indexInfo := &indexInfo{}
 	dirsDepth := strings.Split(indexPath, "/")
 	switch {
-	case dirsDepth[chaincodeIndexDirDepth] == "indexes":
+	case len(dirsDepth) > chaincodeIndexDirDepth &&
+		dirsDepth[chaincodeIndexDirDepth] == "indexes":
 		indexInfo.hasIndexForChaincode = true
-	case dirsDepth[collectionDirDepth] == "collections" && dirsDepth[collectionIndexDirDepth] == "indexes":
+	case len(dirsDepth) > collectionDirDepth &&
+		dirsDepth[collectionDirDepth] == "collections" &&
+		dirsDepth[collectionIndexDirDepth] == "indexes":
 		indexInfo.hasIndexForCollection = true
 		indexInfo.collectionName = dirsDepth[collectionNameDepth]
 	}

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/common_storage_db_test.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/common_storage_db_test.go
@@ -4,37 +4,34 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package privacyenabledstate_test
+package privacyenabledstate
 
 import (
 	"testing"
 
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/statecouchdb"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/stateleveldb"
 	"github.com/hyperledger/fabric/core/ledger/mock"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHealthCheckRegister(t *testing.T) {
-	gt := NewGomegaWithT(t)
 	fakeHealthCheckRegistry := &mock.HealthCheckRegistry{}
-
-	dbProvider := &privacyenabledstate.CommonStorageDBProvider{
+	dbProvider := &CommonStorageDBProvider{
 		VersionedDBProvider: &stateleveldb.VersionedDBProvider{},
 		HealthCheckRegistry: fakeHealthCheckRegistry,
 	}
 
 	err := dbProvider.RegisterHealthChecker()
-	gt.Expect(err).NotTo(HaveOccurred())
-	gt.Expect(fakeHealthCheckRegistry.RegisterCheckerCallCount()).To(Equal(0))
+	require.NoError(t, err)
+	require.Equal(t, 0, fakeHealthCheckRegistry.RegisterCheckerCallCount())
 
 	dbProvider.VersionedDBProvider = &statecouchdb.VersionedDBProvider{}
 	err = dbProvider.RegisterHealthChecker()
-	gt.Expect(err).NotTo(HaveOccurred())
-	gt.Expect(fakeHealthCheckRegistry.RegisterCheckerCallCount()).To(Equal(1))
+	require.NoError(t, err)
+	require.Equal(t, 1, fakeHealthCheckRegistry.RegisterCheckerCallCount())
 
 	arg1, arg2 := fakeHealthCheckRegistry.RegisterCheckerArgsForCall(0)
-	gt.Expect(arg1).To(Equal("couchdb"))
-	gt.Expect(arg2).NotTo(Equal(nil))
+	require.Equal(t, "couchdb", arg1)
+	require.NotNil(t, arg2)
 }

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/common_storage_db_test.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/common_storage_db_test.go
@@ -35,3 +35,40 @@ func TestHealthCheckRegister(t *testing.T) {
 	require.Equal(t, "couchdb", arg1)
 	require.NotNil(t, arg2)
 }
+
+func TestGetIndexInfo(t *testing.T) {
+	chaincodeIndexPath := "META-INF/statedb/couchdb/indexes/indexColorSortName.json"
+	actualIndexInfo := getIndexInfo(chaincodeIndexPath)
+	expectedIndexInfo := &indexInfo{
+		hasIndexForChaincode:  true,
+		hasIndexForCollection: false,
+		collectionName:        "",
+	}
+	require.Equal(t, expectedIndexInfo, actualIndexInfo)
+
+	collectionIndexPath := "META-INF/statedb/couchdb/collections/collectionMarbles/indexes/indexCollMarbles.json"
+	actualIndexInfo = getIndexInfo(collectionIndexPath)
+	expectedIndexInfo = &indexInfo{
+		hasIndexForChaincode:  false,
+		hasIndexForCollection: true,
+		collectionName:        "collectionMarbles",
+	}
+	require.Equal(t, expectedIndexInfo, actualIndexInfo)
+
+	incorrectChaincodeIndexPath := "META-INF/statedb/couchdb/indexColorSortName.json"
+	actualIndexInfo = getIndexInfo(incorrectChaincodeIndexPath)
+	expectedIndexInfo = &indexInfo{
+		hasIndexForChaincode:  false,
+		hasIndexForCollection: false,
+		collectionName:        "",
+	}
+	require.Equal(t, expectedIndexInfo, actualIndexInfo)
+
+	incorrectCollectionIndexPath := "META-INF/statedb/couchdb/collections/indexes/indexCollMarbles.json"
+	actualIndexInfo = getIndexInfo(incorrectCollectionIndexPath)
+	require.Equal(t, expectedIndexInfo, actualIndexInfo)
+
+	incorrectIndexPath := "META-INF/statedb/"
+	actualIndexInfo = getIndexInfo(incorrectIndexPath)
+	require.Equal(t, expectedIndexInfo, actualIndexInfo)
+}


### PR DESCRIPTION
#### Type of change

- Bug fix
- Improvement (improvement to code)

#### Description

While processing the CouchDB index files, we retrieve and store all directories in the index file path into an array in order to find whether it is a `chaincode` index or `collection` index. If it is a collection index, the collection name would be found using the same array. 

Currently, we access this array without checking the number of directories in the path (i.e., the length of the array) assuming that the user would pass the correct path. When the user passes a wrong path, the array access could result in a peer panic. Hence, in this PR, we check the length of the array before accessing it. UT is added too. 

#### Related issues

[FAB-17771](https://jira.hyperledger.org/browse/FAB-17771)