### PR TITLE
[FAB-16435] Improve defaults - maxBlockCountToStore & blockBufferSize

### DIFF
--- a/gossip/gossip/config.go
+++ b/gossip/gossip/config.go
@@ -119,7 +119,7 @@ func (c *Config) loadConfig(endpoint string, certs *common.TLSCertificates, boot
 	c.BindPort = int(port)
 	c.BootstrapPeers = bootPeers
 	c.ID = endpoint
-	c.MaxBlockCountToStore = util.GetIntOrDefault("peer.gossip.maxBlockCountToStore", 100)
+	c.MaxBlockCountToStore = util.GetIntOrDefault("peer.gossip.maxBlockCountToStore", 10)
 	c.MaxPropagationBurstLatency = util.GetDurationOrDefault("peer.gossip.maxPropagationBurstLatency", 10*time.Millisecond)
 	c.MaxPropagationBurstSize = util.GetIntOrDefault("peer.gossip.maxPropagationBurstSize", 10)
 	c.PropagateIterations = util.GetIntOrDefault("peer.gossip.propagateIterations", 1)

--- a/gossip/gossip/config_test.go
+++ b/gossip/gossip/config_test.go
@@ -125,7 +125,7 @@ func TestGlobalConfigDefaults(t *testing.T) {
 		BindPort:                     int(port),
 		BootstrapPeers:               []string{"bootstrap1", "bootstrap2", "bootstrap3"},
 		ID:                           endpoint,
-		MaxBlockCountToStore:         100,
+		MaxBlockCountToStore:         10,
 		MaxPropagationBurstLatency:   10 * time.Millisecond,
 		MaxPropagationBurstSize:      10,
 		PropagateIterations:          1,

--- a/gossip/gossip/orgs_test.go
+++ b/gossip/gossip/orgs_test.go
@@ -106,7 +106,7 @@ func newGossipInstanceWithGRPCWithExternalEndpoint(id int, port int, gRPCServer 
 	conf := &Config{
 		BootstrapPeers:               bootPeersWithPorts(boot...),
 		ID:                           fmt.Sprintf("p%d", id),
-		MaxBlockCountToStore:         100,
+		MaxBlockCountToStore:         10,
 		MaxPropagationBurstLatency:   time.Duration(500) * time.Millisecond,
 		MaxPropagationBurstSize:      20,
 		PropagateIterations:          1,

--- a/gossip/state/config.go
+++ b/gossip/state/config.go
@@ -17,7 +17,7 @@ const (
 	DefStateResponseTimeout = 3 * time.Second
 	DefStateBatchSize       = 10
 	DefStateMaxRetries      = 3
-	DefStateBlockBufferSize = 100
+	DefStateBlockBufferSize = 20
 	DefStateChannelSize     = 100
 	DefStateEnabled         = true
 )

--- a/gossip/state/config_test.go
+++ b/gossip/state/config_test.go
@@ -51,7 +51,7 @@ func TestGlobalConfigDefaults(t *testing.T) {
 		StateResponseTimeout: 3 * time.Second,
 		StateBatchSize:       uint64(10),
 		StateMaxRetries:      3,
-		StateBlockBufferSize: 100,
+		StateBlockBufferSize: 20,
 		StateChannelSize:     100,
 		StateEnabled:         true,
 	}

--- a/gossip/state/state.go
+++ b/gossip/state/state.go
@@ -48,7 +48,7 @@ const (
 	defChannelBufferSize     = 100
 	defAntiEntropyMaxRetries = 3
 
-	defMaxBlockDistance = 100
+	defMaxBlockDistance = 20
 
 	blocking    = true
 	nonBlocking = false

--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -32,7 +32,7 @@ peer:
     useLeaderElection: false
     orgLeader: true
     membershipTrackerInterval: 5s
-    maxBlockCountToStore: 100
+    maxBlockCountToStore: 10
     maxPropagationBurstLatency: 10ms
     maxPropagationBurstSize: 10
     propagateIterations: 1
@@ -75,7 +75,7 @@ peer:
        checkInterval: 10s
        responseTimeout: 3s
        batchSize: 10
-       blockBufferSize: 100
+       blockBufferSize: 20
        maxRetries: 3
   events:
     address: 127.0.0.1:{{ .PeerPort Peer "Events" }}

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -115,7 +115,7 @@ peer:
         # see 'externalEndpoint'
         endpoint:
         # Maximum count of blocks stored in memory
-        maxBlockCountToStore: 100
+        maxBlockCountToStore: 10
         # Max time between consecutive message pushes(unit: millisecond)
         maxPropagationBurstLatency: 10ms
         # Max number of messages stored until a push is triggered to remote peers
@@ -242,9 +242,9 @@ peer:
             batchSize: 10
             # blockBufferSize reflects the size of the re-ordering buffer
             # which captures blocks and takes care to deliver them in order
-            # down to the ledger layer. The actually buffer size is bounded between
+            # down to the ledger layer. The actual buffer size is bounded between
             # 0 and 2*blockBufferSize, each channel maintains its own buffer
-            blockBufferSize: 100
+            blockBufferSize: 20
             # maxRetries maximum number of re-tries to ask
             # for single state transfer request
             maxRetries: 3


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to defaults)

#### Description

peer.gossip.maxBlockCountToStore and peer.gossip.state.blockBufferSize
are two buffers in gossip that have both defaulted to '100' historically.
During normal operations, these buffers don't need to be set so high to
achieve the intended optimizations. Setting the buffers so high by default
has resulted in memory issues in peers in scenarios where a peer has joined
many channels.

New lowered defaults:
peer.gossip.maxBlockCountToStore: 10
peer.gossip.state.blockBufferSize: 20

#### Related issues

[FAB-16435](https://jira.hyperledger.org/browse/FAB-16435)

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
