### PR TITLE
fix infinite loop during open-ended range query -- CouchDB

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
@@ -520,8 +520,14 @@ func (scanner *queryScanner) getNextStateRangeScanResults() error {
 		return err
 	}
 	scanner.resultsInfo.results = queryResult
-	scanner.queryDefinition.startKey = nextStartKey
 	scanner.paginationInfo.cursor = 0
+	if scanner.queryDefinition.endKey == nextStartKey {
+		// as we always set inclusive_end=false to match the behavior of
+		// goleveldb iterator, it is safe to mark the scanner as exhausted
+		scanner.exhausted = true
+		// we still need to update the startKey as it is returned as bookmark
+	}
+	scanner.queryDefinition.startKey = nextStartKey
 	return nil
 }
 
@@ -877,6 +883,7 @@ type queryScanner struct {
 	queryDefinition *queryDefinition
 	paginationInfo  *paginationInfo
 	resultsInfo     *resultsInfo
+	exhausted       bool
 }
 
 type queryDefinition struct {
@@ -899,7 +906,7 @@ type resultsInfo struct {
 
 func newQueryScanner(namespace string, db *couchDatabase, query string, internalQueryLimit,
 	limit int32, bookmark, startKey, endKey string) (*queryScanner, error) {
-	scanner := &queryScanner{namespace, db, &queryDefinition{startKey, endKey, query, internalQueryLimit}, &paginationInfo{-1, limit, bookmark}, &resultsInfo{0, nil}}
+	scanner := &queryScanner{namespace, db, &queryDefinition{startKey, endKey, query, internalQueryLimit}, &paginationInfo{-1, limit, bookmark}, &resultsInfo{0, nil}, false}
 	var err error
 	// query is defined, then execute the query and return the records and bookmark
 	if scanner.queryDefinition.query != "" {
@@ -924,6 +931,9 @@ func (scanner *queryScanner) Next() (statedb.QueryResult, error) {
 	// check to see if additional records are needed
 	// requery if the cursor exceeds the internalQueryLimit
 	if scanner.paginationInfo.cursor >= scanner.queryDefinition.internalQueryLimit {
+		if scanner.exhausted {
+			return nil, nil
+		}
 		var err error
 		// query is defined, then execute the query and return the records and bookmark
 		if scanner.queryDefinition.query != "" {


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

We use a single scanner for achieving both paginated and non-paginated range query.

We have `internalQueryLimit` and `pageSize`. The internalQueryLimit controls the number of records fetched per REST API call. The pageSize controls the total number of records needed by the caller. 

A range query is done by performing `_all_docs?startKey="XXX"&endKey="YYY"` REST API call to CouchDB. The iterator fetches almost `internalQueryLimit` number of records by appending `limit=internalQueryLimit` to the REST API.

In the following two cases, iterator would perform REST API call multiple times.

1. When the requested pageSize is higher than the internalQueryLimit 
2. When the total number of records present in the given range is higher than the internalQueryLimit

 The iterator would execute the query again once the records fetched in the first cycle are consumed and so on. In order to do that, after the execution of the REST API in each cycle, the iterator updates the initially passed `startKey` to the nextStartKey. If there is no nextStartKey, it is set to the `endKey`. Currently, when the nextStartKey and `endKey` are the same, we still run one REST API call which is actually not needed as we always set inclusive_end=false. However, this causes an infinite loop in the following case. 

When we want to retrieve all the records, the user would submit an open-ended query by passing an empty string as the `startKey` and the `endKey`. Refer to chaincode APIs for details -- https://github.com/hyperledger/fabric-chaincode-go/blob/master/shim/interfaces.go#L112-L114 . When the `startKey` is an empty string, the REST API call would become `_all_docs?endKey="YYY"`. When both are empty, it would become `_all_docs`. Given that we set the `startKey` to the `endKey` when there is no nextStartKey and still execute one REST API call after that, it gets into an infinite loop by fetching all records again and again.

In this PR, we avoid this infinite loop by setting `scanner.exhausted = true` when the `startKey` and `endKey` become the same when there is no `nextStartKey`.

#### Additional details

- We would use an open-ended range query while exporting data out of CouchDB for snapshotting.
- If desired, in a separate PR, the integration test would be added. 

#### Related issues

[FAB-17939](https://jira.hyperledger.org/browse/FAB-17939)