### PR TITLE
rm interface from confighistory store

### DIFF
--- a/core/ledger/confighistory/mgr_test.go
+++ b/core/ledger/confighistory/mgr_test.go
@@ -191,7 +191,7 @@ func TestWithImplicitColls(t *testing.T) {
 	p, err := newDBProvider(dbPath)
 	require.NoError(t, err)
 
-	mgr := &mgr{
+	mgr := &Mgr{
 		ccInfoProvider: mockCCInfoProvider,
 		dbProvider:     p,
 	}
@@ -267,7 +267,7 @@ func TestWithImplicitColls(t *testing.T) {
 }
 
 type testEnvForSnapshot struct {
-	mgr             *mgr
+	mgr             *Mgr
 	retriever       *Retriever
 	testSnapshotDir string
 	cleanup         func()
@@ -281,7 +281,7 @@ func newTestEnvForSnapshot(t *testing.T) *testEnvForSnapshot {
 		os.RemoveAll(dbPath)
 		t.Fatalf("Failed to create new leveldb provider: %s", err)
 	}
-	mgr := &mgr{dbProvider: p}
+	mgr := &Mgr{dbProvider: p}
 	retriever := mgr.GetRetriever("ledger1", nil)
 
 	testSnapshotDir, err := ioutil.TempDir("", "confighistorysnapshot")

--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -68,7 +68,7 @@ type lgrInitializer struct {
 	pvtdataStore             *pvtdatastorage.Store
 	stateDB                  *privacyenabledstate.DB
 	historyDB                *history.DB
-	configHistoryMgr         confighistory.Mgr
+	configHistoryMgr         *confighistory.Mgr
 	stateListeners           []ledger.StateListener
 	bookkeeperProvider       bookkeeping.Provider
 	ccInfoProvider           ledger.DeployedChaincodeInfoProvider

--- a/core/ledger/kvledger/kv_ledger_provider.go
+++ b/core/ledger/kvledger/kv_ledger_provider.go
@@ -69,7 +69,7 @@ type Provider struct {
 	pvtdataStoreProvider *pvtdatastorage.Provider
 	dbProvider           *privacyenabledstate.DBProvider
 	historydbProvider    *history.DBProvider
-	configHistoryMgr     confighistory.Mgr
+	configHistoryMgr     *confighistory.Mgr
 	stateListeners       []ledger.StateListener
 	bookkeepingProvider  bookkeeping.Provider
 	initializer          *ledger.Initializer


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

We don't need to definite the interface at the implementation side. Instead, the receiver of this object must ensure that the received object has implemented the required interfaces. 