### PR TITLE
[FAB-17992] Remove ledger blockstore data for a channel

### DIFF
--- a/common/ledger/util/leveldbhelper/leveldb_provider.go
+++ b/common/ledger/util/leveldbhelper/leveldb_provider.go
@@ -12,19 +12,28 @@ import (
 	"sync"
 
 	"github.com/hyperledger/fabric/common/ledger/dataformat"
+	"github.com/pkg/errors"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
 )
 
-// internalDBName is used to keep track of data related to internals such as data format
-// _ is used as name because this is not allowed as a channelname
-const internalDBName = "_"
+const (
+	// internalDBName is used to keep track of data related to internals such as data format
+	// _ is used as name because this is not allowed as a channelname
+	internalDBName = "_"
+	// maxBatchSize limits the memory usage (1MB) for a batch. It is measured by the total number of bytes
+	// of all the keys in a batch.
+	maxBatchSize = 1000000
+)
 
 var (
 	dbNameKeySep     = []byte{0x00}
 	lastKeyIndicator = byte(0x01)
 	formatVersionKey = []byte{'f'} // a single key in db whose value indicates the version of the data format
 )
+
+// closeFunc closes the db handle
+type closeFunc func()
 
 // Conf configuration for `Provider`
 //
@@ -117,7 +126,12 @@ func (p *Provider) GetDBHandle(dbName string) *DBHandle {
 	defer p.mux.Unlock()
 	dbHandle := p.dbHandles[dbName]
 	if dbHandle == nil {
-		dbHandle = &DBHandle{dbName, p.db}
+		closeFunc := func() {
+			p.mux.Lock()
+			defer p.mux.Unlock()
+			delete(p.dbHandles, dbName)
+		}
+		dbHandle = &DBHandle{dbName, p.db, closeFunc}
 		p.dbHandles[dbName] = dbHandle
 	}
 	return dbHandle
@@ -130,8 +144,9 @@ func (p *Provider) Close() {
 
 // DBHandle is an handle to a named db
 type DBHandle struct {
-	dbName string
-	db     *DB
+	dbName    string
+	db        *DB
+	closeFunc closeFunc
 }
 
 // Get returns the value for the given key
@@ -147,6 +162,46 @@ func (h *DBHandle) Put(key []byte, value []byte, sync bool) error {
 // Delete deletes the given key
 func (h *DBHandle) Delete(key []byte, sync bool) error {
 	return h.db.Delete(constructLevelKey(h.dbName, key), sync)
+}
+
+// DeleteAll deletes all the keys that belong to the channel (dbName).
+func (h *DBHandle) DeleteAll() error {
+	iter := h.GetIterator(nil, nil)
+	defer iter.Release()
+	if err := iter.Error(); err != nil {
+		return errors.Wrap(err, "internal leveldb error while obtaining db iterator")
+	}
+
+	// use leveldb iterator directly to be more efficient
+	dbIter := iter.Iterator
+
+	// This is common code shared by all the leveldb instances. Because each leveldb has its own key size pattern,
+	// each batch is limited by memory usage instead of number of keys. Once the batch memory usage reaches maxBatchSize,
+	// the batch will be committed.
+	numKeys := 0
+	batchSize := 0
+	batch := &leveldb.Batch{}
+	for dbIter.Next() {
+		if err := dbIter.Error(); err != nil {
+			return errors.Wrap(err, "internal leveldb error while retrieving data from db iterator")
+		}
+		key := dbIter.Key()
+		numKeys++
+		batchSize = batchSize + len(key)
+		batch.Delete(key)
+		if batchSize >= maxBatchSize {
+			if err := h.db.WriteBatch(batch, true); err != nil {
+				return err
+			}
+			logger.Infof("Have removed %d entries for channel %s in leveldb %s", numKeys, h.dbName, h.db.conf.DBPath)
+			batchSize = 0
+			batch = &leveldb.Batch{}
+		}
+	}
+	if batch.Len() > 0 {
+		return h.db.WriteBatch(batch, true)
+	}
+	return nil
 }
 
 // WriteBatch writes a batch in an atomic way
@@ -181,6 +236,13 @@ func (h *DBHandle) GetIterator(startKey []byte, endKey []byte) *Iterator {
 	}
 	logger.Debugf("Getting iterator for range [%#v] - [%#v]", sKey, eKey)
 	return &Iterator{h.dbName, h.db.GetIterator(sKey, eKey)}
+}
+
+// Close closes the DBHandle after its db data have been deleted
+func (h *DBHandle) Close() {
+	if h.closeFunc != nil {
+		h.closeFunc()
+	}
 }
 
 // UpdateBatch encloses the details of multiple `updates`


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- New feature

#### Description
Add a Remove function to block store provider to remove block index
and blocks directory for a channel. It will be called by the orderer
and peer as part of channel deletion.

#### Additional details
This PR adds the remove function to remove the block indexes and blocks dir for the channel. It is expected that the higher level above block store to handle failure recovery. 

The PR is based on  the current `BlockStoreProvider` design.
- no concurrent calls to BlockStoreProvider
- BlockStoreProvider is not thread-safe, the caller manages thread-safe
- only one ledger instance is created/opened for a particular ledger, all the time.

The opened `BlockStore` for the removed channel should not be used any more because it will return invalid data. If needed, we will close the blockstore and make it unusable in a separate PR.

#### Related issues
Story: https://jira.hyperledger.org/browse/FAB-17992
Epic: https://jira.hyperledger.org/browse/FAB-17712
