### PR TITLE
add iter.Seek() to leveldb wrapper

### DIFF
--- a/common/ledger/util/leveldbhelper/leveldb_provider.go
+++ b/common/ledger/util/leveldbhelper/leveldb_provider.go
@@ -180,7 +180,7 @@ func (h *DBHandle) GetIterator(startKey []byte, endKey []byte) *Iterator {
 		eKey[len(eKey)-1] = lastKeyIndicator
 	}
 	logger.Debugf("Getting iterator for range [%#v] - [%#v]", sKey, eKey)
-	return &Iterator{h.db.GetIterator(sKey, eKey)}
+	return &Iterator{h.dbName, h.db.GetIterator(sKey, eKey)}
 }
 
 // UpdateBatch encloses the details of multiple `updates`
@@ -213,12 +213,21 @@ func (batch *UpdateBatch) Len() int {
 
 // Iterator extends actual leveldb iterator
 type Iterator struct {
+	dbName string
 	iterator.Iterator
 }
 
 // Key wraps actual leveldb iterator method
 func (itr *Iterator) Key() []byte {
 	return retrieveAppKey(itr.Iterator.Key())
+}
+
+// Seek moves the iterator to the first key/value pair
+// whose key is greater than or equal to the given key.
+// It returns whether such pair exist.
+func (itr *Iterator) Seek(key []byte) bool {
+	levelKey := constructLevelKey(itr.dbName, key)
+	return itr.Iterator.Seek(levelKey)
 }
 
 func constructLevelKey(dbName string, key []byte) []byte {

--- a/common/ledger/util/leveldbhelper/leveldb_provider_test.go
+++ b/common/ledger/util/leveldbhelper/leveldb_provider_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -40,17 +41,118 @@ func TestIterator(t *testing.T) {
 		db3.Put([]byte(createTestKey(i)), []byte(createTestValue("db3", i)), false)
 	}
 
-	itr1 := db2.GetIterator([]byte(createTestKey(2)), []byte(createTestKey(4)))
-	defer itr1.Release()
-	checkItrResults(t, itr1, createTestKeys(2, 3), createTestValues("db2", 2, 3))
+	rangeTestCases := []struct {
+		startKey       []byte
+		endKey         []byte
+		expectedKeys   []string
+		expectedValues []string
+	}{
+		{
+			startKey:       []byte(createTestKey(2)),
+			endKey:         []byte(createTestKey(4)),
+			expectedKeys:   createTestKeys(2, 3),
+			expectedValues: createTestValues("db2", 2, 3),
+		},
+		{
+			startKey:       []byte(createTestKey(2)),
+			endKey:         nil,
+			expectedKeys:   createTestKeys(2, 19),
+			expectedValues: createTestValues("db2", 2, 19),
+		},
+		{
+			startKey:       nil,
+			endKey:         nil,
+			expectedKeys:   createTestKeys(0, 19),
+			expectedValues: createTestValues("db2", 0, 19),
+		},
+	}
 
-	itr2 := db2.GetIterator([]byte(createTestKey(2)), nil)
-	defer itr2.Release()
-	checkItrResults(t, itr2, createTestKeys(2, 19), createTestValues("db2", 2, 19))
+	for i, testCase := range rangeTestCases {
+		t.Run(
+			fmt.Sprintf("range testCase %d", i),
+			func(t *testing.T) {
+				itr := db2.GetIterator(testCase.startKey, testCase.endKey)
+				defer itr.Release()
+				checkItrResults(t, itr, testCase.expectedKeys, testCase.expectedValues)
+			},
+		)
+	}
 
-	itr3 := db2.GetIterator(nil, nil)
-	defer itr3.Release()
-	checkItrResults(t, itr3, createTestKeys(0, 19), createTestValues("db2", 0, 19))
+	rangeWithSeekTestCases := []struct {
+		startKey          []byte
+		endKey            []byte
+		seekToKey         []byte
+		itrAtKeyAfterSeek []byte
+		expectedKeys      []string
+		expectedValues    []string
+	}{
+		{
+			startKey:          nil,
+			endKey:            nil,
+			seekToKey:         []byte(createTestKey(10)),
+			itrAtKeyAfterSeek: []byte(createTestKey(10)),
+			expectedKeys:      createTestKeys(11, 19),
+			expectedValues:    createTestValues("db1", 11, 19),
+		},
+		{
+			startKey:          []byte(createTestKey(11)),
+			endKey:            nil,
+			seekToKey:         []byte(createTestKey(5)),
+			itrAtKeyAfterSeek: []byte(createTestKey(11)),
+			expectedKeys:      createTestKeys(12, 19),
+			expectedValues:    createTestValues("db1", 12, 19),
+		},
+		{
+			startKey:          nil,
+			endKey:            nil,
+			seekToKey:         []byte(createTestKey(19)),
+			itrAtKeyAfterSeek: []byte(createTestKey(19)),
+			expectedKeys:      nil,
+			expectedValues:    nil,
+		},
+	}
+
+	for i, testCase := range rangeWithSeekTestCases {
+		t.Run(
+			fmt.Sprintf("range with seek testCase %d", i),
+			func(t *testing.T) {
+				itr := db1.GetIterator(testCase.startKey, testCase.endKey)
+				defer itr.Release()
+				require.True(t, itr.Seek(testCase.seekToKey))
+				require.Equal(t, testCase.itrAtKeyAfterSeek, itr.Key())
+				checkItrResults(t, itr, testCase.expectedKeys, testCase.expectedValues)
+			},
+		)
+	}
+
+	itr := db1.GetIterator(nil, nil)
+	defer itr.Release()
+	require.True(t, itr.Seek([]byte(createTestKey(10))))
+	require.Equal(t, []byte(createTestKey(10)), itr.Key())
+	checkItrResults(t, itr, createTestKeys(11, 19), createTestValues("db1", 11, 19))
+
+	require.True(t, itr.First())
+	require.True(t, itr.Seek([]byte(createTestKey(10))))
+	require.Equal(t, []byte(createTestKey(10)), itr.Key())
+	require.True(t, itr.Prev())
+	checkItrResults(t, itr, createTestKeys(10, 19), createTestValues("db1", 10, 19))
+
+	require.True(t, itr.First())
+	require.False(t, itr.Seek([]byte(createTestKey(20))))
+	require.True(t, itr.First())
+	checkItrResults(t, itr, createTestKeys(1, 19), createTestValues("db1", 1, 19))
+
+	require.True(t, itr.First())
+	require.False(t, itr.Prev())
+	checkItrResults(t, itr, createTestKeys(0, 19), createTestValues("db1", 0, 19))
+
+	require.True(t, itr.First())
+	require.True(t, itr.Last())
+	checkItrResults(t, itr, nil, nil)
+}
+
+func testRange(t *testing.T, start, end string, expectedKeys, expectedValues []string) {
+
 }
 
 func TestBatchedUpdates(t *testing.T) {
@@ -220,7 +322,6 @@ func testDBBasicWriteAndReads(t *testing.T, dbNames ...string) {
 }
 
 func checkItrResults(t *testing.T, itr *Iterator, expectedKeys []string, expectedValues []string) {
-	defer itr.Release()
 	var actualKeys []string
 	var actualValues []string
 	for itr.Next(); itr.Valid(); itr.Next() {


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

This PR adds `iter.Seek()`method  to the leveldb wrapper. The `Seek()` is already supported by leveldb iterator. However, to use this method correctly, this PR introduces a wrapper that adds `dbName` as a prefix to the key. 

#### Additional details

1. `Seek()` will be used in the code that exports data out of stateleveldb by skipping a few namespaces. 
2. This PR also adds test for `First()`, `Last()`, and `Prev()` methods on iterator.