### PR TITLE
Provide more context in identity deserialization warning message

### DIFF
--- a/msp/msp_test.go
+++ b/msp/msp_test.go
@@ -470,7 +470,7 @@ func TestSerializeIdentitiesWithMSPManager(t *testing.T) {
 
 	_, err = mspMgr.DeserializeIdentity(serializedID)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), fmt.Sprintf("MSP %s is unknown", sid.Mspid))
+	assert.Contains(t, err.Error(), fmt.Sprintf("MSP %s is not defined on channel", sid.Mspid))
 
 	_, err = mspMgr.DeserializeIdentity([]byte("barf"))
 	assert.Error(t, err)

--- a/msp/mspmgrimpl.go
+++ b/msp/mspmgrimpl.go
@@ -1,17 +1,7 @@
 /*
-Copyright IBM Corp. 2016 All Rights Reserved.
+Copyright IBM Corp. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-		 http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
 */
 
 package msp
@@ -93,7 +83,7 @@ func (mgr *mspManagerImpl) DeserializeIdentity(serializedID []byte) (Identity, e
 	// we can now attempt to obtain the MSP
 	msp := mgr.mspsMap[sId.Mspid]
 	if msp == nil {
-		return nil, errors.Errorf("MSP %s is unknown", sId.Mspid)
+		return nil, errors.Errorf("MSP %s is not defined on channel", sId.Mspid)
 	}
 
 	switch t := msp.(type) {


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Improve MSP error message and include certificate subject/serial number in logged warning message. 

#### Related issues

[FAB-14099](https://jira.hyperledger.org/browse/FAB-14099)
