### PR TITLE
[FAB-17900] Fixes env variable override bug

### DIFF
--- a/common/viperutil/config_util.go
+++ b/common/viperutil/config_util.go
@@ -93,6 +93,7 @@ func getKeysRecursively(base string, getKey viperGetter, nodeKeys map[string]int
 
 func unmarshalJSON(val interface{}) (map[string]string, bool) {
 	mp := map[string]string{}
+
 	s, ok := val.(string)
 	if !ok {
 		logger.Debugf("Unmarshal JSON: value is not a string: %v", val)
@@ -303,7 +304,7 @@ func bccspHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, e
 
 	config := factory.GetDefaultOpts()
 
-	err := mapstructure.Decode(data, config)
+	err := mapstructure.WeakDecode(data, config)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not decode bcssp type")
 	}

--- a/docs/source/hsm.md
+++ b/docs/source/hsm.md
@@ -53,7 +53,7 @@ bccsp:
   default: PKCS11
   pkcs11:
     Library: /etc/hyperledger/fabric/libsofthsm2.so
-    Pin: 71811222
+    Pin: "71811222"
     Label: fabric
     hash: SHA2
     security: 256
@@ -134,7 +134,7 @@ You can set up a Fabric CA to use an HSM by making the same edits to the CA serv
     default: PKCS11
     pkcs11:
       Library: /etc/hyperledger/fabric/libsofthsm2.so
-      Pin: 71811222
+      Pin: "71811222"
       Label: fabric
       hash: SHA2
       security: 256

--- a/internal/peer/common/common.go
+++ b/internal/peer/common/common.go
@@ -135,7 +135,7 @@ func InitCrypto(mspMgrConfigDir, localMSPID, localMSPType string) error {
 	SetBCCSPKeystorePath()
 	bccspConfig := factory.GetDefaultOpts()
 	if config := viper.Get("peer.BCCSP"); config != nil {
-		err = mapstructure.Decode(config, bccspConfig)
+		err = mapstructure.WeakDecode(config, bccspConfig)
 		if err != nil {
 			return errors.WithMessage(err, "could not decode peer BCCSP configuration")
 		}


### PR DESCRIPTION
#### Type of change

- Bug fix
- Documentation update

#### Description

- Update documentation examples to include quotes around the `Pin` key. 
- Use WeakDecode to fix bug when setting a numeric environment variable override

~Supports Pin being specified as quoted string or integer in the core.yaml or orderer.yaml. Previously If specified as `9876543` an error would occur because mapstructure package decodes the value as an integer while fabric expects a string. To avoid breaking current string this supports quoted strings and integers.~

#### Related issues

[FAB-17900](https://jira.hyperledger.org/browse/FAB-17900)

