### PR TITLE
Eliminate warnings when building documents

### DIFF
--- a/docs/source/CONTRIBUTING.rst
+++ b/docs/source/CONTRIBUTING.rst
@@ -56,7 +56,7 @@ As a developer:
   bring a team to implement it, or join one of the teams working on an existing Epic.
   If you see an Epic that interests you on the
   `release roadmap <https://jira.hyperledger.org/secure/Dashboard.jspa?selectPageId=10104>`_,
-  contact the Epic assignee via the Jira work item or on `RocketChat <https://chat.hyperledger.org/>`_.
+  contact the Epic assignee via the Jira work item or on `RocketChat <https://chat.hyperledger.org/>`__.
 
 Getting a Linux Foundation account
 ----------------------------------
@@ -446,11 +446,9 @@ Related Topics
 .. toctree::
    :maxdepth: 1
 
-   MAINTAINERS
    jira_navigation
    dev-setup/devenv
    dev-setup/build
-   testing
    style-guides/go-style
 
 .. Licensed under Creative Commons Attribution 4.0 International License

--- a/docs/source/build_network.rst
+++ b/docs/source/build_network.rst
@@ -169,7 +169,7 @@ the following command instead:
           `documentation <https://hyperledger.github.io/fabric-chaincode-node/master/api/fabric-shim.ChaincodeInterface.html>`_.
 
 .. note:: For more information on the Java shim, please refer to its
-          `documentation <https://hyperledger.github.io/fabric-chaincode-java/{BRANCH}/api/org/hyperledger/fabric/shim/Chaincode.html>`_.
+          `documentation <https://hyperledger.github.io/fabric-chaincode-java/{BRANCH}/api/org/hyperledger/fabric/shim/Chaincode.html>`__.
 
 Тo make the sample run with Java chaincode, you have to specify ``-l java`` as follows:
 

--- a/docs/source/chaincode4ade.rst
+++ b/docs/source/chaincode4ade.rst
@@ -38,7 +38,7 @@ documentation of the Chaincode Shim API for different languages below:
 
   - `Go <https://godoc.org/github.com/hyperledger/fabric-chaincode-go/shim#Chaincode>`__
   - `Node.js <https://hyperledger.github.io/fabric-chaincode-node/{BRANCH}/api/fabric-shim.ChaincodeInterface.html>`__
-  - `Java <https://hyperledger.github.io/fabric-chaincode-java/{BRANCH}/api/org/hyperledger/fabric/shim/Chaincode.html>`_
+  - `Java <https://hyperledger.github.io/fabric-chaincode-java/{BRANCH}/api/org/hyperledger/fabric/shim/Chaincode.html>`__
 
 In each language, the ``Invoke`` method is called by clients to submit transaction
 proposals. This method allows you to use the chaincode to read and write data on
@@ -56,7 +56,7 @@ The other interface in the chaincode "shim" APIs is the ``ChaincodeStubInterface
 
   - `Go <https://godoc.org/github.com/hyperledger/fabric-chaincode-go/shim#ChaincodeStubInterface>`__
   - `Node.js <https://hyperledger.github.io/fabric-chaincode-node/{BRANCH}/api/fabric-shim.ChaincodeStub.html>`__
-  - `Java <https://hyperledger.github.io/fabric-chaincode-java/{BRANCH}/api/org/hyperledger/fabric/shim/ChaincodeStub.html>`_
+  - `Java <https://hyperledger.github.io/fabric-chaincode-java/{BRANCH}/api/org/hyperledger/fabric/shim/ChaincodeStub.html>`__
 
 which is used to access and modify the ledger, and to make invocations between
 chaincodes.
@@ -75,7 +75,7 @@ Choosing a Location for the Code
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you haven't been doing programming in Go, you may want to make sure that
-you have :ref:`Go` installed and your system properly configured. We assume
+you have `Go <https://golang.org>`_ installed and your system properly configured. We assume
 you are using a version that supports modules.
 
 Now, you will want to create a directory for your chaincode application.

--- a/docs/source/deployment_guide_overview.rst
+++ b/docs/source/deployment_guide_overview.rst
@@ -158,7 +158,7 @@ Create an ordering node
 
 Unlike the creation of a peer, you will need to create a genesis block (or reference a block that has already been created, if adding an ordering node to an existing ordering service) and specify the path to it before launching the ordering node.
 
