### PR TITLE
Channel participation API - set URL in list single channel response

### DIFF
--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -970,7 +970,7 @@ func channelParticipationList(n *nwo.Network, o *nwo.Orderer, expectedChannels [
 		By("listing the details for channel " + channel.Name)
 		expectedChannelInfo := &channelInfo{
 			Name:            channel.Name,
-			URL:             "", // list single channel always returns empty URL
+			URL:             fmt.Sprintf("/participation/v1/channels/%s", channel.Name),
 			Status:          "active",
 			ClusterRelation: clusterRelation(n.Consensus.Type),
 		}

--- a/orderer/common/channelparticipation/restapi_test.go
+++ b/orderer/common/channelparticipation/restapi_test.go
@@ -206,15 +206,12 @@ func TestHTTPHandler_ServeHTTP_ListSingle(t *testing.T) {
 	require.NotNilf(t, h, "cannot create handler")
 
 	t.Run("channel exists", func(t *testing.T) {
-		info := types.ChannelInfo{
+		fakeManager.ChannelInfoReturns(types.ChannelInfo{
 			Name:            "app-channel",
-			URL:             channelparticipation.URLBaseV1Channels + "/app-channel",
 			ClusterRelation: "member",
 			Status:          "active",
 			Height:          3,
-		}
-
-		fakeManager.ChannelInfoReturns(info, nil)
+		}, nil)
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, channelparticipation.URLBaseV1Channels+"/app-channel", nil)
 		h.ServeHTTP(resp, req)
@@ -225,7 +222,14 @@ func TestHTTPHandler_ServeHTTP_ListSingle(t *testing.T) {
 		infoResp := types.ChannelInfo{}
 		err := json.Unmarshal(resp.Body.Bytes(), &infoResp)
 		require.NoError(t, err, "cannot be unmarshaled")
-		assert.Equal(t, info, infoResp)
+		assert.Equal(t, types.ChannelInfo{
+			Name:            "app-channel",
+			URL:             channelparticipation.URLBaseV1Channels + "/app-channel",
+			ClusterRelation: "member",
+			Status:          "active",
+			Height:          3,
+		}, infoResp)
+
 	})
 
 	t.Run("channel does not exists", func(t *testing.T) {
@@ -242,14 +246,12 @@ func TestHTTPHandler_ServeHTTP_Join(t *testing.T) {
 
 	t.Run("created ok", func(t *testing.T) {
 		fakeManager, h := setup(config, t)
-		info := types.ChannelInfo{
+		fakeManager.JoinChannelReturns(types.ChannelInfo{
 			Name:            "app-channel",
-			URL:             channelparticipation.URLBaseV1Channels + "/app-channel",
 			ClusterRelation: "member",
 			Status:          "active",
 			Height:          1,
-		}
-		fakeManager.JoinChannelReturns(info, nil)
+		}, nil)
 
 		resp := httptest.NewRecorder()
 		req := genJoinRequestFormData(t, validBlockBytes("ch-id"))
@@ -260,7 +262,13 @@ func TestHTTPHandler_ServeHTTP_Join(t *testing.T) {
 		infoResp := types.ChannelInfo{}
 		err := json.Unmarshal(resp.Body.Bytes(), &infoResp)
 		require.NoError(t, err, "cannot be unmarshaled")
-		assert.Equal(t, info, infoResp)
+		assert.Equal(t, types.ChannelInfo{
+			Name:            "app-channel",
+			URL:             channelparticipation.URLBaseV1Channels + "/app-channel",
+			ClusterRelation: "member",
+			Status:          "active",
+			Height:          1,
+		}, infoResp)
 	})
 
 	t.Run("Error: System Channel Exists", func(t *testing.T) {

--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -420,6 +420,8 @@ func (r *Registrar) ChannelList() types.ChannelList {
 	return list
 }
 
+// ChannelInfo provides extended status information about a channel.
+// The URL field is empty, and is to be completed by the caller.
 func (r *Registrar) ChannelInfo(channelID string) (types.ChannelInfo, error) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
@@ -437,6 +439,8 @@ func (r *Registrar) ChannelInfo(channelID string) (types.ChannelInfo, error) {
 	return info, nil
 }
 
+// JoinChannel instructs the orderer to create a channel and join it with the provided config block.
+// The URL field is empty, and is to be completed by the caller.
 func (r *Registrar) JoinChannel(channelID string, configBlock *cb.Block, isAppChannel bool) (types.ChannelInfo, error) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
@@ -488,6 +492,8 @@ func (r *Registrar) JoinChannel(channelID string, configBlock *cb.Block, isAppCh
 	return info, nil
 }
 
+// RemoveChannel instructs the orderer to remove a channel.
+// Depending on the removeStorage parameter, the storage resources are either removed or archived.
 func (r *Registrar) RemoveChannel(channelID string, removeStorage bool) error {
 	//TODO
 	return errors.New("Not implemented yet")


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

The channel participation rest API was not setting the URL when listing the details of a single channel. 

#### Related issues

[FAB-18036](https://jira.hyperledger.org/browse/FAB-18036)