### PR TITLE
[FAB-17960] Ch.Part.API: Implement filerepo

### DIFF
--- a/orderer/common/filerepo/filerepo.go
+++ b/orderer/common/filerepo/filerepo.go
@@ -1,0 +1,178 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package filerepo
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/hyperledger/fabric/internal/fileutil"
+	"github.com/pkg/errors"
+)
+
+const (
+	repoFilePermPrivateRW      os.FileMode = 0600
+	defaultTransientFileMarker             = "~"
+)
+
+// Repo manages filesystem operations for saving files marked by the fileSuffix
+// in order to support crash fault tolerance for components that need it by maintaining
+// a file repo structure storing intermediate state.
+type Repo struct {
+	mu                  sync.Mutex
+	fileRepoDir         string
+	fileSuffix          string
+	transientFileMarker string
+}
+
+// New initializes a new file repo at repoParentDir/fileSuffix.
+// All file system operations on the returned file repo are thread safe.
+func New(repoParentDir, fileSuffix string) (*Repo, error) {
+	if err := validateFileSuffix(fileSuffix); err != nil {
+		return nil, err
+	}
+
+	fileRepoDir := filepath.Join(repoParentDir, fileSuffix)
+
+	if _, err := fileutil.CreateDirIfMissing(fileRepoDir); err != nil {
+		return nil, err
+	}
+
+	if err := fileutil.SyncDir(repoParentDir); err != nil {
+		return nil, err
+	}
+
+	files, err := ioutil.ReadDir(fileRepoDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove existing transient files in the repo
+	transientFilePattern := "*" + fileSuffix + defaultTransientFileMarker
+	for _, f := range files {
+		isTransientFile, err := filepath.Match(transientFilePattern, f.Name())
+		if err != nil {
+			return nil, err
+		}
+		if isTransientFile {
+			if err := os.Remove(filepath.Join(fileRepoDir, f.Name())); err != nil {
+				return nil, errors.Wrapf(err, "error cleaning up transient files")
+			}
+		}
+	}
+
+	if err := fileutil.SyncDir(fileRepoDir); err != nil {
+		return nil, err
+	}
+
+	return &Repo{
+		transientFileMarker: defaultTransientFileMarker,
+		fileSuffix:          fileSuffix,
+		fileRepoDir:         fileRepoDir,
+	}, nil
+}
+
+// Save atomically persists the content to suffix/baseName+suffix file by first writing it
+// to a tmp file marked by the transientFileMarker and then moves the file to the final
+// destination indicated by the FileSuffix.
+func (r *Repo) Save(baseName string, content []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	fileName := r.baseToFileName(baseName)
+	dest := r.baseToFilePath(baseName)
+
+	if _, err := os.Stat(dest); err == nil {
+		return fmt.Errorf("file already exists at %s", dest)
+	}
+
+	tmpFileName := fileName + r.transientFileMarker
+	if err := fileutil.CreateAndSyncFileAtomically(r.fileRepoDir, tmpFileName, fileName, content, repoFilePermPrivateRW); err != nil {
+		return err
+	}
+
+	return fileutil.SyncDir(r.fileRepoDir)
+}
+
+// Remove removes the file associated with baseName from the file system.
+func (r *Repo) Remove(baseName string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	filePath := r.baseToFilePath(baseName)
+
+	if err := os.RemoveAll(filePath); err != nil {
+		return err
+	}
+
+	return fileutil.SyncDir(r.fileRepoDir)
+}
+
+// Read reads the file in the fileRepo associated with baseName's contents.
+func (r *Repo) Read(baseName string) ([]byte, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	filePath := r.baseToFilePath(baseName)
+	return ioutil.ReadFile(filePath)
+}
+
+// List parses the directory and produce a list of file names, filtered by suffix.
+func (r *Repo) List() ([]string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var repoFiles []string
+
+	files, err := ioutil.ReadDir(r.fileRepoDir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range files {
+		isFileSuffix, err := filepath.Match("*"+r.fileSuffix, f.Name())
+		if err != nil {
+			return nil, err
+		}
+		if isFileSuffix {
+			repoFiles = append(repoFiles, f.Name())
+		}
+	}
+
+	return repoFiles, nil
+}
+
+// FileToBaseName strips the suffix from the file name to get the associated channel name.
+func (r *Repo) FileToBaseName(fileName string) string {
+	baseFile := filepath.Base(fileName)
+
+	return strings.TrimSuffix(baseFile, "."+r.fileSuffix)
+}
+
+func (r *Repo) baseToFilePath(baseName string) string {
+	return filepath.Join(r.fileRepoDir, r.baseToFileName(baseName))
+}
+
+func (r *Repo) baseToFileName(baseName string) string {
+	return fmt.Sprintf("%s.%s", baseName, r.fileSuffix)
+}
+
+func validateFileSuffix(fileSuffix string) error {
+	if len(fileSuffix) == 0 {
+		return errors.New("fileSuffix illegal, cannot be empty")
+	}
+
+	if strings.Contains(fileSuffix, string(os.PathSeparator)) {
+		return fmt.Errorf("fileSuffix [%s] illegal, cannot contain os path separator", fileSuffix)
+	}
+
+	return nil
+}

--- a/orderer/common/filerepo/filerepo_test.go
+++ b/orderer/common/filerepo/filerepo_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package filerepo_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hyperledger/fabric/orderer/common/filerepo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFileRepo(t *testing.T) {
+	// Write a temporary file
+	tempFilePath := filepath.Join("testdata", "joinblock", "mychannel.joinblock~")
+	tempFile, err := os.Create(tempFilePath)
+	require.NoError(t, err)
+	defer func() {
+		tempFile.Close()
+		os.Remove(tempFilePath)
+	}()
+
+	// Check tempfile exists prior to creating a new file repo
+	_, err = os.Stat(tempFilePath)
+	require.NoError(t, err)
+
+	_, err = filerepo.New("testdata", "joinblock")
+	require.NoError(t, err)
+
+	// Check tempfile was cleared out upon creating a new file repo
+	require.NoFileExists(t, tempFilePath)
+}
+
+func TestNewFileRepoFailure(t *testing.T) {
+	tests := []struct {
+		testName    string
+		fileSuffix  string
+		expectedErr string
+	}{
+		{
+			testName:    "invalid fileSuffix",
+			fileSuffix:  "join/block",
+			expectedErr: "fileSuffix [join/block] illegal, cannot contain os path separator",
+		},
+		{
+			testName:    "empty fileSuffix",
+			fileSuffix:  "",
+			expectedErr: "fileSuffix illegal, cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			_, err := filerepo.New("testdata", tt.fileSuffix)
+			require.EqualError(t, err, tt.expectedErr)
+		})
+	}
+}
+
+func TestFileRepo_Save(t *testing.T) {
+	tests := []struct {
+		testName string
+		content  []byte
+	}{
+		{
+			testName: "Non-empty bytes",
+			content:  []byte("block-bytes"),
+		},
+		{
+			testName: "Empty bytes",
+			content:  []byte{},
+		},
+		{
+			testName: "Nil bytes",
+			content:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			r, err := filerepo.New("testdata", "joinblock")
+			require.NoError(t, err)
+
+			filePath := filepath.Join("testdata", "joinblock", "newchannel.joinblock")
+
+			err = r.Save("newchannel", tt.content)
+			defer os.Remove(filePath)
+			require.NoError(t, err)
+
+			// Check file bytes
+			bytes, err := ioutil.ReadFile(filePath)
+			require.NoError(t, err)
+			if tt.content != nil {
+				require.Equal(t, tt.content, bytes)
+			} else {
+				require.Equal(t, []byte{}, bytes)
+			}
+
+			// Check tempfile doesn't exist
+			require.NoFileExists(t, filePath+"~")
+		})
+	}
+}
+
+func TestFileRepo_SaveFailure(t *testing.T) {
+	r, err := filerepo.New("testdata", "joinblock")
+	require.NoError(t, err)
+
+	filePath := filepath.Join("testdata", "joinblock", "mychannel.joinblock")
+
+	err = r.Save("mychannel", []byte{})
+	require.EqualError(t, err, fmt.Sprintf("file already exists at %s", filePath))
+}
+
+func TestFileRepo_Remove(t *testing.T) {
+	// Write a temporary file
+	tempFilePath := filepath.Join("testdata", "joinblock", "channel2.joinblock")
+	tempFile, err := os.Create(tempFilePath)
+	require.NoError(t, err)
+	defer func() {
+		tempFile.Close()
+		os.Remove(tempFilePath)
+	}()
+
+	r, err := filerepo.New("testdata", "joinblock")
+	require.NoError(t, err)
+
+	err = r.Remove("channel2")
+	require.NoError(t, err)
+
+	require.NoFileExists(t, tempFilePath)
+}
+
+func TestFileRepo_Read(t *testing.T) {
+	t.Run("Successful read, non-empty bytes", func(t *testing.T) {
+		r, err := filerepo.New("testdata", "joinblock")
+		require.NoError(t, err)
+
+		bytes, err := r.Read("mychannel")
+		require.NoError(t, err)
+		require.Equal(t, "dummy-data", string(bytes))
+	})
+
+	t.Run("Successful read, empty bytes", func(t *testing.T) {
+		r, err := filerepo.New("testdata", "remove")
+		require.NoError(t, err)
+
+		bytes, err := r.Read("mychannel")
+		require.NoError(t, err)
+		require.Equal(t, []byte{}, bytes)
+	})
+
+	t.Run("Failed read, invalid file", func(t *testing.T) {
+		r, err := filerepo.New("testdata", "joinblock")
+		require.NoError(t, err)
+
+		_, err = r.Read("invalidfile")
+		require.EqualError(t, err, "open testdata/joinblock/invalidfile.joinblock: no such file or directory")
+	})
+}
+
+func TestFileRepo_List(t *testing.T) {
+	r, err := filerepo.New("testdata", "joinblock")
+	require.NoError(t, err)
+
+	files, err := r.List()
+	require.NoError(t, err)
+	require.Equal(t, []string{"mychannel.joinblock"}, files)
+}
+
+func TestFileRepo_FileToBaseName(t *testing.T) {
+	r, err := filerepo.New("testdata", "joinblock")
+	require.NoError(t, err)
+
+	filePath := filepath.Join("testdata", "joinblock", "mychannel.joinblock")
+	channelName := r.FileToBaseName(filePath)
+	require.Equal(t, "mychannel", channelName)
+}

--- a/orderer/common/filerepo/testdata/joinblock/mychannel.block
+++ b/orderer/common/filerepo/testdata/joinblock/mychannel.block
@@ -1,0 +1,1 @@
+dummy-data

--- a/orderer/common/filerepo/testdata/joinblock/mychannel.joinblock
+++ b/orderer/common/filerepo/testdata/joinblock/mychannel.joinblock
@@ -1,0 +1,1 @@
+dummy-data


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Introduce a general purpose file repo for persisting join block data
as well as supporting CFT on join and remove operations from the
registrar and file ledger.

#### Related issues

Task: [FAB-17960](https://jira.hyperledger.org/browse/FAB-17960)
Story: [FAB-15711](https://jira.hyperledger.org/browse/FAB-15711)
Epic: [FAB-17712](https://jira.hyperledger.org/browse/FAB-17712)