### PR TITLE
 fsync and do not generate empty files in snapshots

### DIFF
--- a/common/ledger/snapshot/file.go
+++ b/common/ledger/snapshot/file.go
@@ -98,6 +98,9 @@ func (c *FileWriter) Done() ([]byte, error) {
 	if err := c.bufWriter.Flush(); err != nil {
 		return nil, errors.Wrapf(err, "error while flushing to the snapshot file: %s ", c.file.Name())
 	}
+	if err := c.file.Sync(); err != nil {
+		return nil, err
+	}
 	if err := c.file.Close(); err != nil {
 		return nil, errors.Wrapf(err, "error while closing the snapshot file: %s ", c.file.Name())
 	}

--- a/core/ledger/confighistory/mgr.go
+++ b/core/ledger/confighistory/mgr.go
@@ -8,7 +8,7 @@ package confighistory
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
@@ -181,22 +181,26 @@ func (r *Retriever) CollectionConfigAt(blockNum uint64, chaincodeName string) (*
 // extra bytes. Further, the collection config namespace is not expected to have
 // millions of entries.
 func (r *Retriever) ExportConfigHistory(dir string, newHashFunc snapshot.NewHashFunc) (map[string][]byte, error) {
-	dataFileWriter, err := snapshot.CreateFile(path.Join(dir, snapshotDataFileName), snapshotFileFormat, newHashFunc)
-	if err != nil {
-		return nil, err
-	}
-	defer dataFileWriter.Close()
-
 	nsItr := r.dbHandle.getNamespaceIterator(collectionConfigNamespace)
 	if err := nsItr.Error(); err != nil {
 		return nil, errors.Wrap(err, "internal leveldb error while obtaining db iterator")
 
 	}
 	defer nsItr.Release()
+
 	var numCollectionConfigs uint64 = 0
+	var dataFileWriter *snapshot.FileWriter
+	var err error
 	for nsItr.Next() {
 		if err := nsItr.Error(); err != nil {
 			return nil, errors.Wrap(err, "internal leveldb error while iterating for collection config history")
+		}
+		if numCollectionConfigs == 0 { // first iteration, create the data file
+			dataFileWriter, err = snapshot.CreateFile(filepath.Join(dir, snapshotDataFileName), snapshotFileFormat, newHashFunc)
+			if err != nil {
+				return nil, err
+			}
+			defer dataFileWriter.Close()
 		}
 		if err := dataFileWriter.EncodeBytes(nsItr.Key()); err != nil {
 			return nil, err
@@ -206,12 +210,16 @@ func (r *Retriever) ExportConfigHistory(dir string, newHashFunc snapshot.NewHash
 		}
 		numCollectionConfigs++
 	}
+
+	if dataFileWriter == nil {
+		return nil, nil
+	}
+
 	dataHash, err := dataFileWriter.Done()
 	if err != nil {
 		return nil, err
 	}
-
-	metadataFileWriter, err := snapshot.CreateFile(path.Join(dir, snapshotMetadataFileName), snapshotFileFormat, newHashFunc)
+	metadataFileWriter, err := snapshot.CreateFile(filepath.Join(dir, snapshotMetadataFileName), snapshotFileFormat, newHashFunc)
 	if err != nil {
 		return nil, err
 	}

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/snapshot_test.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/snapshot_test.go
@@ -12,7 +12,7 @@ import (
 	"hash"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -84,7 +84,9 @@ func testSanpshot(t *testing.T, env TestEnv) {
 		derivePvtDataNs("ns3", "coll1"),
 	)
 
+	testSnapshotWithSampleData(t, env, nil, nil, nil)                                           // no data
 	testSnapshotWithSampleData(t, env, samplePublicState, nil, nil)                             // test with only public data
+	testSnapshotWithSampleData(t, env, nil, samplePvtStateHashes, nil)                          // test with only pvtdata hashes
 	testSnapshotWithSampleData(t, env, samplePublicState, samplePvtStateHashes, nil)            // test with public data and pvtdata hashes
 	testSnapshotWithSampleData(t, env, samplePublicState, samplePvtStateHashes, samplePvtState) // test with public data, pvtdata hashes, and pvt data
 }
@@ -127,32 +129,41 @@ func testSnapshotWithSampleData(t *testing.T, env TestEnv,
 
 	filesAndHashes, err := db.ExportPubStateAndPvtStateHashes(snapshotDir, testNewHashFunc)
 	require.NoError(t, err)
-	require.Len(t, filesAndHashes, 4)
-	require.Contains(t, filesAndHashes, pubStateDataFileName)
-	require.Contains(t, filesAndHashes, pubStateMetadataFileName)
-	require.Contains(t, filesAndHashes, pvtStateHashesFileName)
-	require.Contains(t, filesAndHashes, pvtStateHashesMetadataFileName)
 
 	for f, h := range filesAndHashes {
-		expectedFile := path.Join(snapshotDir, f)
+		expectedFile := filepath.Join(snapshotDir, f)
 		require.FileExists(t, expectedFile)
 		require.Equal(t, sha256ForFileForTest(t, expectedFile), h)
 	}
 
-	// verify snapshot files contents
-	pubStateFromSnapshot := loadSnapshotDataForTest(t,
-		env,
-		path.Join(snapshotDir, pubStateDataFileName),
-		path.Join(snapshotDir, pubStateMetadataFileName),
-	)
+	numFilesExpected := 0
+	if len(publicState) != 0 {
+		numFilesExpected += 2
+		require.Contains(t, filesAndHashes, pubStateDataFileName)
+		require.Contains(t, filesAndHashes, pubStateMetadataFileName)
+		// verify snapshot files contents
+		pubStateFromSnapshot := loadSnapshotDataForTest(t,
+			env,
+			filepath.Join(snapshotDir, pubStateDataFileName),
+			filepath.Join(snapshotDir, pubStateMetadataFileName),
+		)
+		require.Equal(t, publicState, pubStateFromSnapshot)
+	}
 
-	pvtStateHashesFromSnapshot := loadSnapshotDataForTest(t,
-		env,
-		path.Join(snapshotDir, pvtStateHashesFileName),
-		path.Join(snapshotDir, pvtStateHashesMetadataFileName),
-	)
-	require.Equal(t, publicState, pubStateFromSnapshot)
-	require.Equal(t, pvtStateHashes, pvtStateHashesFromSnapshot)
+	if len(pvtStateHashes) != 0 {
+		numFilesExpected += 2
+		require.Contains(t, filesAndHashes, pvtStateHashesFileName)
+		require.Contains(t, filesAndHashes, pvtStateHashesMetadataFileName)
+		// verify snapshot files contents
+		pvtStateHashesFromSnapshot := loadSnapshotDataForTest(t,
+			env,
+			filepath.Join(snapshotDir, pvtStateHashesFileName),
+			filepath.Join(snapshotDir, pvtStateHashesMetadataFileName),
+		)
+
+		require.Equal(t, pvtStateHashes, pvtStateHashesFromSnapshot)
+	}
+	require.Len(t, filesAndHashes, numFilesExpected)
 }
 
 func sha256ForFileForTest(t *testing.T, file string) []byte {
@@ -217,6 +228,7 @@ func TestSnapshotErrorPropagation(t *testing.T) {
 		db = dbEnv.GetDBHandle(generateLedgerID(t))
 		updateBatch := NewUpdateBatch()
 		updateBatch.PubUpdates.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 1))
+		updateBatch.HashUpdates.Put("ns1", "coll1", []byte("key1"), []byte("value1"), version.NewHeight(1, 1))
 		db.ApplyPrivacyAwareUpdates(updateBatch, version.NewHeight(1, 1))
 		snapshotDir, err = ioutil.TempDir("", "testsnapshot")
 		require.NoError(t, err)
@@ -234,7 +246,7 @@ func TestSnapshotErrorPropagation(t *testing.T) {
 	// pubStateDataFile already exists
 	init()
 	defer cleanup()
-	pubStateDataFilePath := path.Join(snapshotDir, pubStateDataFileName)
+	pubStateDataFilePath := filepath.Join(snapshotDir, pubStateDataFileName)
 	_, err = os.Create(pubStateDataFilePath)
 	require.NoError(t, err)
 	_, err = db.ExportPubStateAndPvtStateHashes(snapshotDir, testNewHashFunc)
@@ -242,7 +254,7 @@ func TestSnapshotErrorPropagation(t *testing.T) {
 
 	// pubStateMetadataFile already exists
 	reinit()
-	pubStateMetadataFilePath := path.Join(snapshotDir, pubStateMetadataFileName)
+	pubStateMetadataFilePath := filepath.Join(snapshotDir, pubStateMetadataFileName)
 	_, err = os.Create(pubStateMetadataFilePath)
 	require.NoError(t, err)
 	_, err = db.ExportPubStateAndPvtStateHashes(snapshotDir, testNewHashFunc)
@@ -250,7 +262,7 @@ func TestSnapshotErrorPropagation(t *testing.T) {
 
 	// pvtStateHashesDataFile already exists
 	reinit()
-	pvtStateHashesDataFilePath := path.Join(snapshotDir, pvtStateHashesFileName)
+	pvtStateHashesDataFilePath := filepath.Join(snapshotDir, pvtStateHashesFileName)
 	_, err = os.Create(pvtStateHashesDataFilePath)
 	require.NoError(t, err)
 	_, err = db.ExportPubStateAndPvtStateHashes(snapshotDir, testNewHashFunc)
@@ -258,7 +270,7 @@ func TestSnapshotErrorPropagation(t *testing.T) {
 
 	// pvtStateHashesMetadataFile already exists
 	reinit()
-	pvtStateHashesMetadataFilePath := path.Join(snapshotDir, pvtStateHashesMetadataFileName)
+	pvtStateHashesMetadataFilePath := filepath.Join(snapshotDir, pvtStateHashesMetadataFileName)
 	_, err = os.Create(pvtStateHashesMetadataFilePath)
 	require.NoError(t, err)
 	_, err = db.ExportPubStateAndPvtStateHashes(snapshotDir, testNewHashFunc)


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>
#### Type of change
- Improvement (improvement to code)

#### Description
This PR fixes the following issues
- Perform sync on the snapshot files
- Does not generate empty files (if there is no content in a snapshot-able component)
- Use filepath package instead of path package