### PR TITLE
Fix error creation from recovered in NewPublicNymFromBytes

### DIFF
--- a/bccsp/idemix/bridge/bridge_test.go
+++ b/bccsp/idemix/bridge/bridge_test.go
@@ -277,13 +277,13 @@ var _ = Describe("Idemix Bridge", func() {
 
 			It("panic on nil raw", func() {
 				key, err := User.NewPublicNymFromBytes(nil)
-				Expect(err).To(MatchError("failure [%!s(<nil>)]"))
+				Expect(err).To(MatchError("failure [runtime error: index out of range [0] with length 0]"))
 				Expect(key).To(BeNil())
 			})
 
 			It("failure unmarshalling invalid raw", func() {
 				key, err := User.NewPublicNymFromBytes([]byte{0, 1, 2, 3})
-				Expect(err).To(MatchError("failure [%!s(<nil>)]"))
+				Expect(err).To(MatchError("failure [runtime error: index out of range [2] with length 2]"))
 				Expect(key).To(BeNil())
 			})
 

--- a/bccsp/idemix/bridge/user.go
+++ b/bccsp/idemix/bridge/user.go
@@ -69,10 +69,10 @@ func (u *User) MakeNym(sk handlers.Big, ipk handlers.IssuerPublicKey) (r1 handle
 	return
 }
 
-func (*User) NewPublicNymFromBytes(raw []byte) (r handlers.Ecp, err error) {
+func (*User) NewPublicNymFromBytes(raw []byte) (res handlers.Ecp, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			r = nil
+			res = nil
 			err = errors.Errorf("failure [%s]", r)
 		}
 	}()
@@ -80,7 +80,7 @@ func (*User) NewPublicNymFromBytes(raw []byte) (r handlers.Ecp, err error) {
 	// raw is the concatenation of two big integers
 	lHalve := len(raw) / 2
 
-	r = &Ecp{E: FP256BN.NewECPbigs(FP256BN.FromBytes(raw[:lHalve]), FP256BN.FromBytes(raw[lHalve:]))}
+	res = &Ecp{E: FP256BN.NewECPbigs(FP256BN.FromBytes(raw[:lHalve]), FP256BN.FromBytes(raw[lHalve:]))}
 
 	return
 }


### PR DESCRIPTION
By using the same identifier for a named return and the result of recover, the code inadvertently cleared the recover result before logging instead of clearly the result of the function.
