### PR TITLE
[FAB-17434] Add `queryapproved` command to query the details of the approved chaincode definition

### DIFF
--- a/internal/peer/lifecycle/chaincode/chaincode.go
+++ b/internal/peer/lifecycle/chaincode/chaincode.go
@@ -46,6 +46,7 @@ func Cmd(cryptoProvider bccsp.BCCSP) *cobra.Command {
 	chaincodeCmd.AddCommand(QueryInstalledCmd(nil, cryptoProvider))
 	chaincodeCmd.AddCommand(GetInstalledPackageCmd(nil, cryptoProvider))
 	chaincodeCmd.AddCommand(ApproveForMyOrgCmd(nil, cryptoProvider))
+	chaincodeCmd.AddCommand(QueryApprovedCmd(nil, cryptoProvider))
 	chaincodeCmd.AddCommand(CheckCommitReadinessCmd(nil, cryptoProvider))
 	chaincodeCmd.AddCommand(CommitCmd(nil, cryptoProvider))
 	chaincodeCmd.AddCommand(QueryCommittedCmd(nil, cryptoProvider))
@@ -80,8 +81,8 @@ var (
 
 var chaincodeCmd = &cobra.Command{
 	Use:   "chaincode",
-	Short: "Perform chaincode operations: package|install|queryinstalled|getinstalledpackage|approveformyorg|checkcommitreadiness|commit|querycommitted",
-	Long:  "Perform chaincode operations: package|install|queryinstalled|getinstalledpackage|approveformyorg|checkcommitreadiness|commit|querycommitted",
+	Short: "Perform chaincode operations: package|install|queryinstalled|getinstalledpackage|approveformyorg|queryapproved|checkcommitreadiness|commit|querycommitted",
+	Long:  "Perform chaincode operations: package|install|queryinstalled|getinstalledpackage|approveformyorg|queryapproved|checkcommitreadiness|commit|querycommitted",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		common.InitCmd(cmd, args)
 		common.SetOrdererEnv(cmd, args)

--- a/internal/peer/lifecycle/chaincode/queryapproved.go
+++ b/internal/peer/lifecycle/chaincode/queryapproved.go
@@ -1,0 +1,215 @@
+/*
+Copyright Hitachi America, Ltd. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	lb "github.com/hyperledger/fabric-protos-go/peer/lifecycle"
+	"github.com/hyperledger/fabric/bccsp"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// ApprovedQuerier holds the dependencies needed to query
+// the approved chaincode definition for the organization
+type ApprovedQuerier struct {
+	Command        *cobra.Command
+	EndorserClient EndorserClient
+	Input          *ApprovedQueryInput
+	Signer         Signer
+	Writer         io.Writer
+}
+
+type ApprovedQueryInput struct {
+	ChannelID    string
+	Name         string
+	Sequence     int64
+	OutputFormat string
+}
+
+// QueryApprovedCmd returns the cobra command for
+// querying the approved chaincode definition for the organization
+func QueryApprovedCmd(a *ApprovedQuerier, cryptoProvider bccsp.BCCSP) *cobra.Command {
+	chaincodeQueryApprovedCmd := &cobra.Command{
+		Use:   "queryapproved",
+		Short: fmt.Sprintf("Query an org's approved chaincode definition from its peer."),
+		Long:  fmt.Sprintf("Query an organization's approved chaincode definition from its peer."),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if a == nil {
+				ccInput := &ClientConnectionsInput{
+					CommandName:           cmd.Name(),
+					EndorserRequired:      true,
+					ChannelID:             channelID,
+					PeerAddresses:         peerAddresses,
+					TLSRootCertFiles:      tlsRootCertFiles,
+					ConnectionProfilePath: connectionProfilePath,
+					TLSEnabled:            viper.GetBool("peer.tls.enabled"),
+				}
+
+				cc, err := NewClientConnections(ccInput, cryptoProvider)
+				if err != nil {
+					return err
+				}
+
+				aqInput := &ApprovedQueryInput{
+					ChannelID:    channelID,
+					Name:         chaincodeName,
+					Sequence:     int64(sequence),
+					OutputFormat: output,
+				}
+
+				a = &ApprovedQuerier{
+					Command:        cmd,
+					EndorserClient: cc.EndorserClients[0],
+					Input:          aqInput,
+					Signer:         cc.Signer,
+					Writer:         os.Stdout,
+				}
+			}
+			return a.Query()
+		},
+	}
+	flagList := []string{
+		"channelID",
+		"name",
+		"sequence",
+		"peerAddresses",
+		"tlsRootCertFiles",
+		"connectionProfile",
+		"output",
+	}
+	attachFlags(chaincodeQueryApprovedCmd, flagList)
+
+	return chaincodeQueryApprovedCmd
+}
+
+// Query returns the approved chaincode definition
+// for a given channel and chaincode name
+func (a *ApprovedQuerier) Query() error {
+	if a.Command != nil {
+		// Parsing of the command line is done so silence cmd usage
+		a.Command.SilenceUsage = true
+	}
+
+	err := a.validateInput()
+	if err != nil {
+		return err
+	}
+
+	proposal, err := a.createProposal()
+	if err != nil {
+		return errors.WithMessage(err, "failed to create proposal")
+	}
+
+	signedProposal, err := signProposal(proposal, a.Signer)
+	if err != nil {
+		return errors.WithMessage(err, "failed to create signed proposal")
+	}
+
+	proposalResponse, err := a.EndorserClient.ProcessProposal(context.Background(), signedProposal)
+	if err != nil {
+		return errors.WithMessage(err, "failed to endorse proposal")
+	}
+
+	if proposalResponse == nil {
+		return errors.New("received nil proposal response")
+	}
+
+	if proposalResponse.Response == nil {
+		return errors.New("received proposal response with nil response")
+	}
+
+	if proposalResponse.Response.Status != int32(cb.Status_SUCCESS) {
+		return errors.Errorf("query failed with status: %d - %s", proposalResponse.Response.Status, proposalResponse.Response.Message)
+	}
+
+	if strings.ToLower(a.Input.OutputFormat) == "json" {
+		return printResponseAsJSON(proposalResponse, &lb.QueryApprovedChaincodeDefinitionResult{}, a.Writer)
+	}
+	return a.printResponse(proposalResponse)
+}
+
+// printResponse prints the information included in the response
+// from the server as human readable plain-text.
+func (a *ApprovedQuerier) printResponse(proposalResponse *pb.ProposalResponse) error {
+	result := &lb.QueryApprovedChaincodeDefinitionResult{}
+	err := proto.Unmarshal(proposalResponse.Response.Payload, result)
+	if err != nil {
+		return errors.Wrap(err, "failed to unmarshal proposal response's response payload")
+	}
+	fmt.Fprintf(a.Writer, "Approved chaincode definition for chaincode '%s' on channel '%s':\n", a.Input.Name, a.Input.ChannelID)
+
+	var packageID string
+	if result.Source != nil {
+		switch source := result.Source.Type.(type) {
+		case *lb.ChaincodeSource_LocalPackage:
+			packageID = source.LocalPackage.PackageId
+		case *lb.ChaincodeSource_Unavailable_:
+		}
+	}
+	fmt.Fprintf(a.Writer, "sequence: %d, version: %s, init-required: %t, package-id: %s, endorsement plugin: %s, validation plugin: %s\n",
+		result.Sequence, result.Version, result.InitRequired, packageID, result.EndorsementPlugin, result.ValidationPlugin)
+	return nil
+}
+
+func (a *ApprovedQuerier) validateInput() error {
+	if a.Input.ChannelID == "" {
+		return errors.New("The required parameter 'channelID' is empty. Rerun the command with -C flag")
+	}
+
+	if a.Input.Name == "" {
+		return errors.New("The required parameter 'name' is empty. Rerun the command with -n flag")
+	}
+
+	return nil
+}
+
+func (a *ApprovedQuerier) createProposal() (*pb.Proposal, error) {
+	var function string
+	var args proto.Message
+
+	function = "QueryApprovedChaincodeDefinition"
+	args = &lb.QueryApprovedChaincodeDefinitionArgs{
+		Name:     a.Input.Name,
+		Sequence: a.Input.Sequence,
+	}
+
+	argsBytes, err := proto.Marshal(args)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal args")
+	}
+	ccInput := &pb.ChaincodeInput{Args: [][]byte{[]byte(function), argsBytes}}
+
+	cis := &pb.ChaincodeInvocationSpec{
+		ChaincodeSpec: &pb.ChaincodeSpec{
+			ChaincodeId: &pb.ChaincodeID{Name: lifecycleName},
+			Input:       ccInput,
+		},
+	}
+
+	signerSerialized, err := a.Signer.Serialize()
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to serialize identity")
+	}
+
+	proposal, _, err := protoutil.CreateProposalFromCIS(cb.HeaderType_ENDORSER_TRANSACTION, a.Input.ChannelID, cis, signerSerialized)
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to create ChaincodeInvocationSpec proposal")
+	}
+
+	return proposal, nil
+}

--- a/internal/peer/lifecycle/chaincode/queryapproved_test.go
+++ b/internal/peer/lifecycle/chaincode/queryapproved_test.go
@@ -1,0 +1,311 @@
+/*
+Copyright Hitachi America, Ltd. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	lb "github.com/hyperledger/fabric-protos-go/peer/lifecycle"
+	"github.com/hyperledger/fabric/bccsp/sw"
+	"github.com/hyperledger/fabric/internal/peer/lifecycle/chaincode"
+	"github.com/hyperledger/fabric/internal/peer/lifecycle/chaincode/mock"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("QueryApproved", func() {
+	Describe("ApprovedQuerier", func() {
+		var (
+			mockProposalResponse *pb.ProposalResponse
+			mockEndorserClient   *mock.EndorserClient
+			mockSigner           *mock.Signer
+			input                *chaincode.ApprovedQueryInput
+			approvedQuerier      *chaincode.ApprovedQuerier
+		)
+
+		BeforeEach(func() {
+			mockResult := &lb.QueryApprovedChaincodeDefinitionResult{
+				Sequence:            7,
+				Version:             "version_1.0",
+				EndorsementPlugin:   "endorsement-plugin",
+				ValidationPlugin:    "validation-plugin",
+				ValidationParameter: []byte("validation-parameter"),
+				InitRequired:        true,
+				Collections:         &pb.CollectionConfigPackage{},
+				Source: &lb.ChaincodeSource{
+					Type: &lb.ChaincodeSource_LocalPackage{
+						LocalPackage: &lb.ChaincodeSource_Local{
+							PackageId: "hash",
+						},
+					},
+				},
+			}
+
+			mockResultBytes, err := proto.Marshal(mockResult)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockResultBytes).NotTo(BeNil())
+			mockProposalResponse = &pb.ProposalResponse{
+				Response: &pb.Response{
+					Status:  200,
+					Payload: mockResultBytes,
+				},
+			}
+
+			mockEndorserClient = &mock.EndorserClient{}
+			mockEndorserClient.ProcessProposalReturns(mockProposalResponse, nil)
+
+			mockSigner = &mock.Signer{}
+			buffer := gbytes.NewBuffer()
+
+			input = &chaincode.ApprovedQueryInput{
+				ChannelID: "test-channel",
+				Name:      "cc_name",
+			}
+
+			approvedQuerier = &chaincode.ApprovedQuerier{
+				Input:          input,
+				EndorserClient: mockEndorserClient,
+				Signer:         mockSigner,
+				Writer:         buffer,
+			}
+		})
+
+		It("queries a approved chaincode and writes the output as human readable plain-text", func() {
+			err := approvedQuerier.Query()
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(approvedQuerier.Writer).Should(gbytes.Say("Approved chaincode definition for chaincode 'cc_name' on channel 'test-channel':\n"))
+			Eventually(approvedQuerier.Writer).Should(gbytes.Say("sequence: 7, version: version_1.0, init-required: true, package-id: hash, endorsement plugin: endorsement-plugin, validation plugin: validation-plugin\n"))
+		})
+
+		Context("when the payload contains bytes that aren't a QueryApprovedChaincodeDefinitionResult", func() {
+			BeforeEach(func() {
+				mockProposalResponse.Response = &pb.Response{
+					Payload: []byte("badpayloadbadpayload"),
+					Status:  200,
+				}
+				mockEndorserClient.ProcessProposalReturns(mockProposalResponse, nil)
+			})
+
+			It("returns an error", func() {
+				err := approvedQuerier.Query()
+				Expect(err).To(MatchError(ContainSubstring("failed to unmarshal proposal response's response payload")))
+			})
+		})
+
+		Context("when JSON-formatted output is requested", func() {
+			BeforeEach(func() {
+				approvedQuerier.Input.OutputFormat = "json"
+			})
+
+			It("queries the approved chaincode and writes the output as JSON", func() {
+				err := approvedQuerier.Query()
+				Expect(err).NotTo(HaveOccurred())
+				expectedOutput := &lb.QueryApprovedChaincodeDefinitionResult{
+					Sequence:            7,
+					Version:             "version_1.0",
+					EndorsementPlugin:   "endorsement-plugin",
+					ValidationPlugin:    "validation-plugin",
+					ValidationParameter: []byte("validation-parameter"),
+					InitRequired:        true,
+					Collections:         &pb.CollectionConfigPackage{},
+					Source: &lb.ChaincodeSource{
+						Type: &lb.ChaincodeSource_LocalPackage{
+							LocalPackage: &lb.ChaincodeSource_Local{
+								PackageId: "hash",
+							},
+						},
+					},
+				}
+				json, err := json.MarshalIndent(expectedOutput, "", "\t")
+				Eventually(approvedQuerier.Writer).Should(gbytes.Say(fmt.Sprintf(`\Q%s\E`, string(json))))
+			})
+		})
+
+		Context("when the chaincode source is unavailable", func() {
+			BeforeEach(func() {
+				mockResult := &lb.QueryApprovedChaincodeDefinitionResult{
+					Sequence:            7,
+					Version:             "version_1.0",
+					EndorsementPlugin:   "endorsement-plugin",
+					ValidationPlugin:    "validation-plugin",
+					ValidationParameter: []byte("validation-parameter"),
+					InitRequired:        true,
+					Collections:         &pb.CollectionConfigPackage{},
+					Source: &lb.ChaincodeSource{
+						Type: &lb.ChaincodeSource_Unavailable_{
+							Unavailable: &lb.ChaincodeSource_Unavailable{},
+						},
+					},
+				}
+				mockResultBytes, err := proto.Marshal(mockResult)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mockResultBytes).NotTo(BeNil())
+
+				mockProposalResponse = &pb.ProposalResponse{
+					Response: &pb.Response{
+						Status:  200,
+						Payload: mockResultBytes,
+					},
+				}
+				mockEndorserClient.ProcessProposalReturns(mockProposalResponse, nil)
+			})
+
+			It("queries the approved chaincode and writes the output as human readable plain-text with an empty package-id", func() {
+				err := approvedQuerier.Query()
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(approvedQuerier.Writer).Should(gbytes.Say("Approved chaincode definition for chaincode 'cc_name' on channel 'test-channel':\n"))
+				Eventually(approvedQuerier.Writer).Should(gbytes.Say("sequence: 7, version: version_1.0, init-required: true, package-id: , endorsement plugin: endorsement-plugin, validation plugin: validation-plugin\n"))
+			})
+		})
+
+		Context("when the channel is not provided", func() {
+			BeforeEach(func() {
+				approvedQuerier.Input.ChannelID = ""
+			})
+
+			It("returns an error", func() {
+				err := approvedQuerier.Query()
+				Expect(err).To(MatchError("The required parameter 'channelID' is empty. Rerun the command with -C flag"))
+			})
+		})
+
+		Context("when the chaincode name is not provided", func() {
+			BeforeEach(func() {
+				approvedQuerier.Input.Name = ""
+			})
+
+			It("returns an error", func() {
+				err := approvedQuerier.Query()
+				Expect(err).To(MatchError("The required parameter 'name' is empty. Rerun the command with -n flag"))
+			})
+		})
+
+		Context("when the signer cannot be serialized", func() {
+			BeforeEach(func() {
+				mockSigner.SerializeReturns(nil, errors.New("bad serialization"))
+			})
+
+			It("returns an error", func() {
+				err := approvedQuerier.Query()
+				Expect(err).To(MatchError("failed to create proposal: failed to serialize identity: bad serialization"))
+			})
+		})
+
+		Context("when the signer fails to sign the proposal", func() {
+			BeforeEach(func() {
+				mockSigner.SignReturns(nil, errors.New("bad sign"))
+			})
+
+			It("returns an error", func() {
+				err := approvedQuerier.Query()
+				Expect(err).To(MatchError("failed to create signed proposal: bad sign"))
+			})
+		})
+
+		Context("when the endorser fails to endorse the proposal", func() {
+			BeforeEach(func() {
+				mockEndorserClient.ProcessProposalReturns(nil, errors.New("bad endorsement"))
+			})
+
+			It("returns an error", func() {
+				err := approvedQuerier.Query()
+				Expect(err).To(MatchError("failed to endorse proposal: bad endorsement"))
+			})
+		})
+
+		Context("when the endorser returns a nil proposal response", func() {
+			BeforeEach(func() {
+				mockProposalResponse = nil
+				mockEndorserClient.ProcessProposalReturns(mockProposalResponse, nil)
+			})
+
+			It("returns an error", func() {
+				err := approvedQuerier.Query()
+				Expect(err).To(MatchError("received nil proposal response"))
+			})
+		})
+
+		Context("when the endorser returns a proposal response with a nil response", func() {
+			BeforeEach(func() {
+				mockProposalResponse.Response = nil
+				mockEndorserClient.ProcessProposalReturns(mockProposalResponse, nil)
+			})
+
+			It("returns an error", func() {
+				err := approvedQuerier.Query()
+				Expect(err).To(MatchError("received proposal response with nil response"))
+			})
+		})
+
+		Context("when the endorser returns a non-success status", func() {
+			BeforeEach(func() {
+				mockProposalResponse.Response = &pb.Response{
+					Status:  500,
+					Message: "message",
+				}
+				mockEndorserClient.ProcessProposalReturns(mockProposalResponse, nil)
+			})
+
+			It("returns an error", func() {
+				err := approvedQuerier.Query()
+				Expect(err).To(MatchError("query failed with status: 500 - message"))
+			})
+		})
+	})
+
+	Describe("QueryApprovedCmd", func() {
+		var (
+			queryApprovedCmd *cobra.Command
+		)
+
+		BeforeEach(func() {
+			cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
+			Expect(err).To(BeNil())
+			queryApprovedCmd = chaincode.QueryApprovedCmd(nil, cryptoProvider)
+			queryApprovedCmd.SetArgs([]string{
+				"--name=testcc",
+				"--channelID=testchannel",
+				"--peerAddresses=queryapprovedpeer1",
+				"--tlsRootCertFiles=tls1",
+			})
+		})
+
+		AfterEach(func() {
+			chaincode.ResetFlags()
+		})
+
+		It("attempts to connect to the endorser", func() {
+			err := queryApprovedCmd.Execute()
+			Expect(err).To(MatchError(ContainSubstring("failed to retrieve endorser client")))
+		})
+
+		Context("when more than one peer address is provided", func() {
+			BeforeEach(func() {
+				queryApprovedCmd.SetArgs([]string{
+					"--name=testcc",
+					"--channelID=testchannel",
+					"--peerAddresses=queryapprovedpeer1",
+					"--tlsRootCertFiles=tls1",
+					"--peerAddresses=queryapprovedpeer2",
+					"--tlsRootCertFiles=tls2",
+				})
+			})
+
+			It("returns an error", func() {
+				err := queryApprovedCmd.Execute()
+				Expect(err).To(MatchError(ContainSubstring("failed to validate peer connection parameters")))
+			})
+		})
+	})
+})


### PR DESCRIPTION
This patch adds `queryapproved` command for querying the details of the chaincode definition approved by the organization itself to peer CLI, so that Fabric peer can provide a function to query them.
Also, this patch fixes default value of `sequence` parameter to empty for several reasons.

#### Type of change

- New feature
- Bug fix

#### Description

<!--- Describe your changes in detail, including motivation. -->

Currently, Fabric peer does not provide a function to query the details of approved chaincode definitions.

On the other hand, Fabric admins will need to confirm/use the information after approval for their operations.

So, we propose to add a function for querying the details of the approved chaincode definition to Fabric peer CLI (Refer to https://jira.hyperledger.org/browse/FAB-17401).

As a sub-task of FAB-17401, this patch adds `queryapproved` command for querying the details of the chaincode definition approved by the organization itself to peer CLI, so that Fabric peer can provide a function to query them.

Also, this patch fixes default value of `sequence` parameter to `0` that means empty for the following reasons.

- According to `Validate()` in `approveformyorg.go`, this function is implemented assuming that `sequence` is `0`. This is inconsistent with the default value `1`.

- The current default value `1` enables Fabric users `approveformyorg` without specifying the sequence number. Not forcing the specification of a sequence number may cause operation mistakes (e.g, updating the package-id for sequence 1 by mistake) when running `approveformyorg` in the second and subsequent times.

- The default value is preferably `0` to reuse the same parameter `sequence` in CLI commands to query the details of approved chaincode definitions.


The following patches has been merged to extend lifecycle protos and to add `_lifecycle` function for querying approved chaincode:
- https://github.com/hyperledger/fabric-protos/pull/25
- https://github.com/hyperledger/fabric/pull/1220

Immediately after this patch has been merged into the fabric repository,  I will submit the following related patches:
- https://github.com/satota2/fabric/commit/f4d5fff151dc87a597a058184c203b9e9ce72629

#### Related issues
- Main: 
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17434

- Others: 
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17401
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17432
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17433
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17435
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17436
