### PR TITLE
[FAB-19742] Add channel info provider to enable ledger to query all channel configs

### DIFF
--- a/core/ledger/kvledger/channelinfo_provider.go
+++ b/core/ledger/kvledger/channelinfo_provider.go
@@ -1,0 +1,76 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package kvledger
+
+import (
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric/bccsp/factory"
+	"github.com/hyperledger/fabric/common/channelconfig"
+	"github.com/hyperledger/fabric/common/ledger/blkstorage"
+	"github.com/hyperledger/fabric/protoutil"
+)
+
+type channelInfoProvider struct {
+	channelName string
+	blockStore  *blkstorage.BlockStore
+}
+
+// GetAllMSPIDs retrieves the MSPIDs of application organizations in all the channel configurations,
+// including current and previous channel configurations.
+func (p *channelInfoProvider) GetAllMSPIDs() ([]string, error) {
+	blockchainInfo, err := p.blockStore.GetBlockchainInfo()
+	if err != nil {
+		return nil, err
+	}
+	if blockchainInfo.Height == 0 {
+		return nil, nil
+	}
+
+	// Iterate over the config blocks to get all the channel configs, extract MSPIDs and add to mspidsMap
+	mspidsMap := map[string]struct{}{}
+	blockNum := blockchainInfo.Height - 1
+	for {
+		configBlock, err := p.mostRecentConfigBlockAsOf(blockNum)
+		if err != nil {
+			return nil, err
+		}
+
+		mspids, err := channelconfig.ExtractMSPIDsForApplicationOrgs(configBlock, factory.GetDefault())
+		if err != nil {
+			return nil, err
+		}
+		for _, mspid := range mspids {
+			if _, ok := mspidsMap[mspid]; !ok {
+				mspidsMap[mspid] = struct{}{}
+			}
+		}
+
+		if configBlock.Header.Number == 0 {
+			break
+		}
+		blockNum = configBlock.Header.Number - 1
+	}
+
+	mspids := make([]string, 0, len(mspidsMap))
+	for mspid := range mspidsMap {
+		mspids = append(mspids, mspid)
+	}
+	return mspids, nil
+}
+
+// mostRecentConfigBlockAsOf fetches the most recent config block at or below the blockNum
+func (p *channelInfoProvider) mostRecentConfigBlockAsOf(blockNum uint64) (*cb.Block, error) {
+	block, err := p.blockStore.RetrieveBlockByNumber(blockNum)
+	if err != nil {
+		return nil, err
+	}
+	configBlockNum, err := protoutil.GetLastConfigIndexFromBlock(block)
+	if err != nil {
+		return nil, err
+	}
+	return p.blockStore.RetrieveBlockByNumber(configBlockNum)
+}

