### PR TITLE
rm old proto related code from transient store

### DIFF
--- a/core/transientstore/store_test.go
+++ b/core/transientstore/store_test.go
@@ -154,62 +154,6 @@ func TestTransientStorePersistAndRetrieve(t *testing.T) {
 	assert.Equal(endorsersResults, actualEndorsersResults)
 }
 
-func TestTransientStorePersistAndRetrieveBothOldAndNewProto(t *testing.T) {
-	testStore, cleanup := testStore(t)
-	defer cleanup()
-	assert := assert.New(t)
-	txid := "txid-1"
-	var receivedAtBlockHeight uint64 = 10
-	var err error
-
-	// Create and persist private simulation results with old proto for txid-1
-	samplePvtRWSet := samplePvtData(t)
-	err = testStore.persistOldProto(txid, receivedAtBlockHeight, samplePvtRWSet)
-	assert.NoError(err)
-
-	// Create and persist private simulation results with new proto for txid-1
-	samplePvtRWSetWithConfig := samplePvtDataWithConfigInfo(t)
-	err = testStore.Persist(txid, receivedAtBlockHeight, samplePvtRWSetWithConfig)
-	assert.NoError(err)
-
-	// Construct the expected results
-	var expectedEndorsersResults []*EndorserPvtSimulationResults
-
-	pvtRWSetWithConfigInfo := &transientstore.TxPvtReadWriteSetWithConfigInfo{
-		PvtRwset: samplePvtRWSet,
-	}
-
-	endorser0SimulationResults := &EndorserPvtSimulationResults{
-		ReceivedAtBlockHeight:          receivedAtBlockHeight,
-		PvtSimulationResultsWithConfig: pvtRWSetWithConfigInfo,
-	}
-	expectedEndorsersResults = append(expectedEndorsersResults, endorser0SimulationResults)
-
-	endorser1SimulationResults := &EndorserPvtSimulationResults{
-		ReceivedAtBlockHeight:          receivedAtBlockHeight,
-		PvtSimulationResultsWithConfig: samplePvtRWSetWithConfig,
-	}
-	expectedEndorsersResults = append(expectedEndorsersResults, endorser1SimulationResults)
-
-	// Retrieve simulation results of txid-1 from  store
-	iter, err := testStore.GetTxPvtRWSetByTxid(txid, nil)
-	assert.NoError(err)
-
-	var actualEndorsersResults []*EndorserPvtSimulationResults
-	for {
-		result, err := iter.Next()
-		assert.NoError(err)
-		if result == nil {
-			break
-		}
-		actualEndorsersResults = append(actualEndorsersResults, result)
-	}
-	iter.Close()
-	sortResults(expectedEndorsersResults)
-	sortResults(actualEndorsersResults)
-	assert.Equal(expectedEndorsersResults, actualEndorsersResults)
-}
-
 func TestTransientStorePurgeByTxids(t *testing.T) {
 	testStore, cleanup := testStore(t)
 	defer cleanup()


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Before releasing v1.2, we changed the proto that we used to store entries in the transient store. 

1. v1.1 -- we stored only the private write-set
2. v1.2 & later -- we stored both private write-set and collection config

We had to retain the code related to both protos because the transient store can have entries that were stored
during v1.1 (after it has been upgraded to v1.2). This was done to ensure that we can do a rolling upgrade from v1.1 to v1.2 without any private data loss. 

We don't need to maintain code that handles both protos. Hence, this PR removes the code related to old proto.