### PR TITLE
Remove whitelist comment from core.yaml

### DIFF
--- a/core/chaincode/chaincodetest.yaml
+++ b/core/chaincode/chaincodetest.yaml
@@ -350,8 +350,7 @@ chaincode:
     #A value <= 0 turns keepalive off
     keepalive: 1
 
-    # system chaincodes whitelist. To add system chaincode "myscc" to the
-    # whitelist, add "myscc: enable" to the list
+    # enabled system chaincodes
     system:
         cscc: enable
         lscc: enable

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -582,9 +582,7 @@ chaincode:
     # A value <= 0 turns keepalive off
     keepalive: 0
 
-    # system chaincodes whitelist. To add system chaincode "myscc" to the
-    # whitelist, add "myscc: enable" to the list below, and register in
-    # chaincode/importsysccs.go
+    # enabled system chaincodes
     system:
         _lifecycle: enable
         cscc: enable


### PR DESCRIPTION
Simplified comment for list of enabled system chaincodes.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>