### PR TITLE
[FAB-16435] Improve gossip defaults - Peers to be leaders by default

### DIFF
--- a/integration/gossip/gossip_test.go
+++ b/integration/gossip/gossip_test.go
@@ -78,8 +78,16 @@ var _ = Describe("Gossip State Transfer and Membership", func() {
 		//      peer1: leader
 		for _, peer := range network.Peers {
 			if peer.Organization == "Org1" {
+				if peer.Name == "peer0" {
+					core := network.ReadPeerConfig(peer)
+					core.Peer.Gossip.UseLeaderElection = true
+					core.Peer.Gossip.OrgLeader = false
+					network.WritePeerConfig(peer, core)
+				}
 				if peer.Name == "peer1" {
 					core := network.ReadPeerConfig(peer)
+					core.Peer.Gossip.UseLeaderElection = true
+					core.Peer.Gossip.OrgLeader = false
 					core.Peer.Gossip.Bootstrap = fmt.Sprintf("127.0.0.1:%d", network.ReservePort())
 					network.WritePeerConfig(peer, core)
 				}

--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -29,8 +29,8 @@ peer:
     bootstrap: 127.0.0.1:{{ .PeerPort Peer "Listen" }}
     endpoint: 127.0.0.1:{{ .PeerPort Peer "Listen" }}
     externalEndpoint: 127.0.0.1:{{ .PeerPort Peer "Listen" }}
-    useLeaderElection: true
-    orgLeader: false
+    useLeaderElection: false
+    orgLeader: true
     membershipTrackerInterval: 5s
     maxBlockCountToStore: 100
     maxPropagationBurstLatency: 10ms

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -97,14 +97,15 @@ peer:
         # Defines whenever peer will initialize dynamic algorithm for
         # "leader" selection, where leader is the peer to establish
         # connection with ordering service and use delivery protocol
-        # to pull ledger blocks from ordering service. It is recommended to
-        # use leader election for large networks of peers.
-        useLeaderElection: true
+        # to pull ledger blocks from ordering service.
+        useLeaderElection: false
         # Statically defines peer to be an organization "leader",
         # where this means that current peer will maintain connection
         # with ordering service and disseminate block across peers in
-        # its own organization
-        orgLeader: false
+        # its own organization. Multiple peers or all peers in an organization
+        # may be configured as org leaders, so that they all pull
+        # blocks directly from ordering service.
+        orgLeader: true
 
         # Interval for membershipTracker polling
         membershipTrackerInterval: 5s


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to defaults)

#### Description

Block dissemination via gossip may be removed in a future release,
since it is more straightforward for peers to simply pull blocks from ordering service.

To start the move in this direction, this PR changes the default for each
peer to be an org leader that pulls blocks from the ordering service, and
disables leader election by default.

Most integration tests will use the new defaults, including a lifecycle
integration test that adds an org3 to a channel at a later time, to ensure
that newly added orgs can receive blocks with the new defaults.

There is a gossip integration test that will continue to test both leader election and static leaders.
This PR updates the gossip integration test so that the new defaults are not used, to ensure
the non-default configurations continue to work.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>

#### Related issues

[FAB-16435](https://jira.hyperledger.org/browse/FAB-16435)