--- a/core/ledger/kvledger/channelinfo_provider_test.go
+++ b/core/ledger/kvledger/channelinfo_provider_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package kvledger
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-config/protolator"
+	"github.com/hyperledger/fabric-protos-go/common"
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric/common/channelconfig"
+	"github.com/hyperledger/fabric/common/configtx/test"
+	"github.com/hyperledger/fabric/common/ledger/blkstorage"
+	"github.com/hyperledger/fabric/common/ledger/testutil"
+	"github.com/hyperledger/fabric/common/metrics/disabled"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetAllMSPIDs verifies GetAllMSPIDs by adding and removing organizations to the channel config.
+func TestGetAllMSPIDs(t *testing.T) {
+	channelName := "testgetallmspids"
+	basePath, err := ioutil.TempDir("", "testchannelinfoprovider")
+	require.NoError(t, err)
+	defer os.RemoveAll(basePath)
+
+	blkStoreProvider, err := blkstorage.NewProvider(
+		blkstorage.NewConf(basePath, maxBlockFileSize),
+		&blkstorage.IndexConfig{AttrsToIndex: attrsToIndex},
+		&disabled.Provider{},
+	)
+	require.NoError(t, err)
+	defer blkStoreProvider.Close()
+	blkStore, err := blkStoreProvider.Open(channelName)
+	require.NoError(t, err)
+	channelInfoProvider := &channelInfoProvider{
+		channelName: channelName,
+		blockStore:  blkStore,
+	}
+
+	var block *cb.Block
+	var configBlock *cb.Block
+	var lastBlockNum = uint64(0)
+	var lastConfigBlockNum = uint64(0)
+
+	// verify GetAllMSPIDs in a corner case where the channel has no block
+	verifyGetAllMSPIDs(t, channelInfoProvider, nil)
+
+	// add genesis block and verify GetAllMSPIDs when the channel has only genesis block
+	// the genesis block is created for org "SampleOrg" with MSPID "SampleOrg"
+	configBlock, err = test.MakeGenesisBlock(channelName)
+	require.NoError(t, err)
+	require.NoError(t, blkStore.AddBlock(configBlock))
+	verifyGetAllMSPIDs(t, channelInfoProvider, []string{"SampleOrg"})
+
+	// add some blocks and verify GetAllMSPIDs
+	block = configBlock
+	for i := 0; i < 3; i++ {
+		lastBlockNum++
+		block = newBlock([]*cb.Envelope{}, lastBlockNum, lastConfigBlockNum, protoutil.BlockHeaderHash(block.Header))
+		require.NoError(t, blkStore.AddBlock(block))
+	}
+	verifyGetAllMSPIDs(t, channelInfoProvider, []string{"SampleOrg"})
+
+	// create test org groups, update the config by adding org1 (Org1MSP) and org2 (Org2MSP)
+	orgGroups := createTestOrgGroups(t)
+	config := getConfigFromBlock(configBlock)
+	config.ChannelGroup.Groups[channelconfig.ApplicationGroupKey].Groups["org1"] = orgGroups["org1"]
+	config.ChannelGroup.Groups[channelconfig.ApplicationGroupKey].Groups["org2"] = orgGroups["org2"]
+
+	// add the config block and verify GetAllMSPIDs
+	lastBlockNum++
+	lastConfigBlockNum = lastBlockNum
+	configEnv := getEnvelopeFromConfig(channelName, config)
+	configBlock = newBlock([]*cb.Envelope{configEnv}, lastBlockNum, lastConfigBlockNum, protoutil.BlockHeaderHash(block.Header))
+	require.NoError(t, blkStore.AddBlock(configBlock))
+	verifyGetAllMSPIDs(t, channelInfoProvider, []string{"Org1MSP", "Org2MSP", "SampleOrg"})
+
+	// update the config by removing "org1"
+	config = getConfigFromBlock(configBlock)
+	delete(config.ChannelGroup.Groups[channelconfig.ApplicationGroupKey].Groups, "org1")
+
+	// add the config block and verify GetAllMSPIDs
+	lastBlockNum++
+	lastConfigBlockNum = lastBlockNum
+	configEnv = getEnvelopeFromConfig(channelName, config)
+	configBlock = newBlock([]*cb.Envelope{configEnv}, lastBlockNum, lastConfigBlockNum, protoutil.BlockHeaderHash(configBlock.Header))
+	require.NoError(t, blkStore.AddBlock(configBlock))
+	verifyGetAllMSPIDs(t, channelInfoProvider, []string{"Org1MSP", "Org2MSP", "SampleOrg"})
+
+	// add some blocks and verify GetAllMSPIDs
+	block = configBlock
+	for i := 0; i < 2; i++ {
+		lastBlockNum++
+		block = newBlock([]*cb.Envelope{}, lastBlockNum, lastConfigBlockNum, protoutil.BlockHeaderHash(block.Header))
+		require.NoError(t, blkStore.AddBlock(block))
+	}
+	verifyGetAllMSPIDs(t, channelInfoProvider, []string{"Org1MSP", "Org2MSP", "SampleOrg"})
+
+	// verify the orgs in most recent config block
+	lastConfigBlock, err := channelInfoProvider.mostRecentConfigBlockAsOf(lastBlockNum)
+	require.NoError(t, err)
+	config = getConfigFromBlock(lastConfigBlock)
+	require.Equal(t, 2, len(config.ChannelGroup.Groups[channelconfig.ApplicationGroupKey].Groups))
+	require.Contains(t, config.ChannelGroup.Groups[channelconfig.ApplicationGroupKey].Groups, "SampleOrg")
+	require.Contains(t, config.ChannelGroup.Groups[channelconfig.ApplicationGroupKey].Groups, "org2")
+}
+
+func verifyGetAllMSPIDs(t *testing.T, channelInfoProvider *channelInfoProvider, expectedMSPIDs []string) {
+	mspids, err := channelInfoProvider.GetAllMSPIDs()
+	require.NoError(t, err)
+	require.ElementsMatch(t, expectedMSPIDs, mspids)
+}
+
+func newBlock(env []*common.Envelope, blockNum uint64, lastConfigBlockNum uint64, previousHash []byte) *cb.Block {
+	block := testutil.NewBlock(env, blockNum, previousHash)
+	block.Metadata.Metadata[cb.BlockMetadataIndex_SIGNATURES] = protoutil.MarshalOrPanic(&cb.Metadata{
+		Value: protoutil.MarshalOrPanic(&cb.OrdererBlockMetadata{
+			LastConfig: &cb.LastConfig{Index: lastConfigBlockNum},
+		}),
+	})
+	return block
+}
+
+func getConfigFromBlock(block *cb.Block) *cb.Config {
+	blockDataEnvelope := &cb.Envelope{}
+	err := proto.Unmarshal(block.Data.Data[0], blockDataEnvelope)
+	if err != nil {
+		panic(err)
+	}
+
+	blockDataPayload := &cb.Payload{}
+	err = proto.Unmarshal(blockDataEnvelope.Payload, blockDataPayload)
+	if err != nil {
+		panic(err)
+	}
+
+	config := &cb.ConfigEnvelope{}
+	err = proto.Unmarshal(blockDataPayload.Data, config)
+	if err != nil {
+		panic(err)
+	}
+
+	return config.Config
+}
+
+func getEnvelopeFromConfig(channelName string, config *cb.Config) *cb.Envelope {
+	return &cb.Envelope{
+		Payload: protoutil.MarshalOrPanic(&cb.Payload{
+			Header: &cb.Header{
+				ChannelHeader: protoutil.MarshalOrPanic(&cb.ChannelHeader{
+					ChannelId: channelName,
+					Type:      int32(cb.HeaderType_CONFIG),
+				}),
+			},
+			Data: protoutil.MarshalOrPanic(&cb.ConfigEnvelope{
+				Config: config,
+			}),
+		}),
+	}
+}
+
+// createTestOrgGroups returns application org ConfigGroups based on test_configblock.json.
+// The config block contains the following organizations(MSPIDs): org1(Org1MSP) and org2(Org2MSP)
+func createTestOrgGroups(t *testing.T) map[string]*cb.ConfigGroup {
+	blockData, err := ioutil.ReadFile("testdata/test_configblock.json")
+	require.NoError(t, err)
+	block := &common.Block{}
+	protolator.DeepUnmarshalJSON(bytes.NewBuffer(blockData), block)
+	config := getConfigFromBlock(block)
+	return config.ChannelGroup.Groups[channelconfig.ApplicationGroupKey].Groups
+}

