### PR TITLE
Remove GOPATH references in CI artifacts

### DIFF
--- a/ci/azure-pipelines-merge.yml
+++ b/ci/azure-pipelines-merge.yml
@@ -9,9 +9,9 @@ trigger:
 pr: none
 
 variables:
-  GOPATH: $(Agent.BuildDirectory)/go
-  PATH: $(Agent.BuildDirectory)/go/bin:/usr/local/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+  GOBIN: $(Agent.BuildDirectory)/go/bin
   GOVER: 1.14.1
+  PATH: $(Agent.BuildDirectory)/go/bin:/usr/local/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 
 jobs:
   - job: UnitTests
@@ -20,7 +20,7 @@ jobs:
     steps:
       - template: install_deps.yml
       - checkout: self
-        path: 'go/src/github.com/hyperledger/fabric'
+        path: 'fabric'
         displayName: Checkout Fabric Code
       - script: ./ci/scripts/setup_hsm.sh
         displayName: Install SoftHSM

--- a/ci/azure-pipelines-release.yml
+++ b/ci/azure-pipelines-release.yml
@@ -8,8 +8,6 @@ pr: none
 
 variables:
   - group: credentials
-  - name: GOPATH
-    value: $(Agent.BuildDirectory)/go
   - name: GOVER
     value: 1.14.1
 
@@ -32,7 +30,7 @@ stages:
               TARGET: windows-amd64
         steps:
           - checkout: self
-            path: 'go/src/github.com/hyperledger/fabric'
+            path: 'fabric'
             displayName: Checkout Fabric Code
           - script: ./ci/scripts/create_binary_package.sh
             displayName: Compile Binary and Create Tarball
@@ -50,7 +48,7 @@ stages:
         steps:
           - template: install_deps.yml
           - checkout: self
-            path: 'go/src/github.com/hyperledger/fabric'
+            path: 'fabric'
             displayName: Checkout Fabric Code
           - script: ./ci/scripts/publish_docker.sh
             env:

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -9,9 +9,9 @@ pr:
 - release-2.*
 
 variables:
-  GOPATH: $(Agent.BuildDirectory)/go
-  PATH: $(Agent.BuildDirectory)/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+  GOBIN: $(Agent.BuildDirectory)/go/bin
   GOVER: 1.14.1
+  PATH: $(Agent.BuildDirectory)/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 
 jobs:
   - job: VerifyBuild
@@ -20,7 +20,7 @@ jobs:
     steps:
       - template: install_deps.yml
       - checkout: self
-        path: 'go/src/github.com/hyperledger/fabric'
+        path: 'fabric'
         displayName: Checkout Fabric Code
       - script: make basic-checks native
         displayName: Run Basic Checks
@@ -36,7 +36,7 @@ jobs:
       image: n42org/tox:3.4.0
     steps:
       - checkout: self
-        path: 'go/src/github.com/hyperledger/fabric'
+        path: 'fabric'
         displayName: Checkout Fabric Code
       - script: tox -edocs
         displayName: Build Documentation
@@ -51,7 +51,7 @@ jobs:
     steps:
       - template: install_deps.yml
       - checkout: self
-        path: 'go/src/github.com/hyperledger/fabric'
+        path: 'fabric'
         displayName: Checkout Fabric Code
       - script: ./ci/scripts/setup_hsm.sh
         displayName: Install SoftHSM
@@ -69,7 +69,7 @@ jobs:
     steps:
       - template: install_deps.yml
       - checkout: self
-        path: 'go/src/github.com/hyperledger/fabric'
+        path: 'fabric'
         displayName: Checkout Fabric Code
       - script: make integration-test
         displayName: Run Integration Tests

--- a/ci/install_deps.yml
+++ b/ci/install_deps.yml
@@ -13,5 +13,4 @@ steps:
   - task: GoTool@0
     inputs:
       version: $(GOVER)
-      goPath:  $(GOPATH)
-    displayName: Install GoLang
+    displayName: Install Go

--- a/gotools.mk
+++ b/gotools.mk
@@ -5,7 +5,7 @@
 
 GOTOOLS = counterfeiter ginkgo gocov gocov-xml goimports golint misspell mockery protoc-gen-go
 BUILD_DIR ?= build
-GOTOOLS_BINDIR ?= $(shell go env GOPATH)/bin
+GOTOOLS_BINDIR ?= $(BUILD_DIR)/gotools/bin
 
 # go tool->path mapping
 go.fqp.counterfeiter := github.com/maxbrunsfeld/counterfeiter/v6

--- a/scripts/check_spelling.sh
+++ b/scripts/check_spelling.sh
@@ -11,8 +11,10 @@ filter() {
     done
 }
 
-CHECK=$(git diff --name-only HEAD -- * | filter)
+gotools_bindir="$(cd "$(dirname "$0")/.." && pwd)/build/gotools/bin"
+export PATH="$gotools_bindir:$PATH"
 
+CHECK=$(git diff --name-only HEAD -- * | filter)
 if [[ -z "$CHECK" ]]; then
     CHECK=$(git diff-tree --no-commit-id --name-only -r HEAD^..HEAD | filter)
 fi

--- a/scripts/compile_protos.sh
+++ b/scripts/compile_protos.sh
@@ -5,7 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set -eux -o pipefail
+set -eu -o pipefail
+
+gotools_bindir="$(cd "$(dirname "$0")/.." && pwd)/build/gotools/bin"
+export PATH="$gotools_bindir:$PATH"
 
 # Find all proto dirs to be processed
 PROTO_DIRS="$(find "$(pwd)" \

--- a/scripts/generateHelpDocs.sh
+++ b/scripts/generateHelpDocs.sh
@@ -3,8 +3,9 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
-PATH=build/bin/:${PATH}
+
+fabric_dir="$(cd "$(dirname "$0")/.." && pwd)"
+export PATH="${fabric_dir}/build/bin:$PATH"
 
 # Takes in 4 arguments
 # 1. Output doc file

--- a/scripts/golinter.sh
+++ b/scripts/golinter.sh
@@ -6,10 +6,13 @@
 
 set -e
 
-# shellcheck source=/dev/null
-source "$(cd "$(dirname "$0")" && pwd)/functions.sh"
-
 fabric_dir="$(cd "$(dirname "$0")/.." && pwd)"
+gotools_bindir="$fabric_dir/build/gotools/bin"
+export PATH="$gotools_bindir:$PATH"
+
+# shellcheck source=/dev/null
+source "${fabric_dir}/scripts/functions.sh"
+
 source_dirs=()
 while IFS=$'\n' read -r source_dir; do
     source_dirs+=("$source_dir")

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -12,6 +12,7 @@ set -eu
 
 fabric_dir="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$fabric_dir"
+export PATH="$fabric_dir/build/gotools/bin:$PATH"
 
 declare -a test_dirs
 while IFS='' read -r line; do test_dirs+=("$line"); done < <(


### PR DESCRIPTION
With the move to modules in master, `GOPATH` should be a thing of the past. Remove the remaining references to prevent confusion and help ensure an implicit dependency does not return.