### PR TITLE
[FAB-17862] Allow upgrade-dbs to drop all dbs in multiple runs

### DIFF
--- a/core/ledger/kvledger/kv_ledger_provider.go
+++ b/core/ledger/kvledger/kv_ledger_provider.go
@@ -509,7 +509,7 @@ func (s *idStore) checkUpgradeEligibility() (bool, error) {
 		return false, err
 	}
 	if emptydb {
-		logger.Warnf("Ledger database %s is empty, nothing to upgrade.", s.dbPath)
+		logger.Warnf("Ledger database %s is empty, nothing to upgrade", s.dbPath)
 		return false, nil
 	}
 	format, err := s.db.Get(formatKey)
@@ -517,7 +517,7 @@ func (s *idStore) checkUpgradeEligibility() (bool, error) {
 		return false, err
 	}
 	if bytes.Equal(format, []byte(dataformat.CurrentFormat)) {
-		logger.Info("Ledger data format is current, nothing to upgrade.")
+		logger.Debugf("Ledger database %s has current data format, nothing to upgrade", s.dbPath)
 		return false, nil
 	}
 	if !bytes.Equal(format, []byte(dataformat.PreviousFormat)) {

--- a/core/ledger/kvledger/tests/v20_test.go
+++ b/core/ledger/kvledger/tests/v20_test.go
@@ -26,13 +26,7 @@ func TestV20SampleLedger(t *testing.T) {
 	ledgerFSRoot := env.initializer.Config.RootFSPath
 	require.NoError(t, testutil.Unzip("testdata/v20/sample_ledgers/ledgersData.zip", ledgerFSRoot, false))
 
-	// The UpgradeDBs call is not really needed. It is added to test that dbs are not deleted if someone calls UpgradeDBs against a 2.0 ledger.
-	require.NoError(t, kvledger.UpgradeDBs(env.initializer.Config))
-	rebuildable := rebuildableStatedb | rebuildableBookkeeper | rebuildableConfigHistory | rebuildableHistoryDB | rebuildableBlockIndex
-	env.verifyRebuilablesExist(rebuildable)
-
 	env.initLedgerMgmt()
-
 	h1 := env.newTestHelperOpenLgr("testchannel", t)
 	dataHelper.verify(h1)
 


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
In some cases upgrade-dbs may be run multiple times; e.g., if admin forgot 
to pass the CouchDB variable CORE_LEDGER_STATE_STATEDATABASE,
it will not drop the CouchDB databases as part of upgrade-dbs.
Therefore, upgrade-dbs should be able to drop all dbs when
running multiple times.

#### Related issues
https://jira.hyperledger.org/browse/FAB-17862
