### PR TITLE
Pass HashProvider to ledger instead of Hasher

### DIFF
--- a/common/ledger/blkstorage/blockindex.go
+++ b/common/ledger/blkstorage/blockindex.go
@@ -9,7 +9,6 @@ package blkstorage
 import (
 	"bytes"
 	"fmt"
-	"hash"
 	"path"
 	"unicode/utf8"
 
@@ -256,13 +255,13 @@ func (index *blockIndex) getTXLocByBlockNumTranNum(blockNum uint64, tranNum uint
 	return txFLP, nil
 }
 
-func (index *blockIndex) exportUniqueTxIDs(dir string, hasher hash.Hash) (map[string][]byte, error) {
+func (index *blockIndex) exportUniqueTxIDs(dir string, newHashFunc snapshot.NewHashFunc) (map[string][]byte, error) {
 	if !index.isAttributeIndexed(IndexableAttrTxID) {
 		return nil, ErrAttrNotIndexed
 	}
 
 	// create the data file
-	dataFile, err := snapshot.CreateFile(path.Join(dir, snapshotDataFileName), snapshotFileFormat, hasher)
+	dataFile, err := snapshot.CreateFile(path.Join(dir, snapshotDataFileName), snapshotFileFormat, newHashFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -301,8 +300,7 @@ func (index *blockIndex) exportUniqueTxIDs(dir string, hasher hash.Hash) (map[st
 	}
 
 	// create the metadata file
-	hasher.Reset()
-	metadataFile, err := snapshot.CreateFile(path.Join(dir, snapshotMetadataFileName), snapshotFileFormat, hasher)
+	metadataFile, err := snapshot.CreateFile(path.Join(dir, snapshotMetadataFileName), snapshotFileFormat, newHashFunc)
 	if err != nil {
 		return nil, err
 	}

--- a/common/ledger/blkstorage/blockstore.go
+++ b/common/ledger/blkstorage/blockstore.go
@@ -7,12 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package blkstorage
 
 import (
-	"hash"
 	"time"
 
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/common/ledger"
+	"github.com/hyperledger/fabric/common/ledger/snapshot"
 	"github.com/hyperledger/fabric/common/ledger/util/leveldbhelper"
 )
 
@@ -93,8 +93,8 @@ func (store *BlockStore) RetrieveTxValidationCodeByTxID(txID string) (peer.TxVal
 // the mapping between the names of the files and their hashes.
 // Technically, the TxIDs appear in the sort order of radix-sort/shortlex. However,
 // since practically all the TxIDs are of same length, so the sort order would be the lexical sort order
-func (store *BlockStore) ExportTxIds(dir string, hasher hash.Hash) (map[string][]byte, error) {
-	return store.fileMgr.index.exportUniqueTxIDs(dir, hasher)
+func (store *BlockStore) ExportTxIds(dir string, newHashFunc snapshot.NewHashFunc) (map[string][]byte, error) {
+	return store.fileMgr.index.exportUniqueTxIDs(dir, newHashFunc)
 }
 
 // Shutdown shuts down the block store

--- a/core/ledger/confighistory/mgr.go
+++ b/core/ledger/confighistory/mgr.go
@@ -8,7 +8,6 @@ package confighistory
 
 import (
 	"fmt"
-	"hash"
 	"path"
 
 	"github.com/golang/protobuf/proto"
@@ -181,8 +180,8 @@ func (r *Retriever) CollectionConfigAt(blockNum uint64, chaincodeName string) (*
 // records, it would add only 12 MB overhead. Note that the protobuf also adds some
 // extra bytes. Further, the collection config namespace is not expected to have
 // millions of entries.
-func (r *Retriever) ExportConfigHistory(dir string, hasher hash.Hash) (map[string][]byte, error) {
-	dataFileWriter, err := snapshot.CreateFile(path.Join(dir, snapshotDataFileName), snapshotFileFormat, hasher)
+func (r *Retriever) ExportConfigHistory(dir string, newHashFunc snapshot.NewHashFunc) (map[string][]byte, error) {
+	dataFileWriter, err := snapshot.CreateFile(path.Join(dir, snapshotDataFileName), snapshotFileFormat, newHashFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -212,8 +211,7 @@ func (r *Retriever) ExportConfigHistory(dir string, hasher hash.Hash) (map[strin
 		return nil, err
 	}
 
-	hasher.Reset()
-	metadataFileWriter, err := snapshot.CreateFile(path.Join(dir, snapshotMetadataFileName), snapshotFileFormat, hasher)
+	metadataFileWriter, err := snapshot.CreateFile(path.Join(dir, snapshotMetadataFileName), snapshotFileFormat, newHashFunc)
 	if err != nil {
 		return nil, err
 	}

--- a/core/ledger/kvledger/kv_ledger_provider.go
+++ b/core/ledger/kvledger/kv_ledger_provider.go
@@ -74,15 +74,15 @@ type Provider struct {
 	collElgNotifier      *collElgNotifier
 	stats                *stats
 	fileLock             *leveldbhelper.FileLock
-	hasher               ledger.Hasher
+	hashProvider         ledger.HashProvider
 }
 
 // NewProvider instantiates a new Provider.
 // This is not thread-safe and assumed to be synchronized by the caller
 func NewProvider(initializer *ledger.Initializer) (pr *Provider, e error) {
 	p := &Provider{
-		initializer: initializer,
-		hasher:      initializer.Hasher,
+		initializer:  initializer,
+		hashProvider: initializer.HashProvider,
 	}
 
 	defer func() {
@@ -346,7 +346,7 @@ func (p *Provider) open(ledgerID string) (ledger.PeerLedger, error) {
 		ccLifecycleEventProvider: p.initializer.ChaincodeLifecycleEventProvider,
 		stats:                    p.stats.ledgerStats(ledgerID),
 		customTxProcessors:       p.initializer.CustomTxProcessors,
-		hasher:                   p.hasher,
+		hashProvider:             p.hashProvider,
 	}
 
 	l, err := newKVLedger(initializer)

--- a/core/ledger/kvledger/kv_ledger_provider_test.go
+++ b/core/ledger/kvledger/kv_ledger_provider_test.go
@@ -607,7 +607,7 @@ func testutilNewProvider(conf *lgr.Config, t *testing.T, ccInfoProvider *mock.De
 			DeployedChaincodeInfoProvider: ccInfoProvider,
 			MetricsProvider:               &disabled.Provider{},
 			Config:                        conf,
-			Hasher:                        cryptoProvider,
+			HashProvider:                  cryptoProvider,
 		},
 	)
 	require.NoError(t, err, "Failed to create new Provider")

--- a/core/ledger/kvledger/metrics_test.go
+++ b/core/ledger/kvledger/metrics_test.go
@@ -34,7 +34,7 @@ func TestStatsBlockCommit(t *testing.T) {
 			DeployedChaincodeInfoProvider: &mock.DeployedChaincodeInfoProvider{},
 			MetricsProvider:               testMetricProvider.fakeProvider,
 			Config:                        conf,
-			Hasher:                        cryptoProvider,
+			HashProvider:                  cryptoProvider,
 		},
 	)
 	if err != nil {

--- a/core/ledger/kvledger/state_listener_test.go
+++ b/core/ledger/kvledger/state_listener_test.go
@@ -36,7 +36,7 @@ func TestStateListener(t *testing.T) {
 			StateListeners:                []ledger.StateListener{mockListener},
 			MetricsProvider:               &disabled.Provider{},
 			Config:                        conf,
-			Hasher:                        cryptoProvider,
+			HashProvider:                  cryptoProvider,
 		},
 	)
 	if err != nil {
@@ -107,7 +107,7 @@ func TestStateListener(t *testing.T) {
 			StateListeners:                []ledger.StateListener{mockListener},
 			MetricsProvider:               &disabled.Provider{},
 			Config:                        conf,
-			Hasher:                        cryptoProvider,
+			HashProvider:                  cryptoProvider,
 		},
 	)
 	if err != nil {

--- a/core/ledger/kvledger/tests/customtx_processor_test.go
+++ b/core/ledger/kvledger/tests/customtx_processor_test.go
@@ -31,7 +31,7 @@ func TestReadWriteCustomTxProcessor(t *testing.T) {
 			CustomTxProcessors: map[common.HeaderType]ledger.CustomTxProcessor{
 				100: fakeTxProcessor,
 			},
-			Hasher: cryptoProvider,
+			HashProvider: cryptoProvider,
 		},
 	)
 	defer env.cleanup()
@@ -84,7 +84,7 @@ func TestRangeReadAndWriteCustomTxProcessor(t *testing.T) {
 				102: fakeTxProcessor2,
 				103: fakeTxProcessor3,
 			},
-			Hasher: cryptoProvider,
+			HashProvider: cryptoProvider,
 		},
 	)
 	defer env.cleanup()

--- a/core/ledger/kvledger/tests/env.go
+++ b/core/ledger/kvledger/tests/env.go
@@ -53,7 +53,7 @@ func newEnv(t *testing.T) *env {
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	assert.NoError(t, err)
 	return newEnvWithInitializer(t, &ledgermgmt.Initializer{
-		Hasher: cryptoProvider,
+		HashProvider: cryptoProvider,
 		EbMetadataProvider: &externalbuilder.MetadataProvider{
 			DurablePath: "testdata",
 		},

--- a/core/ledger/ledger_interface.go
+++ b/core/ledger/ledger_interface.go
@@ -8,6 +8,7 @@ package ledger
 
 import (
 	"fmt"
+	"hash"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -31,7 +32,7 @@ type Initializer struct {
 	HealthCheckRegistry             HealthCheckRegistry
 	Config                          *Config
 	CustomTxProcessors              map[common.HeaderType]CustomTxProcessor
-	Hasher                          Hasher
+	HashProvider                    HashProvider
 }
 
 // Config is a structure used to configure a ledger provider.
@@ -691,10 +692,10 @@ func (e *InvalidTxError) Error() string {
 	return e.Msg
 }
 
-// Hasher implements the hash function that should be used for all ledger components.
+// HashProvider provides access to a hash.Hash for ledger components.
 // Currently works at a stepping stone to decrease surface area of bccsp
-type Hasher interface {
-	Hash(msg []byte, opts bccsp.HashOpts) (hash []byte, err error)
+type HashProvider interface {
+	GetHash(opts bccsp.HashOpts) (hash.Hash, error)
 }
 
 //go:generate counterfeiter -o mock/state_listener.go -fake-name StateListener . StateListener

--- a/core/ledger/ledgermgmt/ledger_mgmt.go
+++ b/core/ledger/ledgermgmt/ledger_mgmt.go
@@ -51,7 +51,7 @@ type Initializer struct {
 	MetricsProvider                 metrics.Provider
 	HealthCheckRegistry             ledger.HealthCheckRegistry
 	Config                          *ledger.Config
-	Hasher                          ledger.Hasher
+	HashProvider                    ledger.HashProvider
 	EbMetadataProvider              MetadataProvider
 }
 
@@ -72,7 +72,7 @@ func NewLedgerMgr(initializer *Initializer) *LedgerMgr {
 			HealthCheckRegistry:             initializer.HealthCheckRegistry,
 			Config:                          initializer.Config,
 			CustomTxProcessors:              initializer.CustomTxProcessors,
-			Hasher:                          initializer.Hasher,
+			HashProvider:                    initializer.HashProvider,
 		},
 	)
 	if err != nil {

--- a/core/ledger/ledgermgmt/ledger_mgmt_test.go
+++ b/core/ledger/ledgermgmt/ledger_mgmt_test.go
@@ -143,7 +143,7 @@ func constructDefaultInitializer(testDir string) (*Initializer, error) {
 
 		MetricsProvider:               &disabled.Provider{},
 		DeployedChaincodeInfoProvider: &mock.DeployedChaincodeInfoProvider{},
-		Hasher:                        cryptoProvider,
+		HashProvider:                  cryptoProvider,
 	}, nil
 }
 

--- a/core/ledger/ledgermgmt/ledgermgmttest/ledgermgmttest.go
+++ b/core/ledger/ledgermgmt/ledgermgmttest/ledgermgmttest.go
@@ -41,7 +41,7 @@ func NewInitializer(testLedgerDir string) *ledgermgmt.Initializer {
 		},
 		MetricsProvider:                 &disabled.Provider{},
 		DeployedChaincodeInfoProvider:   &mock.DeployedChaincodeInfoProvider{},
-		Hasher:                          cryptoProvider,
+		HashProvider:                    cryptoProvider,
 		HealthCheckRegistry:             &mock.HealthCheckRegistry{},
 		ChaincodeLifecycleEventProvider: &mock.ChaincodeLifecycleEventProvider{},
 	}

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -426,7 +426,7 @@ func serve(args []string) error {
 			HealthCheckRegistry:             opsSystem,
 			StateListeners:                  []ledger.StateListener{lifecycleCache},
 			Config:                          ledgerConfig(),
-			Hasher:                          factory.GetDefault(),
+			HashProvider:                    factory.GetDefault(),
 			EbMetadataProvider:              ebMetadataProvider,
 		},
 	)


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- Improvement

#### Description
- So far ledger used hash function for computing hash on small amount of data at a time that was kept in memory and hence the dependency passed from `bccsp`, [Hash](https://github.com/hyperledger/fabric/blob/85599979a087765d443a2d569511e52a675d6e05/core/ledger/ledger_interface.go#L697) was sufficient. However, for computing the hash of the data streaming while exporting the data (without caching in memory) for a snapshot, the access to to Hash object is needed. This commit makes the change in this dependency. However, no change is needed on the upper layer as the already passed down dependency already implements the desired function.

- Also makes the function signature for constructing a new Hash object uniform across snapshot-able components 