### PR TITLE
[FAB-17970] Fix statement syntax problem in documents

### DIFF
--- a/docs/wrappers/peer_channel_postscript.md
+++ b/docs/wrappers/peer_channel_postscript.md
@@ -24,7 +24,7 @@ Here's an example of the `peer channel create` command option.
 
 * Create a new channel `mychannel` for the network, using the orderer at ip
   address `orderer.example.com:7050`.  The configuration update transaction
-  required to create this channel is defined the file `./createchannel.tx`.
+  required to create this channel is contained in the file `./createchannel.tx`.
   Wait 30 seconds for the channel to be created.
 
   ```


### PR DESCRIPTION
This fixes #FAB-17970
Change the statement to make it grammatically correct and read smoothly

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Documentation update

#### Description

In the file docs/wrappers/peer_channel_postscripts，the statement "The configuration update transaction required to create this channel is defined the file `./createchannel.tx`." seems to be a grammatical error. 

Maybe "The configuration update transaction required to create this channel is contained in the file `./createchannel.tx`." would be better ?

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

#1381 

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
