### PR TITLE
FAB-17841: Ch.Part.API: Remove channel REST handler

### DIFF
--- a/orderer/common/channelparticipation/mocks/channel_management.go
+++ b/orderer/common/channelparticipation/mocks/channel_management.go
@@ -47,6 +47,18 @@ type ChannelManagement struct {
 		result1 types.ChannelInfo
 		result2 error
 	}
+	RemoveChannelStub        func(string, bool) error
+	removeChannelMutex       sync.RWMutex
+	removeChannelArgsForCall []struct {
+		arg1 string
+		arg2 bool
+	}
+	removeChannelReturns struct {
+		result1 error
+	}
+	removeChannelReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -230,6 +242,67 @@ func (fake *ChannelManagement) JoinChannelReturnsOnCall(i int, result1 types.Cha
 	}{result1, result2}
 }
 
+func (fake *ChannelManagement) RemoveChannel(arg1 string, arg2 bool) error {
+	fake.removeChannelMutex.Lock()
+	ret, specificReturn := fake.removeChannelReturnsOnCall[len(fake.removeChannelArgsForCall)]
+	fake.removeChannelArgsForCall = append(fake.removeChannelArgsForCall, struct {
+		arg1 string
+		arg2 bool
+	}{arg1, arg2})
+	fake.recordInvocation("RemoveChannel", []interface{}{arg1, arg2})
+	fake.removeChannelMutex.Unlock()
+	if fake.RemoveChannelStub != nil {
+		return fake.RemoveChannelStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.removeChannelReturns
+	return fakeReturns.result1
+}
+
+func (fake *ChannelManagement) RemoveChannelCallCount() int {
+	fake.removeChannelMutex.RLock()
+	defer fake.removeChannelMutex.RUnlock()
+	return len(fake.removeChannelArgsForCall)
+}
+
+func (fake *ChannelManagement) RemoveChannelCalls(stub func(string, bool) error) {
+	fake.removeChannelMutex.Lock()
+	defer fake.removeChannelMutex.Unlock()
+	fake.RemoveChannelStub = stub
+}
+
+func (fake *ChannelManagement) RemoveChannelArgsForCall(i int) (string, bool) {
+	fake.removeChannelMutex.RLock()
+	defer fake.removeChannelMutex.RUnlock()
+	argsForCall := fake.removeChannelArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *ChannelManagement) RemoveChannelReturns(result1 error) {
+	fake.removeChannelMutex.Lock()
+	defer fake.removeChannelMutex.Unlock()
+	fake.RemoveChannelStub = nil
+	fake.removeChannelReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ChannelManagement) RemoveChannelReturnsOnCall(i int, result1 error) {
+	fake.removeChannelMutex.Lock()
+	defer fake.removeChannelMutex.Unlock()
+	fake.RemoveChannelStub = nil
+	if fake.removeChannelReturnsOnCall == nil {
+		fake.removeChannelReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.removeChannelReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *ChannelManagement) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -239,6 +312,8 @@ func (fake *ChannelManagement) Invocations() map[string][][]interface{} {
 	defer fake.channelListMutex.RUnlock()
 	fake.joinChannelMutex.RLock()
 	defer fake.joinChannelMutex.RUnlock()
+	fake.removeChannelMutex.RLock()
+	defer fake.removeChannelMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -409,3 +409,8 @@ func (r *Registrar) JoinChannel(channelID string, configBlock *cb.Block) (types.
 	//TODO
 	return types.ChannelInfo{}, errors.New("Not implemented yet")
 }
+
+func (r *Registrar) RemoveChannel(channelID string, removeStorage bool) error {
+	//TODO
+	return errors.New("Not implemented yet")
+}

--- a/orderer/common/types/errors.go
+++ b/orderer/common/types/errors.go
@@ -18,3 +18,6 @@ var ErrChannelAlreadyExists = errors.New("channel already exists")
 // This error is returned when trying to join a system channel (that does not exist) when application channels
 // already exist.
 var ErrAppChannelsAlreadyExists = errors.New("application channels already exist")
+
+// This error is returned when trying to remove a channel that does not exist
+var ErrChannelNotExist = errors.New("channel does not exist")


### PR DESCRIPTION
Handle DELETE request to remove a channel.

- Resolve the removeStorage flag from config & query.
- If system-channel exists - reject with StatusMethodNotAllowed and
  Allow header set to GET.
- If channel does not exist - reject with StatusNotFound.
- If successs - respond with StatusNoContent.

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: I78581df3c7f0cb99007edddc83eb7a6dca5eba07


#### Type of change

- New feature

#### Related issues

Task: FAB-17841
Story: FAB-15710
Epic: FAB-17712