### PR TITLE
Generate statedb snapshot files

### DIFF
--- a/common/ledger/snapshot/file.go
+++ b/common/ledger/snapshot/file.go
@@ -19,7 +19,7 @@ import (
 )
 
 // FileWriter creates a new file for ledger snapshot. This is expected to be used by various
-// components of ledger, such as blockstorage and statedb for exporting the relevent snapshot data
+// components of ledger, such as blockstorage and statedb for exporting the relevant snapshot data
 type FileWriter struct {
 	file              *os.File
 	hasher            hash.Hash
@@ -191,6 +191,9 @@ func (r *FileReader) decodeBytes() ([]byte, error) {
 		return nil, err
 	}
 	size := int(sizeUint)
+	if size == 0 {
+		return []byte{}, nil
+	}
 	if len(r.reusableByteSlice) < size {
 		r.reusableByteSlice = make([]byte, size)
 	}

--- a/common/ledger/snapshot/file_test.go
+++ b/common/ledger/snapshot/file_test.go
@@ -31,6 +31,7 @@ func TestFileCreateAndRead(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, fileCreator.EncodeString("Hi there"))
 	require.NoError(t, fileCreator.EncodeString("How are you?"))
+	require.NoError(t, fileCreator.EncodeString("")) // zreo length string
 	require.NoError(t, fileCreator.EncodeUVarint(uint64(25)))
 	require.NoError(t, fileCreator.EncodeProtoMessage(
 		&common.BlockchainInfo{
@@ -40,6 +41,7 @@ func TestFileCreateAndRead(t *testing.T) {
 		},
 	))
 	require.NoError(t, fileCreator.EncodeBytes([]byte("some junk bytes")))
+	require.NoError(t, fileCreator.EncodeBytes([]byte{})) // zreo length slice
 
 	// Done and verify the returned hash
 	dataHash, err := fileCreator.Done()
@@ -62,6 +64,10 @@ func TestFileCreateAndRead(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "How are you?", str)
 
+	str, err = fileReader.DecodeString()
+	require.NoError(t, err)
+	require.Equal(t, "", str)
+
 	number, err := fileReader.DecodeUVarInt()
 	require.NoError(t, err)
 	require.Equal(t, uint64(25), number)
@@ -80,6 +86,10 @@ func TestFileCreateAndRead(t *testing.T) {
 	b, err := fileReader.DecodeBytes()
 	require.NoError(t, err)
 	require.Equal(t, []byte("some junk bytes"), b)
+
+	b, err = fileReader.DecodeBytes()
+	require.NoError(t, err)
+	require.Equal(t, []byte{}, b)
 }
 
 func TestFileCreatorErrorPropagation(t *testing.T) {

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/db.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/db.go
@@ -351,6 +351,14 @@ func deriveHashedDataNs(namespace, collection string) string {
 	return namespace + nsJoiner + hashDataPrefix + collection
 }
 
+func isPvtdataNs(namespace string) bool {
+	return strings.Contains(namespace, nsJoiner+pvtDataPrefix)
+}
+
+func isHashedDataNs(namespace string) bool {
+	return strings.Contains(namespace, nsJoiner+hashDataPrefix)
+}
+
 func addPvtUpdates(pubUpdateBatch *PubUpdateBatch, pvtUpdateBatch *PvtUpdateBatch) {
 	for ns, nsBatch := range pvtUpdateBatch.UpdateMap {
 		for _, coll := range nsBatch.GetCollectionNames() {

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/snapshot.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/snapshot.go
@@ -1,0 +1,184 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package privacyenabledstate
+
+import (
+	"hash"
+	"path"
+
+	"github.com/hyperledger/fabric/common/ledger/snapshot"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+)
+
+const (
+	snapshotFileFormat             = byte(1)
+	pubStateDataFileName           = "public_state.data"
+	pubStateMetadataFileName       = "public_state.metadata"
+	pvtStateHashesFileName         = "private_state_hashes.data"
+	pvtStateHashesMetadataFileName = "private_state_hashes.metadata"
+)
+
+// ExportPubStateAndPvtStateHashes generates four files in the specified dir. The files, public_state.data and public_state.metadata
+// contains the exported public state and the files private_state_hashes.data and private_state_hashes.data contain the exported private state hashes.
+// The file format for public state and the private state hashes are the same. The data files contains a series of tuple <key,value> and the metadata
+// files contains a series of tuple <namespace, num entries for the namespace in the data file>.
+func (s *DB) ExportPubStateAndPvtStateHashes(dir string, newHasher func() hash.Hash) (map[string][]byte, error) {
+	itr, dbValueFormat, err := s.GetFullScanIterator(isPvtdataNs)
+	if err != nil {
+		return nil, err
+	}
+	defer itr.Close()
+
+	pubStateWriter, err := newSnapshotWriter(
+		path.Join(dir, pubStateDataFileName),
+		path.Join(dir, pubStateMetadataFileName),
+		dbValueFormat,
+		newHasher,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer pubStateWriter.close()
+
+	pvtStateHashesWriter, err := newSnapshotWriter(
+		path.Join(dir, pvtStateHashesFileName),
+		path.Join(dir, pvtStateHashesMetadataFileName),
+		dbValueFormat,
+		newHasher,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer pvtStateHashesWriter.close()
+
+	for {
+		compositeKey, dbValue, err := itr.Next()
+		if err != nil {
+			return nil, err
+		}
+		if compositeKey == nil {
+			break
+		}
+		switch {
+		case isHashedDataNs(compositeKey.Namespace):
+			if err := pvtStateHashesWriter.addData(compositeKey, dbValue); err != nil {
+				return nil, err
+			}
+		default:
+			if err := pubStateWriter.addData(compositeKey, dbValue); err != nil {
+				return nil, err
+			}
+		}
+	}
+	pubStateDataHash, pubStateMetadataHash, err := pubStateWriter.done()
+	if err != nil {
+		return nil, err
+	}
+	pvtStateHahshesDataHash, pvtStateHashesMetadataHash, err := pvtStateHashesWriter.done()
+	if err != nil {
+		return nil, err
+	}
+	return map[string][]byte{
+			pubStateDataFileName:           pubStateDataHash,
+			pubStateMetadataFileName:       pubStateMetadataHash,
+			pvtStateHashesFileName:         pvtStateHahshesDataHash,
+			pvtStateHashesMetadataFileName: pvtStateHashesMetadataHash,
+		},
+		nil
+}
+
+// snapshotWriter generates two files, a data file and a metadata file. The datafile contains a series of tuples <key, dbValue>
+// and the metadata file contains a series of tuples <namesapce, number-of-tuples-in-the-data-file-that-belong-to-this-namespace>
+type snapshotWriter struct {
+	dataFile                *snapshot.FileWriter
+	metadataFile            *snapshot.FileWriter
+	kvCountsPerNamespace    map[string]uint64
+	namespaceInsertionOrder []string
+}
+
+func newSnapshotWriter(
+	dataFilePath, metadataFilePath string,
+	dbValueFormat byte,
+	newHasher func() hash.Hash,
+) (*snapshotWriter, error) {
+
+	var dataFile, metadataFile *snapshot.FileWriter
+	var err error
+	defer func() {
+		if err != nil {
+			dataFile.Close()
+			metadataFile.Close()
+		}
+	}()
+
+	dataFile, err = snapshot.CreateFile(dataFilePath, snapshotFileFormat, newHasher())
+	if err != nil {
+		return nil, err
+	}
+	if err = dataFile.EncodeBytes([]byte{dbValueFormat}); err != nil {
+		return nil, err
+	}
+
+	metadataFile, err = snapshot.CreateFile(metadataFilePath, snapshotFileFormat, newHasher())
+	if err != nil {
+		return nil, err
+	}
+	return &snapshotWriter{
+			dataFile:             dataFile,
+			metadataFile:         metadataFile,
+			kvCountsPerNamespace: map[string]uint64{},
+		},
+		nil
+}
+
+func (w *snapshotWriter) addData(ck *statedb.CompositeKey, dbValue []byte) error {
+	_, ok := w.kvCountsPerNamespace[ck.Namespace]
+	if !ok {
+		// new namespace begins
+		w.namespaceInsertionOrder = append(w.namespaceInsertionOrder, ck.Namespace)
+	}
+	w.kvCountsPerNamespace[ck.Namespace]++
+	if err := w.dataFile.EncodeString(ck.Key); err != nil {
+		return err
+	}
+	if err := w.dataFile.EncodeBytes(dbValue); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w *snapshotWriter) done() ([]byte, []byte, error) {
+	dataHash, err := w.dataFile.Done()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := w.metadataFile.EncodeUVarint(uint64(len(w.kvCountsPerNamespace))); err != nil {
+		return nil, nil, err
+	}
+	for _, ns := range w.namespaceInsertionOrder {
+		if err := w.metadataFile.EncodeString(ns); err != nil {
+			return nil, nil, err
+		}
+		if err := w.metadataFile.EncodeUVarint(w.kvCountsPerNamespace[ns]); err != nil {
+			return nil, nil, err
+		}
+	}
+	metadataHash, err := w.metadataFile.Done()
+	if err != nil {
+		return nil, nil, err
+	}
+	return dataHash, metadataHash, nil
+}
+
+func (w *snapshotWriter) close() {
+	if w == nil {
+		return
+	}
+	w.dataFile.Close()
+	w.metadataFile.Close()
+}

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/snapshot_test.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/snapshot_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package privacyenabledstate
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/hyperledger/fabric/common/ledger/snapshot"
+	"github.com/hyperledger/fabric/core/ledger/internal/version"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshot(t *testing.T) {
+	for _, env := range testEnvs {
+		if _, ok := env.(*LevelDBTestEnv); !ok {
+			continue
+		}
+		t.Run(env.GetName(), func(t *testing.T) {
+			testSanpshot(t, env)
+		})
+	}
+}
+
+func testSanpshot(t *testing.T, env TestEnv) {
+	// generateSampleData returns a slice of KVs. The returned value contains five KVs for each of the namespaces
+	generateSampleData := func(namespaces ...string) []*statedb.VersionedKV {
+		sampleData := []*statedb.VersionedKV{}
+		for _, ns := range namespaces {
+			for i := 0; i < 5; i++ {
+				sampleKV := &statedb.VersionedKV{
+					CompositeKey: statedb.CompositeKey{
+						Namespace: ns,
+						Key:       fmt.Sprintf("key-%d", i),
+					},
+					VersionedValue: statedb.VersionedValue{
+						Value:    []byte(fmt.Sprintf("value-for-key-%d-for-%s", i, ns)),
+						Version:  version.NewHeight(1, 1),
+						Metadata: []byte(fmt.Sprintf("metadata-for-key-%d-for-%s", i, ns)),
+					},
+				}
+				sampleData = append(sampleData, sampleKV)
+			}
+		}
+		return sampleData
+	}
+	samplePublicState := generateSampleData(
+		"",
+		"ns1",
+		"ns2",
+		"ns4",
+	)
+
+	samplePvtStateHashes := generateSampleData(
+		deriveHashedDataNs("", "coll1"),
+		deriveHashedDataNs("ns1", "coll1"),
+		deriveHashedDataNs("ns1", "coll2"),
+		deriveHashedDataNs("ns2", "coll3"),
+		deriveHashedDataNs("ns3", "coll1"),
+	)
+
+	samplePvtState := generateSampleData(
+		derivePvtDataNs("", "coll1"),
+		derivePvtDataNs("ns1", "coll1"),
+		derivePvtDataNs("ns1", "coll2"),
+		derivePvtDataNs("ns2", "coll3"),
+		derivePvtDataNs("ns3", "coll1"),
+	)
+
+	testSnapshotWithSampleData(t, env, samplePublicState, nil, nil)                             // test with only public data
+	testSnapshotWithSampleData(t, env, samplePublicState, samplePvtStateHashes, nil)            // test with public data and pvtdata hashes
+	testSnapshotWithSampleData(t, env, samplePublicState, samplePvtStateHashes, samplePvtState) // test with public data, pvtdata hashes, and pvt data
+}
+
+func testSnapshotWithSampleData(t *testing.T, env TestEnv,
+	publicState []*statedb.VersionedKV,
+	pvtStateHashes []*statedb.VersionedKV,
+	pvtState []*statedb.VersionedKV,
+) {
+	env.Init(t)
+	defer env.Cleanup()
+	db := env.GetDBHandle(generateLedgerID(t))
+
+	// load data into statedb
+	updateBatch := NewUpdateBatch()
+	for _, s := range publicState {
+		updateBatch.PubUpdates.PutValAndMetadata(s.Namespace, s.Key, s.Value, s.Metadata, s.Version)
+	}
+	for _, s := range pvtStateHashes {
+		nsColl := strings.Split(s.Namespace, nsJoiner+hashDataPrefix)
+		ns := nsColl[0]
+		coll := nsColl[1]
+		updateBatch.HashUpdates.PutValHashAndMetadata(ns, coll, []byte(s.Key), s.Value, s.Metadata, s.Version)
+	}
+	for _, s := range pvtState {
+		nsColl := strings.Split(s.Namespace, nsJoiner+pvtDataPrefix)
+		ns := nsColl[0]
+		coll := nsColl[1]
+		updateBatch.PvtUpdates.Put(ns, coll, s.Key, s.Value, s.Version)
+	}
+	err := db.ApplyPrivacyAwareUpdates(updateBatch, version.NewHeight(2, 2))
+	require.NoError(t, err)
+
+	// export snapshot files for statedb
+	snapshotDir, err := ioutil.TempDir("", "testsnapshot")
+	require.NoError(t, err)
+	defer func() {
+		os.RemoveAll(snapshotDir)
+	}()
+
+	newHasher := func() hash.Hash {
+		return sha256.New()
+	}
+	filesAndHashes, err := db.ExportPubStateAndPvtStateHashes(snapshotDir, newHasher)
+	require.NoError(t, err)
+	require.Len(t, filesAndHashes, 4)
+	require.Contains(t, filesAndHashes, pubStateDataFileName)
+	require.Contains(t, filesAndHashes, pubStateMetadataFileName)
+	require.Contains(t, filesAndHashes, pvtStateHashesFileName)
+	require.Contains(t, filesAndHashes, pvtStateHashesMetadataFileName)
+
+	for f, h := range filesAndHashes {
+		expectedFile := path.Join(snapshotDir, f)
+		require.FileExists(t, expectedFile)
+		require.Equal(t, sha256ForFileForTest(t, expectedFile), h)
+	}
+
+	// verify snapshot files contents
+	pubStateFromSnapshot := loadSnapshotDataForTest(t,
+		env,
+		path.Join(snapshotDir, pubStateDataFileName),
+		path.Join(snapshotDir, pubStateMetadataFileName),
+	)
+
+	pvtStateHashesFromSnapshot := loadSnapshotDataForTest(t,
+		env,
+		path.Join(snapshotDir, pvtStateHashesFileName),
+		path.Join(snapshotDir, pvtStateHashesMetadataFileName),
+	)
+	require.Equal(t, publicState, pubStateFromSnapshot)
+	require.Equal(t, pvtStateHashes, pvtStateHashesFromSnapshot)
+}
+
+func sha256ForFileForTest(t *testing.T, file string) []byte {
+	data, err := ioutil.ReadFile(file)
+	require.NoError(t, err)
+	sha := sha256.Sum256(data)
+	return sha[:]
+}
+
+func loadSnapshotDataForTest(
+	t *testing.T,
+	testenv TestEnv,
+	dataFilePath, metadataFilePath string) []*statedb.VersionedKV {
+	dataFile, err := snapshot.OpenFile(dataFilePath, snapshotFileFormat)
+	require.NoError(t, err)
+	defer dataFile.Close()
+	dbValueFormat, err := dataFile.DecodeBytes()
+	require.NoError(t, err)
+	require.Equal(t, []byte{testenv.DBValueFormat()}, dbValueFormat)
+
+	metadataFile, err := snapshot.OpenFile(metadataFilePath, snapshotFileFormat)
+	require.NoError(t, err)
+	defer metadataFile.Close()
+	numMetadataEntries, err := metadataFile.DecodeUVarInt()
+	require.NoError(t, err)
+	if numMetadataEntries == 0 {
+		return nil
+	}
+	data := []*statedb.VersionedKV{}
+	for i := uint64(0); i < numMetadataEntries; i++ {
+		ns, err := metadataFile.DecodeString()
+		require.NoError(t, err)
+		numKVs, err := metadataFile.DecodeUVarInt()
+		require.NoError(t, err)
+		for j := uint64(0); j < numKVs; j++ {
+			key, err := dataFile.DecodeString()
+			require.NoError(t, err)
+			dbValue, err := dataFile.DecodeBytes()
+			require.NoError(t, err)
+			ck := statedb.CompositeKey{
+				Namespace: ns,
+				Key:       key,
+			}
+			data = append(data, &statedb.VersionedKV{
+				CompositeKey:   ck,
+				VersionedValue: testenv.DecodeDBValue(dbValue),
+			})
+		}
+	}
+	return data
+}
+
+func TestSnapshotErrorPropagation(t *testing.T) {
+	var dbEnv *LevelDBTestEnv
+	var snapshotDir string
+	var db *DB
+	var cleanup func()
+	var err error
+	newHasher := func() hash.Hash {
+		return sha256.New()
+	}
+
+	init := func() {
+		dbEnv = &LevelDBTestEnv{}
+		dbEnv.Init(t)
+		db = dbEnv.GetDBHandle(generateLedgerID(t))
+		updateBatch := NewUpdateBatch()
+		updateBatch.PubUpdates.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 1))
+		db.ApplyPrivacyAwareUpdates(updateBatch, version.NewHeight(1, 1))
+		snapshotDir, err = ioutil.TempDir("", "testsnapshot")
+		require.NoError(t, err)
+		cleanup = func() {
+			dbEnv.Cleanup()
+			os.RemoveAll(snapshotDir)
+		}
+	}
+
+	reinit := func() {
+		cleanup()
+		init()
+	}
+
+	// pubStateDataFile already exists
+	init()
+	defer cleanup()
+	pubStateDataFilePath := path.Join(snapshotDir, pubStateDataFileName)
+	_, err = os.Create(pubStateDataFilePath)
+	require.NoError(t, err)
+	_, err = db.ExportPubStateAndPvtStateHashes(snapshotDir, newHasher)
+	require.Contains(t, err.Error(), "error while creating the snapshot file: "+pubStateDataFilePath)
+
+	// pubStateMetadataFile already exists
+	reinit()
+	pubStateMetadataFilePath := path.Join(snapshotDir, pubStateMetadataFileName)
+	_, err = os.Create(pubStateMetadataFilePath)
+	require.NoError(t, err)
+	_, err = db.ExportPubStateAndPvtStateHashes(snapshotDir, newHasher)
+	require.Contains(t, err.Error(), "error while creating the snapshot file: "+pubStateMetadataFilePath)
+
+	// pvtStateHashesDataFile already exists
+	reinit()
+	pvtStateHashesDataFilePath := path.Join(snapshotDir, pvtStateHashesFileName)
+	_, err = os.Create(pvtStateHashesDataFilePath)
+	require.NoError(t, err)
+	_, err = db.ExportPubStateAndPvtStateHashes(snapshotDir, newHasher)
+	require.Contains(t, err.Error(), "error while creating the snapshot file: "+pvtStateHashesDataFilePath)
+
+	// pvtStateHashesMetadataFile already exists
+	reinit()
+	pvtStateHashesMetadataFilePath := path.Join(snapshotDir, pvtStateHashesMetadataFileName)
+	_, err = os.Create(pvtStateHashesMetadataFilePath)
+	require.NoError(t, err)
+	_, err = db.ExportPubStateAndPvtStateHashes(snapshotDir, newHasher)
+	require.Contains(t, err.Error(), "error while creating the snapshot file: "+pvtStateHashesMetadataFilePath)
+
+	reinit()
+	dbEnv.provider.Close()
+	_, err = db.ExportPubStateAndPvtStateHashes(snapshotDir, newHasher)
+	require.Contains(t, err.Error(), "internal leveldb error while obtaining db iterator:")
+}

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/test_exports.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/test_exports.go
@@ -15,9 +15,12 @@ import (
 	"github.com/hyperledger/fabric/common/metrics/disabled"
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/bookkeeping"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/statecouchdb"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/stateleveldb"
 	"github.com/hyperledger/fabric/core/ledger/mock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestEnv - an interface that a test environment implements
@@ -26,6 +29,8 @@ type TestEnv interface {
 	Init(t testing.TB)
 	GetDBHandle(id string) *DB
 	GetName() string
+	DBValueFormat() byte
+	DecodeDBValue(dbVal []byte) statedb.VersionedValue
 	Cleanup()
 	StopExternalResource()
 }
@@ -87,6 +92,18 @@ func (env *LevelDBTestEnv) GetDBHandle(id string) *DB {
 // GetName implements corresponding function from interface TestEnv
 func (env *LevelDBTestEnv) GetName() string {
 	return "levelDBTestEnv"
+}
+
+// DBValueFormat returns the format used by the stateleveldb for dbvalue
+func (env *LevelDBTestEnv) DBValueFormat() byte {
+	return stateleveldb.TestEnvDBValueformat
+}
+
+// DecodeDBValue decodes the dbvalue bytes for tests
+func (env *LevelDBTestEnv) DecodeDBValue(dbVal []byte) statedb.VersionedValue {
+	vv, err := stateleveldb.TestEnvDBValueDecoder(dbVal)
+	require.NoError(env.t, err)
+	return *vv
 }
 
 // Cleanup implements corresponding function from interface TestEnv
@@ -176,6 +193,18 @@ func (env *CouchDBTestEnv) GetDBHandle(id string) *DB {
 // GetName implements corresponding function from interface TestEnv
 func (env *CouchDBTestEnv) GetName() string {
 	return "couchDBTestEnv"
+}
+
+// DBValueFormat returns the format used by the stateleveldb for dbvalue
+// Not yet implemented
+func (env *CouchDBTestEnv) DBValueFormat() byte {
+	return byte(0) //To be implemented
+}
+
+// DecodeDBValue decodes the dbvalue bytes for tests
+// Not yet implemented
+func (env *CouchDBTestEnv) DecodeDBValue(dbVal []byte) statedb.VersionedValue {
+	return statedb.VersionedValue{} //To be implemented
 }
 
 // Cleanup implements corresponding function from interface TestEnv

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/types_test.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/types_test.go
@@ -11,12 +11,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
+	flogging.ActivateSpec("privacyenabledstate=debug")
 	exitCode := m.Run()
 	for _, testEnv := range testEnvs {
 		testEnv.StopExternalResource()

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb.go
@@ -340,5 +340,8 @@ func (s *fullDBScanner) Next() (*statedb.CompositeKey, []byte, error) {
 }
 
 func (s *fullDBScanner) Close() {
+	if s == nil {
+		return
+	}
 	s.dbItr.Release()
 }

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb_test_export.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb_test_export.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,3 +40,12 @@ func (env *TestVDBEnv) Cleanup() {
 	env.DBProvider.Close()
 	os.RemoveAll(env.dbPath)
 }
+
+var (
+	// TestEnvDBValueformat exports the constant to be used used for tests
+	TestEnvDBValueformat = fullScanIteratorValueFormat
+	// TestEnvDBValueDecoder exports the function for decoding the dbvalue bytes
+	TestEnvDBValueDecoder = func(dbValue []byte) (*statedb.VersionedValue, error) {
+		return decodeValue(dbValue)
+	}
+)


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Description
This PR introduces a function in the for exporting the public state and private state hashes from statedb into a separate set of snapshot files in a deterministic format. Also, the function returns the hashes of the exported content.

#### Additional details
These exported state is intended to be included in the point-in-time snapshot for a channel

#### Related issues
FAB-17902