### PR TITLE
[FAB-17793] Generate db name to namespace mapping for state couchdb

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdbutil.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdbutil.go
@@ -183,6 +183,12 @@ func constructCouchDBUrl(connectURL *url.URL, dbName string, pathElements ...str
 
 // constructMetadataDBName truncates the db name to couchdb allowed length to
 // construct the metadataDBName
+// Note:
+// Currently there is a non-deterministic collision between metadataDB and namespaceDB with namespace="".
+// When channel name is not truncated, metadataDB and namespaceDB with namespace="" have the same db name.
+// When channel name is truncated, these two DBs have different db names.
+// We have to deal with this behavior for now. In the future, we may rename metadataDB and
+// migrate the content to avoid the collision.
 func constructMetadataDBName(dbName string) string {
 	if len(dbName) > maxLength {
 		untruncatedDBName := dbName

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdoc_conv.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdoc_conv.go
@@ -184,6 +184,17 @@ type couchSavepointData struct {
 	TxNum    uint64 `json:"TxNum"`
 }
 
+type channelMetadata struct {
+	ChannelName string `json:"ChannelName"`
+	// namespace to namespaceDBInfo mapping
+	NamespaceDBsInfo map[string]*namespaceDBInfo `json:"NamespaceDBsInfo"`
+}
+
+type namespaceDBInfo struct {
+	Namespace string `json:"Namespace"`
+	DBName    string `json:"DBName"`
+}
+
 func encodeSavepoint(height *version.Height) (*couchDoc, error) {
 	var err error
 	var savepointDoc couchSavepointData
@@ -207,6 +218,26 @@ func decodeSavepoint(couchDoc *couchDoc) (*version.Height, error) {
 		return nil, err
 	}
 	return &version.Height{BlockNum: savepointDoc.BlockNum, TxNum: savepointDoc.TxNum}, nil
+}
+
+func encodeChannelMetadata(metadataDoc *channelMetadata) (*couchDoc, error) {
+	metadataJSON, err := json.Marshal(metadataDoc)
+	if err != nil {
+		err = errors.Wrap(err, "failed to marshal channel metadata")
+		logger.Errorf("%+v", err)
+		return nil, err
+	}
+	return &couchDoc{jsonValue: metadataJSON, attachments: nil}, nil
+}
+
+func decodeChannelMetadata(couchDoc *couchDoc) (*channelMetadata, error) {
+	metadataDoc := &channelMetadata{}
+	if err := json.Unmarshal(couchDoc.jsonValue, &metadataDoc); err != nil {
+		err = errors.Wrap(err, "failed to unmarshal channel metadata")
+		logger.Errorf("%+v", err)
+		return nil, err
+	}
+	return metadataDoc, nil
 }
 
 type dataformatInfo struct {


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- New feature

#### Description
This PR generates db name to namespace mapping for state couchdb and
stores the mapping data in channel’s metadata db. Due to couchdb's
length restriction on db names, the mapping is needed to drop all
the databases for a channel as well as snapshot support.

#### Additional details
When CouchDB is used as statedb, internal databases are created at a per-chaincode/collection basis. Because CouchDB has length limitation on db names, channel name may be truncated if the combined length of channel+namespace+collection is over the limit. Due to the truncation, the original namespaces are lot and we may not be able to re-construct the database names. 

#### Related issues
https://jira.hyperledger.org/browse/FAB-17793
https://jira.hyperledger.org/browse/FAB-17787