### PR TITLE
[FAB-17059]: Add missing mspID when init MembershipProvider

### DIFF
--- a/core/common/privdata/membershipinfo.go
+++ b/core/common/privdata/membershipinfo.go
@@ -24,7 +24,7 @@ type MembershipProvider struct {
 
 // NewMembershipInfoProvider returns MembershipProvider
 func NewMembershipInfoProvider(mspID string, selfSignedData protoutil.SignedData, identityDeserializerFunc func(chainID string) msp.IdentityDeserializer) *MembershipProvider {
-	return &MembershipProvider{selfSignedData: selfSignedData, IdentityDeserializerFactory: identityDeserializerFunc}
+	return &MembershipProvider{mspID: mspID, selfSignedData: selfSignedData, IdentityDeserializerFactory: identityDeserializerFunc}
 }
 
 // AmMemberOf checks whether the current peer is a member of the given collection config.

--- a/integration/nwo/standard_networks.go
+++ b/integration/nwo/standard_networks.go
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 package nwo
 
-// BasicSolo is a configuration wtih two organizations and one peer per org.
+// BasicSolo is a configuration with two organizations and one peer per org.
 func BasicSolo() *Config {
 	return &Config{
 		Organizations: []*Organization{{
@@ -75,7 +75,7 @@ func BasicSolo() *Config {
 	}
 }
 
-// FullSolo is a configuration wtih two organizations and two peers per org.
+// FullSolo is a configuration with two organizations and two peers per org.
 func FullSolo() *Config {
 	config := BasicSolo()
 


### PR DESCRIPTION
<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

Add missing mspID when init MembershipProvider.
Otherwise, the mspid match check will not work as expect.

https://github.com/hyperledger/fabric/blob/e9c4f2858f8678d1a80d190595eb90b6267ffc72/core/common/privdata/membershipinfo.go#L38-L44

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

NA

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

See [FAB-17059](https://jira.hyperledger.org/browse/FAB-17059)

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
