### PR TITLE
[FAB-17886] Fix default value of `sequence` parameter to empty

### DIFF
--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -201,7 +201,7 @@ Flags:
   -n, --name string                    Name of the chaincode
       --package-id string              The identifier of the chaincode install package
       --peerAddresses stringArray      The addresses of the peers to connect to
-      --sequence int                   The sequence number of the chaincode definition for the channel (default 1)
+      --sequence int                   The sequence number of the chaincode definition for the channel
       --signature-policy string        The endorsement policy associated to this chaincode specified as a signature policy
       --tlsRootCertFiles stringArray   If TLS is enabled, the paths to the TLS root cert files of the peers to connect to. The order and number of certs specified should match the --peerAddresses flag
   -V, --validation-plugin string       The name of the validation plugin to be used for this chaincode
@@ -239,7 +239,7 @@ Flags:
   -n, --name string                    Name of the chaincode
   -O, --output string                  The output format for query results. Default is human-readable plain-text. json is currently the only supported format.
       --peerAddresses stringArray      The addresses of the peers to connect to
-      --sequence int                   The sequence number of the chaincode definition for the channel (default 1)
+      --sequence int                   The sequence number of the chaincode definition for the channel
       --signature-policy string        The endorsement policy associated to this chaincode specified as a signature policy
       --tlsRootCertFiles stringArray   If TLS is enabled, the paths to the TLS root cert files of the peers to connect to. The order and number of certs specified should match the --peerAddresses flag
   -V, --validation-plugin string       The name of the validation plugin to be used for this chaincode
@@ -274,7 +274,7 @@ Flags:
       --init-required                  Whether the chaincode requires invoking 'init'
   -n, --name string                    Name of the chaincode
       --peerAddresses stringArray      The addresses of the peers to connect to
-      --sequence int                   The sequence number of the chaincode definition for the channel (default 1)
+      --sequence int                   The sequence number of the chaincode definition for the channel
       --signature-policy string        The endorsement policy associated to this chaincode specified as a signature policy
       --tlsRootCertFiles stringArray   If TLS is enabled, the paths to the TLS root cert files of the peers to connect to. The order and number of certs specified should match the --peerAddresses flag
   -V, --validation-plugin string       The name of the validation plugin to be used for this chaincode

--- a/internal/peer/lifecycle/chaincode/chaincode.go
+++ b/internal/peer/lifecycle/chaincode/chaincode.go
@@ -123,7 +123,7 @@ func ResetFlags() {
 	flags.DurationVar(&waitForEventTimeout, "waitForEventTimeout", 30*time.Second,
 		fmt.Sprint("Time to wait for the event from each peer's deliver filtered service signifying that the 'invoke' transaction has been committed successfully"))
 	flags.StringVarP(&packageID, "package-id", "", "", "The identifier of the chaincode install package")
-	flags.IntVarP(&sequence, "sequence", "", 1, "The sequence number of the chaincode definition for the channel")
+	flags.IntVarP(&sequence, "sequence", "", 0, "The sequence number of the chaincode definition for the channel")
 	flags.BoolVarP(&initRequired, "init-required", "", false, "Whether the chaincode requires invoking 'init'")
 	flags.StringVarP(&output, "output", "O", "", "The output format for query results. Default is human-readable plain-text. json is currently the only supported format.")
 	flags.StringVarP(&outputDirectory, "output-directory", "", "", "The output directory to use when writing a chaincode install package to disk. Default is the current working directory.")


### PR DESCRIPTION
This patch fixes the default value of `sequence` parameter for `peer chaincode lifecycle` commands.

#### Type of change

- Bug fix

#### Description

Currently, default value of `sequence` parameter for `peer chaincode lifecycle` commands is set to `1`.

However, the default value should be modified to `0` that means empty for the following several reasons.

- According to `Validate()` in `approveformyorg.go`, this function is implemented assuming that `sequence` is `0`. This is inconsistent with the default value `1`.
- The current default value `1` enables Fabric users `approveformyorg` without specifying the sequence number. Not forcing the specification of a sequence number may cause operation mistakes (e.g, updating the package-id for sequence 1 by mistake) when running `approveformyorg` in the second and subsequent times.
- The default value is preferably `0` to reuse the same parameter `sequence` in CLI commands to query the details of approved chaincode definitions.

#### Related issues

- https://jira.hyperledger.org/projects/FAB/issues/FAB-17434
  - Issues to CLI commands to query the details of approved chaincode definitions
  - https://github.com/hyperledger/fabric/pull/1243