### PR TITLE
Remove references to libtool

### DIFF
--- a/ci/install_deps.yml
+++ b/ci/install_deps.yml
@@ -6,7 +6,7 @@ steps:
   - script: |
       sudo apt-get clean
       sudo apt-get update
-      sudo apt-get install -y libtool gcc make
+      sudo apt-get install -y gcc make
       echo "vsts  hard  nofile  65535" | sudo tee -a /etc/security/limits.conf
       echo "vsts  soft  nofile  65535" | sudo tee -a /etc/security/limits.conf
     displayName: Install Dependencies

--- a/docs/source/dev-setup/devenv.rst
+++ b/docs/source/dev-setup/devenv.rst
@@ -24,13 +24,6 @@ Prerequisites
 
     export PATH=/usr/local/opt/gnu-tar/libexec/gnubin:$PATH
 
--  `Libtool <https://www.gnu.org/software/libtool/>`__. You can use
-   Homebrew to install it as follows:
-
-::
-
-    brew install libtool
-
 -  `SoftHSM <https://github.com/opendnssec/SoftHSMv2>`__. You can use
    Homebrew or apt to install it as follows:
 
@@ -108,7 +101,7 @@ appropriate environment variables. For example, on macOS:
 
 ::
 
-    export PKCS11_LIB="/usr/local/Cellar/softhsm/2.5.0/lib/softhsm/libsofthsm2.so"
+    export PKCS11_LIB="/usr/local/Cellar/softhsm/2.6.1/lib/softhsm/libsofthsm2.so"
     export PKCS11_PIN=98765432
     export PKCS11_LABEL="ForFabric"
 

--- a/vagrant/essentials.sh
+++ b/vagrant/essentials.sh
@@ -22,6 +22,5 @@ apt-get install -y \
     g++ \
     git \
     jq \
-    libtool \
     make \
     unzip


### PR DESCRIPTION
The package we use for pkcs11 no longer uses libtool to interact with shared libraries so we no longer need the prereq for development.