### PR TITLE
[FAB-17993] Add Support For CouchDB 3.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ BASE_VERSION = 2.2.0
 
 # 3rd party image version
 # These versions are also set in the runners in ./integration/runners/
-COUCHDB_VER ?= 2.3
+COUCHDB_VER ?= 3.1
 KAFKA_VER ?= 5.3.1
 ZOOKEEPER_VER ?= 5.3.1
 

--- a/core/ledger/kvledger/tests/v1x_test.go
+++ b/core/ledger/kvledger/tests/v1x_test.go
@@ -381,8 +381,8 @@ func startCouchDBWithV13Data(t *testing.T, ledgerFSRoot string) (*ledger.CouchDB
 	// set required config data to use state couchdb
 	couchdbConfig := &ledger.CouchDBConfig{
 		Address:             couchAddress,
-		Username:            "",
-		Password:            "",
+		Username:            "admin",
+		Password:            "adminpw",
 		MaxRetries:          3,
 		MaxRetriesOnStartup: 3,
 		RequestTimeout:      10 * time.Second,

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/test_exports.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/test_exports.go
@@ -156,8 +156,8 @@ func (env *CouchDBTestEnv) Init(t testing.TB) {
 			StateDatabase: "CouchDB",
 			CouchDB: &ledger.CouchDBConfig{
 				Address:             env.couchAddress,
-				Username:            "",
-				Password:            "",
+				Username:            "admin",
+				Password:            "adminpw",
 				MaxRetries:          3,
 				MaxRetriesOnStartup: 20,
 				RequestTimeout:      35 * time.Second,

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb_test.go
@@ -40,8 +40,8 @@ var assetJSON = []byte(`{"asset_name":"marble1","color":"blue","size":"35","owne
 func testConfig() *ledger.CouchDBConfig {
 	return &ledger.CouchDBConfig{
 		Address:               "",
-		Username:              "",
-		Password:              "",
+		Username:              "admin",
+		Password:              "adminpw",
 		MaxRetries:            3,
 		MaxRetriesOnStartup:   20,
 		RequestTimeout:        35 * time.Second,
@@ -52,8 +52,8 @@ func testConfig() *ledger.CouchDBConfig {
 func TestDBBadConnectionDef(t *testing.T) {
 	config := &ledger.CouchDBConfig{
 		Address:             badParseConnectURL,
-		Username:            "",
-		Password:            "",
+		Username:            "admin",
+		Password:            "adminpw",
 		MaxRetries:          3,
 		MaxRetriesOnStartup: 3,
 		RequestTimeout:      35 * time.Second,
@@ -114,8 +114,8 @@ func TestBadCouchDBInstance(t *testing.T) {
 	badCouchDBInstance := couchInstance{
 		conf: &ledger.CouchDBConfig{
 			Address:             badParseConnectURL,
-			Username:            "",
-			Password:            "",
+			Username:            "admin",
+			Password:            "adminpw",
 			MaxRetries:          3,
 			MaxRetriesOnStartup: 10,
 			RequestTimeout:      30 * time.Second,
@@ -319,8 +319,8 @@ func TestDBBadConnection(t *testing.T) {
 	//Limit the maxRetriesOnStartup to 3 in order to reduce time for the failure
 	config := &ledger.CouchDBConfig{
 		Address:             badConnectURL,
-		Username:            "",
-		Password:            "",
+		Username:            "admin",
+		Password:            "adminpw",
 		MaxRetries:          3,
 		MaxRetriesOnStartup: 3,
 		RequestTimeout:      35 * time.Second,
@@ -854,7 +854,6 @@ func TestCouchDBVersion(t *testing.T) {
 
 	err = checkCouchDBVersion("0.0.0.0")
 	require.Error(t, err, "Error should have been thrown for invalid version")
-
 }
 
 func TestIndexOperations(t *testing.T) {

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
@@ -52,8 +52,8 @@ func (env *testVDBEnv) init(t *testing.T, sysNamespaces []string) {
 	}
 	config := &ledger.CouchDBConfig{
 		Address:             env.couchDBEnv.couchAddress,
-		Username:            "",
-		Password:            "",
+		Username:            "admin",
+		Password:            "adminpw",
 		InternalQueryLimit:  1000,
 		MaxBatchUpdateSize:  1000,
 		MaxRetries:          3,
@@ -1122,6 +1122,8 @@ func testFormatCheck(t *testing.T, dataFormat string, dataExists bool, expectedE
 	defer os.RemoveAll(redoPath)
 	config := &ledger.CouchDBConfig{
 		Address:             vdbEnv.couchDBEnv.couchAddress,
+		Username:            "admin",
+		Password:            "adminpw",
 		MaxRetries:          3,
 		MaxRetriesOnStartup: 20,
 		RequestTimeout:      35 * time.Second,

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -1212,6 +1212,8 @@ func (n *Network) PeerRunner(p *Peer, env ...string) *ginkgomon.Runner {
 		commands.NodeStart{PeerID: p.ID()},
 		"",
 		fmt.Sprintf("FABRIC_CFG_PATH=%s", n.PeerDir(p)),
+		fmt.Sprintf("CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=admin"),
+		fmt.Sprintf("CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=adminpw"),
 	)
 	cmd.Env = append(cmd.Env, env...)
 


### PR DESCRIPTION
Couch 3.x requires the user provide an admin user at startup. It also prevents the DB user from modifying the `_users` security objects. This affects the peer startup behavior where it checks if the `_users` table exists and creates the table. Since the user no longer has permission to access the `_users` security object a check was added to confirm the DB version before attempting to modify the `_users` table.

Tests were updated to included an admin user and password for couchDB in the DB configs as well as on the CouchDB runner

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
