### PR TITLE
Enforce max request body size on channel participation join

### DIFF
--- a/integration/nwo/fabricconfig/orderer.go
+++ b/integration/nwo/fabricconfig/orderer.go
@@ -124,5 +124,6 @@ type OrdererStatsd struct {
 }
 
 type ChannelParticipation struct {
-	Enabled bool `yaml:"Enabled"`
+	Enabled            bool   `yaml:"Enabled"`
+	MaxRequestBodySize string `yaml:"MaxRequestBodySize,omitempty"`
 }

--- a/integration/nwo/orderer_template.go
+++ b/integration/nwo/orderer_template.go
@@ -119,4 +119,5 @@ Metrics:
 {{- end }}
 ChannelParticipation:
   Enabled: {{ .ChannelParticipationEnabled }}
+  MaxRequestBodySize: 1 MB
 `

--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -204,8 +204,9 @@ type Statsd struct {
 // ChannelParticipation provides the channel participation API configuration for the orderer.
 // Channel participation uses the same ListenAddress and TLS settings of the Operations service.
 type ChannelParticipation struct {
-	Enabled       bool
-	RemoveStorage bool // Whether to permanently remove storage on channel removal.
+	Enabled            bool
+	RemoveStorage      bool // Whether to permanently remove storage on channel removal.
+	MaxRequestBodySize uint32
 }
 
 // Defaults carries the default orderer configuration values.
@@ -284,8 +285,9 @@ var Defaults = TopLevel{
 		Provider: "disabled",
 	},
 	ChannelParticipation: ChannelParticipation{
-		Enabled:       false,
-		RemoveStorage: false,
+		Enabled:            false,
+		RemoveStorage:      false,
+		MaxRequestBodySize: 1024 * 1024,
 	},
 }
 

--- a/sampleconfig/orderer.yaml
+++ b/sampleconfig/orderer.yaml
@@ -358,6 +358,9 @@ ChannelParticipation:
     # Defines the default behavior of channel removal.
     RemoveStorage: false
 
+    # The maximum size of the request body when joining a channel.
+    MaxRequestBodySize: 1 MB
+
 
 ################################################################################
 #


### PR DESCRIPTION

#### Type of change

- New feature

#### Description

Allow configuration of the max request body size via Orderer.ChannelParticipation.MaxRequestBodySize and use this when reading the body of join channel requests.

#### Related issues

[FAB-17895](https://jira.hyperledger.org/browse/FAB-17895)