### PR TITLE
Errors should be checked when orderer grpc server is starting

### DIFF
--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -252,7 +252,9 @@ func Main() {
 	}
 	ab.RegisterAtomicBroadcastServer(grpcServer.Server(), server)
 	logger.Info("Beginning to serve requests")
-	grpcServer.Start()
+	if err := grpcServer.Start(); err != nil {
+		logger.Fatalf("Atomic Broadcast gRPC server has terminated while serving requests due to: %v", err)
+	}
 }
 
 func reuseListener(conf *localconfig.TopLevel, typ string) bool {


### PR DESCRIPTION
Signed-off-by: wuyingjun <wuyingjun@cmss.chinamobile.com>

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

- Errors should be checked when orderer grpc server is starting