### PR TITLE
[FAB-18028] Create new ExternalBuilder PropagateEnvironment key

### DIFF
--- a/core/chaincode/config.go
+++ b/core/chaincode/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	LogFormat       string
 	LogLevel        string
 	ShimLogLevel    string
-	SCCWhitelist    map[string]bool
+	SCCAllowlist    map[string]bool
 }
 
 func GlobalConfig() *Config {
@@ -58,9 +58,9 @@ func (c *Config) load() {
 		c.StartupTimeout = minimumStartupTimeout
 	}
 
-	c.SCCWhitelist = map[string]bool{}
+	c.SCCAllowlist = map[string]bool{}
 	for k, v := range viper.GetStringMapString("chaincode.system") {
-		c.SCCWhitelist[k] = parseBool(v)
+		c.SCCAllowlist[k] = parseBool(v)
 	}
 
 	c.LogFormat = viper.GetString("chaincode.logging.format")

--- a/core/container/externalbuilder/externalbuilder.go
+++ b/core/container/externalbuilder/externalbuilder.go
@@ -24,9 +24,9 @@ import (
 )
 
 var (
-	// DefaultEnvWhitelist enumerates the list of environment variables that are
+	// DefaultPropagateEnvironment enumerates the list of environment variables that are
 	// implicitly propagated to external builder and launcher commands.
-	DefaultEnvWhitelist = []string{"LD_LIBRARY_PATH", "LIBPATH", "PATH", "TMPDIR"}
+	DefaultPropagateEnvironment = []string{"LD_LIBRARY_PATH", "LIBPATH", "PATH", "TMPDIR"}
 
 	logger = flogging.MustGetLogger("chaincode.externalbuilder")
 )
@@ -263,11 +263,11 @@ func SanitizeCCIDPath(ccid string) string {
 
 // A Builder is used to interact with an external chaincode builder and launcher.
 type Builder struct {
-	EnvWhitelist []string
-	Location     string
-	Logger       *flogging.FabricLogger
-	Name         string
-	MSPID        string
+	PropagateEnvironment []string
+	Location             string
+	Logger               *flogging.FabricLogger
+	Name                 string
+	MSPID                string
 }
 
 // CreateBuilders will construct builders from the peer configuration.
@@ -275,11 +275,11 @@ func CreateBuilders(builderConfs []peer.ExternalBuilder, mspid string) []*Builde
 	var builders []*Builder
 	for _, builderConf := range builderConfs {
 		builders = append(builders, &Builder{
-			Location:     builderConf.Path,
-			Name:         builderConf.Name,
-			EnvWhitelist: builderConf.EnvironmentWhitelist,
-			Logger:       logger.Named(builderConf.Name),
-			MSPID:        mspid,
+			Location:             builderConf.Path,
+			Name:                 builderConf.Name,
+			PropagateEnvironment: builderConf.PropagateEnvironment,
+			Logger:               logger.Named(builderConf.Name),
+			MSPID:                mspid,
 		})
 	}
 	return builders
@@ -397,11 +397,11 @@ func (b *Builder) runCommand(cmd *exec.Cmd) error {
 
 // NewCommand creates an exec.Cmd that is configured to prune the calling
 // environment down to the environment variables specified in the external
-// builder's EnvironmentWhitelist and the DefaultEnvWhitelist.
+// builder's PropagateEnvironment and the DefaultPropagateEnvironment.
 func (b *Builder) NewCommand(name string, args ...string) *exec.Cmd {
 	cmd := exec.Command(name, args...)
-	whitelist := appendDefaultWhitelist(b.EnvWhitelist)
-	for _, key := range whitelist {
+	propagationList := appendDefaultPropagateEnvironment(b.PropagateEnvironment)
+	for _, key := range propagationList {
 		if val, ok := os.LookupEnv(key); ok {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, val))
 		}
@@ -409,17 +409,17 @@ func (b *Builder) NewCommand(name string, args ...string) *exec.Cmd {
 	return cmd
 }
 
-func appendDefaultWhitelist(envWhitelist []string) []string {
-	for _, variable := range DefaultEnvWhitelist {
-		if !contains(envWhitelist, variable) {
-			envWhitelist = append(envWhitelist, variable)
+func appendDefaultPropagateEnvironment(propagateEnvironment []string) []string {
+	for _, variable := range DefaultPropagateEnvironment {
+		if !contains(propagateEnvironment, variable) {
+			propagateEnvironment = append(propagateEnvironment, variable)
 		}
 	}
-	return envWhitelist
+	return propagateEnvironment
 }
 
-func contains(envWhiteList []string, key string) bool {
-	for _, variable := range envWhiteList {
+func contains(propagateEnvironment []string, key string) bool {
+	for _, variable := range propagateEnvironment {
 		if key == variable {
 			return true
 		}

--- a/core/container/externalbuilder/externalbuilder_test.go
+++ b/core/container/externalbuilder/externalbuilder_test.go
@@ -344,7 +344,7 @@ var _ = Describe("externalbuilder", func() {
 		Describe("NewCommand", func() {
 			It("only propagates expected variables", func() {
 				var expectedEnv []string
-				for _, key := range externalbuilder.DefaultEnvWhitelist {
+				for _, key := range externalbuilder.DefaultPropagateEnvironment {
 					if val, ok := os.LookupEnv(key); ok {
 						expectedEnv = append(expectedEnv, fmt.Sprintf("%s=%s", key, val))
 					}

--- a/core/peer/config_test.go
+++ b/core/peer/config_test.go
@@ -354,6 +354,59 @@ func TestGlobalConfigDefault(t *testing.T) {
 	assert.Equal(t, expectedConfig, coreConfig)
 }
 
+func TestPropagateEnvironment(t *testing.T) {
+	defer viper.Reset()
+	viper.Set("peer.address", "localhost:8080")
+	viper.Set("chaincode.externalBuilders", &[]ExternalBuilder{
+		{
+			Name:        "testName",
+			Environment: []string{"KEY=VALUE"},
+			Path:        "/testPath",
+		},
+		{
+			Name:                 "testName",
+			PropagateEnvironment: []string{"KEY=VALUE"},
+			Path:                 "/testPath",
+		},
+		{
+			Name:                 "testName",
+			Environment:          []string{"KEY=VALUE"},
+			PropagateEnvironment: []string{"KEY=VALUE2"},
+			Path:                 "/testPath",
+		},
+	})
+	coreConfig, err := GlobalConfig()
+	assert.NoError(t, err)
+
+	expectedConfig := &Config{
+		AuthenticationTimeWindow:      15 * time.Minute,
+		PeerAddress:                   "localhost:8080",
+		ValidatorPoolSize:             runtime.NumCPU(),
+		VMNetworkMode:                 "host",
+		DeliverClientKeepaliveOptions: comm.DefaultKeepaliveOptions,
+		ExternalBuilders: []ExternalBuilder{
+			{
+				Name:                 "testName",
+				Environment:          []string{"KEY=VALUE"},
+				PropagateEnvironment: []string{"KEY=VALUE"},
+				Path:                 "/testPath",
+			},
+			{
+				Name:                 "testName",
+				PropagateEnvironment: []string{"KEY=VALUE"},
+				Path:                 "/testPath",
+			},
+			{
+				Name:                 "testName",
+				Environment:          []string{"KEY=VALUE"},
+				PropagateEnvironment: []string{"KEY=VALUE2"},
+				Path:                 "/testPath",
+			},
+		},
+	}
+	assert.Equal(t, expectedConfig, coreConfig)
+}
+
 func TestMissingExternalBuilderPath(t *testing.T) {
 	defer viper.Reset()
 	viper.Set("peer.address", "localhost:8080")

--- a/docs/source/cc_launcher.md
+++ b/docs/source/cc_launcher.md
@@ -176,7 +176,7 @@ chaincode:
   externalBuilders:
   - name: my-golang-builder
     path: /builders/golang
-    environmentWhitelist:
+    propagateEnvironment:
     - GOPROXY
     - GONOPROXY
     - GOSUMDB
@@ -185,7 +185,7 @@ chaincode:
     path: /builders/binary
 ```
 
-In this example, the implementation of "my-golang-builder" is contained within the `/builders/golang` directory and its build scripts are located in `/builders/golang/bin`. When the peer invokes any of the build scripts associated with "my-golang-builder", it will propagate only the values of the environment variables in the `environmentWhitelist`.
+In this example, the implementation of "my-golang-builder" is contained within the `/builders/golang` directory and its build scripts are located in `/builders/golang/bin`. When the peer invokes any of the build scripts associated with "my-golang-builder", it will propagate only the values of the environment variables in the `propagateEnvironment`.
 
 Note: The following environment variables are always propagated to external builders:
 

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -113,7 +113,7 @@ var _ = Describe("EndToEnd", func() {
 			runArtifactsFilePath = filepath.Join(testDir, "run-artifacts.txt")
 			os.Setenv("RUN_ARTIFACTS_FILE", runArtifactsFilePath)
 			for i, e := range network.ExternalBuilders {
-				e.EnvironmentWhitelist = append(e.EnvironmentWhitelist, "RUN_ARTIFACTS_FILE")
+				e.PropagateEnvironment = append(e.PropagateEnvironment, "RUN_ARTIFACTS_FILE")
 				network.ExternalBuilders[i] = e
 			}
 

--- a/integration/ledger/couchdb_indexes_test.go
+++ b/integration/ledger/couchdb_indexes_test.go
@@ -72,7 +72,7 @@ var _ = Describe("CouchDB indexes", func() {
 		network.ExternalBuilders = append(network.ExternalBuilders, fabricconfig.ExternalBuilder{
 			Path:                 filepath.Join(cwd, "..", "externalbuilders", "golang"),
 			Name:                 "external-golang",
-			EnvironmentWhitelist: []string{"GOPATH", "GOCACHE", "GOPROXY", "HOME", "PATH"},
+			PropagateEnvironment: []string{"GOPATH", "GOCACHE", "GOPROXY", "HOME", "PATH"},
 		})
 
 		network.GenerateConfigTree()

--- a/integration/lifecycle/install_test.go
+++ b/integration/lifecycle/install_test.go
@@ -48,7 +48,7 @@ var _ = Describe("chaincode install", func() {
 		network.ExternalBuilders = append(network.ExternalBuilders, fabricconfig.ExternalBuilder{
 			Path:                 filepath.Join(cwd, "..", "externalbuilders", "golang"),
 			Name:                 "external-golang",
-			EnvironmentWhitelist: []string{"GOPATH", "GOCACHE", "GOPROXY", "HOME", "PATH"},
+			PropagateEnvironment: []string{"GOPATH", "GOCACHE", "GOPROXY", "HOME", "PATH"},
 		})
 		network.GenerateConfigTree()
 		network.Bootstrap()

--- a/integration/lifecycle/lifecycle_test.go
+++ b/integration/lifecycle/lifecycle_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Lifecycle", func() {
 			os.Setenv(envKey, termFile)
 			for i, e := range externalBuilders {
 				if e.Name == "binary" {
-					e.EnvironmentWhitelist = append(e.EnvironmentWhitelist, envKey)
+					e.PropagateEnvironment = append(e.PropagateEnvironment, envKey)
 					externalBuilders[i] = e
 				}
 			}

--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -192,7 +192,7 @@ chaincode:
   externalBuilders: {{ range .ExternalBuilders }}
     - path: {{ .Path }}
       name: {{ .Name }}
-      environmentWhitelist: {{ range .EnvironmentWhitelist }}
+      propagateEnvironment: {{ range .PropagateEnvironment }}
          - {{ . }}
       {{- end }}
   {{- end }}

--- a/integration/nwo/fabricconfig/core.go
+++ b/integration/nwo/fabricconfig/core.go
@@ -269,7 +269,7 @@ type Node struct {
 }
 
 type ExternalBuilder struct {
-	EnvironmentWhitelist []string `yaml:"environmentWhitelist,omitempty"`
+	PropagateEnvironment []string `yaml:"propagateEnvironment,omitempty"`
 	Name                 string   `yaml:"name,omitempty"`
 	Path                 string   `yaml:"path,omitempty"`
 }

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -203,7 +203,7 @@ func New(c *Config, rootDir string, client *docker.Client, startPort int, compon
 	network.ExternalBuilders = []fabricconfig.ExternalBuilder{{
 		Path:                 filepath.Join(cwd, "..", "externalbuilders", "binary"),
 		Name:                 "binary",
-		EnvironmentWhitelist: []string{"GOPROXY"},
+		PropagateEnvironment: []string{"GOPROXY"},
 	}}
 
 	if network.Templates == nil {

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -745,7 +745,7 @@ func serve(args []string) error {
 
 	// deploy system chaincodes
 	for _, cc := range []scc.SelfDescribingSysCC{lsccInst, csccInst, qsccInst, lifecycleSCC} {
-		if enabled, ok := chaincodeConfig.SCCWhitelist[cc.Name()]; !ok || !enabled {
+		if enabled, ok := chaincodeConfig.SCCAllowlist[cc.Name()]; !ok || !enabled {
 			logger.Infof("not deploying chaincode %s as it is not enabled", cc.Name())
 			continue
 		}

--- a/protoutil/blockutils.go
+++ b/protoutil/blockutils.go
@@ -51,7 +51,7 @@ func BlockHeaderBytes(b *cb.BlockHeader) []byte {
 	if err != nil {
 		// Errors should only arise for types which cannot be encoded, since the
 		// BlockHeader type is known a-priori to contain only encodable types, an
-		// error here is fatal and should not be propogated
+		// error here is fatal and should not be propagated
 		panic(err)
 	}
 	return result

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -549,7 +549,7 @@ chaincode:
     externalBuilders: []
         # - path: /path/to/directory
         #   name: descriptive-builder-name
-        #   environmentWhitelist:
+        #   propagateEnvironment:
         #      - ENVVAR_NAME_TO_PROPAGATE_FROM_PEER
         #      - GOPROXY
 


### PR DESCRIPTION
Creates a new EnvPropagationList to replace the existing key. If the new key is used, it supersedes the existing key.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
