### PR TITLE
add rlock to IsEmpty() in leveldb wrapper

### DIFF
--- a/common/ledger/util/leveldbhelper/leveldb_helper.go
+++ b/common/ledger/util/leveldbhelper/leveldb_helper.go
@@ -79,6 +79,8 @@ func (dbInst *DB) Open() {
 
 // IsEmpty returns whether or not a database is empty
 func (dbInst *DB) IsEmpty() (bool, error) {
+	dbInst.mutex.RLock()
+	defer dbInst.mutex.RUnlock()
 	itr := dbInst.db.NewIterator(&goleveldbutil.Range{}, dbInst.readOpts)
 	defer itr.Release()
 	hasItems := itr.Next()


### PR DESCRIPTION
#### Type of change

- Improvement to code

#### Description

This PR adds a RLock to IsEmpty() to synchronize between `Close()` and `IsEmpty()`
