### PR TITLE
Update old link in command wrappers

### DIFF
--- a/docs/source/commands/peernode.md
+++ b/docs/source/commands/peernode.md
@@ -62,7 +62,6 @@ peer node start --peer-chaincodedev
 
 starts a peer node in chaincode development mode. Normally chaincode containers are started
 and maintained by peer. However in chaincode development mode, chaincode is built and started by the user. This mode is useful during chaincode development phase for iterative development.
-See more information on development mode in the [chaincode tutorial](../chaincode4ade.html).
 
 ### peer node reset example
 

--- a/docs/wrappers/peer_lifecycle_chaincode_preamble.md
+++ b/docs/wrappers/peer_lifecycle_chaincode_preamble.md
@@ -5,7 +5,7 @@ Fabric chaincode lifecycle to package a chaincode, install it on your peers,
 approve a chaincode definition for your organization, and then commit the
 definition to a channel. The chaincode is ready to be used after the definition
 has been successfully committed to the channel. For more information, visit
-[Chaincode for Operators](../chaincode4noah.html).
+[Fabric chaincode lifecycle](../chaincode_lifecycle.html).
 
 *Note: These instructions use the Fabric chaincode lifecycle introduced in the
 v2.0 release. If you would like to use the old lifecycle to install and

--- a/docs/wrappers/peer_node_postscript.md
+++ b/docs/wrappers/peer_node_postscript.md
@@ -10,7 +10,6 @@ peer node start --peer-chaincodedev
 
 starts a peer node in chaincode development mode. Normally chaincode containers are started
 and maintained by peer. However in chaincode development mode, chaincode is built and started by the user. This mode is useful during chaincode development phase for iterative development.
-See more information on development mode in the [chaincode tutorial](../chaincode4ade.html).
 
 ### peer node reset example
 


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>


#### Type of change

- Documentation update

#### Description

Updated the link to cc lifecycle in the docs, but did not update it to the doc preamble in the wrappers folders. Also one link should be removed. Came accros these changes when I tested the make help-docs text.