### PR TITLE
[FAB-17935] Change unnecessary warning log to debug in gossip privdata

### DIFF
--- a/gossip/privdata/coordinator.go
+++ b/gossip/privdata/coordinator.go
@@ -432,7 +432,7 @@ func getTxInfoFromTransactionBytes(envBytes []byte) (*txInfo, error) {
 
 	if chdr.Type != int32(common.HeaderType_ENDORSER_TRANSACTION) {
 		err := errors.New("header type is not an endorser transaction")
-		logger.Warningf("Invalid transaction type: %s", err)
+		logger.Debugf("Invalid transaction type: %s", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

There are some unnecessary logger.Warning lines in the gossip logs when processing private data from a block.

#### Related issues

[FAB-17935](https://jira.hyperledger.org/browse/FAB-17935)