### PR TITLE
Update configtx dependency and integration test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hyperledger/fabric-amcl v0.0.0-20200128223036-d1aa2665426a
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed
-	github.com/hyperledger/fabric-config v0.0.2
+	github.com/hyperledger/fabric-config v0.0.4
 	github.com/hyperledger/fabric-lib-go v1.0.0
 	github.com/hyperledger/fabric-protos-go v0.0.0-20200506201313-25f6564b9ac4
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/hyperledger/fabric-amcl v0.0.0-20200128223036-d1aa2665426a h1:HgdNn3U
 github.com/hyperledger/fabric-amcl v0.0.0-20200128223036-d1aa2665426a/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=
 github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed h1:VNnrD/ilIUO9DDHQP/uioYSy1309rYy0Z1jf3GLNRIc=
 github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed/go.mod h1:N7H3sA7Tx4k/YzFq7U0EPdqJtqvM4Kild0JoCc7C0Dc=
-github.com/hyperledger/fabric-config v0.0.2 h1:S0ehWN1kpSbD/AnkOzPA5YmekEfagRkIYbxjWb23bKs=
-github.com/hyperledger/fabric-config v0.0.2/go.mod h1:YpITBI/+ZayA3XWY5lF302K7PAsFYjEEPM/zr3hegA8=
+github.com/hyperledger/fabric-config v0.0.4 h1:QwcAaGG01SalE2p2XOk2bQB+rb7oONrMhRcXJPxHYtk=
+github.com/hyperledger/fabric-config v0.0.4/go.mod h1:YpITBI/+ZayA3XWY5lF302K7PAsFYjEEPM/zr3hegA8=
 github.com/hyperledger/fabric-lib-go v1.0.0 h1:UL1w7c9LvHZUSkIvHTDGklxFv2kTeva1QI2emOVc324=
 github.com/hyperledger/fabric-lib-go v1.0.0/go.mod h1:H362nMlunurmHwkYqR5uHL2UDWbQdbfz74n8kbCFsqc=
 github.com/hyperledger/fabric-protos-go v0.0.0-20190919234611-2a87503ac7c9/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=

--- a/vendor/github.com/hyperledger/fabric-config/configtx/config.go
+++ b/vendor/github.com/hyperledger/fabric-config/configtx/config.go
@@ -103,32 +103,40 @@ func (c *ConfigTx) UpdatedConfig() *cb.Config {
 	return c.updated
 }
 
-// ComputeUpdate computes the ConfigUpdate from a base and modified config transaction.
-func (c *ConfigTx) ComputeUpdate(channelID string) (*cb.ConfigUpdate, error) {
+// ComputeMarshaledUpdate computes the ConfigUpdate from a base and modified
+// config transaction and returns the marshaled bytes.
+func (c *ConfigTx) ComputeMarshaledUpdate(channelID string) ([]byte, error) {
 	if channelID == "" {
 		return nil, errors.New("channel ID is required")
 	}
 
-	updt, err := computeConfigUpdate(c.original, c.updated)
+	update, err := computeConfigUpdate(c.original, c.updated)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute update: %v", err)
 	}
 
-	updt.ChannelId = channelID
+	update.ChannelId = channelID
 
-	return updt, nil
-}
-
-// NewEnvelope creates an envelope with the provided config update and config signatures.
-func NewEnvelope(c *cb.ConfigUpdate, signatures ...*cb.ConfigSignature) (*cb.Envelope, error) {
-	cBytes, err := proto.Marshal(c)
+	marshaledUpdate, err := proto.Marshal(update)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling config update: %v", err)
 	}
 
+	return marshaledUpdate, nil
+}
+
+// NewEnvelope creates an envelope with the provided marshaled config update
+// and config signatures.
+func NewEnvelope(marshaledUpdate []byte, signatures ...*cb.ConfigSignature) (*cb.Envelope, error) {
 	configUpdateEnvelope := &cb.ConfigUpdateEnvelope{
-		ConfigUpdate: cBytes,
+		ConfigUpdate: marshaledUpdate,
 		Signatures:   signatures,
+	}
+
+	c := &cb.ConfigUpdate{}
+	err := proto.Unmarshal(marshaledUpdate, c)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshaling config update: %v", err)
 	}
 
 	envelope, err := newEnvelope(cb.HeaderType_CONFIG_UPDATE, c.ChannelId, configUpdateEnvelope)
@@ -139,11 +147,10 @@ func NewEnvelope(c *cb.ConfigUpdate, signatures ...*cb.ConfigSignature) (*cb.Env
 	return envelope, nil
 }
 
