### PR TITLE
Update enable_cc_lifecycle.md

### DIFF
--- a/docs/source/enable_cc_lifecycle.md
+++ b/docs/source/enable_cc_lifecycle.md
@@ -231,7 +231,7 @@ Once you have the environment variables set, navigate to [Step 1: Pull and trans
 Once you have a `modified_config.json`, add the ACLs (as listed in `enable_lifecycle.json`) using this command:
 
 ```
-jq -s '.[0] * {"channel_group":{"groups":{"Application": {"values": {"ACLs": {"value": {"acls": .[1].acls}}}}}}}' config.json ./scripts/policies.json > modified_config.json
+jq -s '.[0] * {"channel_group":{"groups":{"Application": {"values": {"ACLs": {"value": {"acls": .[1].acls}}}}}}}' config.json ./enable_lifecycle.json > modified_config.json
 ```
 
 Then, follow the steps at [Step 3: Re-encode and submit the config](./config_update.html#step-3-re-encode-and-submit-the-config).


### PR DESCRIPTION
#### Type of change
- Documentation update

#### Description

While editing channel ACLs the configurations should be injected using the file **enable_lifecycle.json** instead of the **./scripts/policies.json** file, which might have been used by the developers or testing team.
