### PR TITLE
check leveldb iterator error

### DIFF
--- a/common/ledger/blkstorage/pkg_test.go
+++ b/common/ledger/blkstorage/pkg_test.go
@@ -153,9 +153,10 @@ func (w *testBlockfileMgrWrapper) testGetMultipleDataByTxID(
 	expectedData []*expectedBlkTxValidationCode,
 ) {
 	rangescan := constructTxIDRangeScan(txID)
-	itr := w.blockfileMgr.db.GetIterator(rangescan.startKey, rangescan.stopKey)
-	defer itr.Release()
+	itr, err := w.blockfileMgr.db.GetIterator(rangescan.startKey, rangescan.stopKey)
 	require := require.New(w.t)
+	require.NoError(err)
+	defer itr.Release()
 
 	fetchedData := []*expectedBlkTxValidationCode{}
 	for itr.Next() {

--- a/core/ledger/confighistory/db_helper.go
+++ b/core/ledger/confighistory/db_helper.go
@@ -76,7 +76,10 @@ func (d *db) mostRecentEntryBelow(blockNum uint64, ns, key string) (*compositeKV
 		return nil, errors.New("blockNum should be greater than 0")
 	}
 	startKey := encodeCompositeKey(ns, key, blockNum-1)
-	itr := d.GetIterator(startKey, nil)
+	itr, err := d.GetIterator(startKey, nil)
+	if err != nil {
+		return nil, err
+	}
 	defer itr.Release()
 	if !itr.Next() {
 		logger.Debugf("Key no entry found. Returning nil")
@@ -100,7 +103,7 @@ func (d *db) entryAt(blockNum uint64, ns, key string) (*compositeKV, error) {
 	return &compositeKV{k, v}, nil
 }
 
-func (d *db) getNamespaceIterator(ns string) *leveldbhelper.Iterator {
+func (d *db) getNamespaceIterator(ns string) (*leveldbhelper.Iterator, error) {
 	nsStartKey := []byte(keyPrefix + ns)
 	nsStartKey = append(nsStartKey, separatorByte)
 	nsEndKey := []byte(keyPrefix + ns)

--- a/core/ledger/confighistory/mgr.go
+++ b/core/ledger/confighistory/mgr.go
@@ -176,16 +176,14 @@ func (r *Retriever) CollectionConfigAt(blockNum uint64, chaincodeName string) (*
 // extra bytes. Further, the collection config namespace is not expected to have
 // millions of entries.
 func (r *Retriever) ExportConfigHistory(dir string, newHashFunc snapshot.NewHashFunc) (map[string][]byte, error) {
-	nsItr := r.dbHandle.getNamespaceIterator(collectionConfigNamespace)
-	if err := nsItr.Error(); err != nil {
-		return nil, errors.Wrap(err, "internal leveldb error while obtaining db iterator")
-
+	nsItr, err := r.dbHandle.getNamespaceIterator(collectionConfigNamespace)
+	if err != nil {
+		return nil, err
 	}
 	defer nsItr.Release()
 
 	var numCollectionConfigs uint64 = 0
 	var dataFileWriter *snapshot.FileWriter
-	var err error
 	for nsItr.Next() {
 		if err := nsItr.Error(); err != nil {
 			return nil, errors.Wrap(err, "internal leveldb error while iterating for collection config history")

--- a/core/ledger/kvledger/history/db_test.go
+++ b/core/ledger/kvledger/history/db_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/internal/pkg/txflags"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -195,6 +196,15 @@ func TestHistory(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 4, count)
+
+	t.Run("test-iter-error-path", func(t *testing.T) {
+		env.testHistoryDBProvider.Close()
+		qhistory, err = env.testHistoryDB.NewQueryExecutor(store1)
+		itr, err = qhistory.GetHistoryForKey("ns1", "key7")
+		require.EqualError(t, err, "internal leveldb error while obtaining db iterator: leveldb: closed")
+		require.Nil(t, itr)
+
+	})
 }
 
 func TestHistoryForInvalidTran(t *testing.T) {

--- a/core/ledger/kvledger/history/query_executer.go
+++ b/core/ledger/kvledger/history/query_executer.go
@@ -27,7 +27,10 @@ type QueryExecutor struct {
 // GetHistoryForKey implements method in interface `ledger.HistoryQueryExecutor`
 func (q *QueryExecutor) GetHistoryForKey(namespace string, key string) (commonledger.ResultsIterator, error) {
 	rangeScan := constructRangeScan(namespace, key)
-	dbItr := q.levelDB.GetIterator(rangeScan.startKey, rangeScan.endKey)
+	dbItr, err := q.levelDB.GetIterator(rangeScan.startKey, rangeScan.endKey)
+	if err != nil {
+		return nil, err
+	}
 
 	// By default, dbItr is in the orderer of oldest to newest and its cursor is at the beginning of the entries.
 	// Need to call Last() and Next() to move the cursor to the end of the entries so that we can iterate

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/db.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/db.go
@@ -101,7 +101,10 @@ func (p *DBProvider) GetDBHandle(id string, chInfoProvider channelInfoProvider) 
 		return nil, err
 	}
 	bookkeeper := p.bookkeepingProvider.GetDBHandle(id, bookkeeping.MetadataPresenceIndicator)
-	metadataHint := newMetadataHint(bookkeeper)
+	metadataHint, err := newMetadataHint(bookkeeper)
+	if err != nil {
+		return nil, err
+	}
 	return NewDB(vdb, id, metadataHint)
 }
 

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/optimization.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/optimization.go
@@ -15,15 +15,18 @@ type metadataHint struct {
 	bookkeeper *leveldbhelper.DBHandle
 }
 
-func newMetadataHint(bookkeeper *leveldbhelper.DBHandle) *metadataHint {
+func newMetadataHint(bookkeeper *leveldbhelper.DBHandle) (*metadataHint, error) {
 	cache := map[string]bool{}
-	itr := bookkeeper.GetIterator(nil, nil)
+	itr, err := bookkeeper.GetIterator(nil, nil)
+	if err != nil {
+		return nil, err
+	}
 	defer itr.Release()
 	for itr.Next() {
 		namespace := string(itr.Key())
 		cache[namespace] = true
 	}
-	return &metadataHint{cache, bookkeeper}
+	return &metadataHint{cache, bookkeeper}, nil
 }
 
 func (h *metadataHint) metadataEverUsedFor(namespace string) bool {

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper.go
@@ -74,7 +74,10 @@ func (ek *expiryKeeper) update(toTrack []*expiryInfo, toClear []*expiryInfoKey) 
 func (ek *expiryKeeper) retrieve(expiringAtBlkNum uint64) ([]*expiryInfo, error) {
 	startKey := encodeExpiryInfoKey(&expiryInfoKey{expiryBlk: expiringAtBlkNum, committingBlk: 0})
 	endKey := encodeExpiryInfoKey(&expiryInfoKey{expiryBlk: expiringAtBlkNum + 1, committingBlk: 0})
-	itr := ek.db.GetIterator(startKey, endKey)
+	itr, err := ek.db.GetIterator(startKey, endKey)
+	if err != nil {
+		return nil, err
+	}
 	defer itr.Release()
 
 	var listExpinfo []*expiryInfo

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper_test.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/bookkeeping"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExpiryKVEncoding(t *testing.T) {
@@ -74,6 +75,13 @@ func TestExpiryKeeper(t *testing.T) {
 	assert.Len(t, listExpinfo6, 1)
 	assert.Equal(t, expinfo4.expiryInfoKey, listExpinfo6[0].expiryInfoKey)
 	assert.True(t, proto.Equal(expinfo4.pvtdataKeys, listExpinfo6[0].pvtdataKeys))
+
+	t.Run("test-error-path", func(t *testing.T) {
+		testenv.TestProvider.Close()
+		expirtyInfo, err := expiryKeeper.retrieve(15)
+		require.EqualError(t, err, "internal leveldb error while obtaining db iterator: leveldb: closed")
+		require.Nil(t, expirtyInfo)
+	})
 }
 
 func buildPvtdataKeysForTest(startingEntry int, numEntries int) *PvtdataKeys {

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb.go
@@ -143,7 +143,10 @@ func (vdb *versionedDB) GetStateRangeScanIteratorWithPagination(namespace string
 	if endKey == "" {
 		dataEndKey[len(dataEndKey)-1] = lastKeyIndicator
 	}
-	dbItr := vdb.db.GetIterator(dataStartKey, dataEndKey)
+	dbItr, err := vdb.db.GetIterator(dataStartKey, dataEndKey)
+	if err != nil {
+		return nil, err
+	}
 	return newKVScanner(namespace, dbItr, pageSize), nil
 }
 
@@ -292,9 +295,9 @@ type fullDBScanner struct {
 }
 
 func newFullDBScanner(db *leveldbhelper.DBHandle, skipNamespace func(namespace string) bool) (*fullDBScanner, byte, error) {
-	dbItr := db.GetIterator(dataKeyPrefix, dataKeyStopper)
-	if err := dbItr.Error(); err != nil {
-		return nil, byte(0), errors.Wrap(err, "internal leveldb error while obtaining db iterator")
+	dbItr, err := db.GetIterator(dataKeyPrefix, dataKeyStopper)
+	if err != nil {
+		return nil, byte(0), err
 	}
 	return &fullDBScanner{
 			db:     db,

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb_test.go
@@ -37,6 +37,14 @@ func TestIterator(t *testing.T) {
 	env := NewTestVDBEnv(t)
 	defer env.Cleanup()
 	commontests.TestIterator(t, env.DBProvider)
+	t.Run("test-iter-error-path", func(t *testing.T) {
+		db, err := env.DBProvider.GetDBHandle("testiterator", nil)
+		require.NoError(t, err)
+		env.DBProvider.Close()
+		itr, err := db.GetStateRangeScanIterator("ns1", "", "")
+		require.EqualError(t, err, "internal leveldb error while obtaining db iterator: leveldb: closed")
+		require.Nil(t, itr)
+	})
 }
 
 func TestDataKeyEncoding(t *testing.T) {

--- a/core/ledger/pvtdatastorage/store.go
+++ b/core/ledger/pvtdatastorage/store.go
@@ -586,7 +586,10 @@ func (s *Store) GetPvtDataByBlockNum(blockNum uint64, filter ledger.PvtNsCollFil
 	}
 	startKey, endKey := getDataKeysForRangeScanByBlockNum(blockNum)
 	logger.Debugf("Querying private data storage for write sets using startKey=%#v, endKey=%#v", startKey, endKey)
-	itr := s.db.GetIterator(startKey, endKey)
+	itr, err := s.db.GetIterator(startKey, endKey)
+	if err != nil {
+		return nil, err
+	}
 	defer itr.Release()
 
 	var blockPvtdata []*ledger.TxPvtData
@@ -658,7 +661,10 @@ func (s *Store) GetMissingPvtDataInfoForMostRecentBlocks(maxBlock int) (ledger.M
 	lastCommittedBlock := atomic.LoadUint64(&s.lastCommittedBlock)
 
 	startKey, endKey := createRangeScanKeysForEligibleMissingDataEntries(lastCommittedBlock)
-	dbItr := s.db.GetIterator(startKey, endKey)
+	dbItr, err := s.db.GetIterator(startKey, endKey)
+	if err != nil {
+		return nil, err
+	}
 	defer dbItr.Release()
 
 	for dbItr.Next() {
@@ -779,7 +785,10 @@ func (s *Store) purgeExpiredData(minBlkNum, maxBlkNum uint64) error {
 func (s *Store) retrieveExpiryEntries(minBlkNum, maxBlkNum uint64) ([]*expiryEntry, error) {
 	startKey, endKey := getExpiryKeysForRangeScan(minBlkNum, maxBlkNum)
 	logger.Debugf("retrieveExpiryEntries(): startKey=%#v, endKey=%#v", startKey, endKey)
-	itr := s.db.GetIterator(startKey, endKey)
+	itr, err := s.db.GetIterator(startKey, endKey)
+	if err != nil {
+		return nil, err
+	}
 	defer itr.Release()
 
 	var expiryEntries []*expiryEntry
@@ -801,22 +810,31 @@ func (s *Store) retrieveExpiryEntries(minBlkNum, maxBlkNum uint64) ([]*expiryEnt
 
 func (s *Store) launchCollElgProc() {
 	go func() {
-		s.processCollElgEvents() // process collection eligibility events when store is opened - in case there is an unprocessed events from previous run
+		if err := s.processCollElgEvents(); err != nil {
+			// process collection eligibility events when store is opened -
+			// in case there is an unprocessed events from previous run
+			logger.Errorw("failed to process collection eligibility events", "err", err)
+		}
 		for {
 			logger.Debugf("Waiting for collection eligibility event")
 			s.collElgProcSync.waitForNotification()
-			s.processCollElgEvents()
+			if err := s.processCollElgEvents(); err != nil {
+				logger.Errorw("failed to process collection eligibility events", "err", err)
+			}
 			s.collElgProcSync.done()
 		}
 	}()
 }
 
-func (s *Store) processCollElgEvents() {
+func (s *Store) processCollElgEvents() error {
 	logger.Debugf("Starting to process collection eligibility events")
 	s.purgerLock.Lock()
 	defer s.purgerLock.Unlock()
 	collElgStartKey, collElgEndKey := createRangeScanKeysForCollElg()
-	eventItr := s.db.GetIterator(collElgStartKey, collElgEndKey)
+	eventItr, err := s.db.GetIterator(collElgStartKey, collElgEndKey)
+	if err != nil {
+		return err
+	}
 	defer eventItr.Release()
 	batch := leveldbhelper.NewUpdateBatch()
 	totalEntriesConverted := 0
@@ -835,7 +853,10 @@ func (s *Store) processCollElgEvents() {
 			for _, coll = range colls.Entries {
 				logger.Infof("Converting missing data entries from ineligible to eligible for [ns=%s, coll=%s]", ns, coll)
 				startKey, endKey := createRangeScanKeysForIneligibleMissingData(blkNum, ns, coll)
-				collItr := s.db.GetIterator(startKey, endKey)
+				collItr, err := s.db.GetIterator(startKey, endKey)
+				if err != nil {
+					return err
+				}
 				collEntriesConverted := 0
 
 				for collItr.Next() { // each entry
@@ -869,6 +890,7 @@ func (s *Store) processCollElgEvents() {
 
 	s.db.WriteBatch(batch, true)
 	logger.Debugf("Converted [%d] ineligible missing data entries to eligible", totalEntriesConverted)
+	return nil
 }
 
 // LastCommittedBlockHeight returns the height of the last committed block

--- a/core/transientstore/store.go
+++ b/core/transientstore/store.go
@@ -161,7 +161,10 @@ func (s *Store) GetTxPvtRWSetByTxid(txid string, filter ledger.PvtNsCollFilter) 
 	startKey := createTxidRangeStartKey(txid)
 	endKey := createTxidRangeEndKey(txid)
 
-	iter := s.db.GetIterator(startKey, endKey)
+	iter, err := s.db.GetIterator(startKey, endKey)
+	if err != nil {
+		return nil, err
+	}
 	return &RwsetScanner{txid, iter, filter}, nil
 }
 
@@ -179,7 +182,10 @@ func (s *Store) PurgeByTxids(txids []string) error {
 		startKey := createPurgeIndexByTxidRangeStartKey(txid)
 		endKey := createPurgeIndexByTxidRangeEndKey(txid)
 
-		iter := s.db.GetIterator(startKey, endKey)
+		iter, err := s.db.GetIterator(startKey, endKey)
+		if err != nil {
+			return err
+		}
 
 		// Get all txid and uuid from above result and remove it from transient store (both
 		// write set and the corresponding indexes.
@@ -224,7 +230,10 @@ func (s *Store) PurgeBelowHeight(maxBlockNumToRetain uint64) error {
 	// Do a range query with 0 as startKey and maxBlockNumToRetain-1 as endKey
 	startKey := createPurgeIndexByHeightRangeStartKey(0)
 	endKey := createPurgeIndexByHeightRangeEndKey(maxBlockNumToRetain - 1)
-	iter := s.db.GetIterator(startKey, endKey)
+	iter, err := s.db.GetIterator(startKey, endKey)
+	if err != nil {
+		return err
+	}
 
 	dbBatch := leveldbhelper.NewUpdateBatch()
 
@@ -263,7 +272,10 @@ func (s *Store) GetMinTransientBlkHt() (uint64, error) {
 	// the lowest block height remaining in transient store. An alternative approach
 	// is to explicitly store the minBlockHeight in the transientStore.
 	startKey := createPurgeIndexByHeightRangeStartKey(0)
-	iter := s.db.GetIterator(startKey, nil)
+	iter, err := s.db.GetIterator(startKey, nil)
+	if err != nil {
+		return 0, err
+	}
 	defer iter.Release()
 	// Fetch the minimum transient block height
 	if iter.Next() {


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Goleveldb iterator does not explicitly return an error. We need to call the `itr.Error()` method on the iterator to check for the presence of any error. As the check is missing at a few places, this PR make the `leveldbhelper` pkg itself to return an error by explicitly calling `itr.Error()`
#### Additional details

In the subsequent PR, we would supply the fix for iter.Next() as well.

#### Related issues