### PR TITLE
Explicitly set gossip.endpoint in integration test

### DIFF
--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -27,10 +27,11 @@ peer:
       timeout: 20s
   gossip:
     bootstrap: 127.0.0.1:{{ .PeerPort Peer "Listen" }}
+    endpoint: 127.0.0.1:{{ .PeerPort Peer "Listen" }}
+    externalEndpoint: 127.0.0.1:{{ .PeerPort Peer "Listen" }}
     useLeaderElection: true
     orgLeader: false
     membershipTrackerInterval: 5s
-    endpoint:
     maxBlockCountToStore: 100
     maxPropagationBurstLatency: 10ms
     maxPropagationBurstSize: 10
@@ -52,7 +53,6 @@ peer:
     aliveTimeInterval: 5s
     aliveExpirationTimeout: 25s
     reconnectInterval: 25s
-    externalEndpoint: 127.0.0.1:{{ .PeerPort Peer "Listen" }}
     election:
       startupGracePeriod: 15s
       membershipSampleInterval: 1s


### PR DESCRIPTION
This change explicitly sets the advertised gossip endpoint to override the address computed by the peer.

The configuration used for our integration test networks explicitly sets the listen addresses to the IPv4 loopback address for endpoints other than the chaincode server. The chaincode server listener is special because it must be available to chaincode running in docker containers.

We configure the chaincode server to listen on INADDR_ANY and enable address auto-detection so the peer can try to determine the address to advertise for the chaincode server.

The auto-detect "feature" has a bizarre side effect in that it takes precedence over an explicit configuration of the peer.address and this impacts the advertised address for other subsystems like gossip.