-In Fabric, this configuration file for ordering nodes is called ``orderer.yaml``. You can find a sample ``orderer.yaml`` configuration file `in the sampleconfig directory of Hyperledger Fabric <https://github.com/hyperledger/fabric/blob/master/sampleconfig/orderer.yaml>`_. Note that ``orderer.yaml`` is different than the "genesis block" of an ordering service. This block, which includes the initial configuration of the orderer system channel, must be created before an ordering node is created because it is used to bootstrap the node.
+In Fabric, this configuration file for ordering nodes is called ``orderer.yaml``. You can find a sample ``orderer.yaml`` configuration file `in the sampleconfig directory of Hyperledger Fabric <https://github.com/hyperledger/fabric/blob/master/sampleconfig/orderer.yaml>`__. Note that ``orderer.yaml`` is different than the "genesis block" of an ordering service. This block, which includes the initial configuration of the orderer system channel, must be created before an ordering node is created because it is used to bootstrap the node.
 
 As with the peer, you will see that there are quite a number of parameters you either have the option to set or will need to set for your node to work properly. In general, if you do not have the need to change a tuning value, leave it alone.
 
@@ -193,7 +193,7 @@ When you're comfortable with how your ordering node has been configured, how you
 Next steps
 ----------
 
-Blockchain networks are all about connection, so once you've deployed nodes, you'll obviously want to connect them to other nodes! If you have a peer organization and a peer, you'll want to join your organization to a consortium and join or :doc:`channels`. If you have an ordering node, you will want to add peer organizations to your consortium. You'll also want to learn how to develop chaincode, which you can learn about in the topics :doc:`developapps/scenario` and :doc:`chaincode4noah`.
+Blockchain networks are all about connection, so once you've deployed nodes, you'll obviously want to connect them to other nodes! If you have a peer organization and a peer, you'll want to join your organization to a consortium and join or :doc:`channels`. If you have an ordering node, you will want to add peer organizations to your consortium. You'll also want to learn how to develop chaincode, which you can learn about in the topics :doc:`developapps/scenario` and :doc:`chaincode4ade`.
 
 Part of the process of connecting nodes and creating channels will involve modifying policies to fit the use cases of business networks. For more information about policies, check out :doc:`policies/policies`.
 

--- a/docs/source/dev-setup/devenv.rst
+++ b/docs/source/dev-setup/devenv.rst
@@ -63,7 +63,7 @@ These need to be ``false`` and ``true`` respectively.
 
 The ``curl`` command that comes with Git and Docker Toolbox is old and
 does not handle properly the redirect used in
-:doc:`getting_started`. Make sure you have and use a newer version
+:doc:`../getting_started`. Make sure you have and use a newer version
 which can be downloaded from the `cURL downloads page
 <https://curl.haxx.se/download.html>`__
 

--- a/docs/source/developapps/connectionprofile.md
+++ b/docs/source/developapps/connectionprofile.md
@@ -274,7 +274,7 @@ details of the network topology.
 This file is reproduced inline from the GitHub commercial paper
 [sample](https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/commercial-paper/organization/magnetocorp/gateway/networkConnection.yaml).
 
-```yaml
+```
 1: ---
 2: #
 3: # [Required]. A connection profile contains information about a set of network

--- a/docs/source/discovery-cli.md
+++ b/docs/source/discovery-cli.md
@@ -13,7 +13,7 @@ The `discover` command has the following subcommands:
 
 And the usage of the command is shown below:
 
-~~~~ {.sourceCode .shell}
+```
 usage: discover [<flags>] <command> [<args> ...]
 
 Command line client for fabric discovery service
@@ -43,7 +43,7 @@ Commands:
 
   saveConfig
     Save the config passed by flags into the file specified by --configFile
-~~~~
+```
 
 Configuring external endpoints
 ------------------------------
@@ -65,13 +65,13 @@ Persisting configuration
 To persist the configuration, a config file name should be supplied via
 the flag `--configFile`, along with the command `saveConfig`:
 
-~~~~ {.sourceCode .shell}
+```
 discover --configFile conf.yaml --peerTLSCA tls/ca.crt --userKey msp/keystore/ea4f6a38ac7057b6fa9502c2f5f39f182e320f71f667749100fe7dd94c23ce43_sk --userCert msp/signcerts/User1\@org1.example.com-cert.pem  --MSP Org1MSP saveConfig
-~~~~
+```
 
 By executing the above command, configuration file would be created:
 
