### PR TITLE
Add function in blockstore to export TxIDs

### DIFF
--- a/common/ledger/blkstorage/blockstore.go
+++ b/common/ledger/blkstorage/blockstore.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package blkstorage
 
 import (
+	"io"
 	"time"
 
 	"github.com/hyperledger/fabric-protos-go/common"
@@ -73,17 +74,25 @@ func (store *BlockStore) RetrieveTxByID(txID string) (*common.Envelope, error) {
 	return store.fileMgr.retrieveTransactionByID(txID)
 }
 
-// RetrieveTxByID returns a transaction for given transaction id
+// RetrieveTxByBlockNumTranNum returns a transaction for the given <blockNum, tranNum>
 func (store *BlockStore) RetrieveTxByBlockNumTranNum(blockNum uint64, tranNum uint64) (*common.Envelope, error) {
 	return store.fileMgr.retrieveTransactionByBlockNumTranNum(blockNum, tranNum)
 }
 
+// RetrieveBlockByTxID returns the block for the specified txID
 func (store *BlockStore) RetrieveBlockByTxID(txID string) (*common.Block, error) {
 	return store.fileMgr.retrieveBlockByTxID(txID)
 }
 
+// RetrieveTxValidationCodeByTxID returns the validation code for the specified txID
 func (store *BlockStore) RetrieveTxValidationCodeByTxID(txID string) (peer.TxValidationCode, error) {
 	return store.fileMgr.retrieveTxValidationCodeByTxID(txID)
+}
+
+// ExportTxIds writes all the TxIDs to the writer. Technically, the TxIDs appear in the sort order of radix-sort/shortlex. However,
+// since practically all the TxIDs are of same length, so the sort order would be the lexical sort order
+func (store *BlockStore) ExportTxIds(writer io.Writer) error {
+	return store.fileMgr.index.exportUniqueTxIDs(writer)
 }
 
 // Shutdown shuts down the block store


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Description
This PR is added towards ledger check-pointing. In particular this PR adds a function in the block storage that exports a byte stream of TxIDs

#### Related issues

FAB-17837