### PR TITLE
[FAB-16435] Improve gossip defaults - disable state transfer

### DIFF
--- a/gossip/state/config.go
+++ b/gossip/state/config.go
@@ -19,7 +19,7 @@ const (
 	DefStateMaxRetries      = 3
 	DefStateBlockBufferSize = 100
 	DefStateChannelSize     = 100
-	DefStateEnabled         = true
+	DefStateEnabled         = false
 )
 
 type StateConfig struct {

--- a/gossip/state/config_test.go
+++ b/gossip/state/config_test.go
@@ -24,7 +24,7 @@ func TestGlobalConfig(t *testing.T) {
 	viper.Set("peer.gossip.state.maxRetries", 4)
 	viper.Set("peer.gossip.state.blockBufferSize", 5)
 	viper.Set("peer.gossip.state.channelSize", 6)
-	viper.Set("peer.gossip.state.enabled", false)
+	viper.Set("peer.gossip.state.enabled", true)
 
 	coreConfig := state.GlobalConfig()
 
@@ -35,7 +35,7 @@ func TestGlobalConfig(t *testing.T) {
 		StateMaxRetries:      4,
 		StateBlockBufferSize: 5,
 		StateChannelSize:     6,
-		StateEnabled:         false,
+		StateEnabled:         true,
 	}
 
 	assert.Equal(t, expectedConfig, coreConfig)
@@ -53,7 +53,7 @@ func TestGlobalConfigDefaults(t *testing.T) {
 		StateMaxRetries:      3,
 		StateBlockBufferSize: 100,
 		StateChannelSize:     100,
-		StateEnabled:         true,
+		StateEnabled:         false,
 	}
 
 	assert.Equal(t, expectedConfig, coreConfig)

--- a/gossip/state/state_test.go
+++ b/gossip/state/state_test.go
@@ -429,7 +429,7 @@ func newPeerNodeWithGossipWithValidatorWithMetrics(logger gutil.Logger, id int, 
 		StateMaxRetries:      DefStateMaxRetries,
 		StateBlockBufferSize: DefStateBlockBufferSize,
 		StateChannelSize:     DefStateChannelSize,
-		StateEnabled:         DefStateEnabled,
+		StateEnabled:         true,
 	}
 	sp := NewGossipStateProvider(logger, "testchannelid", servicesAdapater, coord, gossipMetrics.StateMetrics, blocking, stateConfig)
 	if sp == nil {
@@ -1394,7 +1394,7 @@ func TestTransferOfPrivateRWSet(t *testing.T) {
 		StateMaxRetries:      DefStateMaxRetries,
 		StateBlockBufferSize: DefStateBlockBufferSize,
 		StateChannelSize:     DefStateChannelSize,
-		StateEnabled:         DefStateEnabled,
+		StateEnabled:         true,
 	}
 	logger := flogging.MustGetLogger(gutil.StateLogger)
 	st := NewGossipStateProvider(logger, chainID, servicesAdapater, coord1, stateMetrics, blocking, stateConfig)
@@ -1640,7 +1640,7 @@ func TestTransferOfPvtDataBetweenPeers(t *testing.T) {
 		StateMaxRetries:      DefStateMaxRetries,
 		StateBlockBufferSize: DefStateBlockBufferSize,
 		StateChannelSize:     DefStateChannelSize,
-		StateEnabled:         DefStateEnabled,
+		StateEnabled:         true,
 	}
 	logger := flogging.MustGetLogger(gutil.StateLogger)
 	peer1State := NewGossipStateProvider(logger, chainID, mediator, peers["peer1"].coord, stateMetrics, blocking, stateConfig)

--- a/integration/gossip/gossip_test.go
+++ b/integration/gossip/gossip_test.go
@@ -70,8 +70,8 @@ var _ = Describe("Gossip State Transfer and Membership", func() {
 		os.RemoveAll(testDir)
 	})
 
-	It("syncs blocks from the peer when no orderer is available", func() {
-		//  modify peer config
+	It("syncs blocks from the peer via state transfer when no orderer is available", func() {
+		//  modify peer config to enable state transfer on all peers, and configure leaders as follows:
 		//  Org1: leader election
 		//  Org2: no leader election
 		//      peer0: follower
@@ -80,12 +80,14 @@ var _ = Describe("Gossip State Transfer and Membership", func() {
 			if peer.Organization == "Org1" {
 				if peer.Name == "peer0" {
 					core := network.ReadPeerConfig(peer)
+					core.Peer.Gossip.State.Enabled = true
 					core.Peer.Gossip.UseLeaderElection = true
 					core.Peer.Gossip.OrgLeader = false
 					network.WritePeerConfig(peer, core)
 				}
 				if peer.Name == "peer1" {
 					core := network.ReadPeerConfig(peer)
+					core.Peer.Gossip.State.Enabled = true
 					core.Peer.Gossip.UseLeaderElection = true
 					core.Peer.Gossip.OrgLeader = false
 					core.Peer.Gossip.Bootstrap = fmt.Sprintf("127.0.0.1:%d", network.ReservePort())
@@ -94,6 +96,7 @@ var _ = Describe("Gossip State Transfer and Membership", func() {
 			}
 			if peer.Organization == "Org2" {
 				core := network.ReadPeerConfig(peer)
+				core.Peer.Gossip.State.Enabled = true
 				core.Peer.Gossip.UseLeaderElection = false
 				core.Peer.Gossip.OrgLeader = peer.Name == "peer1"
 				network.WritePeerConfig(peer, core)

--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -71,7 +71,7 @@ peer:
         requiredPeerCount: 0
         maxPeerCount: 1
     state:
-       enabled: true
+       enabled: false
        checkInterval: 10s
        responseTimeout: 3s
        batchSize: 10

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -231,7 +231,7 @@ peer:
             # default value is true, i.e. state transfer is active
             # and takes care to sync up missing blocks allowing
             # lagging peer to catch up to speed with rest network
-            enabled: true
+            enabled: false
             # checkInterval interval to check whether peer is lagging behind enough to
             # request blocks via state transfer from another peer.
             checkInterval: 10s


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to defaults)

#### Description

State transfer (better named block replication) is an alternate path for block dissemination
where newly joined peers or lagging peers can retrieve blocks from other peers
instead of from ordering service.
While there are some efficiceny benefits, it also brings additional complexity
and makes troubleshooting more difficult. It also may be replaced in future
releases with peer to peer block sharing via the more efficient delivery
service.

To simplify environments and prepare for a possible retirement of
state transfer, this PR changes the peer default to make
state transfer disabled by default.

Unit and integration tests will generally run with the new default
to ensure everything keeps working without state transfer.
Only the unit tests and integration tests that specifically test
state transfer will override the default to re-enable state transfer.

#### Related issues

[FAB-16435](https://jira.hyperledger.org/browse/FAB-16435)

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