-~~~~ {.sourceCode .YAML}
+```yaml
 $ cat conf.yaml
 version: 0
 tlsconfig:
@@ -83,7 +83,7 @@ signerconfig:
   mspid: Org1MSP
   identitypath: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/signcerts/User1@org1.example.com-cert.pem
   keypath: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/keystore/ea4f6a38ac7057b6fa9502c2f5f39f182e320f71f667749100fe7dd94c23ce43_sk
-~~~~
+```
 
 When the peer runs with TLS enabled, the discovery service on the peer
 requires the client to connect to it with mutual TLS, which means it
@@ -124,7 +124,7 @@ Let's go over them and see how they should be invoked and parsed:
 Peer membership query:
 ----------------------
 
-~~~~ {.sourceCode .shell}
+```
 $ discover --configFile conf.yaml peers --channel mychannel  --server peer0.org1.example.com:7051
 [
 	{
@@ -162,7 +162,7 @@ $ discover --configFile conf.yaml peers --channel mychannel  --server peer0.org1
 		"Chaincodes": null
 	}
 ]
-~~~~
+```
 
 As seen, this command outputs a JSON containing membership information
 about all the peers in the channel that the peer queried possesses.
@@ -170,7 +170,7 @@ about all the peers in the channel that the peer queried possesses.
 The `Identity` that is returned is the enrollment certificate of the
 peer, and it can be parsed with a combination of `jq` and `openssl`:
 
-~~~~ {.sourceCode .shell}
+```
 $ discover --configFile conf.yaml peers --channel mychannel  --server peer0.org1.example.com:7051  | jq .[0].Identity | sed "s/\\\n/\n/g" | sed "s/\"//g"  | openssl x509 -text -noout
 Certificate:
     Data:
@@ -207,7 +207,7 @@ Certificate:
          a1:3d:65:5c:7b:79:a1:7a:d1:94:50:f0:cd:db:ea:61:81:7a:
          02:20:3b:40:5b:60:51:3c:f8:0f:9b:fc:ae:fc:21:fd:c8:36:
          a3:18:39:58:20:72:3d:1a:43:74:30:f3:56:01:aa:26
-~~~~
+```
 
 Configuration query:
 --------------------
@@ -216,7 +216,7 @@ The configuration query returns a mapping from MSP IDs to orderer
 endpoints, as well as the `FabricMSPConfig` which can be used to verify
 all peer and orderer nodes by the SDK:
 
-~~~~ {.sourceCode .shell}
+```
 $ discover --configFile conf.yaml config --channel mychannel  --server peer0.org1.example.com:7051
 {
     "msps": {
@@ -314,12 +314,12 @@ $ discover --configFile conf.yaml config --channel mychannel  --server peer0.org
         }
     }
 }
-~~~~
+```
 
 It's important to note that the certificates here are base64 encoded,
 and thus should decoded in a manner similar to the following:
 
-~~~~ {.sourceCode .shell}
+```
 $ discover --configFile conf.yaml config --channel mychannel  --server peer0.org1.example.com:7051 | jq .msps.OrdererOrg.root_certs[0] | sed "s/\"//g" | base64 --decode | openssl x509 -text -noout
 Certificate:
     Data:
@@ -357,7 +357,7 @@ Certificate:
          d8:a0:47:7a:33:ff:30:c1:09:a6:05:ec:b0:53:53:39:c1:0e:
          02:20:6b:f4:1d:48:e0:72:e4:c2:ef:b0:84:79:d4:2e:c2:c5:
          1b:6f:e4:2f:56:35:51:18:7d:93:51:86:05:84:ce:1f
-~~~~
+```
 
 Endorsers query:
 ----------------
@@ -386,7 +386,7 @@ If chaincode cc2 is not expected to read from collection `col1` then `--noPrivat
 Below is the output of an endorsers query for chaincode **mycc** when
 the endorsement policy is `AND('Org1.peer', 'Org2.peer')`:
 
-~~~~ {.sourceCode .shell}
+```
 $ discover --configFile conf.yaml endorsers --channel mychannel  --server peer0.org1.example.com:7051 --chaincode mycc
 [
     {
@@ -425,7 +425,7 @@ $ discover --configFile conf.yaml endorsers --channel mychannel  --server peer0.
         ]
     }
 ]
