### PR TITLE
Set http header entries before writing header

### DIFF
--- a/common/flogging/httpadmin/spec.go
+++ b/common/flogging/httpadmin/spec.go
@@ -73,9 +73,9 @@ func (h *SpecHandler) sendResponse(resp http.ResponseWriter, code int, payload i
 		payload = &ErrorResponse{Error: err.Error()}
 	}
 
+	resp.Header().Set("Content-Type", "application/json")
 	resp.WriteHeader(code)
 
-	resp.Header().Set("Content-Type", "application/json")
 	if err := encoder.Encode(payload); err != nil {
 		h.Logger.Errorw("failed to encode payload", "error", err)
 	}

--- a/common/flogging/httpadmin/spec_test.go
+++ b/common/flogging/httpadmin/spec_test.go
@@ -39,9 +39,9 @@ var _ = Describe("SpecHandler", func() {
 		handler.ServeHTTP(resp, req)
 
 		Expect(fakeLogging.SpecCallCount()).To(Equal(1))
-		Expect(resp.Code).To(Equal(http.StatusOK))
+		Expect(resp.Result().StatusCode).To(Equal(http.StatusOK))
 		Expect(resp.Body).To(MatchJSON(`{"spec": "the-returned-specification"}`))
-		Expect(resp.Header().Get("Content-Type")).To(Equal("application/json"))
+		Expect(resp.Result().Header.Get("Content-Type")).To(Equal("application/json"))
 	})
 
 	It("sets the current logging spec", func() {
@@ -49,7 +49,7 @@ var _ = Describe("SpecHandler", func() {
 		resp := httptest.NewRecorder()
 		handler.ServeHTTP(resp, req)
 
-		Expect(resp.Code).To(Equal(http.StatusNoContent))
+		Expect(resp.Result().StatusCode).To(Equal(http.StatusNoContent))
 		Expect(fakeLogging.ActivateSpecCallCount()).To(Equal(1))
 		Expect(fakeLogging.ActivateSpecArgsForCall(0)).To(Equal("updated-spec"))
 	})
@@ -61,7 +61,7 @@ var _ = Describe("SpecHandler", func() {
 			handler.ServeHTTP(resp, req)
 
 			Expect(fakeLogging.ActivateSpecCallCount()).To(Equal(0))
-			Expect(resp.Code).To(Equal(http.StatusBadRequest))
+			Expect(resp.Result().StatusCode).To(Equal(http.StatusBadRequest))
 			Expect(resp.Body).To(MatchJSON(`{"error": "invalid character 'g' looking for beginning of value"}`))
 		})
 	})
@@ -76,7 +76,7 @@ var _ = Describe("SpecHandler", func() {
 			resp := httptest.NewRecorder()
 			handler.ServeHTTP(resp, req)
 
-			Expect(resp.Code).To(Equal(http.StatusBadRequest))
+			Expect(resp.Result().StatusCode).To(Equal(http.StatusBadRequest))
 			Expect(resp.Body).To(MatchJSON(`{"error": "ewww; that's not right!"}`))
 		})
 	})
@@ -87,7 +87,7 @@ var _ = Describe("SpecHandler", func() {
 			resp := httptest.NewRecorder()
 			handler.ServeHTTP(resp, req)
 
-			Expect(resp.Code).To(Equal(http.StatusBadRequest))
+			Expect(resp.Result().StatusCode).To(Equal(http.StatusBadRequest))
 			Expect(resp.Body).To(MatchJSON(`{"error": "invalid request method: POST"}`))
 		})
 

