### PR TITLE
[FAB-11732] Add support for private data pagination in query results

### DIFF
--- a/core/chaincode/shim/chaincode.go
+++ b/core/chaincode/shim/chaincode.go
@@ -28,7 +28,7 @@ import (
 	"github.com/hyperledger/fabric/protos/ledger/queryresult"
 	pb "github.com/hyperledger/fabric/protos/peer"
 	"github.com/hyperledger/fabric/protos/utils"
-	logging "github.com/op/go-logging"
+	"github.com/op/go-logging"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
@@ -601,6 +601,21 @@ func (stub *ChaincodeStub) GetPrivateDataQueryResult(collection, query string) (
 	iterator, _, err := stub.handleGetQueryResult(collection, query, nil)
 
 	return iterator, err
+}
+
+// GetPrivateDataQueryResultWithPagination documentation can be found in interfaces.go
+func (stub *ChaincodeStub) GetPrivateDataQueryResultWithPagination(collection, query string, pageSize int32,
+	bookmark string) (StateQueryIteratorInterface, *pb.QueryResponseMetadata, error) {
+	if collection == "" {
+		return nil, nil, fmt.Errorf("collection must not be an empty string")
+	}
+
+	metadata, err := createQueryMetadata(pageSize, bookmark)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return stub.handleGetQueryResult(collection, query, metadata)
 }
 
 // GetPrivateDataValidationParameter documentation can be found in interfaces.go

--- a/core/chaincode/shim/interfaces.go
+++ b/core/chaincode/shim/interfaces.go
@@ -310,6 +310,27 @@ type ChaincodeStubInterface interface {
 	// ledger, and should limit use to read-only chaincode operations.
 	GetPrivateDataQueryResult(collection, query string) (StateQueryIteratorInterface, error)
 
+	// GetPrivateDataQueryResultWithPagination performs a "rich" query against a given private
+	// collection. It is only supported for state databases that support rich query,
+	// e.g.CouchDB. The query string is in the native syntax
+	// of the underlying state database. An iterator is returned
+	// which can be used to iterate (next) over the query result set.
+	// When an empty string is passed as a value to the bookmark argument, the returned
+	// iterator can be used to fetch the first `pageSize` of query results.
+	// When the bookmark is a non-empty string, the iterator can be used to fetch
+	// the first `pageSize` keys between the bookmark and the last key in the query result.
+	// Note that only the bookmark present in a prior page of query results (ResponseMetadata)
+	// can be used as a value to the bookmark argument. Otherwise, an empty string
+	// must be passed as bookmark.
+	// The query is NOT re-executed during validation phase, phantom reads are
+	// not detected. That is, other committed transactions may have added,
+	// updated, or removed keys that impact the result set, and this would not
+	// be detected at validation/commit time. Applications susceptible to this
+	// should therefore not use GetQueryResult as part of transactions that update
+	// ledger, and should limit use to read-only chaincode operations.
+	GetPrivateDataQueryResultWithPagination(collection, query string, pageSize int32,
+		bookmark string) (StateQueryIteratorInterface, *pb.QueryResponseMetadata, error)
+
 	// GetCreator returns `SignatureHeader.Creator` (e.g. an identity)
 	// of the `SignedProposal`. This is the identity of the agent (or user)
 	// submitting the transaction.

--- a/core/chaincode/shim/mockstub.go
+++ b/core/chaincode/shim/mockstub.go
@@ -200,6 +200,14 @@ func (stub *MockStub) GetPrivateDataQueryResult(collection, query string) (State
 	return nil, errors.New("Not Implemented")
 }
 
+func (stub *MockStub) GetPrivateDataQueryResultWithPagination(collection, query string, pageSize int32,
+	bookmark string) (StateQueryIteratorInterface, *pb.QueryResponseMetadata, error) {
+	// Not implemented since the mock engine does not have a query engine.
+	// However, a very simple query engine that supports string matching
+	// could be implemented to test that the framework supports queries
+	return nil, nil, errors.New("Not Implemented")
+}
+
 // GetState retrieves the value for a given key from the ledger
 func (stub *MockStub) GetState(key string) ([]byte, error) {
 	value := stub.State[key]

--- a/docs/source/private-data-arch.rst
+++ b/docs/source/private-data-arch.rst
@@ -234,6 +234,7 @@ And for the CouchDB state database, JSON content queries can be passed using the
 shim API:
 
 * ``GetPrivateDataQueryResult(collection, query string)``
+* ``GetPrivateDataQueryResultWithPagination(collection, query string, pageSize int32, bookmark string)
 
 Limitations:
 


### PR DESCRIPTION
Signed-off-by: Haris Chaniotakis <chanioxaris@gmail.com>

#### Type of change
- New feature
- Documentation update

#### Description
Add support to query private data with pagination. Minimal changes needed, as there was already support for querying state data with pagination.

Stub interface affected, adding a new GetPrivateDataQueryResultWithPagination() function and the implementation. 
Also updated the documentation regarding private data available functions.

#### Additional details

#### Related issues

https://jira.hyperledger.org/browse/FAB-11732