### PR TITLE
Fix use of connection profile for lifecycle CLI install operations

### DIFF
--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -118,6 +118,7 @@ Flags:
       --connectionProfile string       The fully qualified path to the connection profile that provides the necessary connection information for the network. Note: currently only supported for providing peer connection information
   -h, --help                           help for install
       --peerAddresses stringArray      The addresses of the peers to connect to
+      --targetPeer string              When using a connection profile, the name of the peer to target for this action
       --tlsRootCertFiles stringArray   If TLS is enabled, the paths to the TLS root cert files of the peers to connect to. The order and number of certs specified should match the --peerAddresses flag
 
 Global Flags:
@@ -144,6 +145,7 @@ Flags:
   -h, --help                           help for queryinstalled
   -O, --output string                  The output format for query results. Default is human-readable plain-text. json is currently the only supported format.
       --peerAddresses stringArray      The addresses of the peers to connect to
+      --targetPeer string              When using a connection profile, the name of the peer to target for this action
       --tlsRootCertFiles stringArray   If TLS is enabled, the paths to the TLS root cert files of the peers to connect to. The order and number of certs specified should match the --peerAddresses flag
 
 Global Flags:
@@ -171,6 +173,7 @@ Flags:
       --output-directory string        The output directory to use when writing a chaincode install package to disk. Default is the current working directory.
       --package-id string              The identifier of the chaincode install package
       --peerAddresses stringArray      The addresses of the peers to connect to
+      --targetPeer string              When using a connection profile, the name of the peer to target for this action
       --tlsRootCertFiles stringArray   If TLS is enabled, the paths to the TLS root cert files of the peers to connect to. The order and number of certs specified should match the --peerAddresses flag
 
 Global Flags:

--- a/internal/peer/lifecycle/chaincode/chaincode.go
+++ b/internal/peer/lifecycle/chaincode/chaincode.go
@@ -62,6 +62,7 @@ var (
 	peerAddresses         []string
 	tlsRootCertFiles      []string
 	connectionProfilePath string
+	targetPeer            string
 	waitForEvent          bool
 	waitForEventTimeout   time.Duration
 	packageID             string
@@ -107,6 +108,8 @@ func ResetFlags() {
 		"If TLS is enabled, the paths to the TLS root cert files of the peers to connect to. The order and number of certs specified should match the --peerAddresses flag")
 	flags.StringVarP(&connectionProfilePath, "connectionProfile", "", "",
 		"The fully qualified path to the connection profile that provides the necessary connection information for the network. Note: currently only supported for providing peer connection information")
+	flags.StringVarP(&targetPeer, "targetPeer", "", "",
+		"When using a connection profile, the name of the peer to target for this action")
 	flags.BoolVar(&waitForEvent, "waitForEvent", true,
 		"Whether to wait for the event from each peer's deliver filtered service signifying that the transaction has been committed successfully")
 	flags.DurationVar(&waitForEventTimeout, "waitForEventTimeout", 30*time.Second,

--- a/internal/peer/lifecycle/chaincode/getinstalledpackage.go
+++ b/internal/peer/lifecycle/chaincode/getinstalledpackage.go
@@ -60,10 +60,10 @@ func GetInstalledPackageCmd(i *InstalledPackageGetter, cryptoProvider bccsp.BCCS
 				ccInput := &ClientConnectionsInput{
 					CommandName:           cmd.Name(),
 					EndorserRequired:      true,
-					ChannelID:             channelID,
 					PeerAddresses:         peerAddresses,
 					TLSRootCertFiles:      tlsRootCertFiles,
 					ConnectionProfilePath: connectionProfilePath,
+					TargetPeer:            targetPeer,
 					TLSEnabled:            viper.GetBool("peer.tls.enabled"),
 				}
 
@@ -96,6 +96,7 @@ func GetInstalledPackageCmd(i *InstalledPackageGetter, cryptoProvider bccsp.BCCS
 		"peerAddresses",
 		"tlsRootCertFiles",
 		"connectionProfile",
+		"targetPeer",
 		"package-id",
 		"output-directory",
 	}

--- a/internal/peer/lifecycle/chaincode/install.go
+++ b/internal/peer/lifecycle/chaincode/install.go
@@ -64,10 +64,10 @@ func InstallCmd(i *Installer, cryptoProvider bccsp.BCCSP) *cobra.Command {
 				ccInput := &ClientConnectionsInput{
 					CommandName:           cmd.Name(),
 					EndorserRequired:      true,
-					ChannelID:             channelID,
 					PeerAddresses:         peerAddresses,
 					TLSRootCertFiles:      tlsRootCertFiles,
 					ConnectionProfilePath: connectionProfilePath,
+					TargetPeer:            targetPeer,
 					TLSEnabled:            viper.GetBool("peer.tls.enabled"),
 				}
 				c, err := NewClientConnections(ccInput, cryptoProvider)
@@ -91,6 +91,7 @@ func InstallCmd(i *Installer, cryptoProvider bccsp.BCCSP) *cobra.Command {
 		"peerAddresses",
 		"tlsRootCertFiles",
 		"connectionProfile",
+		"targetPeer",
 	}
 	attachFlags(chaincodeInstallCmd, flagList)
 

--- a/internal/peer/lifecycle/chaincode/queryinstalled.go
+++ b/internal/peer/lifecycle/chaincode/queryinstalled.go
@@ -50,10 +50,10 @@ func QueryInstalledCmd(i *InstalledQuerier, cryptoProvider bccsp.BCCSP) *cobra.C
 				ccInput := &ClientConnectionsInput{
 					CommandName:           cmd.Name(),
 					EndorserRequired:      true,
-					ChannelID:             channelID,
 					PeerAddresses:         peerAddresses,
 					TLSRootCertFiles:      tlsRootCertFiles,
 					ConnectionProfilePath: connectionProfilePath,
+					TargetPeer:            targetPeer,
 					TLSEnabled:            viper.GetBool("peer.tls.enabled"),
 				}
 
@@ -85,6 +85,7 @@ func QueryInstalledCmd(i *InstalledQuerier, cryptoProvider bccsp.BCCSP) *cobra.C
 		"peerAddresses",
 		"tlsRootCertFiles",
 		"connectionProfile",
+		"targetPeer",
 		"output",
 	}
 	attachFlags(chaincodeQueryInstalledCmd, flagList)


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Install operations (install, queryinstalled, getinstalledpackage) do not use the --channelID flag and thus the connection profile code did not work. Add a --targetPeer flag to specify the peer in a connection profile to use for these channel-less operations. 

#### Related issues

[FAB-17513](https://jira.hyperledger.org/browse/FAB-17513)