### PR TITLE
[FAB-17933] Fix cache update logic for installed chaincode info when …

### DIFF
--- a/core/chaincode/lifecycle/cache.go
+++ b/core/chaincode/lifecycle/cache.go
@@ -488,11 +488,13 @@ func (c *Cache) update(initializing bool, channelID string, dirtyChaincodes map[
 			// name on this channel
 			for _, lc := range c.localChaincodes {
 				if ref, ok := lc.References[channelID][name]; ok {
-					if ref.InstallInfo == nil || localChaincode.Info == nil {
+					if ref.InstallInfo == nil {
 						continue
 					}
-					if ref.InstallInfo.PackageID == localChaincode.Info.PackageID {
-						continue
+					if localChaincode.Info != nil {
+						if ref.InstallInfo.PackageID == localChaincode.Info.PackageID {
+							continue
+						}
 					}
 
 					// remove existing local chaincode reference, which referred to a


### PR DESCRIPTION
…an empty or uninstalled package ID is specified

This patch fixes cache update logic for installed chaincode information an empty or uninstalled package ID is specified.

#### Type of change

- Bug fix

#### Description

Current cache update logic for install chaincode info implemented in `core/chaincode/lifecycle/cache.go` does not work properly when an empty or uninstalled package ID is specified.

These wrong references may mislead Fabric admins.
So, we should fix the problem.

#### Related issues

- https://jira.hyperledger.org/browse/FAB-17933
