### PR TITLE
Clarify error message when lscc chaincode install fails during build

### DIFF
--- a/core/scc/lscc/lscc.go
+++ b/core/scc/lscc/lscc.go
@@ -722,7 +722,7 @@ func (lscc *SCC) executeInstall(stub shim.ChaincodeStubInterface, ccbytes []byte
 	}
 	<-buildStatus.Done()
 	if err := buildStatus.Err(); err != nil {
-		return errors.WithMessage(err, "could not build chaincode")
+		return errors.WithMessage(err, "chaincode installed to peer but could not build chaincode")
 	}
 
 	md, err := lscc.EbMetadataProvider.PackageMetadata(ccid)

--- a/core/scc/lscc/lscc_test.go
+++ b/core/scc/lscc/lscc_test.go
@@ -209,7 +209,7 @@ func TestInstall(t *testing.T) {
 	assert.Equal(t, 1, chaincodeBuilder.BuildCallCount())
 
 	chaincodeBuilder.BuildReturns(fmt.Errorf("fake-build-error"))
-	testInstall(t, "example02-different", "0", path, false, "could not build chaincode: fake-build-error", "Alice", scc, stub, nil)
+	testInstall(t, "example02-different", "0", path, false, "chaincode installed to peer but could not build chaincode: fake-build-error", "Alice", scc, stub, nil)
 	chaincodeBuilder.BuildReturns(nil)
 
 	// This is a bad test, but it does at least exercise the external builder md path


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

When an LSCC chaincode install fails due to an error building the
chaincode, the chaincode will remain installed on the peer. This commit
updates the error message to indicate this behavior since it is (for better
or worse) working as designed.

#### Related issues

[FAB-17784](https://jira.hyperledger.org/browse/FAB-17784)