### PR TITLE
FAB-17955 Ch.Part.API: Safe access to system channel

### DIFF
--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -510,7 +510,7 @@ var _ = Describe("EndToEnd", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(1))
-			Eventually(sess.Err, network.EventuallyTimeout).Should(gbytes.Say("channel creation request not allowed because the orderer system channel is not yet defined"))
+			Eventually(sess.Err, network.EventuallyTimeout).Should(gbytes.Say("channel creation request not allowed because the orderer system channel is not defined"))
 		})
 	})
 

--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -235,6 +235,13 @@ func (r *Registrar) SystemChannelID() string {
 	return r.systemChannelID
 }
 
+// SystemChannelID returns the ChainSupport for the system channel.
+func (r *Registrar) SystemChannel() *ChainSupport {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.systemChannel
+}
+
 // BroadcastChannelSupport returns the message channel header, whether the message is a config update
 // and the channel resources for a message or an error if the message is not a message which can
 // be processed directly (like CONFIG and ORDERER_TRANSACTION messages)
@@ -247,10 +254,11 @@ func (r *Registrar) BroadcastChannelSupport(msg *cb.Envelope) (*cb.ChannelHeader
 	cs := r.GetChain(chdr.ChannelId)
 	// New channel creation
 	if cs == nil {
-		if r.systemChannel == nil {
+		sysChan := r.SystemChannel()
+		if sysChan == nil {
 			return nil, false, nil, errors.New("channel creation request not allowed because the orderer system channel is not yet defined")
 		}
-		cs = r.systemChannel
+		cs = sysChan
 	}
 
 	isConfig := false

--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -235,7 +235,7 @@ func (r *Registrar) SystemChannelID() string {
 	return r.systemChannelID
 }
 
-// SystemChannelID returns the ChainSupport for the system channel.
+// SystemChannel returns the ChainSupport for the system channel.
 func (r *Registrar) SystemChannel() *ChainSupport {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
@@ -256,7 +256,7 @@ func (r *Registrar) BroadcastChannelSupport(msg *cb.Envelope) (*cb.ChannelHeader
 	if cs == nil {
 		sysChan := r.SystemChannel()
 		if sysChan == nil {
-			return nil, false, nil, errors.New("channel creation request not allowed because the orderer system channel is not yet defined")
+			return nil, false, nil, errors.New("channel creation request not allowed because the orderer system channel is not defined")
 		}
 		cs = sysChan
 	}

--- a/orderer/common/multichannel/registrar_test.go
+++ b/orderer/common/multichannel/registrar_test.go
@@ -505,6 +505,6 @@ func TestBroadcastChannelSupport(t *testing.T) {
 		configTx := makeConfigTxFull("testchannelid", 1)
 		_, _, _, err = registrar.BroadcastChannelSupport(configTx)
 		assert.Error(t, err)
-		assert.Equal(t, "channel creation request not allowed because the orderer system channel is not yet defined", err.Error())
+		assert.Equal(t, "channel creation request not allowed because the orderer system channel is not defined", err.Error())
 	})
 }


### PR DESCRIPTION
In the Registrar, access the system channel ChainSupport
under lock, as it is no longer immutable.

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: If4b1bdcceddcd3752b2796021610e79ef826bd72

#### Type of change

- New feature
#### Related issues

Task: FAB-17955
Story: FAB-15711
Epic: FAB-17712