### PR TITLE
[FAB-17435] Add integration tests for `queryapproved` command

### DIFF
--- a/integration/nwo/commands/peer.go
+++ b/integration/nwo/commands/peer.go
@@ -366,6 +366,36 @@ func (c ChaincodeApproveForMyOrg) Args() []string {
 	return args
 }
 
+type ChaincodeQueryApproved struct {
+	ChannelID     string
+	Name          string
+	Sequence      string
+	PeerAddresses []string
+	ClientAuth    bool
+}
+
+func (c ChaincodeQueryApproved) SessionName() string {
+	return "peer-lifecycle-chaincode-queryapproved"
+}
+
+func (c ChaincodeQueryApproved) Args() []string {
+	args := []string{
+		"lifecycle", "chaincode", "queryapproved",
+		"--channelID", c.ChannelID,
+		"--name", c.Name,
+		"--sequence", c.Sequence,
+		"--output", "json",
+	}
+	for _, p := range c.PeerAddresses {
+		args = append(args, "--peerAddresses", p)
+	}
+	if c.ClientAuth {
+		args = append(args, "--clientauth")
+	}
+
+	return args
+}
+
 type ChaincodeCheckCommitReadiness struct {
 	ChannelID           string
 	Name                string

--- a/integration/nwo/deploy.go
+++ b/integration/nwo/deploy.go
@@ -251,6 +251,16 @@ func ApproveChaincodeForMyOrg(n *Network, channel string, orderer *Orderer, chai
 	}
 }
 
+func EnsureChaincodeApproved(n *Network, peer *Peer, channel, name, sequence string) {
+	sequenceInt, err := strconv.ParseInt(sequence, 10, 64)
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(queryApproved(n, peer, channel, name, sequence), n.EventuallyTimeout).Should(
+		MatchFields(IgnoreExtras, Fields{
+			"Sequence": Equal(sequenceInt),
+		}),
+	)
+}
+
 func CheckCommitReadinessUntilReady(n *Network, channel string, chaincode Chaincode, checkOrgs []*Organization, peers ...*Peer) {
 	for _, p := range peers {
 		keys := Keys{}
@@ -485,6 +495,34 @@ func checkCommitReadiness(n *Network, peer *Peer, channel string, chaincode Chai
 		err = json.Unmarshal(sess.Out.Contents(), output)
 		Expect(err).NotTo(HaveOccurred())
 		return output.Approvals
+	}
+}
+
+type queryApprovedOutput struct {
+	Sequence int64 `json:"sequence"`
+}
+
+// queryApproved returns the result of the queryApproved command.
+// If the command fails for any reason, it will return an empty output object.
+func queryApproved(n *Network, peer *Peer, channel, name, sequence string) func() queryApprovedOutput {
+	return func() queryApprovedOutput {
+		sess, err := n.PeerAdminSession(peer, commands.ChaincodeQueryApproved{
+			ChannelID:     channel,
+			Name:          name,
+			Sequence:      sequence,
+			PeerAddresses: []string{n.PeerAddress(peer, ListenPort)},
+			ClientAuth:    n.ClientAuthRequired,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit())
+		output := &queryApprovedOutput{}
+		if sess.ExitCode() == 1 {
+			// don't try to unmarshal the output as JSON if the query failed
+			return *output
+		}
+		err = json.Unmarshal(sess.Out.Contents(), output)
+		Expect(err).NotTo(HaveOccurred())
+		return *output
 	}
 }
 


### PR DESCRIPTION
This patch adds integration tests for `queryapproved` command for querying the details of
the approved chaincode definition.

#### Type of change

- Test update

#### Description

Currently, Fabric peer does not provide a function to query the details of approved chaincode definitions.

On the other hand, Fabric admins will need to confirm/use the information after approval for their operations.

Other patches add `queryapproved` command for querying the details of the approved chaincode definition to Fabric peer CLI (Refer to FAB-17433 and FAB-17434).

This patch adds integration tests for the command.

The following patches has been merged to add this command:
- https://github.com/hyperledger/fabric-protos/pull/25
- https://github.com/hyperledger/fabric/pull/1220
- https://github.com/hyperledger/fabric/pull/1243

#### Related issues
- Main: 
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17435

- Others: 
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17401
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17432
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17433
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17434
  - https://jira.hyperledger.org/projects/FAB/issues/FAB-17436
