### PR TITLE
Update Pipfile to support localization

### DIFF
--- a/docs/Pipfile
+++ b/docs/Pipfile
@@ -1,14 +1,3 @@
-[[source]]
-name = "pypi"
-url = "https://pypi.org/simple"
-verify_ssl = true
-
-[dev-packages]
-
 [packages]
-sphinx = "*"
-sphinx-rtd-theme = "*"
+Sphinx = "==1.8.5"
 recommonmark = "==0.4.0"
-
-[requires]
-python_version = "3.7"


### PR DESCRIPTION
Signed-off-by: pama-ibm <pama@ibm.com>

Existing Pipfile was causing the toc to break when the docs were built on Ubuntu.  This caused some issues for one of our documentation translators. He figured it out that what's contained in this file is all that is really needed for the buikd.


#### Type of change

- Documentation update

#### Description

I tested the updates on my local build and it worked fine for me on MacOS.
Brett looked it over and ran some tests and agreed this looks good. 

Local build instructions: https://hyperledger-fabric.readthedocs.io/en/latest/docs_guide.html#building-locally