### PR TITLE
[FAB-17844] Copy symlinks as-is in external builder output

### DIFF
--- a/core/container/externalbuilder/copy_test.go
+++ b/core/container/externalbuilder/copy_test.go
@@ -8,8 +8,10 @@ package externalbuilder
 
 import (
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/hyperledger/fabric/common/flogging"
 	. "github.com/onsi/ginkgo"
@@ -19,77 +21,143 @@ import (
 
 var _ = Describe("copy", func() {
 	var (
-		logger                             *flogging.FabricLogger
-		srcRootDir, srcSubDir, destRootDir string
-		srcRootFile, srcSubFile            *os.File
-		err                                error
+		logger                  *flogging.FabricLogger
+		tempDir                 string
+		srcRootDir, destRootDir string
+		srcSubDir, destSubDir   string
 	)
 
 	BeforeEach(func() {
-		srcRootDir, err = ioutil.TempDir("", "copy-test-")
+		var err error
+		tempDir, err = ioutil.TempDir("", "copy-test-")
 		Expect(err).NotTo(HaveOccurred())
-		srcSubDir, err = ioutil.TempDir(srcRootDir, "sub-")
+
+		srcRootDir = filepath.Join(tempDir, "src")
+		err = os.Mkdir(srcRootDir, 0755)
 		Expect(err).NotTo(HaveOccurred())
-		srcRootFile, err = ioutil.TempFile(srcRootDir, "file-")
+
+		err = ioutil.WriteFile(filepath.Join(srcRootDir, "file-in-root.txt"), []byte("root file contents"), 0644)
 		Expect(err).NotTo(HaveOccurred())
-		srcSubFile, err = ioutil.TempFile(srcSubDir, "subfile-")
+
+		err = os.Symlink("file-in-root.txt", filepath.Join(srcRootDir, "symlink-in-root.txt"))
 		Expect(err).NotTo(HaveOccurred())
-		err = os.Chmod(srcSubFile.Name(), os.ModePerm)
+
+		srcSubDir = filepath.Join(srcRootDir, "subdir")
+		err = os.Mkdir(srcSubDir, 0755)
 		Expect(err).NotTo(HaveOccurred())
+
+		err = ioutil.WriteFile(filepath.Join(srcSubDir, "file-in-subdir.txt"), []byte("subdir file contents"), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.Symlink("file-in-subdir.txt", filepath.Join(srcSubDir, "symlink-in-subdir.txt"))
+		Expect(err).NotTo(HaveOccurred())
+		err = os.Symlink(filepath.Join("..", "file-in-root.txt"), filepath.Join(srcSubDir, "symlink-to-root.txt"))
+		Expect(err).NotTo(HaveOccurred())
+
+		destRootDir = filepath.Join(tempDir, "dest")
+		destSubDir = filepath.Join(destRootDir, "subdir")
 
 		logger = flogging.NewFabricLogger(zap.NewNop())
 	})
 
 	AfterEach(func() {
-		os.RemoveAll(srcRootDir)
-		os.RemoveAll(destRootDir)
+		os.RemoveAll(tempDir)
 	})
 
-	When("dest dir does not exist", func() {
-		BeforeEach(func() {
-			destRootDir, err = ioutil.TempDir("", "dest-")
-			Expect(err).NotTo(HaveOccurred())
-			err = os.RemoveAll(destRootDir)
-			Expect(err).NotTo(HaveOccurred())
-		})
+	It("copies all files and subdirectories", func() {
+		err := CopyDir(logger, srcRootDir, destRootDir)
+		Expect(err).NotTo(HaveOccurred())
 
-		It("make copy by simply moving", func() {
-			err = MoveOrCopyDir(logger, srcRootDir, destRootDir)
+		Expect(destRootDir).To(BeADirectory())
+
+		Expect(filepath.Join(destRootDir, "file-in-root.txt")).To(BeARegularFile())
+		contents, err := ioutil.ReadFile(filepath.Join(destRootDir, "file-in-root.txt"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(contents).To(Equal([]byte("root file contents")))
+
+		symlink, err := os.Readlink(filepath.Join(destRootDir, "symlink-in-root.txt"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(symlink).To(Equal("file-in-root.txt"))
+
+		Expect(destSubDir).To(BeADirectory())
+
+		Expect(filepath.Join(destSubDir, "file-in-subdir.txt")).To(BeARegularFile())
+		contents, err = ioutil.ReadFile(filepath.Join(destSubDir, "file-in-subdir.txt"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(contents).To(Equal([]byte("subdir file contents")))
+
+		symlink, err = os.Readlink(filepath.Join(destSubDir, "symlink-in-subdir.txt"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(symlink).To(Equal("file-in-subdir.txt"))
+
+		symlink, err = os.Readlink(filepath.Join(destSubDir, "symlink-to-root.txt"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(symlink).To(Equal(filepath.Join("..", "file-in-root.txt")))
+	})
+
+	When("source contains an absolute symlink", func() {
+		It("returns an error and removes the destination directory", func() {
+			err := os.Symlink("/somewhere/else", filepath.Join(srcRootDir, "absolute-symlink.txt"))
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = os.Stat(srcRootDir)
-			Expect(os.IsNotExist(err)).To(BeTrue())
+			err = CopyDir(logger, srcRootDir, destRootDir)
+			Expect(err).To(MatchError(ContainSubstring("refusing to copy absolute symlink")))
 
-			_, err = os.Stat(filepath.Join(destRootDir, filepath.Base(srcRootFile.Name())))
-			Expect(err).NotTo(HaveOccurred())
-			_, err = os.Stat(filepath.Join(destRootDir, filepath.Base(srcSubDir)))
-			Expect(err).NotTo(HaveOccurred())
-			f, err := os.Stat(filepath.Join(destRootDir, filepath.Base(srcSubDir), filepath.Base(srcSubFile.Name())))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(f.Mode()).To(Equal(os.ModePerm))
+			Expect(destRootDir).NotTo(BeAnExistingFile())
 		})
 	})
 
-	When("dest dir exits", func() {
-		BeforeEach(func() {
-			destRootDir, err = ioutil.TempDir("", "dest-")
+	When("source contains a relative symlink that points outside of the tree", func() {
+		It("returns an error and removes the destination directory", func() {
+			err := os.Symlink("../somewhere/else", filepath.Join(srcRootDir, "relative-symlink-outside.txt"))
 			Expect(err).NotTo(HaveOccurred())
+
+			err = CopyDir(logger, srcRootDir, destRootDir)
+			Expect(err).To(MatchError(ContainSubstring("refusing to copy symlink")))
+
+			Expect(destRootDir).NotTo(BeAnExistingFile())
 		})
+	})
 
-		It("fails to move and try copy", func() {
-			err = MoveOrCopyDir(logger, srcRootDir, destRootDir)
+	When("source contains a relative symlink that goes out and back into the tree", func() {
+		It("returns an error and removes the destination directory", func() {
+			srcRootName := filepath.Dir(srcRootDir)
+			err := os.Symlink(filepath.Join("..", srcRootName, "file-in-root.txt"), filepath.Join(srcRootDir, "relative-symlink-outside-and-inside.txt"))
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = os.Stat(srcRootDir)
+			err = CopyDir(logger, srcRootDir, destRootDir)
+			Expect(err).To(MatchError(ContainSubstring("refusing to copy symlink")))
+
+			Expect(destRootDir).NotTo(BeAnExistingFile())
+		})
+	})
+
+	When("source contains a relative symlink that points outside of the tree", func() {
+		It("returns an error and removes the destination directory", func() {
+			err := os.Symlink("../somewhere/else", filepath.Join(srcRootDir, "relative-symlink-outside.txt"))
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = os.Stat(filepath.Join(destRootDir, filepath.Base(srcRootFile.Name())))
+			err = CopyDir(logger, srcRootDir, destRootDir)
+			Expect(err).To(MatchError(ContainSubstring("refusing to copy symlink")))
+
+			Expect(destRootDir).NotTo(BeAnExistingFile())
+		})
+	})
+
+	When("source contains a file other than a regular file, directory, or symlink", func() {
+		It("returns an error and removes the destination directory", func() {
+			if runtime.GOOS == "windows" {
+				Skip("test not supported on Windows")
+			}
+
+			socket, err := net.Listen("unix", filepath.Join(srcRootDir, "uds-in-root.txt"))
 			Expect(err).NotTo(HaveOccurred())
-			_, err = os.Stat(filepath.Join(destRootDir, filepath.Base(srcSubDir)))
-			Expect(err).NotTo(HaveOccurred())
-			f, err := os.Stat(filepath.Join(destRootDir, filepath.Base(srcSubDir), filepath.Base(srcSubFile.Name())))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(f.Mode()).To(Equal(os.ModePerm))
+			defer socket.Close()
+
+			err = CopyDir(logger, srcRootDir, destRootDir)
+			Expect(err).To(MatchError(ContainSubstring("refusing to copy unsupported file")))
+
+			Expect(destRootDir).NotTo(BeAnExistingFile())
 		})
 	})
 })

--- a/core/container/externalbuilder/externalbuilder.go
+++ b/core/container/externalbuilder/externalbuilder.go
@@ -151,13 +151,13 @@ func (d *Detector) Build(ccid string, mdBytes []byte, codeStream io.Reader) (*In
 	}
 
 	durableReleaseDir := filepath.Join(durablePath, "release")
-	err = MoveOrCopyDir(logger, buildContext.ReleaseDir, durableReleaseDir)
+	err = CopyDir(logger, buildContext.ReleaseDir, durableReleaseDir)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "could not move or copy build context release to persistent location '%s'", durablePath)
 	}
 
 	durableBldDir := filepath.Join(durablePath, "bld")
-	err = MoveOrCopyDir(logger, buildContext.BldDir, durableBldDir)
+	err = CopyDir(logger, buildContext.BldDir, durableBldDir)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "could not move or copy build context bld to persistent location '%s'", durablePath)
 	}


### PR DESCRIPTION
Currently, the external builder code does not check
for symlinks in build output when copying them. This
results in the resolved files being copied as files
instead of symlinks.

Node.js chaincode relies on certain symlinks that npm
creates in the node_modules tree. There may be other
chaincode scenarios that rely on symlinks.

This commit changes the external builder code so that
it tests for symlinks, and copies them as symlinks
instead of copying them as files into the destination
directory.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix
- New feature
- Improvement (improvement to code, performance, etc)
- Test update
- Documentation update

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
