### PR TITLE
Fixed broken hyperlinks in fabric doc, updated old output in doc

### DIFF
--- a/docs/source/deploy_chaincode.md
+++ b/docs/source/deploy_chaincode.md
@@ -91,7 +91,7 @@ module github.com/hyperledger/fabric-samples/chaincode/fabcar/go
 
 go 1.13
 
-require github.com/hyperledger/fabric-contract-api-go v0.0.0-20191118113407-4c6ff12b4f96
+require github.com/hyperledger/fabric-contract-api-go v1.1.0
 ```
 The `go.mod` file imports the Fabric contract API into the smart contract package. You can open `fabcar.go` in a text editor to see how the contract API is used to define the `SmartContract` type at the beginning of the smart contract:
 ```
@@ -193,7 +193,7 @@ async createCar(ctx, carNumber, make, model, color, owner) {
     console.info('============= END : Create Car ===========');
 }
 ```
-You can learn more about the JavaScript contract API by visiting the [API documentation](https://hyperledger.github.io/fabric-chaincode-node/{branch}/api/) and the [smart contract processing topic](developapps/smartcontract.html).
+You can learn more about the JavaScript contract API by visiting the [API documentation](https://hyperledger.github.io/fabric-chaincode-node/{BRANCH}/api/) and the [smart contract processing topic](developapps/smartcontract.html).
 
 To install the smart contract dependencies, run the following command from the `fabcar/javascript` directory.
 ```
@@ -249,7 +249,7 @@ dependencies {
 ```
 The `build.gradle` file imports the Java chaincode shim into the smart contract package, which includes the contract class. You can find Fabcar smart contract in the `src` directory. You can navigate to the `FabCar.java` file and open it in a text editor to see how the contract class is used to create the transaction context for the functions defined that read and write data to the blockchain ledger.
 
-You can learn more about the Java chaincode shim and the contract class by visiting the [Java chaincode documentation](https://hyperledger.github.io/fabric-chaincode-java/{branch}/api/) and the [smart contract processing topic](developapps/smartcontract.html).
+You can learn more about the Java chaincode shim and the contract class by visiting the [Java chaincode documentation](https://hyperledger.github.io/fabric-chaincode-java/{BRANCH}/api/) and the [smart contract processing topic](developapps/smartcontract.html).
 
 To install the smart contract dependencies, run the following command from the `fabcar/java` directory.
 ```

--- a/docs/source/developapps/smartcontract.md
+++ b/docs/source/developapps/smartcontract.md
@@ -88,7 +88,7 @@ and **redeem**. It's these transactions that bring commercial papers into
 existence and move them through their lifecycle. We'll examine these
 [transactions](#transaction-definition) soon, but for now notice for JavaScript, that the
 `CommericalPaperContract` extends the Hyperledger Fabric `Contract`
-[class](https://hyperledger.github.io/fabric-chaincode-node/master/api/fabric-contract-api.Contract.html).
+[class](https://hyperledger.github.io/fabric-chaincode-node/{BRANCH}/api/fabric-contract-api.Contract.html).
 
 With Java, the class must be decorated with the `@Contract(...)` annotation. This provides the opportunity
 to supply additional information about the contract, such as license and author. The `@Default()` annotation

--- a/docs/source/developapps/transactionhandler.md
+++ b/docs/source/developapps/transactionhandler.md
@@ -78,7 +78,7 @@ CommercialPaperContract extends Contract {
 The form of a transaction handler definition is the similar for all handler
 types, but notice how the `afterTransaction(ctx, result)` also receives any
 result returned by the transaction. The [API
-documentation](https://hyperledger.github.io/fabric-chaincode-node/master/api/fabric-contract-api.Contract.html)
+documentation](https://hyperledger.github.io/fabric-chaincode-node/{BRANCH}/api/fabric-contract-api.Contract.html)
 shows you the exact form of these handlers.
 
 ## Handler processing

--- a/docs/source/smartcontract/smartcontract.md
+++ b/docs/source/smartcontract/smartcontract.md
@@ -112,8 +112,8 @@ organizations in that network. It means that only administrators need to worry
 about chaincode; everyone else can think in terms of smart contracts.
 
 At the heart of a smart contract is a set of `transaction` definitions. For
-example, look at
-[`fabcar.js`](https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/chaincode/fabcar/javascript/lib/fabcar.js#L93),
+example, look at fabcar.js
+[here](https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/chaincode/fabcar/javascript/lib/fabcar.js#L93),
 where you can see a smart contract transaction that creates a new car:
 
 ```javascript


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

- fixed broken hyperlinks in fabric doc, due to incorrect `{branch}` substitution, for e.g. see "API documentation" link at
https://hyperledger-fabric.readthedocs.io/en/latest/deploy_chaincode.html#javascript
-  updated old content in go.mod with latest, in fabcar go chaincode section. At https://hyperledger-fabric.readthedocs.io/en/latest/deploy_chaincode.html#go

