### PR TITLE
Address linter issues in internal/peer/lifecycle/chaincode

### DIFF
--- a/internal/peer/lifecycle/chaincode/approveformyorg.go
+++ b/internal/peer/lifecycle/chaincode/approveformyorg.go
@@ -9,7 +9,6 @@ package chaincode
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -83,8 +82,8 @@ func (a *ApproveForMyOrgInput) Validate() error {
 func ApproveForMyOrgCmd(a *ApproverForMyOrg, cryptoProvider bccsp.BCCSP) *cobra.Command {
 	chaincodeApproveForMyOrgCmd := &cobra.Command{
 		Use:   "approveformyorg",
-		Short: fmt.Sprintf("Approve the chaincode definition for my org."),
-		Long:  fmt.Sprintf("Approve the chaincode definition for my organization."),
+		Short: "Approve the chaincode definition for my org.",
+		Long:  "Approve the chaincode definition for my organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if a == nil {
 				// set input from CLI flags

--- a/internal/peer/lifecycle/chaincode/chaincode.go
+++ b/internal/peer/lifecycle/chaincode/chaincode.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package chaincode
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/hyperledger/fabric/bccsp"
@@ -107,22 +106,18 @@ func ResetFlags() {
 	flags.StringVarP(&channelID, "channelID", "C", "", "The channel on which this command should be executed")
 	flags.StringVarP(&signaturePolicy, "signature-policy", "", "", "The endorsement policy associated to this chaincode specified as a signature policy")
 	flags.StringVarP(&channelConfigPolicy, "channel-config-policy", "", "", "The endorsement policy associated to this chaincode specified as a channel config policy reference")
-	flags.StringVarP(&endorsementPlugin, "endorsement-plugin", "E", "",
-		fmt.Sprint("The name of the endorsement plugin to be used for this chaincode"))
-	flags.StringVarP(&validationPlugin, "validation-plugin", "V", "",
-		fmt.Sprint("The name of the validation plugin to be used for this chaincode"))
-	flags.StringVar(&collectionsConfigFile, "collections-config", "",
-		fmt.Sprint("The fully qualified path to the collection JSON file including the file name"))
-	flags.StringArrayVarP(&peerAddresses, "peerAddresses", "", []string{""},
-		fmt.Sprint("The addresses of the peers to connect to"))
+	flags.StringVarP(&endorsementPlugin, "endorsement-plugin", "E", "", "The name of the endorsement plugin to be used for this chaincode")
+	flags.StringVarP(&validationPlugin, "validation-plugin", "V", "", "The name of the validation plugin to be used for this chaincode")
+	flags.StringVar(&collectionsConfigFile, "collections-config", "", "The fully qualified path to the collection JSON file including the file name")
+	flags.StringArrayVarP(&peerAddresses, "peerAddresses", "", []string{""}, "The addresses of the peers to connect to")
 	flags.StringArrayVarP(&tlsRootCertFiles, "tlsRootCertFiles", "", []string{""},
-		fmt.Sprint("If TLS is enabled, the paths to the TLS root cert files of the peers to connect to. The order and number of certs specified should match the --peerAddresses flag"))
+		"If TLS is enabled, the paths to the TLS root cert files of the peers to connect to. The order and number of certs specified should match the --peerAddresses flag")
 	flags.StringVarP(&connectionProfilePath, "connectionProfile", "", "",
-		fmt.Sprint("The fully qualified path to the connection profile that provides the necessary connection information for the network. Note: currently only supported for providing peer connection information"))
+		"The fully qualified path to the connection profile that provides the necessary connection information for the network. Note: currently only supported for providing peer connection information")
 	flags.BoolVar(&waitForEvent, "waitForEvent", true,
-		fmt.Sprint("Whether to wait for the event from each peer's deliver filtered service signifying that the transaction has been committed successfully"))
+		"Whether to wait for the event from each peer's deliver filtered service signifying that the transaction has been committed successfully")
 	flags.DurationVar(&waitForEventTimeout, "waitForEventTimeout", 30*time.Second,
-		fmt.Sprint("Time to wait for the event from each peer's deliver filtered service signifying that the 'invoke' transaction has been committed successfully"))
+		"Time to wait for the event from each peer's deliver filtered service signifying that the 'invoke' transaction has been committed successfully")
 	flags.StringVarP(&packageID, "package-id", "", "", "The identifier of the chaincode install package")
 	flags.IntVarP(&sequence, "sequence", "", 0, "The sequence number of the chaincode definition for the channel")
 	flags.BoolVarP(&initRequired, "init-required", "", false, "Whether the chaincode requires invoking 'init'")

