### PR TITLE
Channel participation api - redirect from base V1 URL

### DIFF
--- a/orderer/common/channelparticipation/restapi.go
+++ b/orderer/common/channelparticipation/restapi.go
@@ -82,10 +82,10 @@ func NewHTTPHandler(config localconfig.ChannelParticipation, registrar ChannelMa
 	handler.router.HandleFunc(urlWithChannelIDKey, handler.serveRemove).Methods(http.MethodDelete)
 	handler.router.HandleFunc(urlWithChannelIDKey, handler.serveNotAllowed)
 
-	handler.router.HandleFunc(URLBaseV1Channels, handler.serveListAll).Methods("GET")
+	handler.router.HandleFunc(URLBaseV1Channels, handler.serveListAll).Methods(http.MethodGet)
 	handler.router.HandleFunc(URLBaseV1Channels, handler.serveNotAllowed)
 
-	handler.router.Handle(URLBaseV1, nil) //TODO redirect to URLBaseV1Channels
+	handler.router.HandleFunc(URLBaseV1, handler.redirectBaseV1).Methods(http.MethodGet)
 
 	return handler
 }
@@ -136,6 +136,10 @@ func (h *HTTPHandler) serveListOne(resp http.ResponseWriter, req *http.Request) 
 		return
 	}
 	h.sendResponseOK(resp, infoFull)
+}
+
+func (h *HTTPHandler) redirectBaseV1(resp http.ResponseWriter, req *http.Request) {
+	http.Redirect(resp, req, URLBaseV1Channels, http.StatusFound)
 }
 
 // Join a channel.

--- a/orderer/common/channelparticipation/restapi_test.go
+++ b/orderer/common/channelparticipation/restapi_test.go
@@ -85,13 +85,6 @@ func TestHTTPHandler_ServeHTTP_ListErrors(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, resp.Result().StatusCode)
 	})
 
-	t.Run("missing channels collection", func(t *testing.T) {
-		resp := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, channelparticipation.URLBaseV1, nil)
-		h.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusNotFound, resp.Result().StatusCode)
-	})
-
 	t.Run("bad resource", func(t *testing.T) {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, channelparticipation.URLBaseV1+"oops", nil)
@@ -193,6 +186,14 @@ func TestHTTPHandler_ServeHTTP_ListAll(t *testing.T) {
 			assert.Nil(t, listAll.Channels)
 			assert.Nil(t, listAll.SystemChannel)
 		}
+	})
+
+	t.Run("redirect from base V1 URL", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, channelparticipation.URLBaseV1, nil)
+		h.ServeHTTP(resp, req)
+		assert.Equal(t, http.StatusFound, resp.Result().StatusCode)
+		assert.Equal(t, channelparticipation.URLBaseV1Channels, resp.Result().Header.Get("Location"))
 	})
 }
 


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Redirect `GET /participation/v1` to `/participation/v1/channels` with error code StatusFound 302.

#### Related issues

[FAB-17892](https://jira.hyperledger.org/browse/FAB-17892)