### PR TITLE
[FAB-17918]Fix the installed binary list in the document

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -74,10 +74,11 @@ created above. It retrieves the following platform-specific binaries:
   * ``configtxlator``,
   * ``cryptogen``,
   * ``discover``,
-  * ``idemixgen``
+  * ``idemixgen``,
   * ``orderer``,
-  * ``peer``, and
-  * ``fabric-ca-client``
+  * ``peer``,
+  * ``fabric-ca-client``,
+  * ``fabric-ca-server``
 
 and places them in the ``bin`` sub-directory of the current working
 directory.


### PR DESCRIPTION
Signed-off-by: Sol Kang <pdpxpd@gmail.com>

#### Type of change

- Documentation update

#### Description

The documentation showed different results than 
what I installed using the `scripts/bootstrap.sh` script.
The latest binary have `fabric-ca-server`.

#### Additional details

None.

#### Related issues

https://jira.hyperledger.org/browse/FAB-17918