### PR TITLE
[FAB-17963] Ch.Part.API: Validate join block

### DIFF
--- a/orderer/common/channelparticipation/mocks/channel_management.go
+++ b/orderer/common/channelparticipation/mocks/channel_management.go
@@ -33,11 +33,12 @@ type ChannelManagement struct {
 	channelListReturnsOnCall map[int]struct {
 		result1 types.ChannelList
 	}
-	JoinChannelStub        func(string, *common.Block) (types.ChannelInfo, error)
+	JoinChannelStub        func(string, *common.Block, bool) (types.ChannelInfo, error)
 	joinChannelMutex       sync.RWMutex
 	joinChannelArgsForCall []struct {
 		arg1 string
 		arg2 *common.Block
+		arg3 bool
 	}
 	joinChannelReturns struct {
 		result1 types.ChannelInfo
@@ -178,17 +179,18 @@ func (fake *ChannelManagement) ChannelListReturnsOnCall(i int, result1 types.Cha
 	}{result1}
 }
 
-func (fake *ChannelManagement) JoinChannel(arg1 string, arg2 *common.Block) (types.ChannelInfo, error) {
+func (fake *ChannelManagement) JoinChannel(arg1 string, arg2 *common.Block, arg3 bool) (types.ChannelInfo, error) {
 	fake.joinChannelMutex.Lock()
 	ret, specificReturn := fake.joinChannelReturnsOnCall[len(fake.joinChannelArgsForCall)]
 	fake.joinChannelArgsForCall = append(fake.joinChannelArgsForCall, struct {
 		arg1 string
 		arg2 *common.Block
-	}{arg1, arg2})
-	fake.recordInvocation("JoinChannel", []interface{}{arg1, arg2})
+		arg3 bool
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("JoinChannel", []interface{}{arg1, arg2, arg3})
 	fake.joinChannelMutex.Unlock()
 	if fake.JoinChannelStub != nil {
-		return fake.JoinChannelStub(arg1, arg2)
+		return fake.JoinChannelStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -203,17 +205,17 @@ func (fake *ChannelManagement) JoinChannelCallCount() int {
 	return len(fake.joinChannelArgsForCall)
 }
 
-func (fake *ChannelManagement) JoinChannelCalls(stub func(string, *common.Block) (types.ChannelInfo, error)) {
+func (fake *ChannelManagement) JoinChannelCalls(stub func(string, *common.Block, bool) (types.ChannelInfo, error)) {
 	fake.joinChannelMutex.Lock()
 	defer fake.joinChannelMutex.Unlock()
 	fake.JoinChannelStub = stub
 }
 
-func (fake *ChannelManagement) JoinChannelArgsForCall(i int) (string, *common.Block) {
+func (fake *ChannelManagement) JoinChannelArgsForCall(i int) (string, *common.Block, bool) {
 	fake.joinChannelMutex.RLock()
 	defer fake.joinChannelMutex.RUnlock()
 	argsForCall := fake.joinChannelArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *ChannelManagement) JoinChannelReturns(result1 types.ChannelInfo, result2 error) {

--- a/orderer/common/channelparticipation/validator.go
+++ b/orderer/common/channelparticipation/validator.go
@@ -1,0 +1,54 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package channelparticipation
+
+import (
+	"errors"
+	"fmt"
+
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric/bccsp/factory"
+	"github.com/hyperledger/fabric/common/channelconfig"
+	"github.com/hyperledger/fabric/protoutil"
+)
+
+// ValidateJoinBlock returns whether this block can be used as a join block for the channel participation API
+// and whether it is an system channel if it contains consortiums, or otherwise
+// and application channel if an application group exists.
+func ValidateJoinBlock(channelID string, configBlock *cb.Block) (isAppChannel bool, err error) {
+	if !protoutil.IsConfigBlock(configBlock) {
+		return false, errors.New("block is not a config block")
+	}
+
+	envelope, err := protoutil.ExtractEnvelope(configBlock, 0)
+	if err != nil {
+		return false, err
+	}
+
+	cryptoProvider := factory.GetDefault()
+	bundle, err := channelconfig.NewBundleFromEnvelope(envelope, cryptoProvider)
+	if err != nil {
+		return false, err
+	}
+
+	// Check channel id from join block matches
+	if bundle.ConfigtxValidator().ChannelID() != channelID {
+		return false, fmt.Errorf("config block channelID [%s] does not match passed channelID [%s]",
+			bundle.ConfigtxValidator().ChannelID(), channelID)
+	}
+
+	// Check channel type
+	_, isSystemChannel := bundle.ConsortiumsConfig()
+	if !isSystemChannel {
+		_, isAppChannel = bundle.ApplicationConfig()
+		if !isAppChannel {
+			return false, errors.New("invalid config: must have at least one of application or consortiums")
+		}
+	}
+
+	return isAppChannel, err
+}

--- a/orderer/common/channelparticipation/validator_test.go
+++ b/orderer/common/channelparticipation/validator_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package channelparticipation_test
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric/bccsp"
+	"github.com/hyperledger/fabric/orderer/common/channelparticipation"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateJoinBlock(t *testing.T) {
+	tests := []struct {
+		testName             string
+		channelID            string
+		joinBlock            *cb.Block
+		expectedIsAppChannel bool
+		expectedErr          error
+	}{
+		{
+			testName:  "Valid system channel join block",
+			channelID: "my-channel",
+			joinBlock: blockWithGroups(
+				map[string]*cb.ConfigGroup{
+					"Consortiums": {},
+				},
+				"my-channel",
+			),
+			expectedIsAppChannel: false,
+			expectedErr:          nil,
+		},
+		{
+			testName:  "Valid application channel join block",
+			channelID: "my-channel",
+			joinBlock: blockWithGroups(
+				map[string]*cb.ConfigGroup{
+					"Application": {},
+				},
+				"my-channel",
+			),
+			expectedIsAppChannel: true,
+			expectedErr:          nil,
+		},
+		{
+			testName:             "Join block not a config block",
+			channelID:            "my-channel",
+			joinBlock:            nonConfigBlock(),
+			expectedIsAppChannel: false,
+			expectedErr:          errors.New("block is not a config block"),
+		},
+		{
+			testName:  "ChannelID does not match join blocks",
+			channelID: "not-my-channel",
+			joinBlock: blockWithGroups(
+				map[string]*cb.ConfigGroup{
+					"Consortiums": {},
+				},
+				"my-channel",
+			),
+			expectedIsAppChannel: false,
+			expectedErr:          errors.New("config block channelID [my-channel] does not match passed channelID [not-my-channel]"),
+		},
+		{
+			testName:  "Invalid bundle",
+			channelID: "my-channel",
+			joinBlock: blockWithGroups(
+				map[string]*cb.ConfigGroup{
+					"InvalidGroup": {},
+				},
+				"my-channel",
+			),
+			expectedIsAppChannel: false,
+			expectedErr:          nil,
+		},
+		{
+			testName:  "Join block has no application or consortiums group",
+			channelID: "my-channel",
+			joinBlock: blockWithGroups(
+				map[string]*cb.ConfigGroup{},
+				"my-channel",
+			),
+			expectedIsAppChannel: false,
+			expectedErr:          errors.New("invalid config: must have at least one of application or consortiums"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			isAppChannel, err := channelparticipation.ValidateJoinBlock(test.channelID, test.joinBlock)
+			assert.Equal(t, isAppChannel, test.expectedIsAppChannel)
+			if test.expectedErr != nil {
+				assert.EqualError(t, err, test.expectedErr.Error())
+			}
+		})
+	}
+}
+
+func blockWithGroups(groups map[string]*cb.ConfigGroup, channelID string) *cb.Block {
+	return &cb.Block{
+		Data: &cb.BlockData{
+			Data: [][]byte{
+				protoutil.MarshalOrPanic(&cb.Envelope{
+					Payload: protoutil.MarshalOrPanic(&cb.Payload{
+						Data: protoutil.MarshalOrPanic(&cb.ConfigEnvelope{
+							Config: &cb.Config{
+								ChannelGroup: &cb.ConfigGroup{
+									Groups: groups,
+									Values: map[string]*cb.ConfigValue{
+										"HashingAlgorithm": {
+											Value: protoutil.MarshalOrPanic(&cb.HashingAlgorithm{
+												Name: bccsp.SHA256,
+											}),
+										},
+										"BlockDataHashingStructure": {
+											Value: protoutil.MarshalOrPanic(&cb.BlockDataHashingStructure{
+												Width: math.MaxUint32,
+											}),
+										},
+										"OrdererAddresses": {
+											Value: protoutil.MarshalOrPanic(&cb.OrdererAddresses{
+												Addresses: []string{"localhost"},
+											}),
+										},
+									},
+								},
+							},
+						}),
+						Header: &cb.Header{
+							ChannelHeader: protoutil.MarshalOrPanic(&cb.ChannelHeader{
+								Type:      int32(cb.HeaderType_CONFIG),
+								ChannelId: channelID,
+							}),
+						},
+					}),
+				}),
+			},
+		},
+	}
+}
+
+func nonConfigBlock() *cb.Block {
+	return &cb.Block{
+		Data: &cb.BlockData{
+			Data: [][]byte{
+				protoutil.MarshalOrPanic(&cb.Envelope{
+					Payload: protoutil.MarshalOrPanic(&cb.Payload{
+						Header: &cb.Header{
+							ChannelHeader: protoutil.MarshalOrPanic(&cb.ChannelHeader{
+								Type: int32(cb.HeaderType_ENDORSER_TRANSACTION),
+							}),
+						},
+					}),
+				}),
+			},
+		},
+	}
+}

--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -417,7 +417,7 @@ func (r *Registrar) ChannelInfo(channelID string) (types.ChannelInfo, error) {
 	return info, nil
 }
 
-func (r *Registrar) JoinChannel(channelID string, configBlock *cb.Block) (types.ChannelInfo, error) {
+func (r *Registrar) JoinChannel(channelID string, configBlock *cb.Block, isAppChannel bool) (types.ChannelInfo, error) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 

--- a/orderer/common/multichannel/registrar_test.go
+++ b/orderer/common/multichannel/registrar_test.go
@@ -531,7 +531,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		registrar := NewRegistrar(localconfig.TopLevel{}, ledgerFactory, mockCrypto(), &disabled.Provider{}, cryptoProvider)
 		registrar.Initialize(mockConsenters)
 
-		info, err := registrar.JoinChannel("some-app-channel", &cb.Block{})
+		info, err := registrar.JoinChannel("some-app-channel", &cb.Block{}, false)
 		assert.EqualError(t, err, "system channel exists")
 		assert.Equal(t, types.ChannelInfo{}, info)
 	})
@@ -559,7 +559,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		registrar.CreateChain("my-channel")
 		assert.NotNil(t, registrar.GetChain("my-channel"))
 
-		info, err := registrar.JoinChannel("my-channel", &cb.Block{})
+		info, err := registrar.JoinChannel("my-channel", &cb.Block{}, false)
 		assert.EqualError(t, err, "channel already exists")
 		assert.Equal(t, types.ChannelInfo{}, info)
 	})
@@ -571,10 +571,12 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 
 		ledgerFactory, _ := newLedgerAndFactory(tmpdir, "", nil)
 		mockConsenters := map[string]consensus.Consenter{"not-raft": &mockConsenter{}}
+
 		config := localconfig.TopLevel{}
 		config.General.BootstrapMethod = "none"
 		config.General.GenesisFile = ""
 		registrar := NewRegistrar(config, ledgerFactory, mockCrypto(), &disabled.Provider{}, cryptoProvider)
+
 		assert.Panics(t, func() { registrar.Initialize(mockConsenters) })
 	})
 }


### PR DESCRIPTION
#### Type of Change

* New Feature

#### Description

Introduce function for validating the join block received by the
registrar's JoinChannel. `validateJoinBlock` will determine whether the
block contains an application channel or system channel and also whether
the node is a member of the consenter set.

#### Related Issues

Task: [FAB-17963](https://jira.hyperledger.org/browse/FAB-17963)
Story: [FAB-15711](https://jira.hyperledger.org/browse/FAB-15711)
Epic: [FAB-17712](https://jira.hyperledger.org/browse/FAB-17712)