### PR TITLE
Set http header entries before writing header (release-1.4)

### DIFF
--- a/common/flogging/httpadmin/spec.go
+++ b/common/flogging/httpadmin/spec.go
@@ -73,9 +73,9 @@ func (h *SpecHandler) sendResponse(resp http.ResponseWriter, code int, payload i
 		payload = &ErrorResponse{Error: err.Error()}
 	}
 
+	resp.Header().Set("Content-Type", "application/json")
 	resp.WriteHeader(code)
 
-	resp.Header().Set("Content-Type", "application/json")
 	if err := encoder.Encode(payload); err != nil {
 		h.Logger.Errorw("failed to encode payload", "error", err)
 	}

--- a/common/flogging/httpadmin/spec_test.go
+++ b/common/flogging/httpadmin/spec_test.go
@@ -39,9 +39,9 @@ var _ = Describe("SpecHandler", func() {
 		handler.ServeHTTP(resp, req)
 
 		Expect(fakeLogging.SpecCallCount()).To(Equal(1))
-		Expect(resp.Code).To(Equal(http.StatusOK))
+		Expect(resp.Result().StatusCode).To(Equal(http.StatusOK))
 		Expect(resp.Body).To(MatchJSON(`{"spec": "the-returned-specification"}`))
-		Expect(resp.Header().Get("Content-Type")).To(Equal("application/json"))
+		Expect(resp.Result().Header.Get("Content-Type")).To(Equal("application/json"))
 	})
 
 	It("sets the current logging spec", func() {
@@ -49,7 +49,7 @@ var _ = Describe("SpecHandler", func() {
 		resp := httptest.NewRecorder()
 		handler.ServeHTTP(resp, req)
 
-		Expect(resp.Code).To(Equal(http.StatusNoContent))
+		Expect(resp.Result().StatusCode).To(Equal(http.StatusNoContent))
 		Expect(fakeLogging.ActivateSpecCallCount()).To(Equal(1))
 		Expect(fakeLogging.ActivateSpecArgsForCall(0)).To(Equal("updated-spec"))
 	})
@@ -61,7 +61,7 @@ var _ = Describe("SpecHandler", func() {
 			handler.ServeHTTP(resp, req)
 
 			Expect(fakeLogging.ActivateSpecCallCount()).To(Equal(0))
-			Expect(resp.Code).To(Equal(http.StatusBadRequest))
+			Expect(resp.Result().StatusCode).To(Equal(http.StatusBadRequest))
 			Expect(resp.Body).To(MatchJSON(`{"error": "invalid character 'g' looking for beginning of value"}`))
 		})
 	})
@@ -76,7 +76,7 @@ var _ = Describe("SpecHandler", func() {
 			resp := httptest.NewRecorder()
 			handler.ServeHTTP(resp, req)
 
-			Expect(resp.Code).To(Equal(http.StatusBadRequest))
+			Expect(resp.Result().StatusCode).To(Equal(http.StatusBadRequest))
 			Expect(resp.Body).To(MatchJSON(`{"error": "ewww; that's not right!"}`))
 		})
 	})
@@ -87,7 +87,7 @@ var _ = Describe("SpecHandler", func() {
 			resp := httptest.NewRecorder()
 			handler.ServeHTTP(resp, req)
 
-			Expect(resp.Code).To(Equal(http.StatusBadRequest))
+			Expect(resp.Result().StatusCode).To(Equal(http.StatusBadRequest))
 			Expect(resp.Body).To(MatchJSON(`{"error": "invalid request method: POST"}`))
 		})
 

