### PR TITLE
Channel participation int. test - Join app channel at genesis block

### DIFF
--- a/integration/configtx/host_port.go
+++ b/integration/configtx/host_port.go
@@ -1,0 +1,34 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package configtx
+
+import (
+	"net"
+	"strconv"
+
+	"github.com/hyperledger/fabric/integration/nwo"
+	. "github.com/onsi/gomega"
+)
+
+// PeerHostPort returns the host name and port number for the specified peer.
+func PeerHostPort(n *nwo.Network, p *nwo.Peer) (string, int) {
+	return splitHostPort(n.PeerAddress(p, nwo.ListenPort))
+}
+
+// OrdererHostPort returns the host name and port number for the specified
+// orderer.
+func OrdererHostPort(n *nwo.Network, o *nwo.Orderer) (string, int) {
+	return splitHostPort(n.OrdererAddress(o, nwo.ListenPort))
+}
+
+func splitHostPort(address string) (string, int) {
+	host, port, err := net.SplitHostPort(address)
+	Expect(err).NotTo(HaveOccurred())
+	portInt, err := strconv.Atoi(port)
+	Expect(err).NotTo(HaveOccurred())
+	return host, portInt
+}

--- a/integration/e2e/health_test.go
+++ b/integration/e2e/health_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Health", func() {
 			process = ginkgomon.Invoke(peerRunner)
 			Eventually(process.Ready(), network.EventuallyTimeout).Should(BeClosed())
 
-			authClient, _ = PeerOperationalClients(network, peer)
+			authClient, _ = nwo.PeerOperationalClients(network, peer)
 			healthURL = fmt.Sprintf("https://127.0.0.1:%d/healthz", network.PeerPort(peer, nwo.OperationsPort))
 		})
 
@@ -162,7 +162,7 @@ var _ = Describe("Health", func() {
 			Eventually(oProcess.Ready(), network.EventuallyTimeout).Should(BeClosed())
 
 			orderer := network.Orderers[0]
-			authClient, _ = OrdererOperationalClients(network, orderer)
+			authClient, _ = nwo.OrdererOperationalClients(network, orderer)
 			healthURL = fmt.Sprintf("https://127.0.0.1:%d/healthz", network.OrdererPort(orderer, nwo.OperationsPort))
 		})
 

