### PR TITLE
FAB-17912 Ch.Part.API: reject joins

### DIFF
--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -426,6 +426,18 @@ func (r *Registrar) ChannelInfo(channelID string) (types.ChannelInfo, error) {
 }
 
 func (r *Registrar) JoinChannel(channelID string, configBlock *cb.Block) (types.ChannelInfo, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	if r.systemChannelID != "" {
+		return types.ChannelInfo{}, types.ErrSystemChannelExists
+	}
+
+	_, ok := r.chains[channelID]
+	if ok {
+		return types.ChannelInfo{}, types.ErrChannelAlreadyExists
+	}
+
 	//TODO
 	return types.ChannelInfo{}, errors.New("Not implemented yet")
 }


### PR DESCRIPTION
Orderer reject joins:
1. when system channel exists, or
2. if channel exists

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: Ia68bcc91fa7d9363f2320ad69439eedb7a7aeab2

#### Type of change

- New feature
#### Related issues

Task: FAB-17912
Story: FAB-15711
Epic: FAB-17712
