### PR TITLE
FAB-17563 Remove BYFN from the toc

### DIFF
--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -43,7 +43,6 @@ Finally, we provide an introduction to how to write a basic smart contract,
    channel_update_tutorial
    config_update.md
    chaincode4ade
-   build_network
    videos
 
 .. Licensed under Creative Commons Attribution 4.0 International License


### PR DESCRIPTION
Signed-off-by: pama-ibm <pama@ibm.com>

Removing BYFN from the toc, although we are leaving the page in the repo with redirects to the test network and production deployment guide in case anyone has bookmarked the link.

#### Type of change

- Documentation update

#### Description

#### Release Note
BYFN has been removed from Fabric. See the Test network and Production deployment guide instead.

