### PR TITLE
Rename variables in blocksotre code for readability

### DIFF
--- a/common/ledger/blkstorage/blockfile_helper.go
+++ b/common/ledger/blkstorage/blockfile_helper.go
@@ -19,11 +19,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// constructCheckpointInfoFromBlockFiles scans the last blockfile (if any) and construct the checkpoint info
+// constructBlockfilesInfo scans the last blockfile (if any) and construct the blockfilesInfo
 // if the last file contains no block or only a partially written block (potentially because of a crash while writing block to the file),
 // this scans the second last file (if any)
-func constructCheckpointInfoFromBlockFiles(rootDir string) (*checkpointInfo, error) {
-	logger.Debugf("Retrieving checkpoint info from block files")
+func constructBlockfilesInfo(rootDir string) (*blockfilesInfo, error) {
+	logger.Debugf("constructing BlockfilesInfo")
 	var lastFileNum int
 	var numBlocksInFile int
 	var endOffsetLastBlock int64
@@ -39,14 +39,14 @@ func constructCheckpointInfoFromBlockFiles(rootDir string) (*checkpointInfo, err
 	logger.Debugf("Last file number found = %d", lastFileNum)
 
 	if lastFileNum == -1 {
-		cpInfo := &checkpointInfo{
-			latestFileChunkSuffixNum:    0,
-			latestFileChunksize:         0,
-			noBlockFiles:                true,
-			lastBlockNumberInBlockFiles: 0,
+		blkfilesInfo := &blockfilesInfo{
+			latestFileNumber:   0,
+			latestFileSize:     0,
+			noBlockFiles:       true,
+			lastPersistedBlock: 0,
 		}
 		logger.Debugf("No block file found")
-		return cpInfo, nil
+		return blkfilesInfo, nil
 	}
 
 	fileInfo := getFileInfoOrPanic(rootDir, lastFileNum)
@@ -74,27 +74,27 @@ func constructCheckpointInfoFromBlockFiles(rootDir string) (*checkpointInfo, err
 		lastBlockNumber = lastBlock.Header.Number
 	}
 
-	cpInfo := &checkpointInfo{
-		lastBlockNumberInBlockFiles: lastBlockNumber,
-		latestFileChunksize:         int(endOffsetLastBlock),
-		latestFileChunkSuffixNum:    lastFileNum,
-		noBlockFiles:                lastFileNum == 0 && numBlocksInFile == 0,
+	blkfilesInfo := &blockfilesInfo{
+		lastPersistedBlock: lastBlockNumber,
+		latestFileSize:     int(endOffsetLastBlock),
+		latestFileNumber:   lastFileNum,
+		noBlockFiles:       lastFileNum == 0 && numBlocksInFile == 0,
 	}
-	logger.Debugf("Checkpoint info constructed from file system = %s", spew.Sdump(cpInfo))
-	return cpInfo, nil
+	logger.Debugf("blockfilesInfo constructed from file system = %s", spew.Sdump(blkfilesInfo))
+	return blkfilesInfo, nil
 }
 
 // binarySearchFileNumForBlock locates the file number that contains the given block number.
 // This function assumes that the caller invokes this function with a block number that has been committed
 // For any uncommitted block, this function returns the last file present
 func binarySearchFileNumForBlock(rootDir string, blockNum uint64) (int, error) {
-	cpInfo, err := constructCheckpointInfoFromBlockFiles(rootDir)
+	blkfilesInfo, err := constructBlockfilesInfo(rootDir)
 	if err != nil {
 		return -1, err
 	}
 
 	beginFile := 0
-	endFile := cpInfo.latestFileChunkSuffixNum
+	endFile := blkfilesInfo.latestFileNumber
 
 	for endFile != beginFile {
 		searchFile := beginFile + (endFile-beginFile)/2 + 1

--- a/common/ledger/blkstorage/blocks_itr.go
+++ b/common/ledger/blkstorage/blocks_itr.go
@@ -23,21 +23,21 @@ type blocksItr struct {
 }
 
 func newBlockItr(mgr *blockfileMgr, startBlockNum uint64) *blocksItr {
-	mgr.cpInfoCond.L.Lock()
-	defer mgr.cpInfoCond.L.Unlock()
-	return &blocksItr{mgr, mgr.cpInfo.lastBlockNumberInBlockFiles, startBlockNum, nil, false, &sync.Mutex{}}
+	mgr.blkfilesInfoCond.L.Lock()
+	defer mgr.blkfilesInfoCond.L.Unlock()
+	return &blocksItr{mgr, mgr.blockfilesInfo.lastPersistedBlock, startBlockNum, nil, false, &sync.Mutex{}}
 }
 
 func (itr *blocksItr) waitForBlock(blockNum uint64) uint64 {
-	itr.mgr.cpInfoCond.L.Lock()
-	defer itr.mgr.cpInfoCond.L.Unlock()
-	for itr.mgr.cpInfo.lastBlockNumberInBlockFiles < blockNum && !itr.shouldClose() {
+	itr.mgr.blkfilesInfoCond.L.Lock()
+	defer itr.mgr.blkfilesInfoCond.L.Unlock()
+	for itr.mgr.blockfilesInfo.lastPersistedBlock < blockNum && !itr.shouldClose() {
 		logger.Debugf("Going to wait for newer blocks. maxAvailaBlockNumber=[%d], waitForBlockNum=[%d]",
-			itr.mgr.cpInfo.lastBlockNumberInBlockFiles, blockNum)
-		itr.mgr.cpInfoCond.Wait()
-		logger.Debugf("Came out of wait. maxAvailaBlockNumber=[%d]", itr.mgr.cpInfo.lastBlockNumberInBlockFiles)
+			itr.mgr.blockfilesInfo.lastPersistedBlock, blockNum)
+		itr.mgr.blkfilesInfoCond.Wait()
+		logger.Debugf("Came out of wait. maxAvailaBlockNumber=[%d]", itr.mgr.blockfilesInfo.lastPersistedBlock)
 	}
-	return itr.mgr.cpInfo.lastBlockNumberInBlockFiles
+	return itr.mgr.blockfilesInfo.lastPersistedBlock
 }
 
 func (itr *blocksItr) initStream() error {
@@ -84,12 +84,12 @@ func (itr *blocksItr) Next() (ledger.QueryResult, error) {
 
 // Close releases any resources held by the iterator
 func (itr *blocksItr) Close() {
-	itr.mgr.cpInfoCond.L.Lock()
-	defer itr.mgr.cpInfoCond.L.Unlock()
+	itr.mgr.blkfilesInfoCond.L.Lock()
+	defer itr.mgr.blkfilesInfoCond.L.Unlock()
 	itr.closeMarkerLock.Lock()
 	defer itr.closeMarkerLock.Unlock()
 	itr.closeMarker = true
-	itr.mgr.cpInfoCond.Broadcast()
+	itr.mgr.blkfilesInfoCond.Broadcast()
 	if itr.stream != nil {
 		itr.stream.close()
 	}

--- a/common/ledger/blkstorage/reset.go
+++ b/common/ledger/blkstorage/reset.go
@@ -142,11 +142,11 @@ const (
 // the existing file (if present). This helps in achieving fail-safe behviour of reset utility
 func recordHeightIfGreaterThanPreviousRecording(ledgerDir string) error {
 	logger.Infof("Preparing to record current height for ledger at [%s]", ledgerDir)
-	checkpointInfo, err := constructCheckpointInfoFromBlockFiles(ledgerDir)
+	blkfilesInfo, err := constructBlockfilesInfo(ledgerDir)
 	if err != nil {
 		return err
 	}
-	logger.Infof("Loaded current info from blockfiles %#v", checkpointInfo)
+	logger.Infof("Loaded current info from blockfiles %#v", blkfilesInfo)
 	preResetHtFile := path.Join(ledgerDir, fileNamePreRestHt)
 	exists, err := pathExists(preResetHtFile)
 	logger.Infof("preResetHtFile already exists? = %t", exists)
@@ -164,7 +164,7 @@ func recordHeightIfGreaterThanPreviousRecording(ledgerDir string) error {
 		}
 		logger.Infof("preResetHtFile contains height = %d", previuoslyRecordedHt)
 	}
-	currentHt := checkpointInfo.lastBlockNumberInBlockFiles + 1
+	currentHt := blkfilesInfo.lastPersistedBlock + 1
 	if currentHt > previuoslyRecordedHt {
 		logger.Infof("Recording current height [%d]", currentHt)
 		return ioutil.WriteFile(preResetHtFile,

--- a/common/ledger/blkstorage/reset_test.go
+++ b/common/ledger/blkstorage/reset_test.go
@@ -191,9 +191,9 @@ func TestRecordHeight(t *testing.T) {
 	fileInfo, err := os.Stat(lastFile)
 	require.NoError(t, err)
 	require.NoError(t, os.Truncate(lastFile, fileInfo.Size()/2))
-	checkpointInfo, err := constructCheckpointInfoFromBlockFiles(ledgerDir)
+	blkfilesInfo, err := constructBlockfilesInfo(ledgerDir)
 	require.NoError(t, err)
-	require.True(t, checkpointInfo.lastBlockNumberInBlockFiles < 59)
+	require.True(t, blkfilesInfo.lastPersistedBlock < 59)
 	require.NoError(t, recordHeightIfGreaterThanPreviousRecording(ledgerDir))
 	assertRecordedHeight(t, ledgerDir, "60")
 }

--- a/common/ledger/blkstorage/rollback_test.go
+++ b/common/ledger/blkstorage/rollback_test.go
@@ -45,14 +45,14 @@ func TestRollback(t *testing.T) {
 	actualBlockchainInfo := blkfileMgrWrapper.blockfileMgr.getBlockchainInfo()
 	assert.Equal(t, expectedBlockchainInfo, actualBlockchainInfo)
 
-	// 3. Check the checkpointInfo
-	expectedCheckpointInfoLastBlockNumber := uint64(49)
-	expectedCheckpointInfoIsChainEmpty := false
-	actualCheckpointInfo, err := blkfileMgrWrapper.blockfileMgr.loadCurrentInfo()
+	// 3. Check the BlockfileInfo
+	expectedblkfilesInfoLastBlockNumber := uint64(49)
+	expectedBlkfilesInfoIsNoFiles := false
+	actualBlkfilesInfo, err := blkfileMgrWrapper.blockfileMgr.loadBlkfilesInfo()
 	assert.NoError(t, err)
-	assert.Equal(t, expectedCheckpointInfoLastBlockNumber, actualCheckpointInfo.lastBlockNumberInBlockFiles)
-	assert.Equal(t, expectedCheckpointInfoIsChainEmpty, actualCheckpointInfo.noBlockFiles)
-	assert.Equal(t, actualCheckpointInfo.latestFileChunkSuffixNum, 4)
+	assert.Equal(t, expectedblkfilesInfoLastBlockNumber, actualBlkfilesInfo.lastPersistedBlock)
+	assert.Equal(t, expectedBlkfilesInfoIsNoFiles, actualBlkfilesInfo.noBlockFiles)
+	assert.Equal(t, actualBlkfilesInfo.latestFileNumber, 4)
 
 	// 4. Check whether all blocks are stored correctly
 	blkfileMgrWrapper.testGetBlockByNumber(blocks, 0, nil)
@@ -138,14 +138,14 @@ func TestRollbackWithOnlyBlockIndexAttributes(t *testing.T) {
 	actualBlockchainInfo := blkfileMgrWrapper.blockfileMgr.getBlockchainInfo()
 	assert.Equal(t, expectedBlockchainInfo, actualBlockchainInfo)
 
-	// 3. Check the checkpointInfo
-	expectedCheckpointInfoLastBlockNumber := uint64(49)
-	expectedCheckpointInfoIsChainEmpty := false
-	actualCheckpointInfo, err := blkfileMgrWrapper.blockfileMgr.loadCurrentInfo()
+	// 3. Check the BlockfilesInfo
+	expectedBlkfilesInfoLastBlockNumber := uint64(49)
+	expectedBlkfilesInfoIsNoBlkFiles := false
+	actualBlkfilesInfo, err := blkfileMgrWrapper.blockfileMgr.loadBlkfilesInfo()
 	assert.NoError(t, err)
-	assert.Equal(t, expectedCheckpointInfoLastBlockNumber, actualCheckpointInfo.lastBlockNumberInBlockFiles)
-	assert.Equal(t, expectedCheckpointInfoIsChainEmpty, actualCheckpointInfo.noBlockFiles)
-	assert.Equal(t, actualCheckpointInfo.latestFileChunkSuffixNum, 4)
+	assert.Equal(t, expectedBlkfilesInfoLastBlockNumber, actualBlkfilesInfo.lastPersistedBlock)
+	assert.Equal(t, expectedBlkfilesInfoIsNoBlkFiles, actualBlkfilesInfo.noBlockFiles)
+	assert.Equal(t, actualBlkfilesInfo.latestFileNumber, 4)
 
 	// 4. Close the blkfileMgrWrapper
 	env.provider.Close()
@@ -188,14 +188,14 @@ func TestRollbackWithNoIndexDir(t *testing.T) {
 	actualBlockchainInfo := blkfileMgrWrapper.blockfileMgr.getBlockchainInfo()
 	assert.Equal(t, expectedBlockchainInfo, actualBlockchainInfo)
 
-	// 3. Check the checkpointInfo
-	expectedCheckpointInfoLastBlockNumber := uint64(49)
-	expectedCheckpointInfoIsChainEmpty := false
-	actualCheckpointInfo, err := blkfileMgrWrapper.blockfileMgr.loadCurrentInfo()
+	// 3. Check the BlockfilesInfo
+	expectedBlkfilesInfoLastBlockNumber := uint64(49)
+	expectedBlkfilesInfoIsChainEmpty := false
+	actualBlkfilesInfo, err := blkfileMgrWrapper.blockfileMgr.loadBlkfilesInfo()
 	assert.NoError(t, err)
-	assert.Equal(t, expectedCheckpointInfoLastBlockNumber, actualCheckpointInfo.lastBlockNumberInBlockFiles)
-	assert.Equal(t, expectedCheckpointInfoIsChainEmpty, actualCheckpointInfo.noBlockFiles)
-	assert.Equal(t, actualCheckpointInfo.latestFileChunkSuffixNum, 4)
+	assert.Equal(t, expectedBlkfilesInfoLastBlockNumber, actualBlkfilesInfo.lastPersistedBlock)
+	assert.Equal(t, expectedBlkfilesInfoIsChainEmpty, actualBlkfilesInfo.noBlockFiles)
+	assert.Equal(t, actualBlkfilesInfo.latestFileNumber, 4)
 
 	// 4. Close the blkfileMgrWrapper
 	env.provider.Close()
@@ -302,15 +302,15 @@ func assertBlockStoreRollback(t *testing.T, path, ledgerID string, blocks []*com
 	actualBlockchainInfo := blkfileMgrWrapper.blockfileMgr.getBlockchainInfo()
 	assert.Equal(t, expectedBlockchainInfo, actualBlockchainInfo)
 
-	// 2. Check the checkpointInfo after the rollback
-	expectedCheckpointInfoLastBlockNumber := rollbackedToBlkNum
-	expectedCheckpointInfoIsChainEmpty := false
+	// 2. Check the BlockfilesInfo after the rollback
+	expectedBlkfilesInfoLastBlockNumber := rollbackedToBlkNum
+	expectedBlkfilesInfoIsNoBlkfiles := false
 	expectedBlockchainInfoLastFileSuffixNum := lastFileSuffixNum
-	actualCheckpointInfo, err := blkfileMgrWrapper.blockfileMgr.loadCurrentInfo()
+	actualBlkfilesInfo, err := blkfileMgrWrapper.blockfileMgr.loadBlkfilesInfo()
 	assert.NoError(t, err)
-	assert.Equal(t, expectedCheckpointInfoLastBlockNumber, actualCheckpointInfo.lastBlockNumberInBlockFiles)
-	assert.Equal(t, expectedCheckpointInfoIsChainEmpty, actualCheckpointInfo.noBlockFiles)
-	assert.Equal(t, expectedBlockchainInfoLastFileSuffixNum, actualCheckpointInfo.latestFileChunkSuffixNum)
+	assert.Equal(t, expectedBlkfilesInfoLastBlockNumber, actualBlkfilesInfo.lastPersistedBlock)
+	assert.Equal(t, expectedBlkfilesInfoIsNoBlkfiles, actualBlkfilesInfo.noBlockFiles)
+	assert.Equal(t, expectedBlockchainInfoLastFileSuffixNum, actualBlkfilesInfo.latestFileNumber)
 
 	// 3. Check whether all blocks till the target block number are stored correctly
 	if blkfileMgrWrapper.blockfileMgr.index.isAttributeIndexed(IndexableAttrBlockNum) {


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
- Renames some of the variables in the blockstore code for improving readability
- Fixes a small mistake caused in the last patch

#### Additional details
With the addition of snapshot related code, some of the existing types and variable names, such as `checkpointInfo` cause ambiguity. So, renaming some of the names to provide better context.