--- a/integration/nwo/channel_participation.go
+++ b/integration/nwo/channel_participation.go
@@ -1,0 +1,136 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package nwo
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-protos-go/common"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+)
+
+func ChannelParticipationJoin(n *Network, o *Orderer, channel string, block *common.Block, expectedChannelInfo ChannelInfo) {
+	blockBytes, err := proto.Marshal(block)
+	Expect(err).NotTo(HaveOccurred())
+	url := fmt.Sprintf("https://127.0.0.1:%d/participation/v1/channels/%s", n.OrdererPort(o, OperationsPort), channel)
+	req := generateJoinRequest(url, channel, blockBytes)
+	authClient, _ := OrdererOperationalClients(n, o)
+
+	body := doBody(authClient, req)
+	c := &ChannelInfo{}
+	err = json.Unmarshal(body, c)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(*c).To(Equal(expectedChannelInfo))
+}
+
+func generateJoinRequest(url, channel string, blockBytes []byte) *http.Request {
+	joinBody := new(bytes.Buffer)
+	writer := multipart.NewWriter(joinBody)
+	part, err := writer.CreateFormFile("config-block", fmt.Sprintf("%s.block", channel))
+	Expect(err).NotTo(HaveOccurred())
+	part.Write(blockBytes)
+	err = writer.Close()
+	Expect(err).NotTo(HaveOccurred())
+
+	req, err := http.NewRequest(http.MethodPost, url, joinBody)
+	Expect(err).NotTo(HaveOccurred())
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	return req
+}
+
+func doBody(client *http.Client, req *http.Request) []byte {
+	resp, err := client.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+	resp.Body.Close()
+
+	return bodyBytes
+}
+
+type channelList struct {
+	SystemChannel *channelInfoShort  `json:"systemChannel"`
+	Channels      []channelInfoShort `json:"channels"`
+}
+
+type channelInfoShort struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+func ChannelParticipationList(n *Network, o *Orderer, expectedChannels []string, systemChannel ...string) {
+	authClient, unauthClient := OrdererOperationalClients(n, o)
+	listChannelsURL := fmt.Sprintf("https://127.0.0.1:%d/participation/v1/channels", n.OrdererPort(o, OperationsPort))
+
+	body := GetBody(authClient, listChannelsURL)()
+	list := &channelList{}
+	err := json.Unmarshal([]byte(body), list)
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(*list).To(MatchFields(IgnoreExtras, Fields{
+		"Channels":      channelsMatcher(expectedChannels),
+		"SystemChannel": systemChannelMatcher(systemChannel...),
+	}))
+
+	resp, err := unauthClient.Get(listChannelsURL)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+}
+
+func channelsMatcher(channels []string) types.GomegaMatcher {
+	if len(channels) == 0 {
+		return BeEmpty()
+	}
+	matchers := make([]types.GomegaMatcher, len(channels))
+	for i, channel := range channels {
+		matchers[i] = channelInfoShortMatcher(channel)
+	}
+	return ConsistOf(matchers)
+}
+
+func systemChannelMatcher(systemChannel ...string) types.GomegaMatcher {
+	if len(systemChannel) == 0 {
+		return BeNil()
+	}
+	return PointTo(channelInfoShortMatcher(systemChannel[0]))
+}
+
+func channelInfoShortMatcher(channel string) types.GomegaMatcher {
+	return MatchFields(IgnoreExtras, Fields{
+		"Name": Equal(channel),
+		"URL":  Equal(fmt.Sprintf("/participation/v1/channels/%s", channel)),
+	})
+}
+
+type ChannelInfo struct {
+	Name            string `json:"name"`
+	URL             string `json:"url"`
+	Status          string `json:"status"`
+	ClusterRelation string `json:"clusterRelation"`
+	Height          uint64 `json:"height"`
+}
+
+func ChannelParticipationListOne(n *Network, o *Orderer, expectedChannelInfo ChannelInfo) {
+	authClient, _ := OrdererOperationalClients(n, o)
+	listChannelURL := fmt.Sprintf("https://127.0.0.1:%d/%s", n.OrdererPort(o, OperationsPort), expectedChannelInfo.URL)
+
+	body := GetBody(authClient, listChannelURL)()
+	c := &ChannelInfo{}
+	err := json.Unmarshal([]byte(body), c)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(*c).To(Equal(expectedChannelInfo))
+}

--- a/integration/nwo/operational_client.go
+++ b/integration/nwo/operational_client.go
@@ -1,0 +1,66 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package nwo
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+
+	. "github.com/onsi/gomega"
+)
+
+func OrdererOperationalClients(n *Network, o *Orderer) (authClient, unauthClient *http.Client) {
+	return operationalClients(n.OrdererLocalTLSDir(o))
+}
+
+func PeerOperationalClients(n *Network, p *Peer) (authClient, unauthClient *http.Client) {
+	return operationalClients(n.PeerLocalTLSDir(p))
+}
+
+func operationalClients(tlsDir string) (authClient, unauthClient *http.Client) {
+	clientCert, err := tls.LoadX509KeyPair(
+		filepath.Join(tlsDir, "server.crt"),
+		filepath.Join(tlsDir, "server.key"),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	clientCertPool := x509.NewCertPool()
+	caCert, err := ioutil.ReadFile(filepath.Join(tlsDir, "ca.crt"))
+	Expect(err).NotTo(HaveOccurred())
+	clientCertPool.AppendCertsFromPEM(caCert)
+
+	authenticatedClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				Certificates: []tls.Certificate{clientCert},
+				RootCAs:      clientCertPool,
+			},
+		},
+	}
+	unauthenticatedClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: clientCertPool},
+		},
+	}
+
+	return authenticatedClient, unauthenticatedClient
+}
+
+func GetBody(client *http.Client, url string) func() string {
+	return func() string {
+		resp, err := client.Get(url)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+		return string(bodyBytes)
+	}
+}

