### PR TITLE
Silence noise when running internal/peer/lifecycle/chaincode tests

### DIFF
--- a/internal/peer/lifecycle/chaincode/approveformyorg_test.go
+++ b/internal/peer/lifecycle/chaincode/approveformyorg_test.go
@@ -297,14 +297,14 @@ var _ = Describe("ApproverForMyOrg", func() {
 	})
 
 	Describe("ApproveForMyOrgCmd", func() {
-		var (
-			approveForMyOrgCmd *cobra.Command
-		)
+		var approveForMyOrgCmd *cobra.Command
 
 		BeforeEach(func() {
 			cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 			Expect(err).To(BeNil())
 			approveForMyOrgCmd = chaincode.ApproveForMyOrgCmd(nil, cryptoProvider)
+			approveForMyOrgCmd.SilenceErrors = true
+			approveForMyOrgCmd.SilenceUsage = true
 			approveForMyOrgCmd.SetArgs([]string{
 				"--channelID=testchannel",
 				"--name=testcc",
@@ -328,9 +328,6 @@ var _ = Describe("ApproverForMyOrg", func() {
 
 		Context("when the channel config policy is specified", func() {
 			BeforeEach(func() {
-				cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
-				Expect(err).To(BeNil())
-				approveForMyOrgCmd = chaincode.ApproveForMyOrgCmd(nil, cryptoProvider)
 				approveForMyOrgCmd.SetArgs([]string{
 					"--channel-config-policy=/Channel/Application/Readers",
 					"--channelID=testchannel",

--- a/internal/peer/lifecycle/chaincode/chaincode_suite_test.go
+++ b/internal/peer/lifecycle/chaincode/chaincode_suite_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/internal/peer/common"
 	"github.com/hyperledger/fabric/internal/peer/lifecycle/chaincode"
 	msptesttools "github.com/hyperledger/fabric/msp/mgmt/testtools"
@@ -63,6 +64,10 @@ func TestChaincode(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Chaincode Suite")
 }
+
+var _ = BeforeSuite(func() {
+	flogging.SetWriter(GinkgoWriter)
+})
 
 // TODO remove this?
 func TestMain(m *testing.M) {

--- a/internal/peer/lifecycle/chaincode/checkcommitreadiness_test.go
+++ b/internal/peer/lifecycle/chaincode/checkcommitreadiness_test.go
@@ -235,14 +235,14 @@ var _ = Describe("CheckCommitReadiness", func() {
 	})
 
 	Describe("CheckCommitReadinessCmd", func() {
-		var (
-			checkCommitReadinessCmd *cobra.Command
-		)
+		var checkCommitReadinessCmd *cobra.Command
 
 		BeforeEach(func() {
 			cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 			Expect(err).To(BeNil())
 			checkCommitReadinessCmd = chaincode.CheckCommitReadinessCmd(nil, cryptoProvider)
+			checkCommitReadinessCmd.SilenceErrors = true
+			checkCommitReadinessCmd.SilenceUsage = true
 			checkCommitReadinessCmd.SetArgs([]string{
 				"--channelID=testchannel",
 				"--name=testcc",

--- a/internal/peer/lifecycle/chaincode/commit_test.go
+++ b/internal/peer/lifecycle/chaincode/commit_test.go
@@ -296,14 +296,14 @@ var _ = Describe("Commit", func() {
 	})
 
 	Describe("CommitCmd", func() {
-		var (
-			commitCmd *cobra.Command
-		)
+		var commitCmd *cobra.Command
 
 		BeforeEach(func() {
 			cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 			Expect(err).To(BeNil())
 			commitCmd = chaincode.CommitCmd(nil, cryptoProvider)
+			commitCmd.SilenceErrors = true
+			commitCmd.SilenceUsage = true
 			commitCmd.SetArgs([]string{
 				"--channelID=testchannel",
 				"--name=testcc",

--- a/internal/peer/lifecycle/chaincode/getinstalledpackage_test.go
+++ b/internal/peer/lifecycle/chaincode/getinstalledpackage_test.go
@@ -216,14 +216,14 @@ var _ = Describe("GetInstalledPackage", func() {
 	})
 
 	Describe("GetInstalledPackageCmd", func() {
-		var (
-			getInstalledPackageCmd *cobra.Command
-		)
+		var getInstalledPackageCmd *cobra.Command
 
 		BeforeEach(func() {
 			cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 			Expect(err).To(BeNil())
 			getInstalledPackageCmd = chaincode.GetInstalledPackageCmd(nil, cryptoProvider)
+			getInstalledPackageCmd.SilenceErrors = true
+			getInstalledPackageCmd.SilenceUsage = true
 			getInstalledPackageCmd.SetArgs([]string{
 				"--package-id=test-package",
 				"--peerAddresses=test1",

--- a/internal/peer/lifecycle/chaincode/install_test.go
+++ b/internal/peer/lifecycle/chaincode/install_test.go
@@ -169,14 +169,14 @@ var _ = Describe("Install", func() {
 	})
 
 	Describe("InstallCmd", func() {
-		var (
-			installCmd *cobra.Command
-		)
+		var installCmd *cobra.Command
 
 		BeforeEach(func() {
 			cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 			Expect(err).To(BeNil())
 			installCmd = chaincode.InstallCmd(nil, cryptoProvider)
+			installCmd.SilenceErrors = true
+			installCmd.SilenceUsage = true
 			installCmd.SetArgs([]string{
 				"testpkg",
 				"--peerAddresses=test1",

--- a/internal/peer/lifecycle/chaincode/package_test.go
+++ b/internal/peer/lifecycle/chaincode/package_test.go
@@ -170,12 +170,12 @@ var _ = Describe("Package", func() {
 	})
 
 	Describe("PackageCmd", func() {
-		var (
-			packageCmd *cobra.Command
-		)
+		var packageCmd *cobra.Command
 
 		BeforeEach(func() {
 			packageCmd = chaincode.PackageCmd(nil)
+			packageCmd.SilenceErrors = true
+			packageCmd.SilenceUsage = true
 			packageCmd.SetArgs([]string{
 				"testPackage",
 				"--path=testPath",
@@ -191,7 +191,6 @@ var _ = Describe("Package", func() {
 
 		Context("when more than one argument is provided", func() {
 			BeforeEach(func() {
-				packageCmd = chaincode.PackageCmd(nil)
 				packageCmd.SetArgs([]string{
 					"testPackage",
 					"whatthe",
@@ -206,7 +205,6 @@ var _ = Describe("Package", func() {
 
 		Context("when no argument is provided", func() {
 			BeforeEach(func() {
-				packageCmd = chaincode.PackageCmd(nil)
 				packageCmd.SetArgs([]string{})
 			})
 

--- a/internal/peer/lifecycle/chaincode/queryapproved_test.go
+++ b/internal/peer/lifecycle/chaincode/queryapproved_test.go
@@ -265,14 +265,14 @@ var _ = Describe("QueryApproved", func() {
 	})
 
 	Describe("QueryApprovedCmd", func() {
-		var (
-			queryApprovedCmd *cobra.Command
-		)
+		var queryApprovedCmd *cobra.Command
 
 		BeforeEach(func() {
 			cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 			Expect(err).To(BeNil())
 			queryApprovedCmd = chaincode.QueryApprovedCmd(nil, cryptoProvider)
+			queryApprovedCmd.SilenceErrors = true
+			queryApprovedCmd.SilenceUsage = true
 			queryApprovedCmd.SetArgs([]string{
 				"--name=testcc",
 				"--channelID=testchannel",

--- a/internal/peer/lifecycle/chaincode/querycommitted_test.go
+++ b/internal/peer/lifecycle/chaincode/querycommitted_test.go
@@ -311,14 +311,14 @@ var _ = Describe("QueryCommitted", func() {
 	})
 
 	Describe("QueryCommittedCmd", func() {
-		var (
-			queryCommittedCmd *cobra.Command
-		)
+		var queryCommittedCmd *cobra.Command
 
 		BeforeEach(func() {
 			cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 			Expect(err).To(BeNil())
 			queryCommittedCmd = chaincode.QueryCommittedCmd(nil, cryptoProvider)
+			queryCommittedCmd.SilenceErrors = true
+			queryCommittedCmd.SilenceUsage = true
 			queryCommittedCmd.SetArgs([]string{
 				"--name=testcc",
 				"--channelID=testchannel",

--- a/internal/peer/lifecycle/chaincode/queryinstalled_test.go
+++ b/internal/peer/lifecycle/chaincode/queryinstalled_test.go
@@ -183,14 +183,14 @@ var _ = Describe("QueryInstalled", func() {
 	})
 
 	Describe("QueryInstalledCmd", func() {
-		var (
-			queryInstalledCmd *cobra.Command
-		)
+		var queryInstalledCmd *cobra.Command
 
 		BeforeEach(func() {
 			cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 			Expect(err).To(BeNil())
 			queryInstalledCmd = chaincode.QueryInstalledCmd(nil, cryptoProvider)
+			queryInstalledCmd.SilenceErrors = true
+			queryInstalledCmd.SilenceUsage = true
 			queryInstalledCmd.SetArgs([]string{
 				"--peerAddresses=querypeer1",
 				"--tlsRootCertFiles=tls1",


### PR DESCRIPTION
The tests exercise a number of commands that result in error and usage messages. These pollute the output and make it difficult to see what’s really going on.

This change sets the `SilenceErrors` and `SilenceUsage` on the commands created in test. These flags prevent Cobra from printing messages.

The change also sets the `GinkgoWriter` as the default logging writer. This suppresses logging messages unless tests fail or are executed in _verbose_ mode.