### PR TITLE
Set Cache-Control no-store for channel participation list

### DIFF
--- a/orderer/common/channelparticipation/restapi.go
+++ b/orderer/common/channelparticipation/restapi.go
@@ -114,6 +114,7 @@ func (h *HTTPHandler) serveListAll(resp http.ResponseWriter, req *http.Request) 
 	for i, info := range channelList.Channels {
 		channelList.Channels[i].URL = path.Join(URLBaseV1Channels, info.Name)
 	}
+	resp.Header().Set("Cache-Control", "no-store")
 	h.sendResponseOK(resp, channelList)
 }
 
@@ -135,6 +136,7 @@ func (h *HTTPHandler) serveListOne(resp http.ResponseWriter, req *http.Request) 
 		h.sendResponseJsonError(resp, http.StatusNotFound, err)
 		return
 	}
+	resp.Header().Set("Cache-Control", "no-store")
 	h.sendResponseOK(resp, infoFull)
 }
 

--- a/orderer/common/channelparticipation/restapi_test.go
+++ b/orderer/common/channelparticipation/restapi_test.go
@@ -138,6 +138,7 @@ func TestHTTPHandler_ServeHTTP_ListAll(t *testing.T) {
 		h.ServeHTTP(resp, req)
 		assert.Equal(t, http.StatusOK, resp.Result().StatusCode)
 		assert.Equal(t, "application/json", resp.Result().Header.Get("Content-Type"))
+		assert.Equal(t, "no-store", resp.Result().Header.Get("Cache-Control"))
 
 		listAll := &types.ChannelList{}
 		err := json.Unmarshal(resp.Body.Bytes(), listAll)
@@ -163,6 +164,7 @@ func TestHTTPHandler_ServeHTTP_ListAll(t *testing.T) {
 		h.ServeHTTP(resp, req)
 		assert.Equal(t, http.StatusOK, resp.Result().StatusCode)
 		assert.Equal(t, "application/json", resp.Result().Header.Get("Content-Type"))
+		assert.Equal(t, "no-store", resp.Result().Header.Get("Cache-Control"))
 
 		listAll := &types.ChannelList{}
 		err := json.Unmarshal(resp.Body.Bytes(), listAll)
@@ -183,6 +185,7 @@ func TestHTTPHandler_ServeHTTP_ListAll(t *testing.T) {
 			h.ServeHTTP(resp, req)
 			assert.Equal(t, http.StatusOK, resp.Result().StatusCode, "Accept: %s", accept)
 			assert.Equal(t, "application/json", resp.Result().Header.Get("Content-Type"))
+			assert.Equal(t, "no-store", resp.Result().Header.Get("Cache-Control"))
 
 			listAll := &types.ChannelList{}
 			err := json.Unmarshal(resp.Body.Bytes(), listAll)
@@ -214,6 +217,7 @@ func TestHTTPHandler_ServeHTTP_ListSingle(t *testing.T) {
 		h.ServeHTTP(resp, req)
 		assert.Equal(t, http.StatusOK, resp.Result().StatusCode)
 		assert.Equal(t, "application/json", resp.Result().Header.Get("Content-Type"))
+		assert.Equal(t, "no-store", resp.Result().Header.Get("Cache-Control"))
 
 		infoResp := types.ChannelInfo{}
 		err := json.Unmarshal(resp.Body.Bytes(), &infoResp)


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Set Cache-Control to no-store in the HTTP header for channel participation list channels and list channel.

#### Related issues

[FAB-17928](https://jira.hyperledger.org/browse/FAB-17928)
