### PR TITLE
handle an empty namespace in FullScanIterator skip list - levedb

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/commontests/test_common.go
+++ b/core/ledger/kvledger/txmgmt/statedb/commontests/test_common.go
@@ -1016,7 +1016,7 @@ func TestFullScanIterator(
 
 	// add the sample data for four namespaces to the db
 	batch := statedb.NewUpdateBatch()
-	for _, kv := range generateSampleData("ns1", "ns2", "ns3", "ns4") {
+	for _, kv := range generateSampleData("", "ns1", "ns2", "ns3", "ns4") {
 		batch.PutValAndMetadata(kv.Namespace, kv.Key, kv.Value, kv.Metadata, kv.Version)
 	}
 	db.ApplyUpdates(batch, version.NewHeight(5, 5))
@@ -1045,7 +1045,7 @@ func TestFullScanIterator(
 			})
 		}
 
-		expectedNamespacesInResults := stringset{"ns1", "ns2", "ns3", "ns4"}.minus(skipNamespaces)
+		expectedNamespacesInResults := stringset{"", "ns1", "ns2", "ns3", "ns4"}.minus(skipNamespaces)
 		expectedResults := []*statedb.VersionedKV{}
 		for _, ns := range expectedNamespacesInResults {
 			expectedResults = append(expectedResults, generateSampleData(ns)...)
@@ -1057,17 +1057,17 @@ func TestFullScanIterator(
 	// skip no namespaces
 	verifyFullScanIterator(stringset{})
 	// skip the first namespace
-	verifyFullScanIterator(stringset{"ns1"})
+	verifyFullScanIterator(stringset{""})
 	// skip the middle namespace
 	verifyFullScanIterator(stringset{"ns2"})
 	// skip the last namespace
 	verifyFullScanIterator(stringset{"ns4"})
 	// skip the first two namespaces
-	verifyFullScanIterator(stringset{"ns1", "ns2"})
+	verifyFullScanIterator(stringset{"", "ns2"})
 	// skip the last two namespaces
 	verifyFullScanIterator(stringset{"ns3", "ns4"})
 	// skip all the namespaces
-	verifyFullScanIterator(stringset{"ns1", "ns2", "ns3", "ns4"})
+	verifyFullScanIterator(stringset{"", "ns1", "ns2", "ns3", "ns4"})
 }
 
 type stringset []string

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb.go
@@ -286,10 +286,9 @@ func (scanner *kvScanner) GetBookmarkAndClose() string {
 }
 
 type fullDBScanner struct {
-	db               *leveldbhelper.DBHandle
-	dbItr            iterator.Iterator
-	toSkip           func(namespace string) bool
-	currentNamespace string
+	db     *leveldbhelper.DBHandle
+	dbItr  iterator.Iterator
+	toSkip func(namespace string) bool
 }
 
 func newFullDBScanner(db *leveldbhelper.DBHandle, skipNamespace func(namespace string) bool) (*fullDBScanner, byte, error) {
@@ -321,13 +320,8 @@ func (s *fullDBScanner) Next() (*statedb.CompositeKey, []byte, error) {
 		}
 
 		switch {
-		case ns == s.currentNamespace:
-			return compositeKey, dbVal, nil
-		// new namespace begins
 		case !s.toSkip(ns):
-			s.currentNamespace = ns
 			return compositeKey, dbVal, nil
-		// skip the new namespace
 		default:
 			s.dbItr.Release()
 			s.dbItr = s.db.GetIterator(dataKeyStarterForNextNamespace(ns), dataKeyStopper)


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code)

#### Description

An empty namespace is used for the config block. However, we would skip only the private data namespaces but not an empty namespace. However, we need to make the function generic.

