### PR TITLE
Replace link to removed topic with link to relavent image

### DIFF
--- a/docs/source/txflow.rst
+++ b/docs/source/txflow.rst
@@ -122,8 +122,10 @@ transaction was validated or invalidated.
           whether your transaction has actually been ordered, validated, and
           committed to the ledger.
 
-See the :ref:`sequence diagram <swimlane>` to better understand the
-transaction flow.
+You can also use the swimlane sequence diagram below to examine the
+transaction flow in more detail.
+
+.. image:: images/flow-4.png
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>

#### Type of change

- Documentation update

#### Description

Docs contain a link to an architecture deep dive topic that no longer exists. However the image that is referenced is still in the docs.
