### PR TITLE
Fix docker network leak from RAFT integration test

### DIFF
--- a/integration/raft/config_test.go
+++ b/integration/raft/config_test.go
@@ -161,6 +161,7 @@ var _ = Describe("EndToEnd reconfiguration and onboarding", func() {
 			ordererRunner := network.OrdererGroupRunner()
 			process := ifrit.Invoke(ordererRunner)
 			Eventually(process.Wait, network.EventuallyTimeout).Should(Receive()) // orderer process should exit
+			network.Cleanup()
 			os.RemoveAll(testDir)
 
 			By("Starting orderer with correct genesis block")


### PR DESCRIPTION
One of the reconfiguration tests bootstrapped a network that it did not clean up. This results in a docker network leak.