### PR TITLE
test for commit hash computation's backward compatibility

### DIFF
--- a/core/ledger/kvledger/tests/client.go
+++ b/core/ledger/kvledger/tests/client.go
@@ -121,6 +121,18 @@ func (c *client) currentHeight() uint64 {
 	return bcInfo.Height
 }
 
+func (c *client) currentCommitHash() []byte {
+	block, err := c.lgr.GetBlockByNumber(c.currentHeight() - 1)
+	c.assert.NoError(err)
+	if len(block.Metadata.Metadata) < int(common.BlockMetadataIndex_COMMIT_HASH+1) {
+		return nil
+	}
+	commitHash := &common.Metadata{}
+	err = proto.Unmarshal(block.Metadata.Metadata[common.BlockMetadataIndex_COMMIT_HASH], commitHash)
+	c.assert.NoError(err)
+	return commitHash.Value
+}
+
 ///////////////////////   simulator wrapper functions  ///////////////////////
 type simulator struct {
 	ledger.TxSimulator

--- a/core/ledger/kvledger/tests/v1x_test.go
+++ b/core/ledger/kvledger/tests/v1x_test.go
@@ -177,7 +177,10 @@ func testV11CommitHashes(t *testing.T,
 	env.initLedgerMgmt()
 	h := env.newTestHelperOpenLgr("ledger1", t)
 	blocksAndPvtData := h.retrieveCommittedBlocksAndPvtdata(0, h.currentHeight()-1)
+
+	var commitHashPreReset []byte
 	if preResetCommitHashExists {
+		commitHashPreReset = h.currentCommitHash()
 		h.verifyCommitHashExists()
 	} else {
 		h.verifyCommitHashNotExists()
@@ -199,6 +202,10 @@ func testV11CommitHashes(t *testing.T,
 		require.NoError(t, h.lgr.CommitLegacy(d, &ledger.CommitOptions{FetchPvtDataFromLedger: true}))
 	}
 
+	if preResetCommitHashExists {
+		commitHashPostReset := h.currentCommitHash()
+		require.Equal(t, commitHashPreReset, commitHashPostReset)
+	}
 	if postResetCommitHashExists {
 		h.verifyCommitHashExists()
 	} else {


### PR DESCRIPTION
#### Type of change

- Test update

#### Description

We might change the code that computes the block commit hash during refactoring or to improve the performance from time to time. When changing the hash computation code, we need to ensure that we are not changing the way commit hash has been computed in previous
releases. Hence, we add a test in this PR to ensure that the commit hash computation is always compatible with the first code added in v1.1

#### Related issues

[FAB-17878](https://jira.hyperledger.org/browse/FAB-17878)