### PR TITLE
[DocUpdate]configtxlator decode/common.ConfigUpdate

### DIFF
--- a/docs/source/commands/configtxlator.md
+++ b/docs/source/commands/configtxlator.md
@@ -134,7 +134,7 @@ Alternatively, after starting the REST server, the following curl commands
 perform the same operations through the REST API.
 
 ```
-curl -X POST -F channel=testchan -F "original=@original_config.pb" -F "updated=@modified_config.pb" "${CONFIGTXLATOR_URL}/configtxlator/compute/update-from-configs" | curl -X POST --data-binary /dev/stdin "${CONFIGTXLATOR_URL}/protolator/encode/common.ConfigUpdate"
+curl -X POST -F channel=testchan -F "original=@original_config.pb" -F "updated=@modified_config.pb" "${CONFIGTXLATOR_URL}/configtxlator/compute/update-from-configs" | curl -X POST --data-binary /dev/stdin "${CONFIGTXLATOR_URL}/protolator/decode/common.ConfigUpdate"
 ```
 
 ## Additional Notes

--- a/docs/wrappers/configtxlator_postscript.md
+++ b/docs/wrappers/configtxlator_postscript.md
@@ -42,7 +42,7 @@ Alternatively, after starting the REST server, the following curl commands
 perform the same operations through the REST API.
 
 ```
-curl -X POST -F channel=testchan -F "original=@original_config.pb" -F "updated=@modified_config.pb" "${CONFIGTXLATOR_URL}/configtxlator/compute/update-from-configs" | curl -X POST --data-binary /dev/stdin "${CONFIGTXLATOR_URL}/protolator/encode/common.ConfigUpdate"
+curl -X POST -F channel=testchan -F "original=@original_config.pb" -F "updated=@modified_config.pb" "${CONFIGTXLATOR_URL}/configtxlator/compute/update-from-configs" | curl -X POST --data-binary /dev/stdin "${CONFIGTXLATOR_URL}/protolator/decode/common.ConfigUpdate"
 ```
 
 ## Additional Notes


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

We found error in docs that we say configtxlator server use route 'encode/common.ConfigUpdate' to decode protobuf into json.
it should be 'decode/common.ConfigUpdate' 

#### Additional details
This affect both release-1.4 and master branch

#### Related issues

FAB-17908

#### Release Note
