### PR TITLE
Fix OSN leader election failure

### DIFF
--- a/orderer/consensus/etcdraft/chain.go
+++ b/orderer/consensus/etcdraft/chain.go
@@ -460,6 +460,12 @@ func (c *Chain) Consensus(req *orderer.ConsensusRequest, sender uint64) error {
 		return fmt.Errorf("failed to unmarshal StepRequest payload to Raft Message: %s", err)
 	}
 
+	if stepMsg.To != c.raftID {
+		c.logger.Warnf("Received msg to %d, my ID is probably wrong due to out of date, cowardly halting", stepMsg.To)
+		c.Halt()
+		return nil
+	}
+
 	if err := c.Node.Step(context.TODO(), *stepMsg); err != nil {
 		return fmt.Errorf("failed to process Raft Step message: %s", err)
 	}

--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -193,7 +193,7 @@ var _ = Describe("Chain", func() {
 
 		campaign := func(c *etcdraft.Chain, observeC <-chan raft.SoftState) {
 			Eventually(func() <-chan raft.SoftState {
-				c.Consensus(&orderer.ConsensusRequest{Payload: protoutil.MarshalOrPanic(&raftpb.Message{Type: raftpb.MsgTimeoutNow})}, 0)
+				c.Consensus(&orderer.ConsensusRequest{Payload: protoutil.MarshalOrPanic(&raftpb.Message{Type: raftpb.MsgTimeoutNow, To: 1})}, 0)
 				return observeC
 			}, LongEventualTimeout).Should(Receive(StateEqual(1, raft.StateLeader)))
 		}
@@ -3749,7 +3749,7 @@ func (n *network) elect(id uint64) {
 
 	// Send node an artificial MsgTimeoutNow to emulate leadership transfer.
 	fmt.Fprintf(GinkgoWriter, "Send artificial MsgTimeoutNow to elect node %d\n", id)
-	candidate.Consensus(&orderer.ConsensusRequest{Payload: protoutil.MarshalOrPanic(&raftpb.Message{Type: raftpb.MsgTimeoutNow})}, 0)
+	candidate.Consensus(&orderer.ConsensusRequest{Payload: protoutil.MarshalOrPanic(&raftpb.Message{Type: raftpb.MsgTimeoutNow, To: id})}, 0)
 	Eventually(candidate.observe, LongEventualTimeout).Should(Receive(StateEqual(id, raft.StateLeader)))
 
 	n.Lock()


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

Currently in fabric 1.4/2.x with raft consensus, when one OSN is deleted
from channel and rejoin later, it will be assigned a new raft id.
However, in some cases including that catchup is triggered or the OSN
is stopped during the re-configuration, the OSN still uses the old raft
id.

Other OSNs including the leader are using the latest view and believe
that the rejoined OSN will use a new raft id.  This will never be
recoved and may fail the leader election due to qurum lost. No new
transaction will be accepted, and no new configuration can be changed.

This patchset fixes the issue by halting the chain proactively and let
it obtain the correct raft id after tracking the latest config block.

Change-Id: I6e352b59e9feba85f2bbc0119b9eb47bce746adc
Signed-off-by: Baohua Yang <baohua.yang@oracle.com>
Signed-off-by: Baohua Yang <yangbaohua@gmail.com>
Signed-off-by: Jay Guo <guojiannan1101@gmail.com>


#### Additional details

Since this is a critical issue that will block the service, need to backport to v1.4 branch too.

#### Related issues

https://jira.hyperledger.org/browse/FAB-17875