--- a/integration/raft/cft_test.go
+++ b/integration/raft/cft_test.go
@@ -465,12 +465,11 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			ordererCAKey, err := ioutil.ReadFile(ordererCAKeyPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			ordererCACertPath := filepath.Join(network.RootDir, "crypto", "ordererOrganizations", ordererDomain, "ca", fmt.Sprintf("ca.%s-cert.pem", ordererDomain))
+			ordererCACertPath := network.OrdererCACert(orderer)
 			ordererCACert, err := ioutil.ReadFile(ordererCACertPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			adminCertPath := fmt.Sprintf("Admin@%s-cert.pem", ordererDomain)
-			adminCertPath = filepath.Join(network.OrdererUserMSPDir(orderer, "Admin"), "signcerts", adminCertPath)
+			adminCertPath := network.OrdererUserCert(orderer, "Admin")
 
 			originalAdminCert, err := ioutil.ReadFile(adminCertPath)
 			Expect(err).NotTo(HaveOccurred())
@@ -487,8 +486,7 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			err = ioutil.WriteFile(ordererCACertPath, earlyCACert, 0600)
 			Expect(err).NotTo(HaveOccurred())
 
-			ordererCACertPath = filepath.Join(network.RootDir, "crypto", "ordererOrganizations",
-				ordererDomain, "msp", "cacerts", fmt.Sprintf("ca.%s-cert.pem", ordererDomain))
+			ordererCACertPath = network.OrdererCACert(orderer)
 			err = ioutil.WriteFile(ordererCACertPath, earlyCACert, 0600)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/integration/raft/channel_participation_test.go
+++ b/integration/raft/channel_participation_test.go
@@ -1,0 +1,305 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package raft
+
+import (
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/hyperledger/fabric-config/configtx"
+	"github.com/hyperledger/fabric-config/configtx/orderer"
+	"github.com/hyperledger/fabric-protos-go/common"
+	conftx "github.com/hyperledger/fabric/integration/configtx"
+	"github.com/hyperledger/fabric/integration/nwo"
+	"github.com/hyperledger/fabric/integration/nwo/commands"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/tedsuo/ifrit"
+	"github.com/tedsuo/ifrit/ginkgomon"
+)
+
+var _ = Describe("ChannelParticipation", func() {
+	var (
+		testDir        string
+		client         *docker.Client
+		network        *nwo.Network
+		ordererProcess ifrit.Process
+		ordererRunner  *ginkgomon.Runner
+	)
+
+	BeforeEach(func() {
+		var err error
+		testDir, err = ioutil.TempDir("", "channel-participation")
+		Expect(err).NotTo(HaveOccurred())
+
+		client, err = docker.NewClientFromEnv()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if ordererProcess != nil {
+			ordererProcess.Signal(syscall.SIGTERM)
+			Eventually(ordererProcess.Wait(), network.EventuallyTimeout).Should(Receive())
+		}
+		if network != nil {
+			network.Cleanup()
+		}
+		os.RemoveAll(testDir)
+	})
+
+	Describe("basic etcdraft network without a system channel", func() {
+		BeforeEach(func() {
+			raftConfig := nwo.BasicEtcdRaft()
+			network = nwo.New(raftConfig, testDir, client, StartPort(), components)
+			network.ChannelParticipationEnabled = true
+			network.GenerateConfigTree()
+
+			orderer := network.Orderer("orderer")
+			ordererConfig := network.ReadOrdererConfig(orderer)
+			ordererConfig.General.BootstrapMethod = "none"
+			network.WriteOrdererConfig(orderer, ordererConfig)
+			network.Bootstrap()
+
+			ordererRunner = network.OrdererRunner(orderer)
+			ordererProcess = ifrit.Invoke(ordererRunner)
+			Eventually(ordererProcess.Ready, network.EventuallyTimeout).Should(BeClosed())
+			Eventually(ordererRunner.Err(), network.EventuallyTimeout).Should(gbytes.Say("Registrar initializing without a system channel, number of application channels: 0"))
+
+			nwo.ChannelParticipationList(network, orderer, nil)
+		})
+
+		It("starts the orderer but rejects channel creation requests via the legacy channel creation", func() {
+			By("attempting to create a channel without a system channel defined")
+			sess, err := network.PeerAdminSession(network.Peer("Org1", "peer0"), commands.ChannelCreate{
+				ChannelID:   "testchannel",
+				Orderer:     network.OrdererAddress(network.Orderer("orderer"), nwo.ListenPort),
+				File:        network.CreateChannelTxPath("testchannel"),
+				OutputBlock: "/dev/null",
+				ClientAuth:  network.ClientAuthRequired,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(1))
+			Eventually(sess.Err, network.EventuallyTimeout).Should(gbytes.Say("channel creation request not allowed because the orderer system channel is not defined"))
+		})
+
+		It("joins application channels using the channel participation API from genesis block", func() {
+			orderer := network.Orderer("orderer")
+			peer := network.Peer("Org1", "peer0")
+
+			By("joining channel as a member")
+			genesisBlock := applicationChannelGenesisBlock(network, orderer, peer, "participation-trophy")
+			expectedChannelInfo := nwo.ChannelInfo{
+				Name:            "participation-trophy",
+				URL:             "/participation/v1/channels/participation-trophy",
+				Status:          "active",
+				ClusterRelation: "member",
+				Height:          1,
+			}
+			nwo.ChannelParticipationJoin(network, orderer, "participation-trophy", genesisBlock, expectedChannelInfo)
+			nwo.ChannelParticipationListOne(network, orderer, expectedChannelInfo)
+
+			By("waiting for the leader to be ready")
+			findLeader([]*ginkgomon.Runner{ordererRunner})
+
+			By("ensuring the channel is usable by submitting a transaction")
+			env := CreateBroadcastEnvelope(network, peer, "participation-trophy", []byte("hello"))
+			resp, err := nwo.Broadcast(network, orderer, env)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Status).To(Equal(common.Status_SUCCESS))
+			waitForBlockReception(orderer, peer, network, "participation-trophy", 1)
+
+			By("checking the channel height")
+			expectedChannelInfo.Height = 2
+			nwo.ChannelParticipationListOne(network, orderer, expectedChannelInfo)
+
+			By("joining another channel as a member")
+			genesisBlock2 := applicationChannelGenesisBlock(network, orderer, peer, "another-participation-trophy")
+			expectedChannelInfo = nwo.ChannelInfo{
+				Name:            "another-participation-trophy",
+				URL:             "/participation/v1/channels/another-participation-trophy",
+				Status:          "active",
+				ClusterRelation: "member",
+				Height:          1,
+			}
+			nwo.ChannelParticipationJoin(network, orderer, "another-participation-trophy", genesisBlock2, expectedChannelInfo)
+			nwo.ChannelParticipationListOne(network, orderer, expectedChannelInfo)
+
+			By("listing all channels")
+			nwo.ChannelParticipationList(network, orderer, []string{"participation-trophy", "another-participation-trophy"})
+		})
+	})
+})
+
+func applicationChannelGenesisBlock(n *nwo.Network, o *nwo.Orderer, p *nwo.Peer, channel string) *common.Block {
+	ordererCACert := nwo.ParseCertificate(n.OrdererCACert(o))
+	ordererAdminCert := nwo.ParseCertificate(n.OrdererUserCert(o, "Admin"))
+	ordererTLSCert := nwo.ParseCertificate(filepath.Join(n.OrdererLocalTLSDir(o), "server.crt"))
+	ordererOrg := n.Organization(o.Organization)
+	host, port := conftx.OrdererHostPort(n, o)
+
+	peerOrg := n.Organization(p.Organization)
+	peerCACert := nwo.ParseCertificate(n.PeerCACert(p))
+	peerAdminCert := nwo.ParseCertificate(n.PeerUserCert(p, "Admin"))
+
+	channelConfig := configtx.Channel{
+		Orderer: configtx.Orderer{
+			OrdererType: "etcdraft",
+			Organizations: []configtx.Organization{
+				{
+					Name: o.Organization,
+					Policies: map[string]configtx.Policy{
+						"Readers": {
+							Type: "Signature",
+							Rule: fmt.Sprintf("OR('%s.member')", ordererOrg.MSPID),
+						},
+						"Writers": {
+							Type: "Signature",
+							Rule: fmt.Sprintf("OR('%s.member')", ordererOrg.MSPID),
+						},
+						"Admins": {
+							Type: "Signature",
+							Rule: fmt.Sprintf("OR('%s.member')", ordererOrg.MSPID),
+						},
+					},
+					OrdererEndpoints: []string{
+						n.OrdererAddress(o, nwo.ListenPort),
+					},
+					MSP: configtx.MSP{
+						Name:      ordererOrg.MSPID,
+						RootCerts: []*x509.Certificate{ordererCACert},
+						Admins:    []*x509.Certificate{ordererAdminCert},
+					},
+				},
+			},
+			EtcdRaft: orderer.EtcdRaft{
+				Consenters: []orderer.Consenter{
+					{
+						Address: orderer.EtcdAddress{
+							Host: host,
+							Port: port,
+						},
+						ClientTLSCert: ordererTLSCert,
+						ServerTLSCert: ordererTLSCert,
+					},
+				},
+				Options: orderer.EtcdRaftOptions{
+					TickInterval:         "500ms",
+					ElectionTick:         10,
+					HeartbeatTick:        1,
+					MaxInflightBlocks:    5,
+					SnapshotIntervalSize: 16 * 1024 * 1024, // 16 MB
+				},
+			},
+			Policies: map[string]configtx.Policy{
+				"Readers": {
+					Type: "ImplicitMeta",
+					Rule: "ANY Readers",
+				},
+				"Writers": {
+					Type: "ImplicitMeta",
+					Rule: "ANY Writers",
+				},
+				"Admins": {
+					Type: "ImplicitMeta",
+					Rule: "MAJORITY Admins",
+				},
+				"BlockValidation": {
+					Type: "ImplicitMeta",
+					Rule: "ANY Writers",
+				},
+			},
+			Capabilities: []string{"V2_0"},
+			BatchSize: orderer.BatchSize{
+				MaxMessageCount:   100,
+				AbsoluteMaxBytes:  1024 * 1024,
+				PreferredMaxBytes: 512 * 1024,
+			},
+			BatchTimeout: 2 * time.Second,
+			State:        "STATE_NORMAL",
+		},
+		Application: configtx.Application{
+			Organizations: []configtx.Organization{
+				{
+					Name: p.Organization,
+					Policies: map[string]configtx.Policy{
+						"Readers": {
+							Type: "Signature",
+							Rule: fmt.Sprintf("OR('%s.member')", peerOrg.MSPID),
+						},
+						"Writers": {
+							Type: "Signature",
+							Rule: fmt.Sprintf("OR('%s.member')", peerOrg.MSPID),
+						},
+						"Admins": {
+							Type: "Signature",
+							Rule: fmt.Sprintf("OR('%s.member')", peerOrg.MSPID),
+						},
+					},
+					OrdererEndpoints: []string{
+						n.OrdererAddress(o, nwo.ListenPort),
+					},
+					MSP: configtx.MSP{
+						Name:      peerOrg.MSPID,
+						RootCerts: []*x509.Certificate{peerCACert},
+						Admins:    []*x509.Certificate{peerAdminCert},
+					},
+				},
+			},
+			Capabilities: []string{"V2_0"},
+			Policies: map[string]configtx.Policy{
+				"Readers": {
+					Type: "ImplicitMeta",
+					Rule: "ANY Readers",
+				},
+				"Writers": {
+					Type: "ImplicitMeta",
+					Rule: "ANY Writers",
+				},
+				"Admins": {
+					Type: "ImplicitMeta",
+					Rule: "MAJORITY Admins",
+				},
+				"Endorsement": {
+					Type: "ImplicitMeta",
+					Rule: "MAJORITY Endorsement",
+				},
+				"LifecycleEndorsement": {
+					Type: "ImplicitMeta",
+					Rule: "MAJORITY Endorsement",
+				},
+			},
+		},
+		Capabilities: []string{"V2_0"},
+		Policies: map[string]configtx.Policy{
+			"Readers": {
+				Type: "ImplicitMeta",
+				Rule: "ANY Readers",
+			},
+			"Writers": {
+				Type: "ImplicitMeta",
+				Rule: "ANY Writers",
+			},
+			"Admins": {
+				Type: "ImplicitMeta",
+				Rule: "MAJORITY Admins",
+			},
+		},
+	}
+
+	genesisBlock, err := configtx.NewApplicationChannelGenesisBlock(channelConfig, channel)
+	Expect(err).NotTo(HaveOccurred())
+
+	return genesisBlock
+}


### PR DESCRIPTION
#### Type of change

- Test update

#### Description

Commit 1:
- Integration test that uses the channel participation API to join an application channel at the genesis block as a member. This scenario uses a single node raft setup. Multi node raft to follow in a subsequent commit/PR.

- Also some related refactoring/addition of helper functions for certificates, private keys, and addresses.

#### Related issues

[FAB-18019](https://jira.hyperledger.org/browse/FAB-18019)
