### PR TITLE
rm no-op error from transient store

### DIFF
--- a/core/endorser/plugin_endorser_test.go
+++ b/core/endorser/plugin_endorser_test.go
@@ -74,7 +74,7 @@ func (s *testTransientStore) Persist(txid string, blockHeight uint64,
 	return s.store.Persist(txid, blockHeight, privateSimulationResultsWithConfig)
 }
 
-func (s *testTransientStore) GetTxPvtRWSetByTxid(txid string, filter ledger.PvtNsCollFilter) (privdata.RWSetScanner, error) {
+func (s *testTransientStore) GetTxPvtRWSetByTxid(txid string, filter ledger.PvtNsCollFilter) privdata.RWSetScanner {
 	return s.store.GetTxPvtRWSetByTxid(txid, filter)
 }
 

--- a/core/endorser/state.go
+++ b/core/endorser/state.go
@@ -47,10 +47,7 @@ type StateContext struct {
 
 // GetTransientByTXID returns the private data associated with this transaction ID.
 func (sc *StateContext) GetTransientByTXID(txID string) ([]*rwset.TxPvtReadWriteSet, error) {
-	scanner, err := sc.Store.GetTxPvtRWSetByTxid(txID, nil)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
+	scanner := sc.Store.GetTxPvtRWSetByTxid(txID, nil)
 	defer scanner.Close()
 	var data []*rwset.TxPvtReadWriteSet
 	for {

--- a/core/transientstore/store.go
+++ b/core/transientstore/store.go
@@ -153,7 +153,7 @@ func (s *Store) Persist(txid string, blockHeight uint64,
 
 // GetTxPvtRWSetByTxid returns an iterator due to the fact that the txid may have multiple private
 // write sets persisted from different endorsers.
-func (s *Store) GetTxPvtRWSetByTxid(txid string, filter ledger.PvtNsCollFilter) (RWSetScanner, error) {
+func (s *Store) GetTxPvtRWSetByTxid(txid string, filter ledger.PvtNsCollFilter) RWSetScanner {
 
 	logger.Debugf("Getting private data from transient store for transaction %s", txid)
 
@@ -162,7 +162,7 @@ func (s *Store) GetTxPvtRWSetByTxid(txid string, filter ledger.PvtNsCollFilter) 
 	endKey := createTxidRangeEndKey(txid)
 
 	iter := s.db.GetIterator(startKey, endKey)
-	return &RwsetScanner{txid, iter, filter}, nil
+	return &RwsetScanner{txid, iter, filter}
 }
 
 // PurgeByTxids removes private write sets of a given set of transactions from the

--- a/core/transientstore/store_test.go
+++ b/core/transientstore/store_test.go
@@ -136,9 +136,7 @@ func TestTransientStorePersistAndRetrieve(t *testing.T) {
 	}
 
 	// Retrieve simulation results of txid-1 from  store
-	iter, err := testStore.GetTxPvtRWSetByTxid(txid, nil)
-	assert.NoError(err)
-
+	iter := testStore.GetTxPvtRWSetByTxid(txid, nil)
 	var actualEndorsersResults []*EndorserPvtSimulationResults
 	for {
 		result, err := iter.Next()
@@ -192,9 +190,7 @@ func TestTransientStorePersistAndRetrieveBothOldAndNewProto(t *testing.T) {
 	expectedEndorsersResults = append(expectedEndorsersResults, endorser1SimulationResults)
 
 	// Retrieve simulation results of txid-1 from  store
-	iter, err := testStore.GetTxPvtRWSetByTxid(txid, nil)
-	assert.NoError(err)
-
+	iter := testStore.GetTxPvtRWSetByTxid(txid, nil)
 	var actualEndorsersResults []*EndorserPvtSimulationResults
 	for {
 		result, err := iter.Next()
@@ -273,9 +269,7 @@ func TestTransientStorePurgeByTxids(t *testing.T) {
 	}
 
 	// Retrieve simulation results of txid-2 from  store
-	iter, err := testStore.GetTxPvtRWSetByTxid("txid-2", nil)
-	assert.NoError(err)
-
+	iter := testStore.GetTxPvtRWSetByTxid("txid-2", nil)
 	// Expected results for txid-2
 	var expectedEndorsersResults []*EndorserPvtSimulationResults
 	expectedEndorsersResults = append(expectedEndorsersResults, endorser2SimulationResults)
@@ -312,8 +306,7 @@ func TestTransientStorePurgeByTxids(t *testing.T) {
 
 		// Check whether private write sets of txid-2 are removed
 		var expectedEndorsersResults *EndorserPvtSimulationResults = nil
-		iter, err = testStore.GetTxPvtRWSetByTxid(txid, nil)
-		assert.NoError(err)
+		iter = testStore.GetTxPvtRWSetByTxid(txid, nil)
 		// Should return nil, nil
 		result, err := iter.Next()
 		assert.NoError(err)
@@ -321,9 +314,7 @@ func TestTransientStorePurgeByTxids(t *testing.T) {
 	}
 
 	// Retrieve simulation results of txid-1 from store
-	iter, err = testStore.GetTxPvtRWSetByTxid("txid-1", nil)
-	assert.NoError(err)
-
+	iter = testStore.GetTxPvtRWSetByTxid("txid-1", nil)
 	// Expected results for txid-1
 	expectedEndorsersResults = nil
 	expectedEndorsersResults = append(expectedEndorsersResults, endorser0SimulationResults)
@@ -360,8 +351,7 @@ func TestTransientStorePurgeByTxids(t *testing.T) {
 
 		// Check whether private write sets of txid-1 are removed
 		var expectedEndorsersResults *EndorserPvtSimulationResults = nil
-		iter, err = testStore.GetTxPvtRWSetByTxid(txid, nil)
-		assert.NoError(err)
+		iter = testStore.GetTxPvtRWSetByTxid(txid, nil)
 		// Should return nil, nil
 		result, err := iter.Next()
 		assert.NoError(err)
@@ -433,8 +423,7 @@ func TestTransientStorePurgeBelowHeight(t *testing.T) {
 	assert.NoError(err)
 
 	// Retrieve simulation results of txid-1 from  store
-	iter, err := testStore.GetTxPvtRWSetByTxid(txid, nil)
-	assert.NoError(err)
+	iter := testStore.GetTxPvtRWSetByTxid(txid, nil)
 
 	// Expected results for txid-1
 	var expectedEndorsersResults []*EndorserPvtSimulationResults
@@ -504,9 +493,7 @@ func TestTransientStoreRetrievalWithFilter(t *testing.T) {
 	filter.Add("ns-1", "coll-1")
 	filter.Add("ns-2", "coll-2")
 
-	itr, err := testStore.GetTxPvtRWSetByTxid(testTxid, filter)
-	assert.NoError(t, err)
-
+	itr := testStore.GetTxPvtRWSetByTxid(testTxid, filter)
 	var actualRes []*EndorserPvtSimulationResults
 	for {
 		res, err := itr.Next()
@@ -517,6 +504,7 @@ func TestTransientStoreRetrievalWithFilter(t *testing.T) {
 		actualRes = append(actualRes, res)
 	}
 
+	var err error
 	// prepare the trimmed pvtrwset manually - retain only "ns-1/coll-1" and "ns-2/coll-2"
 	expectedSimulationRes := samplePvtSimResWithConfig
 	expectedSimulationRes.GetPvtRwset().NsPvtRwset[0].CollectionPvtRwset = expectedSimulationRes.GetPvtRwset().NsPvtRwset[0].CollectionPvtRwset[0:1]

--- a/gossip/privdata/coordinator_test.go
+++ b/gossip/privdata/coordinator_test.go
@@ -193,7 +193,7 @@ func (s *testTransientStore) Persist(txid string, blockHeight uint64,
 	return s.store.Persist(txid, blockHeight, privateSimulationResultsWithConfig)
 }
 
-func (s *testTransientStore) GetTxPvtRWSetByTxid(txid string, filter ledger.PvtNsCollFilter) (RWSetScanner, error) {
+func (s *testTransientStore) GetTxPvtRWSetByTxid(txid string, filter ledger.PvtNsCollFilter) RWSetScanner {
 	return s.store.GetTxPvtRWSetByTxid(txid, filter)
 }
 
@@ -607,12 +607,7 @@ func TestCoordinatorStoreInvalidBlock(t *testing.T) {
 
 	assertPurged := func(txns ...string) {
 		for _, txn := range txns {
-			iterator, err := store.GetTxPvtRWSetByTxid(txn, nil)
-			if err != nil {
-				t.Fatalf("Failed iterating, got err %s", err)
-				iterator.Close()
-				return
-			}
+			iterator := store.GetTxPvtRWSetByTxid(txn, nil)
 			res, err := iterator.Next()
 			if err != nil {
 				t.Fatalf("Failed iterating, got err %s", err)
@@ -927,12 +922,7 @@ func TestCoordinatorToFilterOutPvtRWSetsWithWrongHash(t *testing.T) {
 
 	assertPurged := func(txns ...string) {
 		for _, txn := range txns {
-			iterator, err := store.GetTxPvtRWSetByTxid(txn, nil)
-			if err != nil {
-				t.Fatalf("Failed iterating, got err %s", err)
-				iterator.Close()
-				return
-			}
+			iterator := store.GetTxPvtRWSetByTxid(txn, nil)
 			res, err := iterator.Next()
 			if err != nil {
 				t.Fatalf("Failed iterating, got err %s", err)
@@ -1053,12 +1043,7 @@ func TestCoordinatorStoreBlock(t *testing.T) {
 
 	assertPurged := func(txns ...string) {
 		for _, txn := range txns {
-			iterator, err := store.GetTxPvtRWSetByTxid(txn, nil)
-			if err != nil {
-				t.Fatalf("Failed iterating, got err %s", err)
-				iterator.Close()
-				return
-			}
+			iterator := store.GetTxPvtRWSetByTxid(txn, nil)
 			res, err := iterator.Next()
 			if err != nil {
 				t.Fatalf("Failed iterating, got err %s", err)
@@ -1411,12 +1396,7 @@ func TestProceedWithoutPrivateData(t *testing.T) {
 
 	assertPurged := func(txns ...string) {
 		for _, txn := range txns {
-			iterator, err := store.GetTxPvtRWSetByTxid(txn, nil)
-			if err != nil {
-				t.Fatalf("Failed iterating, got err %s", err)
-				iterator.Close()
-				return
-			}
+			iterator := store.GetTxPvtRWSetByTxid(txn, nil)
 			res, err := iterator.Next()
 			if err != nil {
 				t.Fatalf("Failed iterating, got err %s", err)
@@ -1671,12 +1651,7 @@ func TestPurgeBelowHeight(t *testing.T) {
 		}
 		for i := 1; i <= numTx; i++ {
 			txID := fmt.Sprintf("tx%d", i)
-			iterator, err := store.GetTxPvtRWSetByTxid(txID, nil)
-			if err != nil {
-				t.Fatalf("Failed iterating, got err %s", err)
-				iterator.Close()
-				return
-			}
+			iterator := store.GetTxPvtRWSetByTxid(txID, nil)
 			res, err := iterator.Next()
 			if err != nil {
 				t.Fatalf("Failed iterating, got err %s", err)

--- a/gossip/privdata/dataretriever.go
+++ b/gossip/privdata/dataretriever.go
@@ -158,11 +158,7 @@ func (dr *dataRetriever) fromLedger(digests []*protosgossip.PvtDataDigest, block
 
 func (dr *dataRetriever) fromTransientStore(dig *protosgossip.PvtDataDigest, filter map[string]ledger.PvtCollFilter) (*util.PrivateRWSetWithConfig, error) {
 	results := &util.PrivateRWSetWithConfig{}
-	it, err := dr.store.GetTxPvtRWSetByTxid(dig.TxId, filter)
-	if err != nil {
-		return nil, errors.Errorf("was not able to retrieve private data from transient store, namespace <%s>"+
-			", collection name %s, txID <%s>, due to <%s>", dig.Namespace, dig.Collection, dig.TxId, err)
-	}
+	it := dr.store.GetTxPvtRWSetByTxid(dig.TxId, filter)
 	defer it.Close()
 
 	maxEndorsedAt := uint64(0)

--- a/gossip/privdata/pvtdataprovider.go
+++ b/gossip/privdata/pvtdataprovider.go
@@ -293,11 +293,7 @@ func (pdp *PvtdataProvider) populateFromTransientStore(pvtdata rwsetByKeys, pvtd
 	for k := range pvtdataRetrievalInfo.eligibleMissingKeys {
 		filter := ledger.NewPvtNsCollFilter()
 		filter.Add(k.namespace, k.collection)
-		iterator, err := pdp.transientStore.GetTxPvtRWSetByTxid(k.txID, filter)
-		if err != nil {
-			pdp.logger.Warningf("Failed fetching private data from transient store: Failed obtaining iterator from transient store: %s", err)
-			return
-		}
+		iterator := pdp.transientStore.GetTxPvtRWSetByTxid(k.txID, filter)
 		defer iterator.Close()
 		for {
 			res, err := iterator.Next()

--- a/gossip/privdata/pvtdataprovider_test.go
+++ b/gossip/privdata/pvtdataprovider_test.go
@@ -1150,8 +1150,7 @@ func TestRetrievedPvtdataPurgeBelowHeight(t *testing.T) {
 	for i := 1; i < 9; i++ {
 		func() {
 			txID := fmt.Sprintf("tx%d", i)
-			iterator, err := store.GetTxPvtRWSetByTxid(txID, nil)
-			require.NoError(t, err, fmt.Sprintf("Failed obtaining iterator from transient store, got err %s", err))
+			iterator := store.GetTxPvtRWSetByTxid(txID, nil)
 			defer iterator.Close()
 			res, err := iterator.Next()
 			require.NoError(t, err, fmt.Sprintf("Failed iterating, got err %s", err))
@@ -1198,8 +1197,7 @@ func TestRetrievedPvtdataPurgeBelowHeight(t *testing.T) {
 	for i := 1; i <= 9; i++ {
 		func() {
 			txID := fmt.Sprintf("tx%d", i)
-			iterator, err := store.GetTxPvtRWSetByTxid(txID, nil)
-			require.NoError(t, err, fmt.Sprintf("Failed obtaining iterator from transient store, got err %s", err))
+			iterator := store.GetTxPvtRWSetByTxid(txID, nil)
 			defer iterator.Close()
 			res, err := iterator.Next()
 			require.NoError(t, err, fmt.Sprintf("Failed iterating, got err %s", err))
@@ -1222,8 +1220,7 @@ func TestRetrievedPvtdataPurgeBelowHeight(t *testing.T) {
 	for i := 1; i <= 9; i++ {
 		func() {
 			txID := fmt.Sprintf("tx%d", i)
-			iterator, err := store.GetTxPvtRWSetByTxid(txID, nil)
-			require.NoError(t, err, fmt.Sprintf("Failed obtaining iterator from transient store, got err %s", err))
+			iterator := store.GetTxPvtRWSetByTxid(txID, nil)
 			defer iterator.Close()
 			res, err := iterator.Next()
 			require.NoError(t, err, fmt.Sprintf("Failed iterating, got err %s", err))
@@ -1363,8 +1360,7 @@ func testPurged(t *testing.T,
 			txID := getTxIDBySeqInBlock(pvtdata.SeqInBlock, txPvtdataInfo)
 			require.NotEqual(t, txID, "", fmt.Sprintf("Could not find txID for SeqInBlock %d", pvtdata.SeqInBlock), scenario)
 
-			iterator, err := store.GetTxPvtRWSetByTxid(txID, nil)
-			require.NoError(t, err, fmt.Sprintf("Failed obtaining iterator from transient store, got err %s", err))
+			iterator := store.GetTxPvtRWSetByTxid(txID, nil)
 			defer iterator.Close()
 
 			res, err := iterator.Next()

--- a/gossip/service/gossip_service_test.go
+++ b/gossip/service/gossip_service_test.go
@@ -100,7 +100,7 @@ func (s *testTransientStore) Persist(txid string, blockHeight uint64,
 	return s.Store.Persist(txid, blockHeight, privateSimulationResultsWithConfig)
 }
 
-func (s *testTransientStore) GetTxPvtRWSetByTxid(txid string, filter ledger.PvtNsCollFilter) (privdata.RWSetScanner, error) {
+func (s *testTransientStore) GetTxPvtRWSetByTxid(txid string, filter ledger.PvtNsCollFilter) privdata.RWSetScanner {
 	return s.Store.GetTxPvtRWSetByTxid(txid, filter)
 }
 


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code)

#### Description

We always return a nil error from `transientstore.GetTxPvtRWSetByTxid()`. Hence, this PR remove that no-op error to simplify a few test. 