--- a/core/ledger/kvledger/testdata/test_configblock.json
+++ b/core/ledger/kvledger/testdata/test_configblock.json
@@ -1,0 +1,139 @@
+{
+  "data": {
+    "data": [
+      {
+        "payload": {
+          "data": {
+            "config": {
+              "channel_group": {
+                "groups": {
+                  "Application": {
+                    "groups": {
+                      "org1": {
+                        "mod_policy": "Admins",
+                        "values": {
+                          "MSP": {
+                            "mod_policy": "Admins",
+                            "value": {
+                              "config": {
+                                "crypto_config": {
+                                  "identity_identifier_hash_function": "SHA256",
+                                  "signature_hash_family": "SHA2"
+                                },
+                                "fabric_node_ous": {
+                                  "admin_ou_identifier": {
+                                    "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNVakNDQWZlZ0F3SUJBZ0lRUXNYbWJqQVFWck9CakwyWitqRnAwakFLQmdncWhrak9QUVFEQWpCek1Rc3cKQ1FZRFZRUUdFd0pWVXpFVE1CRUdBMVVFQ0JNS1EyRnNhV1p2Y201cFlURVdNQlFHQTFVRUJ4TU5VMkZ1SUVaeQpZVzVqYVhOamJ6RVpNQmNHQTFVRUNoTVFiM0puTVM1bGVHRnRjR3hsTG1OdmJURWNNQm9HQTFVRUF4TVRZMkV1CmIzSm5NUzVsZUdGdGNHeGxMbU52YlRBZUZ3MHlNREEyTURJeE9UVXpNREJhRncwek1EQTFNekV4T1RVek1EQmEKTUhNeEN6QUpCZ05WQkFZVEFsVlRNUk13RVFZRFZRUUlFd3BEWVd4cFptOXlibWxoTVJZd0ZBWURWUVFIRXcxVApZVzRnUm5KaGJtTnBjMk52TVJrd0Z3WURWUVFLRXhCdmNtY3hMbVY0WVcxd2JHVXVZMjl0TVJ3d0dnWURWUVFECkV4TmpZUzV2Y21jeExtVjRZVzF3YkdVdVkyOXRNRmt3RXdZSEtvWkl6ajBDQVFZSUtvWkl6ajBEQVFjRFFnQUUKS0dIeENPOHAwbXBtcFo4NVYwRUsxbnRoSFdjYnhQT1VWYitOSS9PUmt4VTV1bUZkRU15QlBPQ0hsRWZVbFJhMwphSFpKUk95cnppUW9qdkR4M2dzdGI2TnRNR3N3RGdZRFZSMFBBUUgvQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHCkNDc0dBUVVGQndNQ0JnZ3JCZ0VGQlFjREFUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01Da0dBMVVkRGdRaUJDRC8KTUx2clljQVRnYkZwdStYK1o1T3NhOE9hZm5pRkVkZVVOcWozVlRvNUJqQUtCZ2dxaGtqT1BRUURBZ05KQURCRwpBaUVBa3JBVDFzQkZJSEl3K0E4L2JDL051Qm9RaEZHakZybzJXcFRjOWJ1SVFta0NJUUNwa0tabDZEVm5Iei9jClovVnR3YzE3QlIvYXppZW5VUnVKODI2ZU9zclZZZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
+                                    "organizational_unit_identifier": "admin"
+                                  },
+                                  "enable": true
+                                },
+                                "name": "Org1MSP",
+                                "root_certs": [
+                                  "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNVakNDQWZlZ0F3SUJBZ0lRUXNYbWJqQVFWck9CakwyWitqRnAwakFLQmdncWhrak9QUVFEQWpCek1Rc3cKQ1FZRFZRUUdFd0pWVXpFVE1CRUdBMVVFQ0JNS1EyRnNhV1p2Y201cFlURVdNQlFHQTFVRUJ4TU5VMkZ1SUVaeQpZVzVqYVhOamJ6RVpNQmNHQTFVRUNoTVFiM0puTVM1bGVHRnRjR3hsTG1OdmJURWNNQm9HQTFVRUF4TVRZMkV1CmIzSm5NUzVsZUdGdGNHeGxMbU52YlRBZUZ3MHlNREEyTURJeE9UVXpNREJhRncwek1EQTFNekV4T1RVek1EQmEKTUhNeEN6QUpCZ05WQkFZVEFsVlRNUk13RVFZRFZRUUlFd3BEWVd4cFptOXlibWxoTVJZd0ZBWURWUVFIRXcxVApZVzRnUm5KaGJtTnBjMk52TVJrd0Z3WURWUVFLRXhCdmNtY3hMbVY0WVcxd2JHVXVZMjl0TVJ3d0dnWURWUVFECkV4TmpZUzV2Y21jeExtVjRZVzF3YkdVdVkyOXRNRmt3RXdZSEtvWkl6ajBDQVFZSUtvWkl6ajBEQVFjRFFnQUUKS0dIeENPOHAwbXBtcFo4NVYwRUsxbnRoSFdjYnhQT1VWYitOSS9PUmt4VTV1bUZkRU15QlBPQ0hsRWZVbFJhMwphSFpKUk95cnppUW9qdkR4M2dzdGI2TnRNR3N3RGdZRFZSMFBBUUgvQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHCkNDc0dBUVVGQndNQ0JnZ3JCZ0VGQlFjREFUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01Da0dBMVVkRGdRaUJDRC8KTUx2clljQVRnYkZwdStYK1o1T3NhOE9hZm5pRkVkZVVOcWozVlRvNUJqQUtCZ2dxaGtqT1BRUURBZ05KQURCRwpBaUVBa3JBVDFzQkZJSEl3K0E4L2JDL051Qm9RaEZHakZybzJXcFRjOWJ1SVFta0NJUUNwa0tabDZEVm5Iei9jClovVnR3YzE3QlIvYXppZW5VUnVKODI2ZU9zclZZZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+                                ]
+                              },
+                              "type": 0
+                            },
+                            "version": "0"
+                          }
+                        },
+                        "version": "1"
+                      },
+                      "org2": {
+                        "mod_policy": "Admins",
+                        "values": {
+                          "MSP": {
+                            "mod_policy": "Admins",
+                            "value": {
+                              "config": {
+                               "crypto_config": {
+                                  "identity_identifier_hash_function": "SHA256",
+                                  "signature_hash_family": "SHA2"
+                                },
+                                "fabric_node_ous": {
+                                  "admin_ou_identifier": {
+                                    "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNVVENDQWZlZ0F3SUJBZ0lRUFpsOUZ6Q2ZoQlAyRm83RXdVazFYekFLQmdncWhrak9QUVFEQWpCek1Rc3cKQ1FZRFZRUUdFd0pWVXpFVE1CRUdBMVVFQ0JNS1EyRnNhV1p2Y201cFlURVdNQlFHQTFVRUJ4TU5VMkZ1SUVaeQpZVzVqYVhOamJ6RVpNQmNHQTFVRUNoTVFiM0puTWk1bGVHRnRjR3hsTG1OdmJURWNNQm9HQTFVRUF4TVRZMkV1CmIzSm5NaTVsZUdGdGNHeGxMbU52YlRBZUZ3MHlNREEyTURJeE9UVXpNREJhRncwek1EQTFNekV4T1RVek1EQmEKTUhNeEN6QUpCZ05WQkFZVEFsVlRNUk13RVFZRFZRUUlFd3BEWVd4cFptOXlibWxoTVJZd0ZBWURWUVFIRXcxVApZVzRnUm5KaGJtTnBjMk52TVJrd0Z3WURWUVFLRXhCdmNtY3lMbVY0WVcxd2JHVXVZMjl0TVJ3d0dnWURWUVFECkV4TmpZUzV2Y21jeUxtVjRZVzF3YkdVdVkyOXRNRmt3RXdZSEtvWkl6ajBDQVFZSUtvWkl6ajBEQVFjRFFnQUUKd1hCRFExQzFLRFFsV2o5U1dJaXVxazBwWVppZmNlcTVNM1Q5UG5ORXVkTzUzbm5zL21zeGRrczdjc2NVMTRJdwpxRzVmRkpPbHRBR2tTWGM5WDA5ZGZhTnRNR3N3RGdZRFZSMFBBUUgvQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHCkNDc0dBUVVGQndNQ0JnZ3JCZ0VGQlFjREFUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01Da0dBMVVkRGdRaUJDRG8KQXVBYmFxcXE0OTFiR0ZzSGttTWdDa09YUEQ1ZFlVc2NTbnBoOXV1N1ZEQUtCZ2dxaGtqT1BRUURBZ05JQURCRgpBaUJMQzcwMTVXUjFwOEhzN2ZkRDhPVnBoakN2Y3ZSellRVEQxbDZSc3NNbUZRSWhBS01Gd1l2MDMyVGZMSnd6CnI3ZkV5am5LNmZRVUF3NDdncWpwRlN3ZFZIVmsKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
+                                    "organizational_unit_identifier": "admin"
+                                  },
+                                  "enable": true
+                                },
+                                "name": "Org2MSP",
+                                "root_certs": [
+                                  "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNVVENDQWZlZ0F3SUJBZ0lRUFpsOUZ6Q2ZoQlAyRm83RXdVazFYekFLQmdncWhrak9QUVFEQWpCek1Rc3cKQ1FZRFZRUUdFd0pWVXpFVE1CRUdBMVVFQ0JNS1EyRnNhV1p2Y201cFlURVdNQlFHQTFVRUJ4TU5VMkZ1SUVaeQpZVzVqYVhOamJ6RVpNQmNHQTFVRUNoTVFiM0puTWk1bGVHRnRjR3hsTG1OdmJURWNNQm9HQTFVRUF4TVRZMkV1CmIzSm5NaTVsZUdGdGNHeGxMbU52YlRBZUZ3MHlNREEyTURJeE9UVXpNREJhRncwek1EQTFNekV4T1RVek1EQmEKTUhNeEN6QUpCZ05WQkFZVEFsVlRNUk13RVFZRFZRUUlFd3BEWVd4cFptOXlibWxoTVJZd0ZBWURWUVFIRXcxVApZVzRnUm5KaGJtTnBjMk52TVJrd0Z3WURWUVFLRXhCdmNtY3lMbVY0WVcxd2JHVXVZMjl0TVJ3d0dnWURWUVFECkV4TmpZUzV2Y21jeUxtVjRZVzF3YkdVdVkyOXRNRmt3RXdZSEtvWkl6ajBDQVFZSUtvWkl6ajBEQVFjRFFnQUUKd1hCRFExQzFLRFFsV2o5U1dJaXVxazBwWVppZmNlcTVNM1Q5UG5ORXVkTzUzbm5zL21zeGRrczdjc2NVMTRJdwpxRzVmRkpPbHRBR2tTWGM5WDA5ZGZhTnRNR3N3RGdZRFZSMFBBUUgvQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHCkNDc0dBUVVGQndNQ0JnZ3JCZ0VGQlFjREFUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01Da0dBMVVkRGdRaUJDRG8KQXVBYmFxcXE0OTFiR0ZzSGttTWdDa09YUEQ1ZFlVc2NTbnBoOXV1N1ZEQUtCZ2dxaGtqT1BRUURBZ05JQURCRgpBaUJMQzcwMTVXUjFwOEhzN2ZkRDhPVnBoakN2Y3ZSellRVEQxbDZSc3NNbUZRSWhBS01Gd1l2MDMyVGZMSnd6CnI3ZkV5am5LNmZRVUF3NDdncWpwRlN3ZFZIVmsKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+                                ]
+                              },
+                              "type": 0
+                            },
+                            "version": "0"
+                          }
+                        },
+                        "version": "1"
+                      }
+                    },
+                    "mod_policy": "Admins",
+                    "values": {
+                      "Capabilities": {
+                        "mod_policy": "Admins",
+                        "value": {
+                          "capabilities": {
+                            "V2_0": {}
+                          }
+                        },
+                        "version": "0"
+                      }
+                    },
+                    "version": "1"
+                  }
+                },
+                "mod_policy": "Admins",
+                "values": {
+                  "BlockDataHashingStructure": {
+                    "mod_policy": "Admins",
+                    "value": {
+                      "width": 4294967295
+                    },
+                    "version": "0"
+                  },
+                  "Capabilities": {
+                    "mod_policy": "Admins",
+                    "value": {
+                      "capabilities": {
+                        "V2_0": {}
+                      }
+                    },
+                    "version": "0"
+                  },
+                  "HashingAlgorithm": {
+                    "mod_policy": "Admins",
+                    "value": {
+                      "name": "SHA256"
+                    },
+                    "version": "0"
+                  }
+                },
+                "version": "0"
+              },
+              "sequence": "3"
+            }
+          },
+          "header": {
+            "channel_header": {
+              "channel_id": "testchannel",
+              "epoch": "0",
+              "timestamp": "2020-06-02T19:58:25Z",
+              "tx_id": "",
+              "type": 1,
+              "version": 0
+            },
+            "signature_header": {}
+          }
+        }
+      }
+    ]
+  },
+  "header": {
+    "data_hash": "CG11HLT3vhkk7F5yvMzsHqtLcFoirUFQT1ayZ6JVgrU=",
+    "number": "2",
+    "previous_hash": "GB4HpemWaeP97JEMDvbj13a7Oq26V7868YTmiEXJj5Q="
+  }
+}


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
Implement channelInfoProvider to enable ledger to retrieve MSPIDs from all channel configs (current and previous channel configs). The MSPIDs will be used to construct implicit collection names and corresponding namespaces to db names mapping. The mapping is needed to remove per-channel state couch dbs and creating checkpoint snapshots.

#### Related issues
https://jira.hyperledger.org/browse/FAB-17942
https://jira.hyperledger.org/browse/FAB-17787