-~~~~
+```
 
 Not using a configuration file
 ------------------------------
@@ -435,7 +435,7 @@ configuration file, and just passing all needed configuration as
 commandline flags. The following is an example of a local peer membership
 query which loads administrator credentials:
 
-~~~~ {.sourceCode .shell}
+```
 $ discover --peerTLSCA tls/ca.crt --userKey msp/keystore/cf31339d09e8311ac9ca5ed4e27a104a7f82f1e5904b3296a170ba4725ffde0d_sk --userCert msp/signcerts/Admin\@org1.example.com-cert.pem --MSP Org1MSP --tlsCert tls/client.crt --tlsKey tls/client.key peers --server peer0.org1.example.com:7051
 [
 	{
@@ -459,4 +459,4 @@ $ discover --peerTLSCA tls/ca.crt --userKey msp/keystore/cf31339d09e8311ac9ca5ed
 		"Identity": "-----BEGIN CERTIFICATE-----\nMIICKDCCAc+gAwIBAgIRALnNJzplCrYy4Y8CjZtqL7AwCgYIKoZIzj0EAwIwczEL\nMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDVNhbiBG\ncmFuY2lzY28xGTAXBgNVBAoTEG9yZzIuZXhhbXBsZS5jb20xHDAaBgNVBAMTE2Nh\nLm9yZzIuZXhhbXBsZS5jb20wHhcNMTgwNjE3MTM0NTIxWhcNMjgwNjE0MTM0NTIx\nWjBqMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMN\nU2FuIEZyYW5jaXNjbzENMAsGA1UECxMEcGVlcjEfMB0GA1UEAxMWcGVlcjEub3Jn\nMi5leGFtcGxlLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNDopAkHlDdu\nq10HEkdxvdpkbs7EJyqv1clvCt/YMn1hS6sM+bFDgkJKalG7s9Hg3URF0aGpy51R\nU+4F9Muo+XajTTBLMA4GA1UdDwEB/wQEAwIHgDAMBgNVHRMBAf8EAjAAMCsGA1Ud\nIwQkMCKAIFZMuZfUtY6n2iyxaVr3rl+x5lU0CdG9x7KAeYydQGTMMAoGCCqGSM49\nBAMCA0cAMEQCIAR4fBmIBKW2jp0HbbabVepNtl1c7+6++riIrEBnoyIVAiBBvWmI\nyG02c5hu4wPAuVQMB7AU6tGSeYaWSAAo/ExunQ==\n-----END CERTIFICATE-----\n",
 	}
 ]
