### PR TITLE
[DocUpdate] basic chaincode package tutorial

### DIFF
--- a/docs/source/chaincode_lifecycle.md
+++ b/docs/source/chaincode_lifecycle.md
@@ -82,7 +82,7 @@ automatically create a file in this format.
 - The chaincode needs to be packaged in a tar file, ending with a `.tar.gz` file
   extension.
 - The tar file needs to contain two files (no directory): a metadata file
-  "metadata.json" and another tar containing the chaincode files.
+  "metadata.json" and another tar "code.tar.gz" containing the chaincode files.
 - "metadata.json" contains JSON that specifies the
   chaincode language, code path, and package label. You can see an example of
   a metadata file below:


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

- Remote the sentence
"It is not necessary for organizations to use the same package
label."
- speak out the source tar name required in package
- prune Chaincode-Package-Metadata legacy

#### Additional details

The point especially looking for your feedback is what is the meaning of
"It is not necessary for organizations to use the same package label"

This give me an impression that even we use different label, fabric could smartly detect two package installed on different orgs are same chaincode, meanwhile it suggest label is optional. 

But actually it is not the case. It make reader confused. 

#### Related issues

#### Release Note
