### PR TITLE
[FAB-17992] Allow remove ledger data for a channel

### DIFF
--- a/common/ledger/blkstorage/config.go
+++ b/common/ledger/blkstorage/config.go
@@ -14,6 +14,7 @@ const (
 	// IndexDir is the name of the directory containing all block indexes across ledgers.
 	IndexDir                = "index"
 	defaultMaxBlockfileSize = 64 * 1024 * 1024 // bytes
+	toBeRemovedFilePrefix   = "__toBeRemoved_"
 )
 
 // Conf encapsulates all the configurations for `BlockStore`
@@ -41,4 +42,8 @@ func (conf *Conf) getChainsDir() string {
 
 func (conf *Conf) getLedgerBlockDir(ledgerid string) string {
 	return filepath.Join(conf.getChainsDir(), ledgerid)
+}
+
+func (conf *Conf) getToBeRemovedFilePath(ledgerid string) string {
+	return filepath.Join(conf.blockStorageDir, toBeRemovedFilePrefix+ledgerid)
 }

--- a/common/ledger/blockledger/fileledger/factory.go
+++ b/common/ledger/blockledger/fileledger/factory.go
@@ -17,6 +17,7 @@ import (
 type blockStoreProvider interface {
 	Open(ledgerid string) (*blkstorage.BlockStore, error)
 	List() ([]string, error)
+	Remove(ledgerid string) error
 	Close()
 }
 
@@ -54,6 +55,11 @@ func (flf *fileLedgerFactory) ChannelIDs() []string {
 		logger.Panic(err)
 	}
 	return channelIDs
+}
+
+// Remove removes block indexes and blocks for the given channelID
+func (flf *fileLedgerFactory) Remove(channelID string) error {
+	return flf.blkstorageProvider.Remove(channelID)
 }
 
 // Close releases all resources acquired by the factory

--- a/common/ledger/blockledger/fileledger/factory_test.go
+++ b/common/ledger/blockledger/fileledger/factory_test.go
@@ -32,6 +32,10 @@ func (mbsp *mockBlockStoreProvider) List() ([]string, error) {
 	return mbsp.list, mbsp.error
 }
 
+func (mbsp *mockBlockStoreProvider) Remove(ledgerid string) error {
+	return mbsp.error
+}
+
 func (mbsp *mockBlockStoreProvider) Close() {
 }
 

--- a/common/ledger/blockledger/ledger.go
+++ b/common/ledger/blockledger/ledger.go
@@ -20,6 +20,9 @@ type Factory interface {
 	// ChannelIDs returns the channel IDs the Factory is aware of
 	ChannelIDs() []string
 
+	// Remove removes block indexes and blocks for the given channelID
+	Remove(channelID string) error
+
 	// Close releases all resources acquired by the factory
 	Close()
 }

--- a/orderer/common/server/mocks/factory.go
+++ b/orderer/common/server/mocks/factory.go
@@ -55,3 +55,17 @@ func (_m *Factory) GetOrCreate(chainID string) (blockledger.ReadWriter, error) {
 
 	return r0, r1
 }
+
+// Remove provides a mock function with given fields: channelID
+func (_m *Factory) Remove(channelID string) error {
+	ret := _m.Called(channelID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(channelID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/orderer/common/server/onboarding.go
+++ b/orderer/common/server/onboarding.go
@@ -261,6 +261,9 @@ type Factory interface {
 	// ChannelIDs returns the channel IDs the Factory is aware of
 	ChannelIDs() []string
 
+	// Remove removes block indexes and block files for the channel
+	Remove(channelID string) error
+
 	// Close releases all resources acquired by the factory
 	Close()
 }


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- New feature

#### Description
Add a Remove function to block storage provider in oder to
remove ledger data for a channel. It creates a temporary file
to indicate the channel is to be removed and start a goroutine
to remove channel ledger data in background. If remove fails or
orderer is stopped before remove is done, upon ledger restart,
it checks the existence of the temporary file and complete remove
as needed.

#### Additional details

#### Related issues
Story: https://jira.hyperledger.org/browse/FAB-17992
Epic: https://jira.hyperledger.org/browse/FAB-17712