### PR TITLE
Remove call to couchdb API _ensure_full_commit

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb_test.go
@@ -148,10 +148,6 @@ func TestBadCouchDBInstance(t *testing.T) {
 	_, _, err = badCouchDBInstance.verifyCouchConfig()
 	assert.Error(t, err, "Error should have been thrown with verifyCouchConfig and invalid connection")
 
-	//Test ensureFullCommit with bad connection
-	_, err = badDB.ensureFullCommit()
-	assert.Error(t, err, "Error should have been thrown with ensureFullCommit and invalid connection")
-
 	//Test dropDatabase with bad connection
 	_, err = badDB.dropDatabase()
 	assert.Error(t, err, "Error should have been thrown with dropDatabase and invalid connection")
@@ -239,10 +235,6 @@ func TestDBCreateEnsureFullCommit(t *testing.T) {
 	//Save the test document
 	_, saveerr := db.saveDoc("2", "", &couchDoc{jsonValue: assetJSON, attachments: nil})
 	assert.NoError(t, saveerr, "Error when trying to save a document")
-
-	//Ensure a full commit
-	_, commiterr := db.ensureFullCommit()
-	assert.NoError(t, commiterr, "Error when trying to ensure a full commit")
 }
 
 func TestIsEmpty(t *testing.T) {

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
@@ -1526,8 +1526,6 @@ func TestInitChannelMetadta(t *testing.T) {
 
 	// test an existing DB with no channelMetadata by deleting channelMetadata, namespace provider should be called
 	require.NoError(t, vdb.metadataDB.deleteDoc(channelMetadataDocID, ""))
-	_, err = vdb.metadataDB.ensureFullCommit()
-	require.NoError(t, err)
 	require.NoError(t, vdb.initChannelMetadata(false, fakeNsProvider))
 	require.Equal(t, expectedChannelMetadata, vdb.channelMetadata)
 	require.Equal(t, 1, fakeNsProvider.PossibleNamespacesCallCount())
@@ -1538,8 +1536,6 @@ func TestInitChannelMetadta(t *testing.T) {
 	// test namespaceProvider error
 	fakeNsProvider.PossibleNamespacesReturns(nil, errors.New("fake-namespaceprivder-error"))
 	require.NoError(t, vdb.metadataDB.deleteDoc(channelMetadataDocID, ""))
-	_, err = vdb.metadataDB.ensureFullCommit()
-	require.NoError(t, err)
 	err = vdb.initChannelMetadata(false, fakeNsProvider)
 	require.EqualError(t, err, "fake-namespaceprivder-error")
 


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
This PR removes the invocation to the couchdb API "_ensure_full_commit".

#### Additional details
We recommended `delayed_commits=true` in couchdb config for better performance and then at the block commit time, we invoke `_ensure_full_commit`. This arrangement was under the assumption that the `_ensure_full_commit` fsyncs the data as per the couchdb docs https://docs.couchdb.org/en/2.3.1/api/database/compact.html#db-ensure-full-commit. However, after talking to couchdb experts, we figured that this was true only till couchdb 1.x. Since then, this is more or less a no-op call as far as `fsync` is concerned.

#### Related issues
https://jira.hyperledger.org/browse/FABB-151
https://jira.hyperledger.org/browse/FAB-17999
