### PR TITLE
Change default CouchDB maxRetriesOnStartup to 10

### DIFF
--- a/release_notes/v2.2.0.md
+++ b/release_notes/v2.2.0.md
@@ -1,0 +1,28 @@
+v2.2.0 Release Notes - July XX, 2020
+====================================
+
+What's New in Hyperledger Fabric v2.2
+-------------------------------------
+
+
+Fixes
+-----
+
+
+Changes
+-------
+
+- **FAB-17917: Change default CouchDB maxRetriesOnStartup property from 12 to 10**
+
+  The time between retries doubles after each attempt.
+  Therefore if CouchDB is not yet started, the peer start will now retry
+  for about 2 minutes rather than 16 minutes before retries are exhausted.
+
+
+Dependency updates
+------------------
+
+Change log
+----------
+For the full list of changes, refer to the release change log:
+https://github.com/hyperledger/fabric/blob/release-2.2/CHANGELOG.md#v220

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -627,8 +627,10 @@ ledger:
        password:
        # Number of retries for CouchDB errors
        maxRetries: 3
-       # Number of retries for CouchDB errors during peer startup
-       maxRetriesOnStartup: 12
+       # Number of retries for CouchDB errors during peer startup.
+       # The delay between retries doubles for each attempt.
+       # Default of 10 retries results in 11 attempts over 2 minutes.
+       maxRetriesOnStartup: 10
        # CouchDB request timeout (unit: duration, e.g. 20s)
        requestTimeout: 35s
        # Limit on the number of records per each CouchDB query


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to default peer config)

#### Description

Change default maxRetriesOnStartup from 12 to 10.
Also fix retries so that there is no sleep after the last attempt,
and improve the retry message to make it clear how many attempts and when retries are exhausted.
The changes result in peer start failure after 2 minutes rather than 16 minutes, so that admin doesn't have to endure 16 minutes of waiting. For environments that bring up peer and couchdb containers at the same time, 2 minutes should be sufficient for most (CouchDB usually finishes startup within a few seconds). 

#### Additional details

Updated retry log entries:

```
2020-05-19 17:50:48.380 EDT [statecouchdb] handleRequest -> WARN 028 Attempt 1 of 11 returned error: Get "http://127.0.0.1:5984/": dial tcp 127.0.0.1:5984: connect: connection refused. Retrying couchdb request in 125ms
2020-05-19 17:50:48.510 EDT [statecouchdb] handleRequest -> WARN 029 Attempt 2 of 11 returned error: Get "http://127.0.0.1:5984/": dial tcp 127.0.0.1:5984: connect: connection refused. Retrying couchdb request in 250ms
...
2020-05-19 17:52:56.285 EDT [statecouchdb] handleRequest -> WARN 032 Attempt 11 of 11 returned error: Get "http://127.0.0.1:5984/": dial tcp 127.0.0.1:5984: connect: connection refused. Retries exhausted
```

#### Related issues

[FAB-17917](https://jira.hyperledger.org/browse/FAB-17917)

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
