### PR TITLE
Fixed write_first_app.rst typo

### DIFF
--- a/docs/source/write_first_app.rst
+++ b/docs/source/write_first_app.rst
@@ -71,7 +71,7 @@ Set up the blockchain network
 -----------------------------
 
 If you've already run through :doc:`test_network` tutorial and have a network up
-and running, this tutorial will bring down your running network network before
+and running, this tutorial will bring down your running network before
 bringing up a new one.
 
 


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

I was going through the documentation and found a typo in the "Writing Your First Application" tutorial (write_first_app.rst file).
I hope it will help fellow learners.