### PR TITLE
use iter.Seek() instead of creating a new iterator while skipping namespace

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/commontests/test_common.go
+++ b/core/ledger/kvledger/txmgmt/statedb/commontests/test_common.go
@@ -1051,23 +1051,29 @@ func TestFullScanIterator(
 			expectedResults = append(expectedResults, generateSampleData(ns)...)
 		}
 		require.Equal(t, expectedResults, results)
-		fmt.Printf("Len = %d", len(results))
 	}
 
-	// skip no namespaces
-	verifyFullScanIterator(stringset{})
-	// skip the first namespace
-	verifyFullScanIterator(stringset{""})
-	// skip the middle namespace
-	verifyFullScanIterator(stringset{"ns2"})
-	// skip the last namespace
-	verifyFullScanIterator(stringset{"ns4"})
-	// skip the first two namespaces
-	verifyFullScanIterator(stringset{"", "ns2"})
-	// skip the last two namespaces
-	verifyFullScanIterator(stringset{"ns3", "ns4"})
-	// skip all the namespaces
-	verifyFullScanIterator(stringset{"", "ns1", "ns2", "ns3", "ns4"})
+	testCases := []stringset{
+		{},                               // skip no namespaces
+		{"", "ns1", "ns2", "ns3", "ns4"}, // skip all the namespaces
+		{""},                             // skip the first namespace
+		{"ns2"},                          // skip the middle namespace
+		{"ns4"},                          // skip the last namespace
+		{"", "ns1"},                      // skip the first two namespaces
+		{"ns3", "ns4"},                   // skip the last two namespaces
+		{"", "ns3"},                      // skip two non-consequitive namespaces
+		{"ns1", "ns4"},                   // skip two non-consequitive namespaces
+		{"", "ns4"},                      // skip the first and last namespace
+	}
+
+	for i, testCase := range testCases {
+		t.Run(
+			fmt.Sprintf("testCase %d", i),
+			func(t *testing.T) {
+				verifyFullScanIterator(testCase)
+			},
+		)
+	}
 }
 
 type stringset []string

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb.go
@@ -323,11 +323,8 @@ func (s *fullDBScanner) Next() (*statedb.CompositeKey, []byte, error) {
 		case !s.toSkip(ns):
 			return compositeKey, dbVal, nil
 		default:
-			s.dbItr.Release()
-			s.dbItr = s.db.GetIterator(dataKeyStarterForNextNamespace(ns), dataKeyStopper)
-			if err := s.dbItr.Error(); err != nil {
-				return nil, nil, errors.Wrapf(err, "internal leveldb error while obtaining db iterator for skipping a namespace [%s]", ns)
-			}
+			s.dbItr.Seek(dataKeyStarterForNextNamespace(ns))
+			s.dbItr.Prev()
 		}
 	}
 	return nil, nil, errors.Wrap(s.dbItr.Error(), "internal leveldb error while retrieving data from db iterator")

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb_test.go
@@ -185,31 +185,4 @@ func TestFullScanIteratorErrorPropagation(t *testing.T) {
 	itr.Close()
 	_, _, err = itr.Next()
 	require.Contains(t, err.Error(), "internal leveldb error while retrieving data from db iterator:")
-
-	// error from function Next when switching to new iterator for skipping a namespace
-	reInitEnv()
-	batch := statedb.NewUpdateBatch()
-	batch.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 1))
-	batch.Put("ns2", "key2", []byte("value2"), version.NewHeight(1, 1))
-	batch.Put("ns3", "key3", []byte("value3"), version.NewHeight(1, 1))
-	vdb.ApplyUpdates(batch, version.NewHeight(2, 2))
-
-	itr, _, err = vdb.GetFullScanIterator(
-		func(ns string) bool {
-			return ns == "ns2"
-		},
-	)
-	require.NoError(t, err)
-	compositeKey, _, err := itr.Next()
-	require.NoError(t, err)
-	require.Equal(t,
-		&statedb.CompositeKey{
-			Namespace: "ns1",
-			Key:       "key1",
-		},
-		compositeKey,
-	)
-	vdbProvider.Close()
-	_, _, err = itr.Next()
-	require.Contains(t, err.Error(), "internal leveldb error while obtaining db iterator for skipping a namespace [ns2]:")
 }


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Instead of creating a new iterator whenever we want to skip a namespace during a statedb export, it is natural to use Seek() method on iterator. Hence, this PR make that change. 