### PR TITLE
[FAB-17864] DropApplicationDBs should return error when createCouchInstance fails

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdbutil.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdbutil.go
@@ -304,7 +304,7 @@ func DropApplicationDBs(config *ledger.CouchDBConfig) error {
 	logger.Info("Dropping CouchDB application databases ...")
 	couchInstance, err := createCouchInstance(config, &disabled.Provider{})
 	if err != nil {
-		return nil
+		return err
 	}
 	dbNames, err := couchInstance.retrieveApplicationDBNames()
 	if err != nil {

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdbutil_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdbutil_test.go
@@ -213,3 +213,11 @@ func TestDropApplicationDBs(t *testing.T) {
 	assert.NoError(t, err, "Error when retrieving application db names")
 	assert.Equal(t, 0, len(dbs), "Databases should be dropped")
 }
+
+func TestDropApplicationDBsWhenDBNotStarted(t *testing.T) {
+	config := testConfig()
+	config.MaxRetriesOnStartup = 1
+	config.Address = "127.0.0.1:5984"
+	err := DropApplicationDBs(config)
+	assert.EqualError(t, err, `unable to connect to CouchDB, check the hostname and port: http error calling couchdb: Get "http://127.0.0.1:5984/": dial tcp 127.0.0.1:5984: connect: connection refused`)
+}


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Bug fix

#### Description
Fix DropApplicationDBs to return error when getting an error from
createCouchInstance. Also set CouchDB config to limit the number
of retries.

#### Related issues
https://jira.hyperledger.org/browse/FAB-17864