### PR TITLE
Fix unsupported syntax for policy in the documents

### DIFF
--- a/docs/source/access_control.md
+++ b/docs/source/access_control.md
@@ -50,7 +50,7 @@ to be satisfied. For example:
 Policies:
   MyPolicy:
     Type: Signature
-    Rule: “Org1.Peer OR Org2.Peer”
+    Rule: "OR('Org1.peer', 'Org2.peer')"
 
 ```
 

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -496,7 +496,7 @@ Policy
 ------
 
 Policies are expressions composed of properties of digital identities, for
-example: ``Org1.Peer OR Org2.Peer``. They are used to restrict access to
+example: ``OR('Org1.peer', 'Org2.peer')``. They are used to restrict access to
 resources on a blockchain network. For instance, they dictate who can read from
 or write to a channel, or who can use a specific chaincode API via an ACL_.
 Policies may be defined in ``configtx.yaml`` prior to bootstrapping an ordering
@@ -571,7 +571,7 @@ Raft
 
 New for v1.4.1, Raft is a crash fault tolerant (CFT) ordering service
 implementation based on the `etcd library <https://coreos.com/etcd/>`_
-of the `Raft protocol` <https://raft.github.io/raft.pdf>`_. Raft follows a
+of the `Raft protocol <https://raft.github.io/raft.pdf>`_. Raft follows a
 "leader and follower" model, where a leader node is elected (per channel) and
 its decisions are replicated by the followers. Raft ordering services should
 be easier to set up and manage than Kafka-based ordering services, and their

--- a/docs/source/policies.rst
+++ b/docs/source/policies.rst
@@ -21,10 +21,11 @@ data meet some condition required for those signatures to be considered
 'valid'. This is useful for determining that the correct parties have
 agreed to a transaction, or change.
 
-For example a policy may define any of the following: \* Administrators
-from 2 out 5 possible different organizations must sign. \* Any member
-from any organization must sign. \* Two specific certificates must both
-sign.
+For example a policy may define any of the following:
+
+* Administrators from 2 out 5 possible different organizations must sign.
+* Any member from any organization must sign.
+* Two specific certificates must both sign.
 
 Of course these are only examples, and other more powerful rules can be
 constructed.
@@ -90,7 +91,7 @@ minimally as follows:
                     Writers
                     Admins
                 Groups:
-                    OrdereringOrganization1:
+                    OrderingOrganization1:
                         Policies:
                             Readers
                             Writers

--- a/docs/source/policies/policies.md
+++ b/docs/source/policies/policies.md
@@ -182,13 +182,13 @@ sign offs use the `ImplicitMeta` syntax.
 ### Signature policies
 
 `Signature` policies define specific types of users who must sign in order for a
-policy to be satisfied such as `Org1.Peer OR Org2.Peer`. These policies are
+policy to be satisfied such as `OR('Org1.peer', 'Org2.peer')`. These policies are
 considered the most versatile because they allow for the construction of
 extremely specific rules like: “An admin of org A and 2 other admins, or 5 of 6
 organization admins”. The syntax supports arbitrary combinations of `AND`, `OR`
-and `NOutOf`. For example, a policy can be easily expressed by using `AND
-(Org1, Org2)` which means that a signature from at least one member in Org1 AND
-one member in Org2 is required for the policy to be satisfied.
+and `NOutOf`. For example, a policy can be easily expressed by using
+`AND('Org1.member', 'Org2.member')` which means that a signature from at least
+one member in Org1 AND one member in Org2 is required for the policy to be satisfied.
 
 ### ImplicitMeta policies
 


### PR DESCRIPTION
This patch fixes unsupported syntax for policy in the documents.

#### Type of change

- Bug fix
- Documentation update

#### Description

This patch fixes unsupported syntax for policy in the documents.
Also, this patch includes minor fixes like typo.

#### Additional details

#### Related issues