-~~~~
+```

--- a/docs/source/discovery-overview.rst
+++ b/docs/source/discovery-overview.rst
@@ -65,7 +65,7 @@ service will then compute a descriptor comprised of two objects:
 The following is an example of a descriptor from the evaluation of a policy of
 ``AND(Org1, Org2)`` where there are two peers in each of the organizations.
 
-.. code-block:: JSON
+.. code-block:: none
 
    Layouts: [
         QuantitiesByGroup: {

--- a/docs/source/endorsement-policies.rst
+++ b/docs/source/endorsement-policies.rst
@@ -104,7 +104,7 @@ For example:
 
 In addition to the specifying an endorsement policy from the CLI or SDK, a
 chaincode can also use policies in the channel configuration as endorsement
-policies. You can use the ``--channel-config-policy``flag to select a channel policy with
+policies. You can use the ``--channel-config-policy`` flag to select a channel policy with
 format used by the channel configuration and by ACLs.
 
 For example:

--- a/docs/source/fabric_model.rst
+++ b/docs/source/fabric_model.rst
@@ -4,26 +4,25 @@ Hyperledger Fabric Model
 This section outlines the key design features woven into Hyperledger Fabric that
 fulfill its promise of a comprehensive, yet customizable, enterprise blockchain solution:
 
-* :ref:`Assets` --- Asset definitions enable the exchange of almost anything with
+* `Assets`_ --- Asset definitions enable the exchange of almost anything with
   monetary value over the network, from whole foods to antique cars to currency
   futures.
-* :ref:`Chaincode` --- Chaincode execution is partitioned from transaction ordering,
+* `Chaincode`_ --- Chaincode execution is partitioned from transaction ordering,
   limiting the required levels of trust and verification across node types, and
   optimizing network scalability and performance.
-* :ref:`Ledger-Features` --- The immutable, shared ledger encodes the entire
+* `Ledger Features`_ --- The immutable, shared ledger encodes the entire
   transaction history for each channel, and includes SQL-like query capability
   for efficient auditing and dispute resolution.
-* :ref:`Privacy` --- Channels and private data collections enable private and
+* `Privacy`_ --- Channels and private data collections enable private and
   confidential multi-lateral transactions that are usually required by
   competing businesses and regulated industries that exchange assets on a common
   network.
-* :ref:`Security-Membership-Services` --- Permissioned membership provides a
+* `Security & Membership Services`_ --- Permissioned membership provides a
   trusted blockchain network, where participants know that all transactions can
   be detected and traced by authorized regulators and auditors.
-* :ref:`Consensus` --- A unique approach to consensus enables the
+* `Consensus`_ --- A unique approach to consensus enables the
   flexibility and scalability needed for the enterprise.
 
-.. _Assets:
 
 Assets
 ------
@@ -36,7 +35,6 @@ Assets are represented in Hyperledger Fabric as a collection of
 key-value pairs, with state changes recorded as transactions on a :ref:`Channel`
 ledger.  Assets can be represented in binary and/or JSON form.
 
-.. _Chaincode:
 
 Chaincode
 ---------
@@ -48,7 +46,6 @@ the ledger's current state database and are initiated through a transaction prop
 results in a set of key-value writes (write set) that can be submitted to the network and applied to
 the ledger on all peers.
 
-.. _Ledger-Features:
 
 Ledger Features
 ---------------
@@ -78,7 +75,6 @@ Some features of a Fabric ledger:
 
 See the :doc:`ledger` topic for a deeper dive on the databases, storage structure, and "query-ability."
 
-.. _Privacy:
 
 Privacy
 -------
@@ -114,7 +110,6 @@ text.
 See the :doc:`private-data-arch` topic for more details on how to achieve
 privacy on your blockchain network.
 
-.. _Security-Membership-Services:
 
 Security & Membership Services
 ------------------------------
@@ -131,7 +126,6 @@ See the :doc:`msp` topic to better understand cryptographic
 implementations, and the sign, verify, authenticate approach used in
 Hyperledger Fabric.
 
-.. _Consensus:
 
 Consensus
 ---------

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -330,7 +330,7 @@ submit the read-only transaction, unless there is desire to log the read on the 
 for audit purpose. The invoke includes a channel identifier, the chaincode function to
 invoke, and an array of arguments.
 
-.. _Leader
+.. _Leader:
 
 Leader
 ------
@@ -383,7 +383,7 @@ process called **consensus**. The term **Distributed Ledger Technology**
 singular, but has many identical copies distributed across a set of network
 nodes (peers and the ordering service).
 
-.. _Log-entry
+.. _Log-entry:
 
 Log entry
 ---------

--- a/docs/source/kafka.rst
+++ b/docs/source/kafka.rst
@@ -210,4 +210,4 @@ Set environment variable ``FABRIC_LOGGING_SPEC`` to ``DEBUG`` and set
 ``Kafka.Verbose`` to ``true`` in ``orderer.yaml`` .
 
 .. Licensed under Creative Commons Attribution 4.0 International License
-https://creativecommons.org/licenses/by/4.0/
+   https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/kafka_raft_migration.md
+++ b/docs/source/kafka_raft_migration.md
@@ -102,7 +102,7 @@ tutorial to pull, translate, and scope the configuration of **each channel,
 starting with the system channel**. The only field you should change during
 this step is in the channel configuration at `/Channel/Orderer/ConsensusType`.
 In a JSON representation of the channel configuration, this would be
-`.channel_group.groups.Orderer.values.ConsensusType​`.
+`.channel_group.groups.Orderer.values.ConsensusType`.
 
 The `ConsensusType` is represented by three values: `Type`, `Metadata`, and
 `State`, where:
@@ -154,9 +154,9 @@ service and then the ordering service nodes.
 The next step in the migration process is another channel configuration update
 for each channel. In this configuration update, switch the `Type` to `etcdraft`
 (for Raft) while keeping the `State` in `STATE_MAINTENANCE`, and fill in the
-`Metadata` configuration​. It is highly recommended that the `Metadata` configuration​ be
-identical​ on all channels. If you want to establish different consenter sets
-with different nodes, you will be able to reconfigure the `Metadata` configuration​
+`Metadata` configuration. It is highly recommended that the `Metadata` configuration be
+identical on all channels. If you want to establish different consenter sets
+with different nodes, you will be able to reconfigure the `Metadata` configuration
 after the system is restarted into `etcdraft` mode. Supplying an identical metadata
 object, and hence, an identical consenter set, means that when the nodes are
 restarted, if the system channel forms a quorum and can exit maintenance mode,
@@ -194,9 +194,9 @@ successfully.
 
 When a leader is elected, the log will show, for each channel:
 
-``` ​
-"Raft leader changed: 0 -> ​node-number​ ​channel=​channel-name​
-node=​node-number​ ​"
+```
+"Raft leader changed: 0 -> node-number channel=channel-name
+node=node-number "
 ```
 
 For example:
