### PR TITLE
Sort JSON value to ensure deterministic stateDB snapshot hash across peers

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdoc_conv_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdoc_conv_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package statecouchdb
+
+import (
+	"bytes"
+	"encoding/json"
+	fmt "fmt"
+	"io/ioutil"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortJSON(t *testing.T) {
+	// TODO: testdata 6_unsorted.json is yet to be addressed
+	for i := 1; i <= 5; i++ {
+		t.Run(
+			fmt.Sprintf("testdata/json_documents/%d_unsorted.json", i),
+			func(t *testing.T) {
+				testSortJSON(t, i)
+			},
+		)
+	}
+}
+
+func testSortJSON(t *testing.T, filePrefix int) {
+	input, err := ioutil.ReadFile(
+		fmt.Sprintf("testdata/json_documents/%d_unsorted.json",
+			filePrefix,
+		))
+	require.NoError(t, err)
+	m := make(map[string]interface{})
+	decoder := json.NewDecoder(bytes.NewBuffer(input))
+	decoder.UseNumber()
+	require.NoError(t, decoder.Decode(&m))
+	val := reflect.ValueOf(m)
+
+	sortedJSONStr := sortJSON(val)
+
+	var prettyPrintJSON bytes.Buffer
+	err = json.Indent(&prettyPrintJSON, []byte(sortedJSONStr), "", "  ")
+	require.NoError(t, err)
+	expected, err := ioutil.ReadFile(
+		fmt.Sprintf("testdata/json_documents/%d_sorted.json",
+			filePrefix,
+		))
+	require.NoError(t, err)
+	require.Equal(t, string(expected), prettyPrintJSON.String())
+}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/1_sorted.json
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/1_sorted.json
@@ -1,0 +1,78 @@
+{
+  "batters": {
+    "batter": [
+      null,
+      {
+        "id": "1001",
+        "type": "Regular"
+      },
+      {
+        "id": "1002",
+        "type": "Chocolate"
+      },
+      {
+        "id": "1003",
+        "type": "Blueberry"
+      },
+      {
+        "id": "1004",
+        "type": "Devil's Food"
+      },
+      {
+        "propery": {
+          "color": "blue",
+          "shape": "round"
+        }
+      }
+    ]
+  },
+  "bool": true,
+  "cars": [
+    "BMW",
+    "Fiat",
+    "Ford"
+  ],
+  "id": "0001",
+  "name": "Cake",
+  "num": 1,
+  "ppu": 0.55,
+  "topping": [
+    {
+      "cars": [
+        "BMW",
+        "Fiat",
+        "Ford",
+        null
+      ]
+    },
+    {
+      "id": "5001",
+      "type": "None"
+    },
+    {
+      "id": "5002",
+      "type": "Glazed"
+    },
+    {
+      "id": "5003",
+      "type": "Chocolate"
+    },
+    {
+      "id": "5004",
+      "type": "Maple"
+    },
+    {
+      "id": "5005",
+      "type": "Sugar"
+    },
+    {
+      "id": "5006",
+      "type": "Chocolate with Sprinkles"
+    },
+    {
+      "id": "5007",
+      "type": "Powdered Sugar"
+    }
+  ],
+  "type": "donut"
+}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/1_unsorted.json
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/1_unsorted.json
@@ -1,0 +1,78 @@
+{
+  "id": "0001",
+  "type": "donut",
+  "name": "Cake",
+  "ppu": 0.55,
+  "num": 1,
+  "bool": true,
+  "batters": {
+    "batter": [
+      null,
+      {
+        "id": "1004",
+        "type": "Devil's Food"
+      },
+      {
+        "id": "1001",
+        "type": "Regular"
+      },
+      {
+        "propery": {
+          "color": "blue",
+          "shape": "round"
+        }
+      },
+      {
+        "id": "1002",
+        "type": "Chocolate"
+      },
+      {
+        "id": "1003",
+        "type": "Blueberry"
+      }
+    ]
+  },
+  "topping": [
+    {
+      "id": "5001",
+      "type": "None"
+    },
+    {
+      "id": "5002",
+      "type": "Glazed"
+    },
+    {
+      "id": "5005",
+      "type": "Sugar"
+    },
+    {
+      "id": "5007",
+      "type": "Powdered Sugar"
+    },
+    {
+      "id": "5006",
+      "type": "Chocolate with Sprinkles"
+    },
+    {
+      "id": "5003",
+      "type": "Chocolate"
+    },
+    {
+      "id": "5004",
+      "type": "Maple"
+    },
+    {
+      "cars": [
+        "Ford",
+        null,
+        "BMW",
+        "Fiat"
+      ]
+    }
+  ],
+  "cars": [
+    "Ford",
+    "BMW",
+    "Fiat"
+  ]
+}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/2_sorted.json
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/2_sorted.json
@@ -1,0 +1,62 @@
+{
+  "problems": [
+    {
+      "Asthma": [
+        {}
+      ],
+      "Diabetes": [
+        {
+          "labs": [
+            {
+              "missing_field": "missing_value"
+            }
+          ],
+          "medications": [
+            {
+              "medicationsClasses": [
+                {
+                  "className": [
+                    {
+                      "associatedDrug": [
+                        {
+                          "dose": "",
+                          "name": "asprin",
+                          "strength": "500 mg"
+                        }
+                      ],
+                      "associatedDrug#2": [
+                        {
+                          "dose": "",
+                          "name": "somethingElse",
+                          "strength": "500 mg"
+                        }
+                      ]
+                    }
+                  ],
+                  "className2": [
+                    {
+                      "associatedDrug": [
+                        {
+                          "dose": "",
+                          "name": "asprin",
+                          "strength": "500 mg"
+                        }
+                      ],
+                      "associatedDrug#2": [
+                        {
+                          "dose": "",
+                          "name": "somethingElse",
+                          "strength": "500 mg"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/2_unsorted.json
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/2_unsorted.json
@@ -1,0 +1,62 @@
+{
+  "problems": [
+    {
+      "Diabetes": [
+        {
+          "medications": [
+            {
+              "medicationsClasses": [
+                {
+                  "className2": [
+                    {
+                      "associatedDrug#2": [
+                        {
+                          "name": "somethingElse",
+                          "dose": "",
+                          "strength": "500 mg"
+                        }
+                      ],
+                      "associatedDrug": [
+                        {
+                          "name": "asprin",
+                          "dose": "",
+                          "strength": "500 mg"
+                        }
+                      ]
+                    }
+                  ],
+                  "className": [
+                    {
+                      "associatedDrug#2": [
+                        {
+                          "name": "somethingElse",
+                          "dose": "",
+                          "strength": "500 mg"
+                        }
+                      ],
+                      "associatedDrug": [
+                        {
+                          "name": "asprin",
+                          "dose": "",
+                          "strength": "500 mg"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "labs": [
+            {
+              "missing_field": "missing_value"
+            }
+          ]
+        }
+      ],
+      "Asthma": [
+        {}
+      ]
+    }
+  ]
+}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/3_sorted.json
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/3_sorted.json
@@ -1,0 +1,30 @@
+{
+  "A": 1,
+  "Backslash": "\\",
+  "Backspace": "\b",
+  "CarriageReturn": "\r",
+  "FormFeed": "\f",
+  "Newline": "\n",
+  "PublicKey": {
+    "Curve": {
+      "B": 4.105836372515214e+76,
+      "BitSize": 256,
+      "Gx": 4.8439561293906455e+76,
+      "Gy": 3.6134250956749796e+76,
+      "N": 1.1579208921035625e+77,
+      "Name": "P-256",
+      "P": 1.1579208921035625e+77
+    },
+    "X": 1.2713421817418933e+76,
+    "Y": 3.4338776428353404e+76
+  },
+  "Tab": "\t",
+  "Z": 1,
+  "description": "Information about SBA CIO√¢‚Ç¨‚Ñ¢s ƒ¶ membership ≈í≈Æ≈ß≈∏∆ï∆¢Œ£ in ƒà governance boards.",
+  "writes": [
+    {
+      "key": "marble4",
+      "value": "{\"docType\":\"marble\",\"name\":\"marble4\",\"color\":\"blue\",\"size\":70,\"owner\":\"jerry\"}"
+    }
+  ]
+}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/3_unsorted.json
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/3_unsorted.json
@@ -1,0 +1,30 @@
+{
+  "writes": [
+    {
+      "value": "{\"docType\":\"marble\",\"name\":\"marble4\",\"color\":\"blue\",\"size\":70,\"owner\":\"jerry\"}",
+      "key": "marble4"
+    }
+  ],
+  "PublicKey": {
+    "Curve": {
+      "P": 1.1579208921035625e+77,
+      "N": 1.1579208921035625e+77,
+      "B": 4.105836372515214e+76,
+      "Gx": 4.8439561293906455e+76,
+      "Gy": 3.6134250956749796e+76,
+      "BitSize": 256,
+      "Name": "P-256"
+    },
+    "X": 1.2713421817418933e+76,
+    "Y": 3.4338776428353404e+76
+  },
+  "description": "Information about SBA CIO√¢‚Ç¨‚Ñ¢s ƒ¶ membership ≈í≈Æ≈ß≈∏∆ï∆¢Œ£ in ƒà governance boards.",
+  "Z": 1,
+  "A": 1,
+  "Backslash": "\\",
+  "Tab": "\t",
+  "CarriageReturn": "\r",
+  "Newline": "\n",
+  "FormFeed": "\f",
+  "Backspace": "\b"
+}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/4_sorted.json
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/4_sorted.json
@@ -1,0 +1,86 @@
+{
+  "destination_addresses": [
+    "Austin, TX, USA",
+    "Miami, FL, USA",
+    "Napa County, CA, USA",
+    "Philadelphia, PA, USA",
+    "Santa Barbara, CA, USA",
+    "Washington, DC, USA"
+  ],
+  "origin_addresses": [
+    "New York, NY, USA"
+  ],
+  "rows": [
+    {
+      "elements": [
+        {
+          "distance": {
+            "text": "1,286 mi",
+            "value": 2069031
+          },
+          "duration": {
+            "text": "18 hours 43 mins",
+            "value": 67405
+          },
+          "status": "OK"
+        },
+        {
+          "distance": {
+            "text": "1,742 mi",
+            "value": 2802972
+          },
+          "duration": {
+            "text": "1 day 2 hours",
+            "value": 93070
+          },
+          "status": "OK"
+        },
+        {
+          "distance": {
+            "text": "2,871 mi",
+            "value": 4620514
+          },
+          "duration": {
+            "text": "1 day 18 hours",
+            "value": 152913
+          },
+          "status": "OK"
+        },
+        {
+          "distance": {
+            "text": "2,878 mi",
+            "value": 4632197
+          },
+          "duration": {
+            "text": "1 day 18 hours",
+            "value": 151772
+          },
+          "status": "OK"
+        },
+        {
+          "distance": {
+            "text": "227 mi",
+            "value": 365468
+          },
+          "duration": {
+            "text": "3 hours 54 mins",
+            "value": 14064
+          },
+          "status": "OK"
+        },
+        {
+          "distance": {
+            "text": "94.6 mi",
+            "value": 152193
+          },
+          "duration": {
+            "text": "1 hour 44 mins",
+            "value": 6227
+          },
+          "status": "OK"
+        }
+      ]
+    }
+  ],
+  "status": "OK"
+}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/4_unsorted.json
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/4_unsorted.json
@@ -1,0 +1,86 @@
+{
+  "destination_addresses": [
+    "Washington, DC, USA",
+    "Philadelphia, PA, USA",
+    "Santa Barbara, CA, USA",
+    "Miami, FL, USA",
+    "Austin, TX, USA",
+    "Napa County, CA, USA"
+  ],
+  "origin_addresses": [
+    "New York, NY, USA"
+  ],
+  "rows": [
+    {
+      "elements": [
+        {
+          "distance": {
+            "text": "227 mi",
+            "value": 365468
+          },
+          "duration": {
+            "text": "3 hours 54 mins",
+            "value": 14064
+          },
+          "status": "OK"
+        },
+        {
+          "distance": {
+            "text": "94.6 mi",
+            "value": 152193
+          },
+          "duration": {
+            "text": "1 hour 44 mins",
+            "value": 6227
+          },
+          "status": "OK"
+        },
+        {
+          "distance": {
+            "text": "2,878 mi",
+            "value": 4632197
+          },
+          "duration": {
+            "text": "1 day 18 hours",
+            "value": 151772
+          },
+          "status": "OK"
+        },
+        {
+          "distance": {
+            "text": "1,286 mi",
+            "value": 2069031
+          },
+          "duration": {
+            "text": "18 hours 43 mins",
+            "value": 67405
+          },
+          "status": "OK"
+        },
+        {
+          "distance": {
+            "text": "1,742 mi",
+            "value": 2802972
+          },
+          "duration": {
+            "text": "1 day 2 hours",
+            "value": 93070
+          },
+          "status": "OK"
+        },
+        {
+          "distance": {
+            "text": "2,871 mi",
+            "value": 4620514
+          },
+          "duration": {
+            "text": "1 day 18 hours",
+            "value": 152913
+          },
+          "status": "OK"
+        }
+      ]
+    }
+  ],
+  "status": "OK"
+}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/5_sorted.json
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/5_sorted.json
@@ -1,0 +1,62 @@
+{
+  "problems": [
+    {
+      "Asthma": [
+        {}
+      ],
+      "Diabetes": [
+        {
+          "labs": [
+            {
+              "missing_field": "missing_value"
+            }
+          ],
+          "medications": [
+            {
+              "medicationsClasses": [
+                {
+                  "className": [
+                    {
+                      "associatedDrug": [
+                        {
+                          "dose": "",
+                          "name": "asprin",
+                          "strength": "500 mg"
+                        }
+                      ],
+                      "associatedDrug#2": [
+                        {
+                          "dose": "",
+                          "name": "somethingElse",
+                          "strength": "500 mg"
+                        }
+                      ]
+                    }
+                  ],
+                  "className2": [
+                    {
+                      "associatedDrug": [
+                        {
+                          "dose": "",
+                          "name": "asprin",
+                          "strength": "500 mg"
+                        }
+                      ],
+                      "associatedDrug#2": [
+                        {
+                          "dose": "",
+                          "name": "somethingElse",
+                          "strength": "500 mg"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/5_unsorted.json
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/5_unsorted.json
@@ -1,0 +1,62 @@
+{
+  "problems": [
+    {
+      "Diabetes": [
+        {
+          "medications": [
+            {
+              "medicationsClasses": [
+                {
+                  "className": [
+                    {
+                      "associatedDrug": [
+                        {
+                          "name": "asprin",
+                          "dose": "",
+                          "strength": "500 mg"
+                        }
+                      ],
+                      "associatedDrug#2": [
+                        {
+                          "name": "somethingElse",
+                          "dose": "",
+                          "strength": "500 mg"
+                        }
+                      ]
+                    }
+                  ],
+                  "className2": [
+                    {
+                      "associatedDrug": [
+                        {
+                          "name": "asprin",
+                          "dose": "",
+                          "strength": "500 mg"
+                        }
+                      ],
+                      "associatedDrug#2": [
+                        {
+                          "name": "somethingElse",
+                          "dose": "",
+                          "strength": "500 mg"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "labs": [
+            {
+              "missing_field": "missing_value"
+            }
+          ]
+        }
+      ],
+      "Asthma": [
+        {}
+      ]
+    }
+  ]
+}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/6_sorted.json
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/6_sorted.json
@@ -1,0 +1,36 @@
+{
+  "chaincode_spec": {
+    "chaincode_id": {
+      "name": "lscc"
+    },
+    "input": {
+      "Args": [
+        "",
+        "\nU\b\u0001\u0012I\n=github.com/hyperledger/fabric/examples/chaincode/go/marbles02\u0012\u0005mycc1\u001a\u00010\u001a\u0006\n\u0004init",
+        "ch1",
+        "deploy",
+        "escc",
+        "vscc"
+      ]
+    },
+    "type": 1
+  },
+  "ns_read_write_Set": [
+    {
+      "KVRWSet": {
+        "reads": [
+          {
+            "key": "mycc1"
+          }
+        ],
+        "writes": [
+          {
+            "key": "mycc1",
+            "value": "\n\u0005mycc1\u0012\u00010\u001a\u0004escc\"\u0004vscc*\u0017\u0012\b\u0012\u0006\b\u0001\u0012\u0002\b\u0000\u001a\u000b\u0012\t\n\u0007DEFAULT2D\n ��$˞�K݂o�pJ{��_��(\u0015ݮ�>\u001a�c�\tS�\u0012 \u0012V�1\u000e�\u000e��\u0010Q�i�$�VtV\\�\u0018L(�I����F�: E��ؿk�<\u0015�x��F\r�\u0005��C9\u0001�\t�bA\u000e\u0018�5�B\u0019\u0012\b\u0012\u0006\b\u0001\u0012\u0002\b\u0000\u001a\r\u0012\u000b\n\u0007DEFAULT\u0010\u0001"
+          }
+        ]
+      },
+      "Namespace": "lscc"
+    }
+  ]
+}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/6_unsorted.json
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/testdata/json_documents/6_unsorted.json
@@ -1,0 +1,36 @@
+{
+  "ns_read_write_Set": [
+    {
+      "Namespace": "lscc",
+      "KVRWSet": {
+        "reads": [
+          {
+            "key": "mycc1"
+          }
+        ],
+        "writes": [
+          {
+            "key": "mycc1",
+            "value": "\n\u0005mycc1\u0012\u00010\u001a\u0004escc\"\u0004vscc*\u0017\u0012\b\u0012\u0006\b\u0001\u0012\u0002\b\u0000\u001a\u000b\u0012\t\n\u0007DEFAULT2D\n ��$˞�K݂o�pJ{��_��(\u0015ݮ�>\u001a�c�\tS�\u0012 \u0012V�1\u000e�\u000e��\u0010Q�i�$�VtV\\�\u0018L(�I����F�: E��ؿk�<\u0015�x��F\r�\u0005��C9\u0001�\t�bA\u000e\u0018�5�B\u0019\u0012\b\u0012\u0006\b\u0001\u0012\u0002\b\u0000\u001a\r\u0012\u000b\n\u0007DEFAULT\u0010\u0001"
+          }
+        ]
+      }
+    }
+  ],
+  "chaincode_spec": {
+    "type": 1,
+    "chaincode_id": {
+      "name": "lscc"
+    },
+    "input": {
+      "Args": [
+        "deploy",
+        "ch1",
+        "\nU\b\u0001\u0012I\n=github.com/hyperledger/fabric/examples/chaincode/go/marbles02\u0012\u0005mycc1\u001a\u00010\u001a\u0006\n\u0004init",
+        "",
+        "escc",
+        "vscc"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

We need to ensure that the json document written to the snapshot file is the same across peers. Hence, this commit adds an utility function to sort json.

#### Additional details

#1348 will use this utility function while exporting the data out of CouchDB

#### Related issues

[FAB-17901](https://jira.hyperledger.org/browse/FAB-17901)