### PR TITLE
[FAB-17846] Replace sample scripts for external chaincode with /bin/s…

### DIFF
--- a/docs/source/cc_launcher.md
+++ b/docs/source/cc_launcher.md
@@ -8,6 +8,8 @@ Starting with Fabric 2.0, External Builders and Launchers address these limitati
 
 Note that if no configured external builder claims a chaincode package, the peer will attempt to process the package as if it were created with the standard Fabric packaging tools such as the peer CLI or node SDK.
 
+**Note:** This is an advanced feature that will likely require custom packaging of the peer image. For example, the following samples use `go` and `bash`, which are not included in the current official `fabric-peer` image.
+
 ## External builder model
 
 Hyperledger Fabric External Builders and Launchers are loosely based on Heroku [Buildpacks](https://devcenter.heroku.com/articles/buildpack-api). A buildpack implementation is simply a collection of programs or scripts that transform application artifacts into something that can run. The buildpack model has been adapted for chaincode packages and extended to support chaincode execution and discovery.

--- a/docs/source/cc_service.md
+++ b/docs/source/cc_service.md
@@ -13,6 +13,8 @@ The rest of this topic describes how to configure chaincode as an external servi
 * [Deploying the chaincode](#deploying-the-chaincode)
 * [Running the chaincode as an external service](#running-the-chaincode-as-an-external-service)
 
+**Note:** This is an advanced feature that will likely require custom packaging of the peer image. For example, the following samples use `jq` and `bash`, which are not included in the current official `fabric-peer` image.
+
 ## Packaging chaincode
 
 With the Fabric v2.0 chaincode lifecycle, chaincode is [packaged](./cc_launcher.html#chaincode-packages) and installed in a `.tar.gz` format. The following `myccpackage.tgz` archive  demonstrates the required structure:


### PR DESCRIPTION
…h based ones

#### Type of change

- Documentation update

#### Description

This patch replaces `/bin/bash` based sample scripts for external chaincode builder and launcher with `/bin/sh` based ones for the following reasons:
* Peer images use Alpine Linux, which does not contain bash.
* Scripts with bash shebang are not executed in the peers but it is not easy to detect it from the peer logs.

The patch includes some fixes to comply with the POSIX specifications.

#### Related issues

- https://jira.hyperledger.org/browse/FAB-17846