--- a/core/middleware/request_id_test.go
+++ b/core/middleware/request_id_test.go
@@ -46,7 +46,7 @@ var _ = Describe("WithRequestID", func() {
 
 	It("returns the generated request ID in a header", func() {
 		chain.ServeHTTP(resp, req)
-		Expect(resp.Header().Get("X-Request-Id")).To(Equal("generated-id"))
+		Expect(resp.Result().Header.Get("X-Request-Id")).To(Equal("generated-id"))
 	})
 
 	Context("when a request ID is already present", func() {
@@ -69,7 +69,7 @@ var _ = Describe("WithRequestID", func() {
 
 		It("propagates the request ID to the response", func() {
 			chain.ServeHTTP(resp, req)
-			Expect(resp.Header().Get("X-Request-Id")).To(Equal("received-id"))
+			Expect(resp.Result().Header.Get("X-Request-Id")).To(Equal("received-id"))
 		})
 	})
 })

--- a/core/middleware/require_cert_test.go
+++ b/core/middleware/require_cert_test.go
@@ -41,7 +41,7 @@ var _ = Describe("RequireCert", func() {
 
 	It("delegates to the next handler when the first verified chain is not empty", func() {
 		chain.ServeHTTP(resp, req)
-		Expect(resp.Code).To(Equal(http.StatusOK))
+		Expect(resp.Result().StatusCode).To(Equal(http.StatusOK))
 		Expect(handler.ServeHTTPCallCount()).To(Equal(1))
 	})
 
@@ -52,7 +52,7 @@ var _ = Describe("RequireCert", func() {
 
 		It("responds with http.StatusUnauthorized", func() {
 			chain.ServeHTTP(resp, req)
-			Expect(resp.Code).To(Equal(http.StatusUnauthorized))
+			Expect(resp.Result().StatusCode).To(Equal(http.StatusUnauthorized))
 		})
 
 		It("does not call the next handler", func() {
@@ -68,7 +68,7 @@ var _ = Describe("RequireCert", func() {
 
 		It("responds with http.StatusUnauthorized", func() {
 			chain.ServeHTTP(resp, req)
-			Expect(resp.Code).To(Equal(http.StatusUnauthorized))
+			Expect(resp.Result().StatusCode).To(Equal(http.StatusUnauthorized))
 		})
 
 		It("does not call the next handler", func() {
@@ -84,7 +84,7 @@ var _ = Describe("RequireCert", func() {
 
 		It("responds with http.StatusUnauthorized", func() {
 			chain.ServeHTTP(resp, req)
-			Expect(resp.Code).To(Equal(http.StatusUnauthorized))
+			Expect(resp.Result().StatusCode).To(Equal(http.StatusUnauthorized))
 		})
 
 		It("does not call the next handler", func() {
@@ -100,7 +100,7 @@ var _ = Describe("RequireCert", func() {
 
 		It("responds with http.StatusUnauthorized", func() {
 			chain.ServeHTTP(resp, req)
-			Expect(resp.Code).To(Equal(http.StatusUnauthorized))
+			Expect(resp.Result().StatusCode).To(Equal(http.StatusUnauthorized))
 		})
 
 		It("does not call the next handler", func() {

--- a/core/operations/version.go
+++ b/core/operations/version.go
@@ -42,9 +42,9 @@ func (m *VersionInfoHandler) sendResponse(resp http.ResponseWriter, code int, pa
 		logger := flogging.MustGetLogger("operations.runner")
 		logger.Errorw("failed to encode payload", "error", err)
 		resp.WriteHeader(http.StatusInternalServerError)
-	} else {
-		resp.WriteHeader(code)
-		resp.Header().Set("Content-Type", "application/json")
-		resp.Write(js)
+		return
 	}
+	resp.Header().Set("Content-Type", "application/json")
+	resp.WriteHeader(code)
+	resp.Write(js)
 }

--- a/core/operations/version_test.go
+++ b/core/operations/version_test.go
@@ -21,6 +21,7 @@ var _ = Describe("Version", func() {
 		versionInfoHandler := &VersionInfoHandler{Version: "latest"}
 		versionInfoHandler.ServeHTTP(resp, &http.Request{Method: http.MethodGet})
 		Expect(resp.Result().StatusCode).To(Equal(http.StatusOK))
+		Expect(resp.Result().Header.Get("Content-Type")).To(Equal("application/json"))
 		Expect(resp.Body).To(MatchJSON(`{"Version": "latest"}`))
 	})
 


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Header entries must be set before calling WriteHeader(). Otherwise, they aren't returned to the client. Also, update unit tests to use the httptest.ResponseRecorder.Result() to get the actual result of the http operation. By directly using the ResponseRecorder before, our unit tests passed even though an end user was not receiving a response with the correct entries in the http header (I noticed this in our integration tests).

#### Related issues

[FAB-18007](https://jira.hyperledger.org/browse/FAB-18007)