### PR TITLE
FAB-17985 Registrar newChain not to copy chains map

### DIFF
--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -346,22 +346,12 @@ func (r *Registrar) newChain(configtx *cb.Envelope) {
 	if ledgerResources.Height() == 0 {
 		ledgerResources.Append(blockledger.CreateNextBlock(ledgerResources, []*cb.Envelope{configtx}))
 	}
-
-	// Copy the map to allow concurrent reads from broadcast/deliver while the new chainSupport is
-	newChains := make(map[string]*ChainSupport)
-	for key, value := range r.chains {
-		newChains[key] = value
-	}
-
 	cs := newChainSupport(r, ledgerResources, r.consenters, r.signer, r.blockcutterMetrics, r.bccsp)
 	chainID := ledgerResources.ConfigtxValidator().ChannelID()
+	r.chains[chainID] = cs
 
 	logger.Infof("Created and starting new channel %s", chainID)
-
-	newChains[string(chainID)] = cs
 	cs.start()
-
-	r.chains = newChains
 }
 
 // ChannelsCount returns the count of the current total number of channels.


### PR DESCRIPTION
Currently the Registrar.newChain() copies the chains map to a new one,
supposedly to allow concurrent reads on the map while a chain is created.
This is redundant because the newChain takes rwmutex.Lock(), which blocks reads.

It is enough to just create the chain and insert it to the map.

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: I61ca191a4d0529210163b0fa4711509ac6669fa2

- Improvement (improvement to code, performance, etc)

#### Related issues

Task: FAB-17985
Story: FAB-15711