### PR TITLE
minor refactoring of pvtstatepurgemgmt

### DIFF
--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper.go
@@ -33,7 +33,7 @@ type expiryInfo struct {
 	pvtdataKeys   *PvtdataKeys
 }
 
-// expiryInfoKey is used as a key of an entry in the bookkeeper (backed by a leveldb instance)
+// expiryInfoKey is used as a key of an entry in the expiryKeeper (backed by a leveldb instance)
 type expiryInfoKey struct {
 	committingBlk uint64
 	expiryBlk     uint64
@@ -43,9 +43,9 @@ func newExpiryKeeper(ledgerid string, provider bookkeeping.Provider) *expiryKeep
 	return &expiryKeeper{provider.GetDBHandle(ledgerid, bookkeeping.PvtdataExpiry)}
 }
 
-// updateBookkeeping keeps track of the list of keys and their corresponding expiry block number
-// 'toTrack' parameter causes new entries in the bookkeeper and  'toClear' parameter contains the entries that
-// are to be removed from the bookkeeper. This function is invoked with the commit of every block. As an
+// update keeps track of the list of keys and their corresponding expiry block number
+// 'toTrack' parameter causes new entries in the expiryKeeper and  'toClear' parameter contains the entries that
+// are to be removed from the expiryKeeper. This function is invoked with the commit of every block. As an
 // example, the commit of the block with block number 50, 'toTrack' parameter may contain following two entries:
 // (1) &expiryInfo{&expiryInfoKey{committingBlk: 50, expiryBlk: 55}, pvtdataKeys....} and
 // (2) &expiryInfo{&expiryInfoKey{committingBlk: 50, expiryBlk: 60}, pvtdataKeys....}
@@ -55,7 +55,7 @@ func newExpiryKeeper(ledgerid string, provider bookkeeping.Provider) *expiryKeep
 // (1) &expiryInfoKey{committingBlk: 45, expiryBlk: 50} and (2) &expiryInfoKey{committingBlk: 40, expiryBlk: 50}. The first entry was created
 // at the time of the commit of the block number 45 and the second entry was created at the time of the commit of the block number 40, however
 // both are expiring with the commit of block number 50.
