### PR TITLE
[FAB-17471] Fix OrdererType line in configtx.yaml

### DIFF
--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -485,8 +485,8 @@ Profiles:
     SampleInsecureKafka:
         <<: *ChannelDefaults
         Orderer:
-            OrdererType: kafka
             <<: *OrdererDefaults
+            OrdererType: kafka
         Consortiums:
             SampleConsortium:
                 Organizations:


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description
This CR moves OrdererType to the correct line in sampleconfig/configtx.yaml. SampleInsecureKafka profile tries to change consensus type solo to Kafka using OrdererType. But it was written above "<<: *OrdererDefaults" line. That causes the overwrite consensus type again.
This CR can generate the correct ordererer type's genesis block.
