### PR TITLE
[FAB-17863] Enhance rebuild-dbs to drop CouchDB state database

### DIFF
--- a/core/ledger/kvledger/rebuild_dbs_test.go
+++ b/core/ledger/kvledger/rebuild_dbs_test.go
@@ -28,15 +28,15 @@ func TestRebuildDBs(t *testing.T) {
 	}
 
 	// rebuild should fail when provider is still open
-	err := RebuildDBs(conf.RootFSPath)
+	err := RebuildDBs(conf)
 	require.Error(t, err, "as another peer node command is executing, wait for that command to complete its execution or terminate it before retrying")
 	provider.Close()
 
-	rootFSPath := conf.RootFSPath
-	err = RebuildDBs(rootFSPath)
+	err = RebuildDBs(conf)
 	require.NoError(t, err)
 
 	// verify blockstoreIndex, configHistory, history, state, bookkeeper dbs are deleted
+	rootFSPath := conf.RootFSPath
 	_, err = os.Stat(filepath.Join(BlockStorePath(rootFSPath), "index"))
 	require.Equal(t, os.IsNotExist(err), true)
 	_, err = os.Stat(ConfigHistoryDBPath(rootFSPath))
@@ -49,6 +49,6 @@ func TestRebuildDBs(t *testing.T) {
 	require.Equal(t, os.IsNotExist(err), true)
 
 	// rebuild again should be successful
-	err = RebuildDBs(rootFSPath)
+	err = RebuildDBs(conf)
 	require.NoError(t, err)
 }

--- a/core/ledger/kvledger/tests/v20_test.go
+++ b/core/ledger/kvledger/tests/v20_test.go
@@ -26,7 +26,7 @@ func TestV20SampleLedger(t *testing.T) {
 	ledgerFSRoot := env.initializer.Config.RootFSPath
 	require.NoError(t, testutil.Unzip("testdata/v20/sample_ledgers/ledgersData.zip", ledgerFSRoot, false))
 
-	// The UpgradeDBs call is not really needed. It is added to test that dbs are not deleted if someone calls UpgradeDBs agains a 2.0 ledger.
+	// The UpgradeDBs call is not really needed. It is added to test that dbs are not deleted if someone calls UpgradeDBs against a 2.0 ledger.
 	require.NoError(t, kvledger.UpgradeDBs(env.initializer.Config))
 	rebuildable := rebuildableStatedb | rebuildableBookkeeper | rebuildableConfigHistory | rebuildableHistoryDB | rebuildableBlockIndex
 	env.verifyRebuilablesExist(rebuildable)
@@ -38,7 +38,7 @@ func TestV20SampleLedger(t *testing.T) {
 
 	// rebuild and verify again
 	env.closeLedgerMgmt()
-	kvledger.RebuildDBs(env.getLedgerRootPath())
+	kvledger.RebuildDBs(env.initializer.Config)
 	env.initLedgerMgmt()
 	h1 = env.newTestHelperOpenLgr("testchannel", t)
 	dataHelper.verify(h1)

--- a/internal/peer/node/rebuild_dbs.go
+++ b/internal/peer/node/rebuild_dbs.go
@@ -21,6 +21,6 @@ var nodeRebuildCmd = &cobra.Command{
 	Long:  "Drops the databases for all the channels and rebuilds them upon peer restart. When the command is executed, the peer must be offline.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		config := ledgerConfig()
-		return kvledger.RebuildDBs(config.RootFSPath)
+		return kvledger.RebuildDBs(config)
 	},
 }


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
The rebuild-dbs command should be able to drop CouchDB state db.

#### Related issues
https://jira.hyperledger.org/browse/FAB-17863