-func (ek *expiryKeeper) updateBookkeeping(toTrack []*expiryInfo, toClear []*expiryInfoKey) error {
+func (ek *expiryKeeper) update(toTrack []*expiryInfo, toClear []*expiryInfoKey) error {
 	updateBatch := leveldbhelper.NewUpdateBatch()
 	for _, expinfo := range toTrack {
 		k, v, err := encodeKV(expinfo)

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper.go
@@ -20,10 +20,8 @@ const (
 	expiryPrefix = '1'
 )
 
-// expiryInfoKey is used as a key of an entry in the bookkeeper (backed by a leveldb instance)
-type expiryInfoKey struct {
-	committingBlk uint64
-	expiryBlk     uint64
+type expiryKeeper struct {
+	db *leveldbhelper.DBHandle
 }
 
 // expiryInfo encapsulates an 'expiryInfoKey' and corresponding private data keys.
@@ -35,12 +33,14 @@ type expiryInfo struct {
 	pvtdataKeys   *PvtdataKeys
 }
 
-func newExpiryKeeper(ledgerid string, provider bookkeeping.Provider) *expiryKeeper {
-	return &expiryKeeper{provider.GetDBHandle(ledgerid, bookkeeping.PvtdataExpiry)}
+// expiryInfoKey is used as a key of an entry in the bookkeeper (backed by a leveldb instance)
+type expiryInfoKey struct {
+	committingBlk uint64
+	expiryBlk     uint64
 }
 
-type expiryKeeper struct {
-	db *leveldbhelper.DBHandle
+func newExpiryKeeper(ledgerid string, provider bookkeeping.Provider) *expiryKeeper {
+	return &expiryKeeper{provider.GetDBHandle(ledgerid, bookkeeping.PvtdataExpiry)}
 }
 
 // updateBookkeeping keeps track of the list of keys and their corresponding expiry block number

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper.go
@@ -35,25 +35,15 @@ type expiryInfo struct {
 	pvtdataKeys   *PvtdataKeys
 }
 
-// expiryKeeper is used to keep track of the expired items in the pvtdata space
-type expiryKeeper interface {
-	// updateBookkeeping keeps track of the list of keys and their corresponding expiry block number
-	updateBookkeeping(toTrack []*expiryInfo, toClear []*expiryInfoKey) error
-	// retrieve returns the keys info that are supposed to be expired by the given block number
-	retrieve(expiringAtBlkNum uint64) ([]*expiryInfo, error)
-	// retrieveByExpiryKey retrieves the expiryInfo for given expiryKey
-	retrieveByExpiryKey(expiryKey *expiryInfoKey) (*expiryInfo, error)
+func newExpiryKeeper(ledgerid string, provider bookkeeping.Provider) *expiryKeeper {
+	return &expiryKeeper{provider.GetDBHandle(ledgerid, bookkeeping.PvtdataExpiry)}
 }
 
-func newExpiryKeeper(ledgerid string, provider bookkeeping.Provider) expiryKeeper {
-	return &expKeeper{provider.GetDBHandle(ledgerid, bookkeeping.PvtdataExpiry)}
-}
-
-type expKeeper struct {
+type expiryKeeper struct {
 	db *leveldbhelper.DBHandle
 }
 
-// updateBookkeeping updates the information stored in the bookkeeper
+// updateBookkeeping keeps track of the list of keys and their corresponding expiry block number
 // 'toTrack' parameter causes new entries in the bookkeeper and  'toClear' parameter contains the entries that
 // are to be removed from the bookkeeper. This function is invoked with the commit of every block. As an
 // example, the commit of the block with block number 50, 'toTrack' parameter may contain following two entries:
@@ -65,7 +55,7 @@ type expKeeper struct {
 // (1) &expiryInfoKey{committingBlk: 45, expiryBlk: 50} and (2) &expiryInfoKey{committingBlk: 40, expiryBlk: 50}. The first entry was created
 // at the time of the commit of the block number 45 and the second entry was created at the time of the commit of the block number 40, however
 // both are expiring with the commit of block number 50.
-func (ek *expKeeper) updateBookkeeping(toTrack []*expiryInfo, toClear []*expiryInfoKey) error {
+func (ek *expiryKeeper) updateBookkeeping(toTrack []*expiryInfo, toClear []*expiryInfoKey) error {
 	updateBatch := leveldbhelper.NewUpdateBatch()
 	for _, expinfo := range toTrack {
 		k, v, err := encodeKV(expinfo)
@@ -80,7 +70,8 @@ func (ek *expKeeper) updateBookkeeping(toTrack []*expiryInfo, toClear []*expiryI
 	return ek.db.WriteBatch(updateBatch, true)
 }
 
-func (ek *expKeeper) retrieve(expiringAtBlkNum uint64) ([]*expiryInfo, error) {
+// retrieve returns the keys info that are supposed to be expired by the given block number
+func (ek *expiryKeeper) retrieve(expiringAtBlkNum uint64) ([]*expiryInfo, error) {
 	startKey := encodeExpiryInfoKey(&expiryInfoKey{expiryBlk: expiringAtBlkNum, committingBlk: 0})
 	endKey := encodeExpiryInfoKey(&expiryInfoKey{expiryBlk: expiringAtBlkNum + 1, committingBlk: 0})
 	itr := ek.db.GetIterator(startKey, endKey)
@@ -97,7 +88,8 @@ func (ek *expKeeper) retrieve(expiringAtBlkNum uint64) ([]*expiryInfo, error) {
 	return listExpinfo, nil
 }
 
-func (ek *expKeeper) retrieveByExpiryKey(expiryKey *expiryInfoKey) (*expiryInfo, error) {
+// retrieveByExpiryKey retrieves the expiryInfo for given expiryKey
+func (ek *expiryKeeper) retrieveByExpiryKey(expiryKey *expiryInfoKey) (*expiryInfo, error) {
 	key := encodeExpiryInfoKey(expiryKey)
 	value, err := ek.db.Get(key)
 	if err != nil {

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper_test.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper_test.go
@@ -40,9 +40,9 @@ func TestExpiryKeeper(t *testing.T) {
 	expinfo4 := &expiryInfo{&expiryInfoKey{committingBlk: 5, expiryBlk: 17}, buildPvtdataKeysForTest(4, 4)}
 
 	// Insert entries for keys at committingBlk 3
-	expiryKeeper.updateBookkeeping([]*expiryInfo{expinfo1, expinfo2}, nil)
+	expiryKeeper.update([]*expiryInfo{expinfo1, expinfo2}, nil)
 	// Insert entries for keys at committingBlk 4 and 5
-	expiryKeeper.updateBookkeeping([]*expiryInfo{expinfo3, expinfo4}, nil)
+	expiryKeeper.update([]*expiryInfo{expinfo3, expinfo4}, nil)
 
 	// Retrieve entries by expiring block 13, 15, and 17
 	listExpinfo1, _ := expiryKeeper.retrieve(13)
@@ -63,7 +63,7 @@ func TestExpiryKeeper(t *testing.T) {
 	assert.True(t, proto.Equal(expinfo4.pvtdataKeys, listExpinfo3[0].pvtdataKeys))
 
 	// Clear entries for keys expiring at block 13 and 15 and again retrieve by expiring block 13, 15, and 17
-	expiryKeeper.updateBookkeeping(nil, []*expiryInfoKey{expinfo1.expiryInfoKey, expinfo2.expiryInfoKey, expinfo3.expiryInfoKey})
+	expiryKeeper.update(nil, []*expiryInfoKey{expinfo1.expiryInfoKey, expinfo2.expiryInfoKey, expinfo3.expiryInfoKey})
 	listExpinfo4, _ := expiryKeeper.retrieve(13)
 	assert.Nil(t, listExpinfo4)
 

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_schedule_builder.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_schedule_builder.go
@@ -43,14 +43,6 @@ func (builder *expiryScheduleBuilder) add(ns, coll, key string, keyHash []byte, 
 	return nil
 }
 
-func isDelete(versionedValue *statedb.VersionedValue) bool {
-	return versionedValue.Value == nil
-}
-
-func neverExpires(expiryBlk uint64) bool {
-	return expiryBlk == math.MaxUint64
-}
-
 func (builder *expiryScheduleBuilder) getExpiryInfo() []*expiryInfo {
 	var listExpinfo []*expiryInfo
 	for expinfoKey, pvtdataKeys := range builder.scheduleEntries {
@@ -97,4 +89,12 @@ func buildExpirySchedule(
 		}
 	}
 	return expiryScheduleBuilder.getExpiryInfo(), nil
+}
+
+func isDelete(versionedValue *statedb.VersionedValue) bool {
+	return versionedValue.Value == nil
+}
+
+func neverExpires(expiryBlk uint64) bool {
+	return expiryBlk == math.MaxUint64
 }

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/purge_mgr.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/purge_mgr.go
@@ -18,21 +18,6 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/util"
 )
 
-type keyAndVersion struct {
-	key             string
-	committingBlock uint64
-	purgeKeyOnly    bool
-}
-
-type expiryInfoMap map[privacyenabledstate.HashedCompositeKey]*keyAndVersion
-
-type workingset struct {
-	toPurge             expiryInfoMap
-	toClearFromSchedule []*expiryInfoKey
-	expiringBlk         uint64
-	err                 error
-}
-
 type PurgeMgr struct {
 	btlPolicy pvtdatapolicy.BTLPolicy
 	db        *privacyenabledstate.DB
@@ -42,6 +27,21 @@ type PurgeMgr struct {
 	waitGrp *sync.WaitGroup
 
 	workingset *workingset
+}
+
+type workingset struct {
+	toPurge             expiryInfoMap
+	toClearFromSchedule []*expiryInfoKey
+	expiringBlk         uint64
+	err                 error
+}
+
+type expiryInfoMap map[privacyenabledstate.HashedCompositeKey]*keyAndVersion
+
+type keyAndVersion struct {
+	key             string
+	committingBlock uint64
+	purgeKeyOnly    bool
 }
 
 // InstantiatePurgeMgr instantiates a PurgeMgr.

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/purge_mgr_test.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/purge_mgr_test.go
@@ -179,7 +179,7 @@ func TestKeyUpdateBeforeExpiryBlock(t *testing.T) {
 	block1Updates := privacyenabledstate.NewUpdateBatch()
 	putHashUpdates(block1Updates, "ns", "coll", "pvtkey", []byte("pvtvalue-1"), version.NewHeight(1, 1))
 	helper.commitUpdatesForTesting(1, block1Updates)
-	expInfo, _ := helper.purgeMgr.(*purgeMgr).expKeeper.retrieve(3)
+	expInfo, _ := helper.purgeMgr.expKeeper.retrieve(3)
 	assert.Len(t, expInfo, 1)
 
 	// block-2 update: Update both hash and pvt data
@@ -286,7 +286,7 @@ type testHelper struct {
 	dbEnv          privacyenabledstate.TestEnv
 
 	db       *privacyenabledstate.DB
-	purgeMgr PurgeMgr
+	purgeMgr *PurgeMgr
 }
 
 func (h *testHelper) init(t *testing.T, ledgerid string, btlPolicy pvtdatapolicy.BTLPolicy, dbEnv privacyenabledstate.TestEnv) {
@@ -362,13 +362,13 @@ func (h *testHelper) fetchPvtdataFronDB(ns, coll, key string) (kv *statedb.Versi
 }
 
 func (h *testHelper) checkExpiryEntryExistsForBlockNum(expiringBlk uint64, expectedNumEntries int) {
-	expInfo, err := h.purgeMgr.(*purgeMgr).expKeeper.retrieve(expiringBlk)
+	expInfo, err := h.purgeMgr.expKeeper.retrieve(expiringBlk)
 	assert.NoError(h.t, err)
 	assert.Len(h.t, expInfo, expectedNumEntries)
 }
 
 func (h *testHelper) checkNoExpiryEntryExistsForBlockNum(expiringBlk uint64) {
-	expInfo, err := h.purgeMgr.(*purgeMgr).expKeeper.retrieve(expiringBlk)
+	expInfo, err := h.purgeMgr.expKeeper.retrieve(expiringBlk)
 	assert.NoError(h.t, err)
 	assert.Len(h.t, expInfo, 0)
 }

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/purge_mgr_test.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/purge_mgr_test.go
@@ -308,14 +308,15 @@ func (h *testHelper) cleanup() {
 
 func (h *testHelper) commitUpdatesForTesting(blkNum uint64, updates *privacyenabledstate.UpdateBatch) {
 	h.purgeMgr.PrepareForExpiringKeys(blkNum)
-	assert.NoError(h.t, h.purgeMgr.DeleteExpiredAndUpdateBookkeeping(updates.PvtUpdates, updates.HashUpdates))
+	assert.NoError(h.t, h.purgeMgr.UpdateExpiryInfo(updates.PvtUpdates, updates.HashUpdates))
+	assert.NoError(h.t, h.purgeMgr.AddExpiredEntriesToUpdateBatch(updates.PvtUpdates, updates.HashUpdates))
 	assert.NoError(h.t, h.db.ApplyPrivacyAwareUpdates(updates, version.NewHeight(blkNum, 1)))
 	h.db.ClearCachedVersions()
 	h.purgeMgr.BlockCommitDone()
 }
 
 func (h *testHelper) commitPvtDataOfOldBlocksForTesting(updates *privacyenabledstate.UpdateBatch) {
-	assert.NoError(h.t, h.purgeMgr.UpdateBookkeepingForPvtDataOfOldBlocks(updates.PvtUpdates))
+	assert.NoError(h.t, h.purgeMgr.UpdateExpiryInfoOfPvtDataOfOldBlocks(updates.PvtUpdates))
 	assert.NoError(h.t, h.db.ApplyPrivacyAwareUpdates(updates, nil))
 }
 

--- a/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/lockbased_txmgr.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/lockbased_txmgr.go
@@ -633,6 +633,6 @@ func (txmgr *LockBasedTxMgr) reset() {
 // pvtdataPurgeMgr wraps the actual purge manager and an additional flag 'usedOnce'
 // for usage of this additional flag, see the relevant comments in the txmgr.Commit() function above
 type pvtdataPurgeMgr struct {
-	pvtstatepurgemgmt.PurgeMgr
+	*pvtstatepurgemgmt.PurgeMgr
 	usedOnce bool
 }

--- a/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/lockbased_txmgr.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/lockbased_txmgr.go
@@ -45,6 +45,13 @@ type LockBasedTxMgr struct {
 	hasher              ledger.Hasher
 }
 
+// pvtdataPurgeMgr wraps the actual purge manager and an additional flag 'usedOnce'
+// for usage of this additional flag, see the relevant comments in the txmgr.Commit() function above
+type pvtdataPurgeMgr struct {
+	*pvtstatepurgemgmt.PurgeMgr
+	usedOnce bool
+}
+
 type current struct {
 	block     *common.Block
 	batch     *privacyenabledstate.UpdateBatch
@@ -628,11 +635,4 @@ func (txmgr *LockBasedTxMgr) updateStateListeners() {
 
 func (txmgr *LockBasedTxMgr) reset() {
 	txmgr.current = nil
-}
-
-// pvtdataPurgeMgr wraps the actual purge manager and an additional flag 'usedOnce'
-// for usage of this additional flag, see the relevant comments in the txmgr.Commit() function above
-type pvtdataPurgeMgr struct {
-	*pvtstatepurgemgmt.PurgeMgr
-	usedOnce bool
 }

--- a/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/lockbased_txmgr.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/lockbasedtxmgr/lockbased_txmgr.go
@@ -241,8 +241,8 @@ func (txmgr *LockBasedTxMgr) RemoveStaleAndCommitPvtDataOfOldBlocks(reconciledPv
 	// to update the list. This is because RemoveStaleAndCommitPvtDataOfOldBlocks
 	// may have added new data which might be eligible for expiry during the
 	// next regular block commit.
-	logger.Debug("Updating bookkeeping info in the purge manager")
-	if err := txmgr.pvtdataPurgeMgr.UpdateBookkeepingForPvtDataOfOldBlocks(batch.PvtUpdates); err != nil {
+	logger.Debug("Updating expiry info in the purge manager")
+	if err := txmgr.pvtdataPurgeMgr.UpdateExpiryInfoOfPvtDataOfOldBlocks(batch.PvtUpdates); err != nil {
 		return err
 	}
 
@@ -514,7 +514,12 @@ func (txmgr *LockBasedTxMgr) Commit() error {
 		panic("validateAndPrepare() method should have been called before calling commit()")
 	}
 
-	if err := txmgr.pvtdataPurgeMgr.DeleteExpiredAndUpdateBookkeeping(
+	if err := txmgr.pvtdataPurgeMgr.UpdateExpiryInfo(
+		txmgr.current.batch.PvtUpdates, txmgr.current.batch.HashUpdates); err != nil {
+		return err
+	}
+
+	if err := txmgr.pvtdataPurgeMgr.AddExpiredEntriesToUpdateBatch(
 		txmgr.current.batch.PvtUpdates, txmgr.current.batch.HashUpdates); err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code)

#### Description

1. As we have only one implementation of both `PurgeMgr` and `expiryKeeper`, we remove these interfaces.
2. All types are moved to the top of the file and also kept in order.
3. To be explicit, we remove the term `bookkeeping` and replace it with either `expiryKeeper` or `expiryInfo` as appropriate. As a result, had to split `DeleteExpiredAndUpdateBookeeping` into two functions.  

#### Related issues

[FAB-17884](https://jira.hyperledger.org/browse/FAB-17884) 