### PR TITLE
[FAB-17819] Discovery returns user friendly errors

### DIFF
--- a/discovery/endorsement/endorsement_test.go
+++ b/discovery/endorsement/endorsement_test.go
@@ -129,7 +129,7 @@ func TestPeersForEndorsement(t *testing.T) {
 			},
 		})
 		assert.Nil(t, desc)
-		assert.Equal(t, err.Error(), "cannot satisfy any principal combination")
+		assert.Equal(t, err.Error(), "no peer combination can satisfy the endorsement policy")
 	})
 
 	t.Run("DisjointViews", func(t *testing.T) {
@@ -222,7 +222,7 @@ func TestPeersForEndorsement(t *testing.T) {
 			},
 		})
 		assert.Nil(t, desc)
-		assert.Equal(t, "cannot satisfy any principal combination", err.Error())
+		assert.Equal(t, "required chaincodes are not installed on sufficient peers", err.Error())
 
 		// Scenario VI: Policy is found, there are enough peers to satisfy policy combinations,
 		// but some peers have the wrong chaincode version, and some don't even have it installed.
@@ -247,7 +247,7 @@ func TestPeersForEndorsement(t *testing.T) {
 			},
 		})
 		assert.Nil(t, desc)
-		assert.Equal(t, "cannot satisfy any principal combination", err.Error())
+		assert.Equal(t, "required chaincodes are not installed on sufficient peers", err.Error())
 	})
 
 	t.Run("NoChaincodeMetadataFromLedger", func(t *testing.T) {


### PR DESCRIPTION
Currently, the discovery service filters out peers that don't have the chaincode installed
early on in the computation, and as a result - the service cannot distinguish from a case
where there are not enough alive peers to satisfy the endorsement policy, or that there are
enough peers but the chaincode is not installed on enough of them.

This change set defers the chaincode filtering to the end of the computation, so
the layouts and peer group mapping is creating without taking into account if the peers
have the chaincode installed on them, and if there is no layout that can be satisfied
without taking into account the chaincodes - the error that is returned now
is "no peer combination can satisfy the endorsement policy",
instead of "cannot satisfy any principal combination".

Afterwards, the layouts are being inspected once again, and then the layouts
that cannot be satisfied are filtered out, when the error returned
when no layout can be satisfied is now: "required chaincodes are not installed on sufficient peers".

Change-Id: I74eb29b30aec1a87842d220414c73872cdbc8304
Signed-off-by: yacovm <yacovm@il.ibm.com>
