### PR TITLE
Remove an internal interface in block storage code

### DIFF
--- a/common/ledger/blkstorage/fsblkstorage/blockfile_mgr.go
+++ b/common/ledger/blkstorage/fsblkstorage/blockfile_mgr.go
@@ -39,7 +39,7 @@ type blockfileMgr struct {
 	rootDir           string
 	conf              *Conf
 	db                *leveldbhelper.DBHandle
-	index             index
+	index             *blockIndex
 	cpInfo            *checkpointInfo
 	cpInfoCond        *sync.Cond
 	currentFileWriter *blockfileWriter

--- a/common/ledger/blkstorage/fsblkstorage/blockindex.go
+++ b/common/ledger/blkstorage/fsblkstorage/blockindex.go
@@ -32,18 +32,6 @@ const (
 var indexCheckpointKey = []byte(indexCheckpointKeyStr)
 var errIndexEmpty = errors.New("NoBlockIndexed")
 
-type index interface {
-	getLastBlockIndexed() (uint64, error)
-	indexBlock(blockIdxInfo *blockIdxInfo) error
-	getBlockLocByHash(blockHash []byte) (*fileLocPointer, error)
-	getBlockLocByBlockNum(blockNum uint64) (*fileLocPointer, error)
-	getTxLoc(txID string) (*fileLocPointer, error)
-	getTXLocByBlockNumTranNum(blockNum uint64, tranNum uint64) (*fileLocPointer, error)
-	getBlockLocByTxID(txID string) (*fileLocPointer, error)
-	getTxValidationCodeByTxID(txID string) (peer.TxValidationCode, error)
-	isAttributeIndexed(attribute blkstorage.IndexableAttr) bool
-}
-
 type blockIdxInfo struct {
 	blockNum  uint64
 	blockHash []byte


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- Improvement

#### Description
Block storage code was initially written such that a more efficient
custom index could be written, given the property that the writes to
this index are append-only. However, for now, we can remove the
interface for a better code navigation.