### PR TITLE
Backfill test for BCCSP environment overrides...

### DIFF
--- a/bccsp/factory/nopkcs11.go
+++ b/bccsp/factory/nopkcs11.go
@@ -18,7 +18,7 @@ const pkcs11Enabled = false
 // FactoryOpts holds configuration information used to initialize factory implementations
 type FactoryOpts struct {
 	ProviderName string  `mapstructure:"default" json:"default" yaml:"Default"`
-	SwOpts       *SwOpts `mapstructure:"SW,omitempty" json:"SW,omitempty" yaml:"SwOpts"`
+	SwOpts       *SwOpts `mapstructure:"SW,omitempty" json:"SW,omitempty" yaml:"SW,omitempty"`
 }
 
 // InitFactories must be called before using factory interfaces

--- a/bccsp/factory/pkcs11.go
+++ b/bccsp/factory/pkcs11.go
@@ -19,7 +19,7 @@ const pkcs11Enabled = false
 // FactoryOpts holds configuration information used to initialize factory implementations
 type FactoryOpts struct {
 	ProviderName string             `mapstructure:"default" json:"default" yaml:"Default"`
-	SwOpts       *SwOpts            `mapstructure:"SW,omitempty" json:"SW,omitempty" yaml:"SwOpts"`
+	SwOpts       *SwOpts            `mapstructure:"SW,omitempty" json:"SW,omitempty" yaml:"SW,omitempty"`
 	Pkcs11Opts   *pkcs11.PKCS11Opts `mapstructure:"PKCS11,omitempty" json:"PKCS11,omitempty" yaml:"PKCS11"`
 }
 


### PR DESCRIPTION
... and consistently use SW as the key for `SwOpts` in the configuration structures. Right now tags for mapstructure and JSON do not match the tags for YAML yet our sample configuration documents (in YAML) use `SW`.