### PR TITLE
fix broken code: check iter error

### DIFF
--- a/common/ledger/blkstorage/blockstore_provider_test.go
+++ b/common/ledger/blkstorage/blockstore_provider_test.go
@@ -220,7 +220,8 @@ func TestRemove(t *testing.T) {
 	exists, err := provider.Exists("ledger1")
 	require.NoError(t, err)
 	require.False(t, exists)
-	itr := provider.leveldbProvider.GetDBHandle("ledger1").GetIterator(nil, nil)
+	itr, err := provider.leveldbProvider.GetDBHandle("ledger1").GetIterator(nil, nil)
+	require.NoError(t, err)
 	defer itr.Release()
 	require.False(t, itr.Next())
 

--- a/common/ledger/util/leveldbhelper/leveldb_provider.go
+++ b/common/ledger/util/leveldbhelper/leveldb_provider.go
@@ -166,11 +166,11 @@ func (h *DBHandle) Delete(key []byte, sync bool) error {
 
 // DeleteAll deletes all the keys that belong to the channel (dbName).
 func (h *DBHandle) DeleteAll() error {
-	iter := h.GetIterator(nil, nil)
-	defer iter.Release()
-	if err := iter.Error(); err != nil {
-		return errors.Wrap(err, "internal leveldb error while obtaining db iterator")
+	iter, err := h.GetIterator(nil, nil)
+	if err != nil {
+		return err
 	}
+	defer iter.Release()
 
 	// use leveldb iterator directly to be more efficient
 	dbIter := iter.Iterator

--- a/common/ledger/util/leveldbhelper/leveldb_provider_test.go
+++ b/common/ledger/util/leveldbhelper/leveldb_provider_test.go
@@ -246,7 +246,8 @@ func TestDeleteAll(t *testing.T) {
 	}
 
 	for _, dbSetup := range expectedSetup {
-		itr := dbSetup.db.GetIterator(nil, nil)
+		itr, err := dbSetup.db.GetIterator(nil, nil)
+		require.NoError(t, err)
 		checkItrResults(t, itr, dbSetup.expectedKeys, dbSetup.expectedValues)
 		itr.Release()
 	}
@@ -282,7 +283,8 @@ func TestDeleteAll(t *testing.T) {
 	}
 
 	for _, result := range expectedResults {
-		itr := result.db.GetIterator(nil, nil)
+		itr, err := result.db.GetIterator(nil, nil)
+		require.NoError(t, err)
 		checkItrResults(t, itr, result.expectedKeys, result.expectedValues)
 		itr.Release()
 	}


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

A indirectly conflict between two PRs went undetected. 

1. https://github.com/hyperledger/fabric/pull/1428 enforced checking of iter error
2. https://github.com/hyperledger/fabric/pull/1423 used the old iter

https://github.com/hyperledger/fabric/pull/1423 was merged first and then https://github.com/hyperledger/fabric/pull/1428 The GitHub couldn't detect a conflict or enforced the need for rebuild/reverify. 