@@ -206,8 +206,8 @@ For example:
 INFO 047 Raft leader changed: 0 -> 1 channel=testchannel1 node=2
 ```
 
-In this example `​node 2​` reports that a leader was elected (the leader is
-​`node 1`​) by the cluster of channel `​testchannel1​`.
+In this example `node 2` reports that a leader was elected (the leader is
+`node 1`) by the cluster of channel `testchannel1`.
 
 ### Switch out of maintenance mode
 

--- a/docs/source/txflow.rst
+++ b/docs/source/txflow.rst
@@ -128,4 +128,4 @@ transaction flow in more detail.
 .. image:: images/flow-4.png
 
 .. Licensed under Creative Commons Attribution 4.0 International License
-https://creativecommons.org/licenses/by/4.0/
+   https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
This patch fixes the documents to eliminate about 40 warnings occurring for some reasons when building the documents.

#### Type of change

- Bug fix
- Documentation update

#### Description

Prior to this patch, about 40 warnings occurs for some reasons when building the documentations.
These warnings may be noisy and may prevent document maintainers or translators from confirming for their new patches.

Below are examples of the warnings that occurred before this patch.

```
Running Sphinx v1.8.5
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 14 source files that are out of date
updating environment: 122 added, 0 changed, 0 removed
reading sources... [100%] write_first_app                                                                                                                                                                                                                                              
(Omitted)/github.com/hyperledger/fabric/docs/source/CONTRIBUTING.rst:2: WARNING: Duplicate explicit target name: "rocketchat".
(Omitted)/github.com/hyperledger/fabric/docs/source/CONTRIBUTING.rst:446: WARNING: toctree contains reference to nonexisting document u'MAINTAINERS'
(Omitted)/github.com/hyperledger/fabric/docs/source/CONTRIBUTING.rst:446: WARNING: toctree contains reference to nonexisting document u'testing'
(Omitted)/github.com/hyperledger/fabric/docs/source/build_network.rst:2: WARNING: Duplicate explicit target name: "documentation".
(Omitted)/github.com/hyperledger/fabric/docs/source/chaincode4ade.rst:2: WARNING: Duplicate explicit target name: "java".
(Omitted)/github.com/hyperledger/fabric/docs/source/chaincode4ade.rst:2: WARNING: Duplicate explicit target name: "java".
(Omitted)/github.com/hyperledger/fabric/docs/source/deployment_guide_overview.rst:2: WARNING: Duplicate explicit target name: "in the sampleconfig directory of hyperledger fabric".
(Omitted)/github.com/hyperledger/fabric/docs/source/endorsement-policies.rst:105: WARNING: Inline literal start-string without end-string.
(Omitted)/github.com/hyperledger/fabric/docs/source/fabric_model.rst:42: WARNING: duplicate label chaincode, other instance in (Omitted)/github.com/hyperledger/fabric/docs/source/glossary.rst
(Omitted)/github.com/hyperledger/fabric/docs/source/fabric_model.rst:137: WARNING: duplicate label consensus, other instance in (Omitted)/github.com/hyperledger/fabric/docs/source/glossary.rst
(Omitted)/github.com/hyperledger/fabric/docs/source/glossary.rst:333: WARNING: malformed hyperlink target.
(Omitted)/github.com/hyperledger/fabric/docs/source/glossary.rst:386: WARNING: malformed hyperlink target.
(Omitted)/github.com/hyperledger/fabric/docs/source/glossary.rst:108: WARNING: duplicate label chaincode, other instance in (Omitted)/github.com/hyperledger/fabric/docs/source/fabric_model.rst
(Omitted)/github.com/hyperledger/fabric/docs/source/glossary.rst:171: WARNING: duplicate label consensus, other instance in (Omitted)/github.com/hyperledger/fabric/docs/source/fabric_model.rst
(Omitted)/github.com/hyperledger/fabric/docs/source/kafka.rst:213: WARNING: Explicit markup ends without a blank line; unexpected unindent.
(Omitted)/github.com/hyperledger/fabric/docs/source/txflow.rst:131: WARNING: Explicit markup ends without a blank line; unexpected unindent.
looking for now-outdated files... none found
pickling environment... done
checking consistency... (Omitted)/github.com/hyperledger/fabric/docs/source/developapps/apis.md: WARNING: document isn't included in any toctree
(Omitted)/github.com/hyperledger/fabric/docs/source/github/github.rst: WARNING: document isn't included in any toctree
(Omitted)/github.com/hyperledger/fabric/docs/source/ledger.rst: WARNING: document isn't included in any toctree
(Omitted)/github.com/hyperledger/fabric/docs/source/msp-identity-validity-rules.rst: WARNING: document isn't included in any toctree
(Omitted)/github.com/hyperledger/fabric/docs/source/policies.rst: WARNING: document isn't included in any toctree
(Omitted)/github.com/hyperledger/fabric/docs/source/security_model.rst: WARNING: document isn't included in any toctree
(Omitted)/github.com/hyperledger/fabric/docs/source/tutorial/installxcode.md: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] write_first_app                                                                                                                                                                                                                                               
(Omitted)/github.com/hyperledger/fabric/docs/source/chaincode4ade.rst:77: WARNING: undefined label: go (if the link has no caption the label must precede a section header)
(Omitted)/github.com/hyperledger/fabric/docs/source/deployment_guide_overview.rst:196: WARNING: unknown document: chaincode4noah
(Omitted)/github.com/hyperledger/fabric/docs/source/dev-setup/devenv.rst:64: WARNING: unknown document: getting_started
(Omitted)/github.com/hyperledger/fabric/docs/source/developapps/connectionprofile.md: WARNING: Could not lex literal_block as "yaml". Highlighting skipped.
(Omitted)/github.com/hyperledger/fabric/docs/source/discovery-cli.md: WARNING: Pygments lexer name u'{.sourceCode .shell}' is not known
(Omitted)/github.com/hyperledger/fabric/docs/source/discovery-cli.md: WARNING: Pygments lexer name u'{.sourceCode .shell}' is not known
(Omitted)/github.com/hyperledger/fabric/docs/source/discovery-cli.md: WARNING: Pygments lexer name u'{.sourceCode .YAML}' is not known
(Omitted)/github.com/hyperledger/fabric/docs/source/discovery-cli.md: WARNING: Pygments lexer name u'{.sourceCode .shell}' is not known
(Omitted)/github.com/hyperledger/fabric/docs/source/discovery-cli.md: WARNING: Pygments lexer name u'{.sourceCode .shell}' is not known
(Omitted)/github.com/hyperledger/fabric/docs/source/discovery-cli.md: WARNING: Pygments lexer name u'{.sourceCode .shell}' is not known
(Omitted)/github.com/hyperledger/fabric/docs/source/discovery-cli.md: WARNING: Pygments lexer name u'{.sourceCode .shell}' is not known
(Omitted)/github.com/hyperledger/fabric/docs/source/discovery-cli.md: WARNING: Pygments lexer name u'{.sourceCode .shell}' is not known
(Omitted)/github.com/hyperledger/fabric/docs/source/discovery-cli.md: WARNING: Pygments lexer name u'{.sourceCode .shell}' is not known
(Omitted)/github.com/hyperledger/fabric/docs/source/discovery-overview.rst:68: WARNING: Could not lex literal_block as "JSON". Highlighting skipped.
(Omitted)/github.com/hyperledger/fabric/docs/source/kafka_raft_migration.md: WARNING: Pygments lexer name u'\u200b' is not known
generating indices... genindex
writing additional pages... search
copying images... [100%] tutorial/./commercial_paper.diagram.2.png                                                                                                                                                                                                                     
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 38 warnings.

The HTML pages are in build/html.
```

So, this patch fixes the documents to eliminate their warnings.

NOTE: Some "document isn't included in any toctree" errors still remain because necessity of the target documents or the proper position of them in the TOC is still unclear.