### PR TITLE
Fixed a typo (that that)

### DIFF
--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -21,7 +21,7 @@ current master branch, it is possible that you will encounter errors.
 ## Before you begin
 
 Before you can run the test network, you need to clone the `fabric-samples`
-repository and download the Fabric images. Make sure that that you have installed
+repository and download the Fabric images. Make sure that you have installed
 the [Prerequisites](prereqs.html) and [Installed the Samples, Binaries and Docker Images](install.html).
 
 ## Bring up the test network


### PR DESCRIPTION
Fixed a typo

#### Type of change

- Documentation update

#### Description

Fixed a typo where the word "that" was repeated two times

#### Additional details

No additional information.