--- a/core/middleware/request_id_test.go
+++ b/core/middleware/request_id_test.go
@@ -46,7 +46,7 @@ var _ = Describe("WithRequestID", func() {
 
 	It("returns the generated request ID in a header", func() {
 		chain.ServeHTTP(resp, req)
-		Expect(resp.Header().Get("X-Request-Id")).To(Equal("generated-id"))
+		Expect(resp.Result().Header.Get("X-Request-Id")).To(Equal("generated-id"))
 	})
 
 	Context("when a request ID is already present", func() {
@@ -69,7 +69,7 @@ var _ = Describe("WithRequestID", func() {
 
 		It("propagates the request ID to the response", func() {
 			chain.ServeHTTP(resp, req)
-			Expect(resp.Header().Get("X-Request-Id")).To(Equal("received-id"))
+			Expect(resp.Result().Header.Get("X-Request-Id")).To(Equal("received-id"))
 		})
 	})
 })

--- a/core/middleware/require_cert_test.go
+++ b/core/middleware/require_cert_test.go
@@ -41,7 +41,7 @@ var _ = Describe("RequireCert", func() {
 
 	It("delegates to the next handler when the first verified chain is not empty", func() {
 		chain.ServeHTTP(resp, req)
-		Expect(resp.Code).To(Equal(http.StatusOK))
+		Expect(resp.Result().StatusCode).To(Equal(http.StatusOK))
 		Expect(handler.ServeHTTPCallCount()).To(Equal(1))
 	})
 
@@ -52,7 +52,7 @@ var _ = Describe("RequireCert", func() {
 
 		It("responds with http.StatusUnauthorized", func() {
 			chain.ServeHTTP(resp, req)
-			Expect(resp.Code).To(Equal(http.StatusUnauthorized))
+			Expect(resp.Result().StatusCode).To(Equal(http.StatusUnauthorized))
 		})
 
 		It("does not call the next handler", func() {
@@ -68,7 +68,7 @@ var _ = Describe("RequireCert", func() {
 
 		It("responds with http.StatusUnauthorized", func() {
 			chain.ServeHTTP(resp, req)
-			Expect(resp.Code).To(Equal(http.StatusUnauthorized))
+			Expect(resp.Result().StatusCode).To(Equal(http.StatusUnauthorized))
 		})
 
 		It("does not call the next handler", func() {
@@ -84,7 +84,7 @@ var _ = Describe("RequireCert", func() {
 
 		It("responds with http.StatusUnauthorized", func() {
 			chain.ServeHTTP(resp, req)
-			Expect(resp.Code).To(Equal(http.StatusUnauthorized))
+			Expect(resp.Result().StatusCode).To(Equal(http.StatusUnauthorized))
 		})
 
 		It("does not call the next handler", func() {
@@ -100,7 +100,7 @@ var _ = Describe("RequireCert", func() {
 
 		It("responds with http.StatusUnauthorized", func() {
 			chain.ServeHTTP(resp, req)
-			Expect(resp.Code).To(Equal(http.StatusUnauthorized))
+			Expect(resp.Result().StatusCode).To(Equal(http.StatusUnauthorized))
 		})
 
 		It("does not call the next handler", func() {

--- a/core/operations/version.go
+++ b/core/operations/version.go
@@ -42,9 +42,9 @@ func (m *VersionInfoHandler) sendResponse(resp http.ResponseWriter, code int, pa
 		logger := flogging.MustGetLogger("operations.runner")
 		logger.Errorw("failed to encode payload", "error", err)
 		resp.WriteHeader(http.StatusInternalServerError)
-	} else {
-		resp.WriteHeader(code)
-		resp.Header().Set("Content-Type", "application/json")
-		resp.Write(js)
+		return
 	}
+	resp.Header().Set("Content-Type", "application/json")
+	resp.WriteHeader(code)
+	resp.Write(js)
 }

--- a/core/operations/version_test.go
+++ b/core/operations/version_test.go
@@ -21,6 +21,7 @@ var _ = Describe("Version", func() {
 		versionInfoHandler := &VersionInfoHandler{Version: "latest"}
 		versionInfoHandler.ServeHTTP(resp, &http.Request{Method: http.MethodGet})
 		Expect(resp.Result().StatusCode).To(Equal(http.StatusOK))
+		Expect(resp.Result().Header.Get("Content-Type")).To(Equal("application/json"))
 		Expect(resp.Body).To(MatchJSON(`{"Version": "latest"}`))
 	})
 

--- a/orderer/common/channelparticipation/restapi.go
+++ b/orderer/common/channelparticipation/restapi.go
@@ -355,8 +355,8 @@ func negotiateContentType(req *http.Request) (string, error) {
 
 func (h *HTTPHandler) sendResponseJsonError(resp http.ResponseWriter, code int, err error) {
 	encoder := json.NewEncoder(resp)
-	resp.WriteHeader(code)
 	resp.Header().Set("Content-Type", "application/json")
+	resp.WriteHeader(code)
 	if err := encoder.Encode(&types.ErrorResponse{Error: err.Error()}); err != nil {
 		h.logger.Errorf("failed to encode error, err: %s", err)
 	}
@@ -364,8 +364,8 @@ func (h *HTTPHandler) sendResponseJsonError(resp http.ResponseWriter, code int, 
 
 func (h *HTTPHandler) sendResponseOK(resp http.ResponseWriter, content interface{}) {
 	encoder := json.NewEncoder(resp)
-	resp.WriteHeader(http.StatusOK)
 	resp.Header().Set("Content-Type", "application/json")
+	resp.WriteHeader(http.StatusOK)
 	if err := encoder.Encode(content); err != nil {
 		h.logger.Errorf("failed to encode content, err: %s", err)
 	}
@@ -373,9 +373,9 @@ func (h *HTTPHandler) sendResponseOK(resp http.ResponseWriter, content interface
 
 func (h *HTTPHandler) sendResponseCreated(resp http.ResponseWriter, location string, content interface{}) {
 	encoder := json.NewEncoder(resp)
-	resp.WriteHeader(http.StatusCreated)
 	resp.Header().Set("Location", location)
 	resp.Header().Set("Content-Type", "application/json")
+	resp.WriteHeader(http.StatusCreated)
 	if err := encoder.Encode(content); err != nil {
 		h.logger.Errorf("failed to encode content, err: %s", err)
 	}
@@ -383,10 +383,10 @@ func (h *HTTPHandler) sendResponseCreated(resp http.ResponseWriter, location str
 
 func (h *HTTPHandler) sendResponseNotAllowed(resp http.ResponseWriter, err error, allow ...string) {
 	encoder := json.NewEncoder(resp)
-	resp.WriteHeader(http.StatusMethodNotAllowed)
 	allowVal := strings.Join(allow, ", ")
 	resp.Header().Set("Allow", allowVal)
 	resp.Header().Set("Content-Type", "application/json")
+	resp.WriteHeader(http.StatusMethodNotAllowed)
 	if err := encoder.Encode(&types.ErrorResponse{Error: err.Error()}); err != nil {
 		h.logger.Errorf("failed to encode error, err: %s", err)
 	}

--- a/orderer/common/channelparticipation/restapi_test.go
+++ b/orderer/common/channelparticipation/restapi_test.go
@@ -56,7 +56,7 @@ func TestHTTPHandler_ServeHTTP_InvalidMethods(t *testing.T) {
 			req := httptest.NewRequest(method, path.Join(channelparticipation.URLBaseV1Channels, "ch-id"), nil)
 			h.ServeHTTP(resp, req)
 			checkErrorResponse(t, http.StatusMethodNotAllowed, fmt.Sprintf("invalid request method: %s", method), resp)
-			assert.Equal(t, "GET, POST, DELETE", resp.Header().Get("Allow"), "%s", method)
+			assert.Equal(t, "GET, POST, DELETE", resp.Result().Header.Get("Allow"), "%s", method)
 		}
 	})
 
@@ -67,7 +67,7 @@ func TestHTTPHandler_ServeHTTP_InvalidMethods(t *testing.T) {
 			req := httptest.NewRequest(method, channelparticipation.URLBaseV1Channels, nil)
 			h.ServeHTTP(resp, req)
 			checkErrorResponse(t, http.StatusMethodNotAllowed, fmt.Sprintf("invalid request method: %s", method), resp)
-			assert.Equal(t, "GET", resp.Header().Get("Allow"), "%s", method)
+			assert.Equal(t, "GET", resp.Result().Header.Get("Allow"), "%s", method)
 		}
 	})
 }
@@ -80,28 +80,28 @@ func TestHTTPHandler_ServeHTTP_ListErrors(t *testing.T) {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/oops", nil)
 		h.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusNotFound, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Result().StatusCode)
 	})
 
 	t.Run("missing channels collection", func(t *testing.T) {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, channelparticipation.URLBaseV1, nil)
 		h.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusNotFound, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Result().StatusCode)
 	})
 
 	t.Run("bad resource", func(t *testing.T) {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, channelparticipation.URLBaseV1+"oops", nil)
 		h.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusNotFound, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Result().StatusCode)
 	})
 
 	t.Run("bad channel ID", func(t *testing.T) {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, channelparticipation.URLBaseV1Channels+"/no/slash", nil)
 		h.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusNotFound, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Result().StatusCode)
 	})
 
 	t.Run("illegal character in channel ID", func(t *testing.T) {
@@ -136,8 +136,8 @@ func TestHTTPHandler_ServeHTTP_ListAll(t *testing.T) {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, channelparticipation.URLBaseV1Channels, nil)
 		h.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, http.StatusOK, resp.Result().StatusCode)
+		assert.Equal(t, "application/json", resp.Result().Header.Get("Content-Type"))
 
 		listAll := &types.ChannelList{}
 		err := json.Unmarshal(resp.Body.Bytes(), listAll)
@@ -161,8 +161,8 @@ func TestHTTPHandler_ServeHTTP_ListAll(t *testing.T) {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, channelparticipation.URLBaseV1Channels, nil)
 		h.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, http.StatusOK, resp.Result().StatusCode)
+		assert.Equal(t, "application/json", resp.Result().Header.Get("Content-Type"))
 
 		listAll := &types.ChannelList{}
 		err := json.Unmarshal(resp.Body.Bytes(), listAll)
@@ -181,8 +181,8 @@ func TestHTTPHandler_ServeHTTP_ListAll(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, channelparticipation.URLBaseV1Channels, nil)
 			req.Header.Set("Accept", accept)
 			h.ServeHTTP(resp, req)
-			assert.Equal(t, http.StatusOK, resp.Code, "Accept: %s", accept)
-			assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+			assert.Equal(t, http.StatusOK, resp.Result().StatusCode, "Accept: %s", accept)
+			assert.Equal(t, "application/json", resp.Result().Header.Get("Content-Type"))
 
 			listAll := &types.ChannelList{}
 			err := json.Unmarshal(resp.Body.Bytes(), listAll)
@@ -212,8 +212,8 @@ func TestHTTPHandler_ServeHTTP_ListSingle(t *testing.T) {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, channelparticipation.URLBaseV1Channels+"/app-channel", nil)
 		h.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, http.StatusOK, resp.Result().StatusCode)
+		assert.Equal(t, "application/json", resp.Result().Header.Get("Content-Type"))
 
 		infoResp := types.ChannelInfo{}
 		err := json.Unmarshal(resp.Body.Bytes(), &infoResp)
@@ -247,8 +247,8 @@ func TestHTTPHandler_ServeHTTP_Join(t *testing.T) {
 		resp := httptest.NewRecorder()
 		req := genJoinRequestFormData(t, []byte{})
 		h.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusCreated, resp.Code)
-		assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+		assert.Equal(t, http.StatusCreated, resp.Result().StatusCode)
+		assert.Equal(t, "application/json", resp.Result().Header.Get("Content-Type"))
 
 		infoResp := types.ChannelInfo{}
 		err := json.Unmarshal(resp.Body.Bytes(), &infoResp)
@@ -263,7 +263,7 @@ func TestHTTPHandler_ServeHTTP_Join(t *testing.T) {
 		req := genJoinRequestFormData(t, []byte{})
 		h.ServeHTTP(resp, req)
 		checkErrorResponse(t, http.StatusMethodNotAllowed, "cannot join: system channel exists", resp)
-		assert.Equal(t, "GET", resp.Header().Get("Allow"))
+		assert.Equal(t, "GET", resp.Result().Header.Get("Allow"))
 	})
 
 	t.Run("Error: Channel Exists", func(t *testing.T) {
@@ -273,7 +273,7 @@ func TestHTTPHandler_ServeHTTP_Join(t *testing.T) {
 		req := genJoinRequestFormData(t, []byte{})
 		h.ServeHTTP(resp, req)
 		checkErrorResponse(t, http.StatusMethodNotAllowed, "cannot join: channel already exists", resp)
-		assert.Equal(t, "GET, DELETE", resp.Header().Get("Allow"))
+		assert.Equal(t, "GET, DELETE", resp.Result().Header.Get("Allow"))
 	})
 
 	t.Run("Error: App Channels Exist", func(t *testing.T) {
@@ -477,7 +477,7 @@ func TestHTTPHandler_ServeHTTP_Remove(t *testing.T) {
 			h.ServeHTTP(resp, req)
 
 			if testCase.expectedErr == nil {
-				assert.Equal(t, testCase.expectedCode, resp.Code)
+				assert.Equal(t, testCase.expectedCode, resp.Result().StatusCode)
 				assert.Equal(t, 0, resp.Body.Len(), "empty body")
 			} else {
 				checkErrorResponse(t, testCase.expectedCode, testCase.expectedErr.Error(), resp)
@@ -492,7 +492,7 @@ func TestHTTPHandler_ServeHTTP_Remove(t *testing.T) {
 		req := httptest.NewRequest(http.MethodDelete, path.Join(channelparticipation.URLBaseV1Channels, "my-channel"), nil)
 		h.ServeHTTP(resp, req)
 		checkErrorResponse(t, http.StatusMethodNotAllowed, "cannot remove: system channel exists", resp)
-		assert.Equal(t, "GET", resp.Header().Get("Allow"))
+		assert.Equal(t, "GET", resp.Result().Header.Get("Allow"))
 	})
 }
 
@@ -504,10 +504,9 @@ func setup(config localconfig.ChannelParticipation, t *testing.T) (*mocks.Channe
 }
 
 func checkErrorResponse(t *testing.T, expectedCode int, expectedErrMsg string, resp *httptest.ResponseRecorder) {
-	assert.Equal(t, expectedCode, resp.Code)
+	assert.Equal(t, expectedCode, resp.Result().StatusCode)
 
-	header := resp.Header()
-	headerArray, headerOK := header["Content-Type"]
+	headerArray, headerOK := resp.Result().Header["Content-Type"]
 	assert.True(t, headerOK)
 	require.Len(t, headerArray, 1)
 	assert.Equal(t, "application/json", headerArray[0])


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Header entries must be set before calling WriteHeader(). Otherwise, they aren't returned to the client. Also, update unit tests to use the httptest.ResponseRecorder.Result() to get the actual result of the http operation. By directly using the ResponseRecorder before, our unit tests passed even though an end user was not receiving a response with the correct entries in the http header (I noticed this in our integration tests).

#### Related issues

[FAB-18007](https://jira.hyperledger.org/browse/FAB-18007)