### PR TITLE
Fix Second-Chance Algorithm issue

### DIFF
--- a/msp/cache/second_chance.go
+++ b/msp/cache/second_chance.go
@@ -82,7 +82,6 @@ func (cache *secondChanceCache) add(key string, value interface{}) {
 	var item cacheItem
 	item.key = key
 	item.value = value
-	atomic.StoreInt32(&item.referenced, 1)
 
 	size := len(cache.items)
 	num := len(cache.table)
@@ -95,7 +94,7 @@ func (cache *secondChanceCache) add(key string, value interface{}) {
 
 	// starts victim scan since cache is full
 	for {
-		// checks whether this item is recently accsessed or not
+		// checks whether this item is recently accessed or not
 		victim := cache.items[cache.position]
 		if atomic.LoadInt32(&victim.referenced) == 0 {
 			// a victim is found. delete it, and store the new item here.

--- a/msp/cache/second_chance_test.go
+++ b/msp/cache/second_chance_test.go
@@ -20,39 +20,33 @@ func TestSecondChanceCache(t *testing.T) {
 
 	cache.add("a", "xyz")
 
-	obj, ok := cache.get("a")
-	assert.True(t, ok)
-	assert.Equal(t, "xyz", obj.(string))
-
 	cache.add("b", "123")
-
-	obj, ok = cache.get("b")
+	// get b, b referenced bit is set to true
+	obj, ok := cache.get("b")
 	assert.True(t, ok)
 	assert.Equal(t, "123", obj.(string))
 
+	// add c. victim scan: delete a and set b as the next candidate of a victim
 	cache.add("c", "777")
 
-	obj, ok = cache.get("c")
-	assert.True(t, ok)
-	assert.Equal(t, "777", obj.(string))
-
+	// check a is deleted
 	_, ok = cache.get("a")
 	assert.False(t, ok)
 
-	_, ok = cache.get("b")
-	assert.True(t, ok)
-
-	cache.add("b", "456")
-
-	obj, ok = cache.get("b")
-	assert.True(t, ok)
-	assert.Equal(t, "456", obj.(string))
-
+	// add d. victim scan: b referenced bit is set to false and delete c
 	cache.add("d", "555")
 
-	obj, ok = cache.get("b")
-	_, ok = cache.get("b")
+	// check c is deleted
+	_, ok = cache.get("c")
 	assert.False(t, ok)
+
+	// check b and d
+	obj, ok = cache.get("b")
+	assert.True(t, ok)
+	assert.Equal(t, "123", obj.(string))
+	obj, ok = cache.get("d")
+	assert.True(t, ok)
+	assert.Equal(t, "555", obj.(string))
 }
 
 func TestSecondChanceCacheConcurrent(t *testing.T) {


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

New added item's referenced bit should be set to false when cache is not full.

#### Reproduce:
```golang
func TestSecondChanceCache(t *testing.T) {
	cache := newSecondChanceCache(2)
	assert.NotNil(t, cache)

	cache.add("a", "xyz")

	cache.add("b", "123")
	// get b, b referenced bit is set to true
	obj, ok := cache.get("b")
	assert.True(t, ok)
	assert.Equal(t, "123", obj.(string))

	// add c. victim scan: delete a and set b as the next candidate of a victim
	cache.add("c", "777")

	// check a is deleted
	_, ok = cache.get("a")
	assert.False(t, ok)

	// add d. victim scan: b referenced bit is set to false and delete c
	cache.add("d", "555")

	// check c is deleted
	_, ok = cache.get("c")
	assert.False(t, ok)

	// check b and d
	obj, ok = cache.get("b")
	assert.True(t, ok)
	assert.Equal(t, "123", obj.(string))
	obj, ok = cache.get("d")
	assert.True(t, ok)
	assert.Equal(t, "555", obj.(string))
}
```

**Result**:

test failed when check c is deleted.

**Expect**:

test success.

**Explain**:

- When add c, delete a and set b as the next candidate of a victim.
- When add d, b referenced bit changes from true to false and c should be deleted.
- But the result is: b is deleted instead of c.

#### Related issues

NA

#### Release Note

NA
