### PR TITLE
Enable stateleveldb for scanning for snapshot files generation

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/mock/versioned_db.go
+++ b/core/ledger/kvledger/txmgmt/statedb/mock/versioned_db.go
@@ -65,6 +65,21 @@ type VersionedDB struct {
 		result1 statedb.QueryResultsIterator
 		result2 error
 	}
+	GetFullScanIteratorStub        func(func(string) bool) (statedb.FullScanIterator, byte, error)
+	getFullScanIteratorMutex       sync.RWMutex
+	getFullScanIteratorArgsForCall []struct {
+		arg1 func(string) bool
+	}
+	getFullScanIteratorReturns struct {
+		result1 statedb.FullScanIterator
+		result2 byte
+		result3 error
+	}
+	getFullScanIteratorReturnsOnCall map[int]struct {
+		result1 statedb.FullScanIterator
+		result2 byte
+		result3 error
+	}
 	GetLatestSavePointStub        func() (*version.Height, error)
 	getLatestSavePointMutex       sync.RWMutex
 	getLatestSavePointArgsForCall []struct {
@@ -440,6 +455,72 @@ func (fake *VersionedDB) ExecuteQueryWithPaginationReturnsOnCall(i int, result1 
 		result1 statedb.QueryResultsIterator
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *VersionedDB) GetFullScanIterator(arg1 func(string) bool) (statedb.FullScanIterator, byte, error) {
+	fake.getFullScanIteratorMutex.Lock()
+	ret, specificReturn := fake.getFullScanIteratorReturnsOnCall[len(fake.getFullScanIteratorArgsForCall)]
+	fake.getFullScanIteratorArgsForCall = append(fake.getFullScanIteratorArgsForCall, struct {
+		arg1 func(string) bool
+	}{arg1})
+	fake.recordInvocation("GetFullScanIterator", []interface{}{arg1})
+	fake.getFullScanIteratorMutex.Unlock()
+	if fake.GetFullScanIteratorStub != nil {
+		return fake.GetFullScanIteratorStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.getFullScanIteratorReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *VersionedDB) GetFullScanIteratorCallCount() int {
+	fake.getFullScanIteratorMutex.RLock()
+	defer fake.getFullScanIteratorMutex.RUnlock()
+	return len(fake.getFullScanIteratorArgsForCall)
+}
+
+func (fake *VersionedDB) GetFullScanIteratorCalls(stub func(func(string) bool) (statedb.FullScanIterator, byte, error)) {
+	fake.getFullScanIteratorMutex.Lock()
+	defer fake.getFullScanIteratorMutex.Unlock()
+	fake.GetFullScanIteratorStub = stub
+}
+
+func (fake *VersionedDB) GetFullScanIteratorArgsForCall(i int) func(string) bool {
+	fake.getFullScanIteratorMutex.RLock()
+	defer fake.getFullScanIteratorMutex.RUnlock()
+	argsForCall := fake.getFullScanIteratorArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *VersionedDB) GetFullScanIteratorReturns(result1 statedb.FullScanIterator, result2 byte, result3 error) {
+	fake.getFullScanIteratorMutex.Lock()
+	defer fake.getFullScanIteratorMutex.Unlock()
+	fake.GetFullScanIteratorStub = nil
+	fake.getFullScanIteratorReturns = struct {
+		result1 statedb.FullScanIterator
+		result2 byte
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *VersionedDB) GetFullScanIteratorReturnsOnCall(i int, result1 statedb.FullScanIterator, result2 byte, result3 error) {
+	fake.getFullScanIteratorMutex.Lock()
+	defer fake.getFullScanIteratorMutex.Unlock()
+	fake.GetFullScanIteratorStub = nil
+	if fake.getFullScanIteratorReturnsOnCall == nil {
+		fake.getFullScanIteratorReturnsOnCall = make(map[int]struct {
+			result1 statedb.FullScanIterator
+			result2 byte
+			result3 error
+		})
+	}
+	fake.getFullScanIteratorReturnsOnCall[i] = struct {
+		result1 statedb.FullScanIterator
+		result2 byte
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *VersionedDB) GetLatestSavePoint() (*version.Height, error) {
@@ -956,6 +1037,8 @@ func (fake *VersionedDB) Invocations() map[string][][]interface{} {
 	defer fake.executeQueryMutex.RUnlock()
 	fake.executeQueryWithPaginationMutex.RLock()
 	defer fake.executeQueryWithPaginationMutex.RUnlock()
+	fake.getFullScanIteratorMutex.RLock()
+	defer fake.getFullScanIteratorMutex.RUnlock()
 	fake.getLatestSavePointMutex.RLock()
 	defer fake.getLatestSavePointMutex.RUnlock()
 	fake.getStateMutex.RLock()

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
@@ -769,6 +769,10 @@ func (vdb *VersionedDB) GetLatestSavePoint() (*version.Height, error) {
 	return decodeSavepoint(couchDoc)
 }
 
+func (vdb *VersionedDB) GetFullScanIterator(skipNamespace func(string) bool) (statedb.FullScanIterator, byte, error) {
+	return nil, byte(0), errors.New("Not yet implemented")
+}
+
 // applyAdditionalQueryOptions will add additional fields to the query required for query processing
 func applyAdditionalQueryOptions(queryString string, queryLimit int32, queryBookmark string) (string, error) {
 	const jsonQueryFields = "fields"

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb_test_export.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb_test_export.go
@@ -1,17 +1,7 @@
 /*
-Copyright IBM Corp. 2016 All Rights Reserved.
+Copyright IBM Corp. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-		 http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
 */
 
 package stateleveldb
@@ -22,14 +12,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 )
 
 // TestVDBEnv provides a level db backed versioned db for testing
 type TestVDBEnv struct {
 	t          testing.TB
-	DBProvider statedb.VersionedDBProvider
+	DBProvider *VersionedDBProvider
 	dbPath     string
 }
 


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Description
This PR
 - Introduces a function in the statedb interface for getting access to
   an iterator that can be used for scanning the entire state,
   including private data hashes for a particular channel

- Provides the implementation of the above mentioned function for the
  leveldb based statedb.

#### Additional details
- In a separate PR, the same function would be implemented for the couchdb
- Also, in another PR, in the common layer above, i.e., `privacyenabledstate` the code for the generation of snapshot files for the public state and private data hashes would be implemented

#### Related issues
FAB-17885