### PR TITLE
Update gotools mockery path for release-1.4

### DIFF
--- a/gotools.mk
+++ b/gotools.mk
@@ -16,7 +16,7 @@ go.fqp.goimports     := golang.org/x/tools/cmd/goimports
 go.fqp.golint        := golang.org/x/lint/golint
 go.fqp.manifest-tool := github.com/estesp/manifest-tool
 go.fqp.misspell      := github.com/client9/misspell/cmd/misspell
-go.fqp.mockery       := github.com/vektra/mockery/cmd/mockery
+go.fqp.mockery       := github.com/vektra/mockery
 
 .PHONY: gotools-install
 gotools-install: $(patsubst %,$(GOTOOLS_BINDIR)/%, $(GOTOOLS))


### PR DESCRIPTION
#### Description

Update path to mockery to fix build break.