### PR TITLE
FAB-18013 Ch.Part.API: orderer main.go code hygiene

### DIFF
--- a/orderer/common/onboarding/onboarding.go
+++ b/orderer/common/onboarding/onboarding.go
@@ -228,6 +228,9 @@ func NewInactiveChainReplicator(
 	registerChainFunc func(chain string),
 	replicationRefreshInterval time.Duration,
 ) *InactiveChainReplicator {
+	if replicationRefreshInterval == 0 {
+		replicationRefreshInterval = DefaultReplicationBackgroundRefreshInterval
+	}
 	exponentialSleep := exponentialDurationSeries(replicationBackgroundInitialRefreshInterval, replicationRefreshInterval)
 	ticker := newTicker(exponentialSleep)
 

--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -752,11 +752,6 @@ func initializeEtcdraftConsenter(
 	metricsProvider metrics.Provider,
 	bccsp bccsp.BCCSP,
 ) *etcdraft.Consenter {
-	replicationRefreshInterval := conf.General.Cluster.ReplicationBackgroundRefreshInterval
-	if replicationRefreshInterval == 0 {
-		replicationRefreshInterval = onboarding.DefaultReplicationBackgroundRefreshInterval
-	}
-
 	systemChannelName, err := protoutil.GetChannelIDFromBlock(bootstrapBlock)
 	if err != nil {
 		logger.Panicf("Failed extracting system channel name from bootstrap block: %v", err)
@@ -769,7 +764,7 @@ func initializeEtcdraftConsenter(
 		return multichannel.ConfigBlock(systemLedger)
 	}
 
-	icr := onboarding.NewInactiveChainReplicator(ri, getConfigBlock, ri.RegisterChain, replicationRefreshInterval)
+	icr := onboarding.NewInactiveChainReplicator(ri, getConfigBlock, ri.RegisterChain, conf.General.Cluster.ReplicationBackgroundRefreshInterval)
 
 	// Use the inactiveChainReplicator as a channel lister, since it has knowledge
 	// of all inactive chains.


### PR DESCRIPTION
Move timeout default override to onboarding

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: Ib63c698efd2a556ef4811757f2a9b819ade65cbe

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Related issues

Task: FAB-18013
Story: FAB-15711
Epic: FAB-17712