### PR TITLE
Bump Go and Alpine Version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@
 #   - unit-test - runs the go-test based unit tests
 #   - verify - runs unit tests for only the changed package tree
 
-ALPINE_VER ?= 3.11
+ALPINE_VER ?= 3.12
 BASE_VERSION = 2.2.0
 
 # 3rd party image version
@@ -76,7 +76,7 @@ METADATA_VAR += CommitSHA=$(EXTRA_VERSION)
 METADATA_VAR += BaseDockerLabel=$(BASE_DOCKER_LABEL)
 METADATA_VAR += DockerNamespace=$(DOCKER_NS)
 
-GO_VER = 1.14.1
+GO_VER = 1.14.4
 GO_TAGS ?=
 
 RELEASE_EXES = orderer $(TOOLS_EXES)

--- a/ci/azure-pipelines-merge.yml
+++ b/ci/azure-pipelines-merge.yml
@@ -11,7 +11,7 @@ pr: none
 variables:
   GOPATH: $(Agent.BuildDirectory)/go
   PATH: $(Agent.BuildDirectory)/go/bin:/usr/local/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-  GOVER: 1.14.1
+  GOVER: 1.14.4
 
 jobs:
   - job: UnitTests

--- a/ci/azure-pipelines-release.yml
+++ b/ci/azure-pipelines-release.yml
@@ -11,7 +11,7 @@ variables:
   - name: GOPATH
     value: $(Agent.BuildDirectory)/go
   - name: GOVER
-    value: 1.14.1
+    value: 1.14.4
 
 stages:
   - stage: BuildBinaries

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -11,7 +11,7 @@ pr:
 variables:
   GOPATH: $(Agent.BuildDirectory)/go
   PATH: $(Agent.BuildDirectory)/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-  GOVER: 1.14.1
+  GOVER: 1.14.4
 
 jobs:
   - job: VerifyBuild


### PR DESCRIPTION
Bump Go to 1.14.4. This is also the first Go release to switch to alpine 3.12 with 1.14.3 being the last to support 3.11. Performing this update now will allow us to cross the alpine minor version barrier prior to our LTS release of 2.2 to give us time to test the stability of the release.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