-// NewCreateChannelTx creates a create channel config update transaction using the
-// provided application channel configuration.
-func NewCreateChannelTx(channelConfig Channel, channelID string) (*cb.ConfigUpdate, error) {
-	var err error
-
+// NewMarshaledCreateChannelTx creates a create channel config update
+// transaction using the provided application channel configuration and returns
+// the marshaled bytes.
+func NewMarshaledCreateChannelTx(channelConfig Channel, channelID string) ([]byte, error) {
 	if channelID == "" {
 		return nil, errors.New("profile's channel ID is required")
 	}
@@ -153,12 +160,16 @@ func NewCreateChannelTx(channelConfig Channel, channelID string) (*cb.ConfigUpda
 		return nil, fmt.Errorf("creating default config template: %v", err)
 	}
 
-	configUpdate, err := newChannelCreateConfigUpdate(channelID, channelConfig, ct)
+	update, err := newChannelCreateConfigUpdate(channelID, channelConfig, ct)
 	if err != nil {
 		return nil, fmt.Errorf("creating channel create config update: %v", err)
 	}
 
-	return configUpdate, nil
+	marshaledUpdate, err := proto.Marshal(update)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling config update: %v", err)
+	}
+	return marshaledUpdate, nil
 }
 
 // NewSystemChannelGenesisBlock creates a genesis block using the provided consortiums and orderer

--- a/vendor/github.com/hyperledger/fabric-config/configtx/orderer.go
+++ b/vendor/github.com/hyperledger/fabric-config/configtx/orderer.go
@@ -192,17 +192,21 @@ func (o *OrdererOrg) Configuration() (Organization, error) {
 		return Organization{}, err
 	}
 
-	// Orderer organization requires orderer endpoints.
-	endpointsProtos := &cb.OrdererAddresses{}
-	err = unmarshalConfigValueAtKey(o.orgGroup, EndpointsKey, endpointsProtos)
-	if err != nil {
-		return Organization{}, err
+	// OrdererEndpoints are optional when retrieving from an existing config
+	org.OrdererEndpoints = nil
+	_, ok := o.orgGroup.Values[EndpointsKey]
+	if ok {
+		endpointsProtos := &cb.OrdererAddresses{}
+		err = unmarshalConfigValueAtKey(o.orgGroup, EndpointsKey, endpointsProtos)
+		if err != nil {
+			return Organization{}, err
+		}
+		ordererEndpoints := make([]string, len(endpointsProtos.Addresses))
+		for i, address := range endpointsProtos.Addresses {
+			ordererEndpoints[i] = address
+		}
+		org.OrdererEndpoints = ordererEndpoints
 	}
-	ordererEndpoints := make([]string, len(endpointsProtos.Addresses))
-	for i, address := range endpointsProtos.Addresses {
-		ordererEndpoints[i] = address
-	}
-	org.OrdererEndpoints = ordererEndpoints
 
 	// Remove AnchorPeers which are application org specific.
 	org.AnchorPeers = nil

--- a/vendor/github.com/hyperledger/fabric-config/configtx/signer.go
+++ b/vendor/github.com/hyperledger/fabric-config/configtx/signer.go
@@ -90,7 +90,7 @@ func toLowS(key ecdsa.PublicKey, sig ecdsaSignature) ecdsaSignature {
 
 // CreateConfigSignature creates a config signature for the the given configuration
 // update using the specified signing identity.
-func (s *SigningIdentity) CreateConfigSignature(configUpdate *cb.ConfigUpdate) (*cb.ConfigSignature, error) {
+func (s *SigningIdentity) CreateConfigSignature(marshaledUpdate []byte) (*cb.ConfigSignature, error) {
 	signatureHeader, err := s.signatureHeader()
 	if err != nil {
 		return nil, fmt.Errorf("creating signature header: %v", err)
@@ -105,14 +105,9 @@ func (s *SigningIdentity) CreateConfigSignature(configUpdate *cb.ConfigUpdate) (
 		SignatureHeader: header,
 	}
 
-	configUpdateBytes, err := proto.Marshal(configUpdate)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling config update: %v", err)
-	}
-
 	configSignature.Signature, err = s.Sign(
 		rand.Reader,
-		concatenateBytes(configSignature.SignatureHeader, configUpdateBytes),
+		concatenateBytes(configSignature.SignatureHeader, marshaledUpdate),
 		nil,
 	)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -154,7 +154,7 @@ github.com/hyperledger/fabric-chaincode-go/pkg/statebased
 github.com/hyperledger/fabric-chaincode-go/shim
 github.com/hyperledger/fabric-chaincode-go/shim/internal
 github.com/hyperledger/fabric-chaincode-go/shimtest
-# github.com/hyperledger/fabric-config v0.0.2
+# github.com/hyperledger/fabric-config v0.0.4
 ## explicit
 github.com/hyperledger/fabric-config/configtx
 github.com/hyperledger/fabric-config/configtx/internal/policydsl


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update

#### Description

- Bump fabric-config/configtx dependency to v0.0.4.
- Update configtx integration test to use nwo.Broadcast for submitting envelopes.
- Add tests to update orderer and other application configuration.

#### Related issues

[FAB-17956](https://jira.hyperledger.org/browse/FAB-17956)