### PR TITLE
[FAB-17877] Correct Doc on HSM environment variables

### DIFF
--- a/docs/source/hsm.md
+++ b/docs/source/hsm.md
@@ -84,9 +84,9 @@ If you are connecting to softhsm2 using the Fabric orderer, you could set the fo
 
 ```
 ORDERER_GENERAL_BCCSP_DEFAULT=PKCS11
-ORDERER_GENERAL_PKCS11_LIBRARY=/etc/hyperledger/fabric/libsofthsm2.so
-ORDERER_GENERAL_PKCS11_PIN=71811222
-ORDERER_GENERAL_PKCS11_LABEL=fabric
+ORDERER_GENERAL_BCCSP_PKCS11_LIBRARY=/etc/hyperledger/fabric/libsofthsm2.so
+ORDERER_GENERAL_BCCSP_PKCS11_PIN=71811222
+ORDERER_GENERAL_BCCSP_PKCS11_LABEL=fabric
 ```
 
 If you are deploying your nodes using docker compose, after building your own


### PR DESCRIPTION
The HSM doc omits the BCCSP section from the variable name.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
