### PR TITLE
FAB-17951 fetch correct node id for validation

### DIFF
--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -1171,10 +1171,11 @@ func (n *Network) BrokerGroupRunner() ifrit.Runner {
 
 // OrdererRunner returns an ifrit.Runner for the specified orderer. The runner
 // can be used to start and manage an orderer process.
-func (n *Network) OrdererRunner(o *Orderer) *ginkgomon.Runner {
+func (n *Network) OrdererRunner(o *Orderer, env ...string) *ginkgomon.Runner {
 	cmd := exec.Command(n.Components.Orderer())
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("FABRIC_CFG_PATH=%s", n.OrdererDir(o)))
+	cmd.Env = append(cmd.Env, env...)
 
 	config := ginkgomon.Config{
 		AnsiColorCode:     n.nextColor(),

--- a/orderer/consensus/etcdraft/chain.go
+++ b/orderer/consensus/etcdraft/chain.go
@@ -1301,7 +1301,10 @@ func (c *Chain) ValidateConsensusMetadata(oldMetadataBytes, newMetadataBytes []b
 	}
 
 	// create the dummy parameters for ComputeMembershipChanges
-	dummyOldBlockMetadata, _ := ReadBlockMetadata(nil, oldMetadata)
+	c.raftMetadataLock.RLock()
+	dummyOldBlockMetadata := proto.Clone(c.opts.BlockMetadata).(*etcdraft.BlockMetadata)
+	c.raftMetadataLock.RUnlock()
+
 	dummyOldConsentersMap := CreateConsentersMap(dummyOldBlockMetadata, oldMetadata)
 	changes, err := ComputeMembershipChanges(dummyOldBlockMetadata, dummyOldConsentersMap, newMetadata.Consenters, c.support.SharedConfig())
 	if err != nil {

--- a/orderer/consensus/etcdraft/validator_test.go
+++ b/orderer/consensus/etcdraft/validator_test.go
@@ -24,21 +24,19 @@ import (
 
 var _ = Describe("Metadata Validation", func() {
 	var (
-		chain *etcdraft.Chain
-		tlsCA tlsgen.CA
+		chain             *etcdraft.Chain
+		tlsCA             tlsgen.CA
+		channelID         string
+		consenterMetadata *raftprotos.ConfigMetadata
+		consenters        map[uint64]*raftprotos.Consenter
+		support           *consensusmocks.FakeConsenterSupport
+		dataDir           string
+		err               error
+		cryptoProvider    bccsp.BCCSP
+		meta              *raftprotos.BlockMetadata
 	)
 
 	BeforeEach(func() {
-		var (
-			channelID         string
-			consenterMetadata *raftprotos.ConfigMetadata
-			consenters        map[uint64]*raftprotos.Consenter
-			support           *consensusmocks.FakeConsenterSupport
-			dataDir           string
-			err               error
-			cryptoProvider    bccsp.BCCSP
-		)
-
 		channelID = "test-channel"
 
 		cryptoProvider, err = sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
@@ -52,11 +50,11 @@ var _ = Describe("Metadata Validation", func() {
 
 		support = &consensusmocks.FakeConsenterSupport{}
 		support.ChannelIDReturns(channelID)
-		consenterMetadata = createMetadata(1, tlsCA)
+		consenterMetadata = createMetadata(3, tlsCA)
 		mockOrdererConfig := mockOrdererWithTLSRootCert(time.Hour, marshalOrPanic(consenterMetadata), tlsCA)
 		support.SharedConfigReturns(mockOrdererConfig)
 
-		meta := &raftprotos.BlockMetadata{
+		meta = &raftprotos.BlockMetadata{
 			ConsenterIds:    make([]uint64, len(consenterMetadata.Consenters)),
 			NextConsenterId: 1,
 		}
@@ -70,10 +68,13 @@ var _ = Describe("Metadata Validation", func() {
 		for i, c := range consenterMetadata.Consenters {
 			consenters[meta.ConsenterIds[i]] = c
 		}
+	})
 
+	JustBeforeEach(func() {
 		c := newChain(10*time.Second, channelID, dataDir, 1, meta, consenters, cryptoProvider, support)
 		c.init()
 		chain = c.Chain
+		chain.ActiveNodes.Store([]uint64{1, 2, 3})
 	})
 
 	When("determining parameter well-formedness", func() {
@@ -262,6 +263,41 @@ var _ = Describe("Metadata Validation", func() {
 				newBytes, _ := proto.Marshal(newMetadata)
 				Expect(chain.ValidateConsensusMetadata(oldBytes, newBytes, newChannel)).To(
 					MatchError("2 out of 3 nodes are alive, configuration will result in quorum loss"))
+			})
+
+			When("node id starts from 2", func() {
+				// this test case is mainly to assure that validator does NOT assume node ID to
+				// always start from 1. Consider following case:
+				// - we have [2, 3, 4] in consenter set
+				// - 4 is inactive and subject to remove, which should NOT result in quorum loss
+				// - if validator assumes node to start from 1, it would incorrectly conclude that
+				//   node 3 is to be removed, therefore rejecting such request
+				// - instead, validator should recognize that 4 is the one to be removed, which is
+				//   not harmful to network and happily allows it
+
+				BeforeEach(func() {
+					meta = &raftprotos.BlockMetadata{
+						ConsenterIds:    make([]uint64, len(consenterMetadata.Consenters)),
+						NextConsenterId: 2, // id starts from 2
+					}
+
+					for i := range meta.ConsenterIds {
+						meta.ConsenterIds[i] = meta.NextConsenterId
+						meta.NextConsenterId++
+					}
+
+					consenters = map[uint64]*raftprotos.Consenter{}
+					for i, c := range consenterMetadata.Consenters {
+						consenters[meta.ConsenterIds[i]] = c
+					}
+				})
+
+				It("succeeds on removal of inactive node in 2/3 cluster", func() {
+					chain.ActiveNodes.Store([]uint64{2, 3}) // 4 is inactive
+					newMetadata.Consenters = newMetadata.Consenters[:2]
+					newBytes, _ := proto.Marshal(newMetadata)
+					Expect(chain.ValidateConsensusMetadata(oldBytes, newBytes, newChannel)).To(Succeed())
+				})
 			})
 		})
 	})


### PR DESCRIPTION
Today, when a config update that modifies consenter set (add/remove
node), there's validator performing basics checks, including dangerous
configs that may result in quorum loss, e.g. removing active node from
a network with 2/3 alive nodes.

However, this validator always assumes node ID in consenter set to start
from 1. This is benign in most cases, as nodes are normally online, and
actual node ID doesn't really matter from validation pov. Although, in
certain special cases, this is problematic:
- we have [2, 3, 4] in consenter set
- [2, 3] are alive, and [4] is inactive and subject to remove
- if validator assume node starts from 1, then it would incorrectly conclude
  that [3] out of [1, 2, 3] is to be removed, while [2, 3] are the 2/3 alive
  nodes. Therefore, it would reject such request
- instead, we need to take actual node IDs into account

This commit fixes the problem and adds some UTs. IT will be added in a seperate
commit.

Signed-off-by: Jay Guo <guojiannan1101@gmail.com>