--- a/internal/peer/lifecycle/chaincode/checkcommitreadiness.go
+++ b/internal/peer/lifecycle/chaincode/checkcommitreadiness.go
@@ -85,8 +85,8 @@ func (c *CommitReadinessCheckInput) Validate() error {
 func CheckCommitReadinessCmd(c *CommitReadinessChecker, cryptoProvider bccsp.BCCSP) *cobra.Command {
 	chaincodeCheckCommitReadinessCmd := &cobra.Command{
 		Use:   "checkcommitreadiness",
-		Short: fmt.Sprintf("Check whether a chaincode definition is ready to be committed on a channel."),
-		Long:  fmt.Sprintf("Check whether a chaincode definition is ready to be committed on a channel."),
+		Short: "Check whether a chaincode definition is ready to be committed on a channel.",
+		Long:  "Check whether a chaincode definition is ready to be committed on a channel.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if c == nil {
 				// set input from CLI flags

--- a/internal/peer/lifecycle/chaincode/checkcommitreadiness_test.go
+++ b/internal/peer/lifecycle/chaincode/checkcommitreadiness_test.go
@@ -8,7 +8,6 @@ package chaincode_test
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/golang/protobuf/proto"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
@@ -98,7 +97,8 @@ var _ = Describe("CheckCommitReadiness", func() {
 					},
 				}
 				json, err := json.MarshalIndent(expectedOutput, "", "\t")
-				Eventually(commitReadinessChecker.Writer).Should(gbytes.Say(fmt.Sprintf("%s", string(json))))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(commitReadinessChecker.Writer).Should(gbytes.Say(string(json)))
 			})
 		})
 

--- a/internal/peer/lifecycle/chaincode/commit.go
+++ b/internal/peer/lifecycle/chaincode/commit.go
@@ -9,7 +9,6 @@ package chaincode
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -83,8 +82,8 @@ func (c *CommitInput) Validate() error {
 func CommitCmd(c *Committer, cryptoProvider bccsp.BCCSP) *cobra.Command {
 	chaincodeCommitCmd := &cobra.Command{
 		Use:   "commit",
-		Short: fmt.Sprintf("Commit the chaincode definition on the channel."),
-		Long:  fmt.Sprintf("Commit the chaincode definition on the channel."),
+		Short: "Commit the chaincode definition on the channel.",
+		Long:  "Commit the chaincode definition on the channel.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if c == nil {
 				// set input from CLI flags

--- a/internal/peer/lifecycle/chaincode/queryapproved.go
+++ b/internal/peer/lifecycle/chaincode/queryapproved.go
@@ -46,8 +46,8 @@ type ApprovedQueryInput struct {
 func QueryApprovedCmd(a *ApprovedQuerier, cryptoProvider bccsp.BCCSP) *cobra.Command {
 	chaincodeQueryApprovedCmd := &cobra.Command{
 		Use:   "queryapproved",
-		Short: fmt.Sprintf("Query an org's approved chaincode definition from its peer."),
-		Long:  fmt.Sprintf("Query an organization's approved chaincode definition from its peer."),
+		Short: "Query an org's approved chaincode definition from its peer.",
+		Long:  "Query an organization's approved chaincode definition from its peer.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if a == nil {
 				ccInput := &ClientConnectionsInput{

--- a/internal/peer/lifecycle/chaincode/queryapproved_test.go
+++ b/internal/peer/lifecycle/chaincode/queryapproved_test.go
@@ -128,6 +128,7 @@ var _ = Describe("QueryApproved", func() {
 					},
 				}
 				json, err := json.MarshalIndent(expectedOutput, "", "\t")
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(approvedQuerier.Writer).Should(gbytes.Say(fmt.Sprintf(`\Q%s\E`, string(json))))
 			})
 		})

--- a/internal/peer/lifecycle/chaincode/querycommitted_test.go
+++ b/internal/peer/lifecycle/chaincode/querycommitted_test.go
@@ -117,6 +117,7 @@ var _ = Describe("QueryCommitted", func() {
 					},
 				}
 				json, err := json.MarshalIndent(expectedOutput, "", "\t")
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(committedQuerier.Writer).Should(gbytes.Say(fmt.Sprintf(`\Q%s\E`, string(json))))
 			})
 		})
@@ -190,6 +191,7 @@ var _ = Describe("QueryCommitted", func() {
 						},
 					}
 					json, err := json.MarshalIndent(expectedOutput, "", "\t")
+					Expect(err).NotTo(HaveOccurred())
 					Eventually(committedQuerier.Writer).Should(gbytes.Say(fmt.Sprintf(`\Q%s\E`, string(json))))
 				})
 			})

--- a/internal/peer/lifecycle/chaincode/queryinstalled_test.go
+++ b/internal/peer/lifecycle/chaincode/queryinstalled_test.go
@@ -90,6 +90,7 @@ var _ = Describe("QueryInstalled", func() {
 					},
 				}
 				json, err := json.MarshalIndent(expectedOutput, "", "\t")
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(installedQuerier.Writer).Should(gbytes.Say(fmt.Sprintf(`\Q%s\E`, string(json))))
 			})
 		})


### PR DESCRIPTION
Address some issues highlighted by linters in the in `internal/peer/lifecycle/chaincode` package.

The two patterns that were addressed were using fmt.Xprintf with strings that did not include formatting directives and assignment to error values that were not checked.