### PR TITLE
FAB-17910 Ch.Pat.API: join member w/o onboarding

### DIFF
--- a/orderer/common/multichannel/util_test.go
+++ b/orderer/common/multichannel/util_test.go
@@ -7,8 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package multichannel
 
 import (
+	"errors"
 	"fmt"
-	"github.com/hyperledger/fabric/orderer/common/types"
 
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/common/capabilities"
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/fabric/internal/configtxgen/genesisconfig"
 	"github.com/hyperledger/fabric/orderer/common/blockcutter"
 	"github.com/hyperledger/fabric/orderer/common/msgprocessor"
+	"github.com/hyperledger/fabric/orderer/common/types"
 	"github.com/hyperledger/fabric/orderer/consensus"
 	"github.com/hyperledger/fabric/protoutil"
 )
@@ -43,6 +44,11 @@ func (mc *mockConsenter) HandleChain(support consensus.ConsenterSupport, metadat
 	}
 
 	return chain, nil
+}
+
+func (mc *mockConsenter) JoinChain(support consensus.ConsenterSupport, joinBlock *cb.Block) (consensus.Chain, error) {
+	//TODO
+	return nil, errors.New("not implemented")
 }
 
 type mockChainCluster struct {

--- a/orderer/consensus/consensus.go
+++ b/orderer/consensus/consensus.go
@@ -24,6 +24,12 @@ type Consenter interface {
 	// the last block committed to the ledger of this Chain. For a new chain, or one which is migrated,
 	// this metadata will be nil (or contain a zero-length Value), as there is no prior metadata to report.
 	HandleChain(support ConsenterSupport, metadata *cb.Metadata) (Chain, error)
+
+	// JoinChain should create and return a reference to a Chain when the channel is started with a join-block
+	// that is not a genesis block (i.e. join-block.number>0), and a ledger with height <= than join-block.number.
+	// This means that there is a gap between the join-block and the last block in the ledger that requires
+	// on-boarding. In contrast, HandleChain creates a Chain based on the last block found in the ledger.
+	JoinChain(support ConsenterSupport, joinBlock *cb.Block) (Chain, error)
 }
 
 // MetadataValidator performs the validation of updates to ConsensusMetadata during config updates to the channel.

--- a/orderer/consensus/etcdraft/consenter.go
+++ b/orderer/consensus/etcdraft/consenter.go
@@ -255,6 +255,11 @@ func (c *Consenter) HandleChain(support consensus.ConsenterSupport, metadata *co
 	)
 }
 
+func (c *Consenter) JoinChain(support consensus.ConsenterSupport, joinBlock *common.Block) (consensus.Chain, error) {
+	//TODO fully construct a follower.Chain
+	return nil, errors.New("not implemented")
+}
+
 // ReadBlockMetadata attempts to read raft metadata from block metadata, if available.
 // otherwise, it reads raft metadata from config metadata supplied.
 func ReadBlockMetadata(blockMetadata *common.Metadata, configMetadata *etcdraft.ConfigMetadata) (*etcdraft.BlockMetadata, error) {

--- a/orderer/consensus/kafka/consenter.go
+++ b/orderer/consensus/kafka/consenter.go
@@ -103,6 +103,10 @@ func (consenter *consenterImpl) HandleChain(support consensus.ConsenterSupport, 
 	return ch, nil
 }
 
+func (c *consenterImpl) JoinChain(support consensus.ConsenterSupport, joinBlock *cb.Block) (consensus.Chain, error) {
+	return nil, errors.New("the Kafka orderer does not support JoinChain")
+}
+
 // commonConsenter allows us to retrieve the configuration options set on the
 // consenter object. These will be common across all chain objects derived by
 // this consenter. They are set using local configuration settings. This

--- a/orderer/consensus/solo/consensus.go
+++ b/orderer/consensus/solo/consensus.go
@@ -13,6 +13,7 @@ import (
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/orderer/consensus"
+	"github.com/pkg/errors"
 )
 
 var logger = flogging.MustGetLogger("orderer.consensus.solo")
@@ -42,6 +43,10 @@ func New() consensus.Consenter {
 func (solo *consenter) HandleChain(support consensus.ConsenterSupport, metadata *cb.Metadata) (consensus.Chain, error) {
 	logger.Warningf("Use of the Solo orderer is deprecated and remains only for use in test environments but may be removed in the future.")
 	return newChain(support), nil
+}
+
+func (c *consenter) JoinChain(support consensus.ConsenterSupport, joinBlock *cb.Block) (consensus.Chain, error) {
+	return nil, errors.New("the Solo orderer does not support JoinChain")
 }
 
 func newChain(support consensus.ConsenterSupport) *chain {


### PR DESCRIPTION
This commit handles the following scenario:
* The orderer is a member of the cluster - the config block given at
  join has the self ID of the orderer.
* The config block given at join is number 0 - no onboarding needed.

In this case the join block is first appended to the ledger as a
genesis block, and the multichannel.ChainSupport is created in the
normal fashion, reading the last-block from the ledger and constructing
the consensus.Chain accordingly.

In addition this commit prepares the ground for joining with a join block with number >0, which requires on-boarding. For that purpose a new method is added to the consensus.Consenter interface.

This commit also handles the case of an orderer rejecting a join to the system channel when there are already application channels (FAB-17913), as it is just two lines of code (and a test).

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: I0b2bd4e4da901c6b9c53585bffc6dc0dd5573948

#### Type of change

- New feature
#### Related issues

Tasks: FAB-17910 FAB-17913
Story: FAB-15711
Epic: FAB-17712
