### PR TITLE
[FAB-17869] Allow TLS CAs with overlapping issuers

### DIFF
--- a/internal/pkg/comm/util.go
+++ b/internal/pkg/comm/util.go
@@ -22,7 +22,7 @@ import (
 
 // AddPemToCertPool adds PEM-encoded certs to a cert pool
 func AddPemToCertPool(pemCerts []byte, pool *x509.CertPool) error {
-	certs, _, err := pemToX509Certs(pemCerts)
+	certs, err := pemToX509Certs(pemCerts)
 	if err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func AddPemToCertPool(pemCerts []byte, pool *x509.CertPool) error {
 }
 
 // parse PEM-encoded certs
-func pemToX509Certs(pemCerts []byte) ([]*x509.Certificate, []string, error) {
+func pemToX509Certs(pemCerts []byte) ([]*x509.Certificate, error) {
 	var certs []*x509.Certificate
 	var subjects []string
 
@@ -47,14 +47,14 @@ func pemToX509Certs(pemCerts []byte) ([]*x509.Certificate, []string, error) {
 
 		cert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
-			return nil, []string{}, err
+			return nil, err
 		}
 
 		certs = append(certs, cert)
 		subjects = append(subjects, string(cert.RawSubject))
 	}
 
-	return certs, subjects, nil
+	return certs, nil
 }
 
 // BindingInspector receives as parameters a gRPC context and an Envelope,


### PR DESCRIPTION
The client root TLS CA certificate pool construction doesn't allow different issuers
with the same subject name to exist in the CA cert pool.

This prevents use cases where different organizations have issued CAs with the same subject name.

There is little sense to prevent this in the first place, as there can be only 2 possible cases:
I) The certificate chain validation of a TLS handshake allows this: In this case, Fabric should not
   artificially prevent supporting such scenarios.
II) The certificate chain validation of a TLS handshake disallows this: In this case, there is little
    gained in skipping pluralities in subject name during TLS CA cert pool construction, as the
    chain validation would prevent it anyway. 

This change set removes the artificial constraint, and adjust one of the integration tests
that was built to adjust to the said constraint.

Change-Id: Ie93c34997ad3e134a0a04b805fb007cd036d9683
Signed-off-by: yacovm <yacovm@il.ibm.com>
