### PR TITLE
Remove s390x, powerpc64le from RELEASE_PLATFORMS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ GO_TAGS ?=
 
 RELEASE_EXES = orderer $(TOOLS_EXES)
 RELEASE_IMAGES = baseos ccenv orderer peer tools
-RELEASE_PLATFORMS = darwin-amd64 linux-amd64 linux-ppc64le linux-s390x windows-amd64
+RELEASE_PLATFORMS = darwin-amd64 linux-amd64 windows-amd64
 TOOLS_EXES = configtxgen configtxlator cryptogen discover idemixgen peer
 
 pkgmap.configtxgen    := $(PKGNAME)/cmd/configtxgen

--- a/bccsp/pkcs11/impl.go
+++ b/bccsp/pkcs11/impl.go
@@ -226,17 +226,13 @@ func (csp *impl) Decrypt(k bccsp.Key, ciphertext []byte, opts bccsp.DecrypterOpt
 // This is a convenience function. Useful to self-configure, for tests where usual configuration is not
 // available
 func FindPKCS11Lib() (lib, pin, label string) {
-	//FIXME: Till we workout the configuration piece, look for the libraries in the familiar places
 	lib = os.Getenv("PKCS11_LIB")
 	if lib == "" {
 		pin = "98765432"
 		label = "ForFabric"
 		possibilities := []string{
-			"/usr/lib/softhsm/libsofthsm2.so",                            //Debian
-			"/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so",           //Ubuntu
-			"/usr/lib/s390x-linux-gnu/softhsm/libsofthsm2.so",            //Ubuntu
-			"/usr/lib/powerpc64le-linux-gnu/softhsm/libsofthsm2.so",      //Power
-			"/usr/local/Cellar/softhsm/2.5.0/lib/softhsm/libsofthsm2.so", //MacOS
+			"/usr/lib/softhsm/libsofthsm2.so",                  //Debian
+			"/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so", //Ubuntu
 		}
 		for _, path := range possibilities {
 			if _, err := os.Stat(path); !os.IsNotExist(err) {

--- a/core/chaincode/platforms/golang/platform.go
+++ b/core/chaincode/platforms/golang/platform.go
@@ -490,7 +490,6 @@ func distributions() []dist {
 	// pre-populate linux architecutures
 	dists := map[dist]bool{
 		{goos: "linux", goarch: "amd64"}: true,
-		{goos: "linux", goarch: "s390x"}: true,
 	}
 
 	// add local OS and ARCH

--- a/core/handlers/library/race_test.go
+++ b/core/handlers/library/race_test.go
@@ -1,6 +1,4 @@
 // +build race
-// +build go1.9,linux,cgo go1.10,darwin,cgo
-// +build !ppc64le
 
 /*
 Copyright IBM Corp. All Rights Reserved.

--- a/core/handlers/library/registry_plugin_test.go
+++ b/core/handlers/library/registry_plugin_test.go
@@ -1,6 +1,3 @@
-// +build go1.9,linux,cgo go1.10,darwin,cgo
-// +build !ppc64le
-
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
 

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -171,11 +171,6 @@ run_tests_with_coverage() {
 }
 
 main() {
-    # explicit exclusions for ppc and s390x
-    if [ "$(uname -m)" == "ppc64le" ] || [ "$(uname -m)" == "s390x" ]; then
-        excluded_packages+=("github.com/hyperledger/fabric/core/chaincode/platforms/java")
-    fi
-
     # default behavior is to run all tests
     local -a package_spec=("${TEST_PKGS:-github.com/hyperledger/fabric/...}")
 


### PR DESCRIPTION
Things have changed with release-2.0. In particular,
- Release automation only creates amd64 binaries for darwin, linux, and windows.
- Continuous integration no longer runs on powerpc64le or s390x
Given we’re not producing release artifacts for those two platforms and we are not performing automated tests in CI for them, we can remove the references from the build process.

If we get to the point where we want to/need to release or test on these platforms again, this will force us to re-evaluate the required changes at that time. This is a good thing as it will prevent us from carrying baggage that we don’t understand.
