### PR TITLE
[FAB-17831] Use generic constant/var names for ledger data format

### DIFF
--- a/common/ledger/blkstorage/blockstore_provider.go
+++ b/common/ledger/blkstorage/blockstore_provider.go
@@ -65,8 +65,8 @@ type BlockStoreProvider struct {
 // NewProvider constructs a filesystem based block store provider
 func NewProvider(conf *Conf, indexConfig *IndexConfig, metricsProvider metrics.Provider) (*BlockStoreProvider, error) {
 	dbConf := &leveldbhelper.Conf{
-		DBPath:                conf.getIndexDir(),
-		ExpectedFormatVersion: dataFormatVersion(indexConfig),
+		DBPath:         conf.getIndexDir(),
+		ExpectedFormat: dataFormatVersion(indexConfig),
 	}
 
 	p, err := leveldbhelper.NewProvider(dbConf)
@@ -117,7 +117,7 @@ func (p *BlockStoreProvider) Close() {
 func dataFormatVersion(indexConfig *IndexConfig) string {
 	// in version 2.0 we merged three indexable into one `IndexableAttrTxID`
 	if indexConfig.Contains(IndexableAttrTxID) {
-		return dataformat.Version20
+		return dataformat.CurrentFormat
 	}
-	return dataformat.Version1x
+	return dataformat.PreviousFormat
 }

--- a/common/ledger/blkstorage/rollback.go
+++ b/common/ledger/blkstorage/rollback.go
@@ -61,8 +61,8 @@ func newRollbackMgr(blockStorageDir, ledgerID string, indexConfig *IndexConfig, 
 	var err error
 	r.dbProvider, err = leveldbhelper.NewProvider(
 		&leveldbhelper.Conf{
-			DBPath:                r.indexDir,
-			ExpectedFormatVersion: dataFormatVersion(indexConfig),
+			DBPath:         r.indexDir,
+			ExpectedFormat: dataFormatVersion(indexConfig),
 		},
 	)
 	if err != nil {

--- a/common/ledger/dataformat/dataformats.go
+++ b/common/ledger/dataformat/dataformats.go
@@ -8,35 +8,36 @@ package dataformat
 
 import "fmt"
 
+// The data format stored in ledger databases may be changed in a new release to
+// support new features. This file defines the constants to check whether or not
+// the data format on the ledger matches the CurrentFormat. If not matched, peer start
+// will fail and the ledger must be upgraded to the CurrentFormat. If a Fabric version
+// does not introduce a new data format, CurrentFormat will remain the same as the latest
+// format prior to the Fabric version.
 const (
-	// Version1x specifies the data format in version 1.x
-	Version1x = ""
+	// PreviousFormat specifies the data format in previous fabric version
+	PreviousFormat = ""
 
-	// Version20 specifies the data format in version 2.0
-	Version20 = "2.0"
+	// CurrentFormat specifies the data format in current fabric version
+	CurrentFormat = "2.0"
 )
 
-var (
-	// Version1xBytes defines the []byte for Version1x to be nil
-	Version1xBytes []byte = nil
-)
-
-// ErrVersionMismatch is returned if it is detected that the version of the format recorded in
+// ErrFormatMismatch is returned if it is detected that the version of the format recorded in
 // the internal database is different from what is specified in the `Conf` that is used for opening the db
-type ErrVersionMismatch struct {
-	DBInfo          string
-	ExpectedVersion string
-	Version         string
+type ErrFormatMismatch struct {
+	DBInfo         string
+	ExpectedFormat string
+	Format         string
 }
 
-func (e *ErrVersionMismatch) Error() string {
+func (e *ErrFormatMismatch) Error() string {
 	return fmt.Sprintf("unexpected format. db info = [%s], data format = [%s], expected format = [%s]",
-		e.DBInfo, e.Version, e.ExpectedVersion,
+		e.DBInfo, e.Format, e.ExpectedFormat,
 	)
 }
 
-// IsVersionMismatch returns true if err is an ErrVersionMismatch
+// IsVersionMismatch returns true if err is an ErrFormatMismatch
 func IsVersionMismatch(err error) bool {
-	_, ok := err.(*ErrVersionMismatch)
+	_, ok := err.(*ErrFormatMismatch)
 	return ok
 }

--- a/common/ledger/util/leveldbhelper/leveldb_provider.go
+++ b/common/ledger/util/leveldbhelper/leveldb_provider.go
@@ -28,14 +28,14 @@ var (
 
 // Conf configuration for `Provider`
 //
-// `ExpectedFormatVersion` is the expected value of the format key in the internal database.
+// `ExpectedFormat` is the expected value of the format key in the internal database.
 // At the time of opening the db, A check is performed that
 // either the db is empty (i.e., opening for the first time) or the value
-// of the formatVersionKey is equal to `ExpectedFormatVersion`. Otherwise, an error is returned.
-// A nil value for ExpectedFormatVersion indicates that the format is never set and hence there is no such record
+// of the formatVersionKey is equal to `ExpectedFormat`. Otherwise, an error is returned.
+// A nil value for ExpectedFormat indicates that the format is never set and hence there is no such record.
 type Conf struct {
-	DBPath                string
-	ExpectedFormatVersion string
+	DBPath         string
+	ExpectedFormat string
 }
 
 // Provider enables to use a single leveldb as multiple logical leveldbs
@@ -78,9 +78,9 @@ func openDBAndCheckFormat(conf *Conf) (d *DB, e error) {
 		return nil, err
 	}
 
-	if dbEmpty && conf.ExpectedFormatVersion != "" {
-		logger.Infof("DB is empty Setting db format as %s", conf.ExpectedFormatVersion)
-		if err := internalDB.Put(formatVersionKey, []byte(conf.ExpectedFormatVersion), true); err != nil {
+	if dbEmpty && conf.ExpectedFormat != "" {
+		logger.Infof("DB is empty Setting db format as %s", conf.ExpectedFormat)
+		if err := internalDB.Put(formatVersionKey, []byte(conf.ExpectedFormat), true); err != nil {
 			return nil, err
 		}
 		return db, nil
@@ -92,13 +92,13 @@ func openDBAndCheckFormat(conf *Conf) (d *DB, e error) {
 	}
 	logger.Debugf("Checking for db format at path [%s]", conf.DBPath)
 
-	if !bytes.Equal(formatVersion, []byte(conf.ExpectedFormatVersion)) {
+	if !bytes.Equal(formatVersion, []byte(conf.ExpectedFormat)) {
 		logger.Errorf("The db at path [%s] contains data in unexpected format. expected data format = [%s] (%#v), data format = [%s] (%#v).",
-			conf.DBPath, conf.ExpectedFormatVersion, []byte(conf.ExpectedFormatVersion), formatVersion, formatVersion)
-		return nil, &dataformat.ErrVersionMismatch{
-			ExpectedVersion: conf.ExpectedFormatVersion,
-			Version:         string(formatVersion),
-			DBInfo:          fmt.Sprintf("leveldb at [%s]", conf.DBPath),
+			conf.DBPath, conf.ExpectedFormat, []byte(conf.ExpectedFormat), formatVersion, formatVersion)
+		return nil, &dataformat.ErrFormatMismatch{
+			ExpectedFormat: conf.ExpectedFormat,
+			Format:         string(formatVersion),
+			DBInfo:         fmt.Sprintf("leveldb at [%s]", conf.DBPath),
 		}
 	}
 	logger.Debug("format is latest, nothing to do")

--- a/common/ledger/util/leveldbhelper/leveldb_provider_test.go
+++ b/common/ledger/util/leveldbhelper/leveldb_provider_test.go
@@ -94,7 +94,7 @@ func TestFormatCheck(t *testing.T) {
 		dataFormat     string
 		dataExists     bool
 		expectedFormat string
-		expectedErr    *dataformat.ErrVersionMismatch
+		expectedErr    *dataformat.ErrFormatMismatch
 	}{
 		{
 			dataFormat:     "",
@@ -118,7 +118,7 @@ func TestFormatCheck(t *testing.T) {
 			dataFormat:     "",
 			dataExists:     true,
 			expectedFormat: "2.0",
-			expectedErr:    &dataformat.ErrVersionMismatch{Version: "", ExpectedVersion: "2.0"},
+			expectedErr:    &dataformat.ErrFormatMismatch{Format: "", ExpectedFormat: "2.0"},
 		},
 		{
 			dataFormat:     "2.0",
@@ -130,7 +130,7 @@ func TestFormatCheck(t *testing.T) {
 			dataFormat:     "2.0",
 			dataExists:     true,
 			expectedFormat: "3.0",
-			expectedErr:    &dataformat.ErrVersionMismatch{Version: "2.0", ExpectedVersion: "3.0"},
+			expectedErr:    &dataformat.ErrFormatMismatch{Format: "2.0", ExpectedFormat: "3.0"},
 		},
 	}
 
@@ -143,14 +143,14 @@ func TestFormatCheck(t *testing.T) {
 	}
 }
 
-func testFormatCheck(t *testing.T, dataFormat, expectedFormat string, dataExists bool, expectedErr *dataformat.ErrVersionMismatch) {
+func testFormatCheck(t *testing.T, dataFormat, expectedFormat string, dataExists bool, expectedErr *dataformat.ErrFormatMismatch) {
 	assert.NoError(t, os.RemoveAll(testDBPath))
 	defer func() {
 		assert.NoError(t, os.RemoveAll(testDBPath))
 	}()
 
 	// setup test pre-conditions (create a db with dbformat)
-	p, err := NewProvider(&Conf{DBPath: testDBPath, ExpectedFormatVersion: dataFormat})
+	p, err := NewProvider(&Conf{DBPath: testDBPath, ExpectedFormat: dataFormat})
 	assert.NoError(t, err)
 	f, err := p.GetDataFormat()
 	assert.NoError(t, err)
@@ -161,7 +161,7 @@ func testFormatCheck(t *testing.T, dataFormat, expectedFormat string, dataExists
 
 	// close and reopen with new conf
 	p.Close()
-	p, err = NewProvider(&Conf{DBPath: testDBPath, ExpectedFormatVersion: expectedFormat})
+	p, err = NewProvider(&Conf{DBPath: testDBPath, ExpectedFormat: expectedFormat})
 	if expectedErr != nil {
 		expectedErr.DBInfo = fmt.Sprintf("leveldb at [%s]", testDBPath)
 		assert.Equal(t, err, expectedErr)

--- a/core/ledger/kvledger/history/db.go
+++ b/core/ledger/kvledger/history/db.go
@@ -31,8 +31,8 @@ func NewDBProvider(path string) (*DBProvider, error) {
 	logger.Debugf("constructing HistoryDBProvider dbPath=%s", path)
 	levelDBProvider, err := leveldbhelper.NewProvider(
 		&leveldbhelper.Conf{
-			DBPath:                path,
-			ExpectedFormatVersion: dataformat.Version20,
+			DBPath:         path,
+			ExpectedFormat: dataformat.CurrentFormat,
 		},
 	)
 	if err != nil {

--- a/core/ledger/kvledger/kv_ledger_provider_test.go
+++ b/core/ledger/kvledger/kv_ledger_provider_test.go
@@ -56,7 +56,7 @@ func TestLedgerProvider(t *testing.T) {
 	s := provider.idStore
 	val, err := s.db.Get(formatKey)
 	require.NoError(t, err)
-	require.Equal(t, []byte(dataformat.Version20), val)
+	require.Equal(t, []byte(dataformat.CurrentFormat), val)
 
 	provider.Close()
 
@@ -196,7 +196,7 @@ func TestCheckUpgradeEligibilityCurrentVersion(t *testing.T) {
 	db.Open()
 	defer db.Close()
 
-	err := idStore.db.Put(formatKey, []byte(dataformat.Version20), true)
+	err := idStore.db.Put(formatKey, []byte(dataformat.CurrentFormat), true)
 	require.NoError(t, err)
 
 	eligible, err := idStore.checkUpgradeEligibility()
@@ -216,10 +216,10 @@ func TestCheckUpgradeEligibilityBadFormat(t *testing.T) {
 	err := idStore.db.Put(formatKey, []byte("x.0"), true)
 	require.NoError(t, err)
 
-	expectedErr := &dataformat.ErrVersionMismatch{
-		ExpectedVersion: dataformat.Version1x,
-		Version:         "x.0",
-		DBInfo:          fmt.Sprintf("leveldb for channel-IDs at [%s]", LedgerProviderPath(conf.RootFSPath)),
+	expectedErr := &dataformat.ErrFormatMismatch{
+		ExpectedFormat: dataformat.PreviousFormat,
+		Format:         "x.0",
+		DBInfo:         fmt.Sprintf("leveldb for channel-IDs at [%s]", LedgerProviderPath(conf.RootFSPath)),
 	}
 	eligible, err := idStore.checkUpgradeEligibility()
 	require.EqualError(t, err, expectedErr.Error())

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
@@ -78,18 +78,18 @@ func checkExpectedDataformatVersion(couchInstance *couchInstance) error {
 		return err
 	}
 	if isEmpty {
-		logger.Debugf("couch instance is empty. Setting dataformat version to %s", dataformat.Version20)
-		return writeDataFormatVersion(couchInstance, dataformat.Version20)
+		logger.Debugf("couch instance is empty. Setting dataformat version to %s", dataformat.CurrentFormat)
+		return writeDataFormatVersion(couchInstance, dataformat.CurrentFormat)
 	}
 	dataformatVersion, err := readDataformatVersion(couchInstance)
 	if err != nil {
 		return err
 	}
-	if dataformatVersion != dataformat.Version20 {
-		return &dataformat.ErrVersionMismatch{
-			DBInfo:          "CouchDB for state database",
-			ExpectedVersion: dataformat.Version20,
-			Version:         dataformatVersion,
+	if dataformatVersion != dataformat.CurrentFormat {
+		return &dataformat.ErrFormatMismatch{
+			DBInfo:         "CouchDB for state database",
+			ExpectedFormat: dataformat.CurrentFormat,
+			Format:         dataformatVersion,
 		}
 	}
 	return nil

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
@@ -1069,18 +1069,18 @@ func assertQueryResults(t *testing.T, results []*queryResult, expectedIds []stri
 
 func TestFormatCheck(t *testing.T) {
 	testCases := []struct {
-		dataFormat     string                         // precondition
-		dataExists     bool                           // precondition
-		expectedFormat string                         // postcondition
-		expectedErr    *dataformat.ErrVersionMismatch // postcondition
+		dataFormat     string                        // precondition
+		dataExists     bool                          // precondition
+		expectedFormat string                        // postcondition
+		expectedErr    *dataformat.ErrFormatMismatch // postcondition
 	}{
 		{
 			dataFormat: "",
 			dataExists: true,
-			expectedErr: &dataformat.ErrVersionMismatch{
-				DBInfo:          "CouchDB for state database",
-				Version:         "",
-				ExpectedVersion: "2.0",
+			expectedErr: &dataformat.ErrFormatMismatch{
+				DBInfo:         "CouchDB for state database",
+				Format:         "",
+				ExpectedFormat: "2.0",
 			},
 			expectedFormat: "does not matter as the test should not reach to check this",
 		},
@@ -1089,30 +1089,30 @@ func TestFormatCheck(t *testing.T) {
 			dataFormat:     "",
 			dataExists:     false,
 			expectedErr:    nil,
-			expectedFormat: dataformat.Version20,
+			expectedFormat: dataformat.CurrentFormat,
 		},
 
 		{
-			dataFormat:     dataformat.Version20,
+			dataFormat:     dataformat.CurrentFormat,
 			dataExists:     false,
-			expectedFormat: dataformat.Version20,
+			expectedFormat: dataformat.CurrentFormat,
 			expectedErr:    nil,
 		},
 
 		{
-			dataFormat:     dataformat.Version20,
+			dataFormat:     dataformat.CurrentFormat,
 			dataExists:     true,
-			expectedFormat: dataformat.Version20,
+			expectedFormat: dataformat.CurrentFormat,
 			expectedErr:    nil,
 		},
 
 		{
 			dataFormat: "3.0",
 			dataExists: true,
-			expectedErr: &dataformat.ErrVersionMismatch{
-				DBInfo:          "CouchDB for state database",
-				Version:         "3.0",
-				ExpectedVersion: dataformat.Version20,
+			expectedErr: &dataformat.ErrFormatMismatch{
+				DBInfo:         "CouchDB for state database",
+				Format:         "3.0",
+				ExpectedFormat: dataformat.CurrentFormat,
 			},
 			expectedFormat: "does not matter as the test should not reach to check this",
 		},
@@ -1128,7 +1128,7 @@ func TestFormatCheck(t *testing.T) {
 	}
 }
 
-func testFormatCheck(t *testing.T, dataFormat string, dataExists bool, expectedErr *dataformat.ErrVersionMismatch, expectedFormat string, vdbEnv *testVDBEnv) {
+func testFormatCheck(t *testing.T, dataFormat string, dataExists bool, expectedErr *dataformat.ErrFormatMismatch, expectedFormat string, vdbEnv *testVDBEnv) {
 	redoPath, err := ioutil.TempDir("", "redoPath")
 	require.NoError(t, err)
 	defer os.RemoveAll(redoPath)

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb.go
@@ -37,8 +37,8 @@ func NewVersionedDBProvider(dbPath string) (*VersionedDBProvider, error) {
 	logger.Debugf("constructing VersionedDBProvider dbPath=%s", dbPath)
 	dbProvider, err := leveldbhelper.NewProvider(
 		&leveldbhelper.Conf{
-			DBPath:                dbPath,
-			ExpectedFormatVersion: dataformat.Version20,
+			DBPath:         dbPath,
+			ExpectedFormat: dataformat.CurrentFormat,
 		})
 	if err != nil {
 		return nil, err

--- a/core/ledger/kvledger/upgrade_dbs_test.go
+++ b/core/ledger/kvledger/upgrade_dbs_test.go
@@ -27,10 +27,10 @@ func TestUpgradeWrongFormat(t *testing.T) {
 	require.NoError(t, err)
 
 	err = UpgradeDBs(conf)
-	expectedErr := &dataformat.ErrVersionMismatch{
-		ExpectedVersion: dataformat.Version1x,
-		Version:         "x.0",
-		DBInfo:          fmt.Sprintf("leveldb for channel-IDs at [%s]", LedgerProviderPath(conf.RootFSPath)),
+	expectedErr := &dataformat.ErrFormatMismatch{
+		ExpectedFormat: dataformat.PreviousFormat,
+		Format:         "x.0",
+		DBInfo:         fmt.Sprintf("leveldb for channel-IDs at [%s]", LedgerProviderPath(conf.RootFSPath)),
 	}
 	require.EqualError(t, err, expectedErr.Error())
 }


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
Currently Version1x and Version20 are defined in common/ledger/dataformat.go.
They should be renamed to more generic names such as PreviousVersion and CurrentVersion.
Note that these versions are used for the data format in ledger databases. They would change only when the data format is changed. 

#### Related issues
https://jira.hyperledger.org/browse/FAB-17831