### PR TITLE
FAB-17889 Ch.Part.API: Registrar channel list

### DIFF
--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -381,10 +381,7 @@ func (r *Registrar) ChannelList() types.ChannelList {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
-	list := types.ChannelList{
-		SystemChannel: nil,
-		Channels:      nil,
-	}
+	list := types.ChannelList{}
 
 	if len(r.chains) == 0 {
 		return list

--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -391,14 +391,13 @@ func (r *Registrar) ChannelList() types.ChannelList {
 	}
 
 	if r.systemChannelID != "" {
-		list.SystemChannel = &types.ChannelInfoShort{Name: r.systemChannelID, URL: ""}
+		list.SystemChannel = &types.ChannelInfoShort{Name: r.systemChannelID}
 	}
-	list.Channels = make([]types.ChannelInfoShort, 0)
 	for name := range r.chains {
 		if name == r.systemChannelID {
 			continue
 		}
-		list.Channels = append(list.Channels, types.ChannelInfoShort{Name: name, URL: ""})
+		list.Channels = append(list.Channels, types.ChannelInfoShort{Name: name})
 	}
 
 	return list

--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -230,6 +230,8 @@ func (r *Registrar) Initialize(consenters map[string]consensus.Consenter) {
 
 // SystemChannelID returns the ChannelID for the system channel.
 func (r *Registrar) SystemChannelID() string {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
 	return r.systemChannelID
 }
 
@@ -372,12 +374,34 @@ func (r *Registrar) CreateBundle(channelID string, config *cb.Config) (channelco
 	return channelconfig.NewBundle(channelID, config, r.bccsp)
 }
 
+// ChannelList returns a slice of ChannelInfoShort containing all application channels (excluding the system
+// channel), and ChannelInfoShort of the system channel (nil if does not exist).
+// The URL fields are empty, and are to be completed by the caller.
 func (r *Registrar) ChannelList() types.ChannelList {
-	//TODO
-	return types.ChannelList{
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	list := types.ChannelList{
 		SystemChannel: nil,
 		Channels:      nil,
 	}
+
+	if len(r.chains) == 0 {
+		return list
+	}
+
+	if r.systemChannelID != "" {
+		list.SystemChannel = &types.ChannelInfoShort{Name: r.systemChannelID, URL: ""}
+	}
+	list.Channels = make([]types.ChannelInfoShort, 0)
+	for name := range r.chains {
+		if name == r.systemChannelID {
+			continue
+		}
+		list.Channels = append(list.Channels, types.ChannelInfoShort{Name: name, URL: ""})
+	}
+
+	return list
 }
 
 func (r *Registrar) ChannelInfo(channelID string) (types.ChannelInfo, error) {

--- a/orderer/common/multichannel/registrar_test.go
+++ b/orderer/common/multichannel/registrar_test.go
@@ -227,7 +227,7 @@ func TestNewRegistrar(t *testing.T) {
 			t,
 			types.ChannelList{
 				SystemChannel: &types.ChannelInfoShort{Name: "testchannelid", URL: ""},
-				Channels:      []types.ChannelInfoShort{}},
+				Channels:      nil},
 			list,
 		)
 

--- a/orderer/common/types/channelinfo.go
+++ b/orderer/common/types/channelinfo.go
@@ -15,22 +15,31 @@ type ErrorResponse struct {
 // ChannelList carries the response to an HTTP request to List all the channels.
 // This is marshaled into the body of the HTTP response.
 type ChannelList struct {
-	SystemChannel *ChannelInfoShort  `json:"systemChannel"` // The system channel, nil if doesn't exist
-	Channels      []ChannelInfoShort `json:"channels"`      // Application channels only
+	// The system channel info, nil if it doesn't exist.
+	SystemChannel *ChannelInfoShort `json:"systemChannel"`
+	// Application channels only, nil or empty if no channels defined.
+	Channels []ChannelInfoShort `json:"channels"`
 }
 
 // ChannelInfoShort carries a short info of a single channel.
 type ChannelInfoShort struct {
-	Name string `json:"name"` // The channel name
-	URL  string `json:"url"`  // The channel relative URL (no Host:Port)
+	// The channel name.
+	Name string `json:"name"`
+	// The channel relative URL (no Host:Port, only path), e.g.: "/participation/v1/channels/my-channel".
+	URL string `json:"url"`
 }
 
 // ChannelInfo carries the response to an HTTP request to List a single channel.
 // This is marshaled into the body of the HTTP response.
 type ChannelInfo struct {
-	Name            string `json:"name"`            // The channel name
-	URL             string `json:"url"`             // The channel relative URL (no Host:Port)
-	ClusterRelation string `json:"clusterRelation"` // Whether it is a “member” or ”follower”, case insensitive
-	Status          string `json:"status"`          // ”onboarding” or ”active”, case insensitive
-	Height          uint64 `json:"height"`          // Current block height
+	// The channel name.
+	Name string `json:"name"`
+	// The channel relative URL (no Host:Port, only path), e.g.: "/participation/v1/channels/my-channel".
+	URL string `json:"url"`
+	// Whether the orderer is a “member” or ”follower” of the cluster, for this channel. Case insensitive.
+	ClusterRelation string `json:"clusterRelation"`
+	// Whether the orderer is ”onboarding” or ”active”, for this channel. Case insensitive.
+	Status string `json:"status"`
+	// Current block height.
+	Height uint64 `json:"height"`
 }


### PR DESCRIPTION
Allow the registrar to produce a list of all channels.

Note that all access to the system channel name is now under lock,
because with the introduction of this API it is no longer immutable.

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: I4993372eb9961af528cd35d868e53dec6d53ae74

#### Type of change

- New feature

#### Related issues

Task: FAB-17889
Story: FAB-17824
Epic: FAB-17712
