### PR TITLE
Update CONTRIBUTING guide

### DIFF
--- a/docs/source/CONTRIBUTING.rst
+++ b/docs/source/CONTRIBUTING.rst
@@ -1,13 +1,3 @@
-.. note:: Users who are migrating from Gerrit to GitHub: You can follow simple
-          Git workflows to move your development from Gerrit to GitHub. After
-          forking the Fabric repo, simply push the branches you want to save from
-          your current Gerrit-based local repo to your remote forked repository.
-          Once you've pushed the changes you want to save, simply delete your
-          local Gerrit-based repository and clone your fork.
-
-          For a basic Git workflow recommendation please see our doc at
-          :doc:`github/github`.
-
 Contributions Welcome!
 ======================
 


### PR DESCRIPTION
Removed reference to Gerrit

#### Type of change

- Documentation update

#### Description

The CONTRIBUTING guide talks about moving from Gerrit to GitHub,
which happened quite a while ago.

#### Additional details

#### Related issues

#### Release Note