### PR TITLE
Disable channel participation API in release-2.2

### DIFF
--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -36,8 +36,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
-	. "github.com/onsi/gomega/gstruct"
-	"github.com/onsi/gomega/types"
 	"github.com/tedsuo/ifrit"
 	"github.com/tedsuo/ifrit/ginkgomon"
 )
@@ -160,7 +158,6 @@ var _ = Describe("EndToEnd", func() {
 
 			By("setting up the channel")
 			network.CreateAndJoinChannel(orderer, "testchannel")
-			channelParticipationList(network, orderer, []string{"testchannel"}, "systemchannel")
 			nwo.EnableCapabilities(network, "testchannel", "Application", "V2_0", orderer, network.Peer("Org1", "peer0"), network.Peer("Org2", "peer0"))
 
 			By("attempting to install unsupported chaincode without docker")
@@ -261,7 +258,6 @@ var _ = Describe("EndToEnd", func() {
 			orderer := network.Orderer("orderer")
 
 			network.CreateAndJoinChannel(orderer, "testchannel")
-			channelParticipationList(network, orderer, []string{"testchannel"}, "systemchannel")
 			nwo.EnableCapabilities(network, "testchannel", "Application", "V2_0", orderer, network.Peer("Org1", "peer0"), network.Peer("Org2", "peer0"))
 
 			// package, install, and approve by org1 - module chaincode
@@ -397,7 +393,6 @@ var _ = Describe("EndToEnd", func() {
 
 			By("Create second channel and deploy chaincode")
 			network.CreateAndJoinChannel(orderer, "testchannel2")
-			channelParticipationList(network, orderer, []string{"testchannel", "testchannel2"}, "systemchannel")
 			peers := network.PeersWithChannel("testchannel2")
 			nwo.EnableCapabilities(network, "testchannel2", "Application", "V2_0", orderer, network.Peer("Org1", "peer0"), network.Peer("Org2", "peer0"))
 			nwo.ApproveChaincodeForMyOrg(network, "testchannel2", orderer, chaincode, peers...)
@@ -499,8 +494,6 @@ var _ = Describe("EndToEnd", func() {
 			ordererProcess = ifrit.Invoke(ordererRunner)
 			Eventually(ordererProcess.Ready, network.EventuallyTimeout).Should(BeClosed())
 			Eventually(ordererRunner.Err(), network.EventuallyTimeout).Should(gbytes.Say("Registrar initializing without a system channel, number of application channels: 0"))
-
-			channelParticipationList(network, orderer, nil)
 		})
 
 		AfterEach(func() {
@@ -924,111 +917,4 @@ func hashFile(file string) string {
 
 func chaincodeContainerNameFilter(n *nwo.Network, chaincode nwo.Chaincode) string {
 	return fmt.Sprintf("^/%s-.*-%s-%s$", n.NetworkID, chaincode.Label, hashFile(chaincode.PackageFile))
-}
-
-type channelList struct {
-	SystemChannel *channelInfoShort  `json:"systemChannel"`
-	Channels      []channelInfoShort `json:"channels"`
-}
-
-type channelInfoShort struct {
-	Name string `json:"name"`
-	URL  string `json:"url"`
-}
-
-func channelParticipationList(n *nwo.Network, o *nwo.Orderer, expectedChannels []string, systemChannel ...string) {
-	authClient, unauthClient := OrdererOperationalClients(n, o)
-	listChannelsURL := fmt.Sprintf("https://127.0.0.1:%d/participation/v1/channels", n.OrdererPort(o, nwo.OperationsPort))
-
-	By("using the channel participation API to list the channels")
-	body := getBody(authClient, listChannelsURL)()
-	list := &channelList{}
-	err := json.Unmarshal([]byte(body), list)
-	Expect(err).NotTo(HaveOccurred())
-
-	Expect(*list).To(MatchFields(IgnoreExtras, Fields{
-		"Channels":      channelsMatcher(expectedChannels),
-		"SystemChannel": systemChannelMatcher(systemChannel...),
-	}))
-
-	By("listing the channels without a client cert")
-	resp, err := unauthClient.Get(listChannelsURL)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
-
-	// for the current test scenarios, we only have these two cluster relations.
-	// other possible values are "follower" and "config-tracker"
-	// TODO generalize and relocate this after join operations are usable/testable
-	clusterRelation := func(consensusType string) string {
-		if consensusType == "etcdraft" {
-			return "member"
-		}
-		return "none"
-	}
-
-	for _, channel := range list.Channels {
-		By("listing the details for channel " + channel.Name)
-		expectedChannelInfo := &channelInfo{
-			Name:            channel.Name,
-			URL:             "", // list single channel always returns empty URL
-			Status:          "active",
-			ClusterRelation: clusterRelation(n.Consensus.Type),
-		}
-
-		if len(n.PeersWithChannel(channel.Name)) > 0 {
-			// get max peer height for the channel since there isn't a way to
-			// directly get the orderer's height that I'm aware of beyond the channel
-			// participation API (and maybe metrics?)
-			maxPeerHeight := nwo.GetMaxLedgerHeight(n, channel.Name, n.PeersWithChannel(channel.Name)...)
-			expectedChannelInfo.Height = uint64(maxPeerHeight)
-		}
-
-		channelParticipationListOne(n, o, channel.URL, expectedChannelInfo)
-	}
-}
-
-func channelsMatcher(channels []string) types.GomegaMatcher {
-	if len(channels) == 0 {
-		return BeEmpty()
-	}
-	matchers := make([]types.GomegaMatcher, len(channels))
-	for i, channel := range channels {
-		matchers[i] = channelInfoShortMatcher(channel)
-	}
-	return ConsistOf(matchers)
-}
-
-func systemChannelMatcher(systemChannel ...string) types.GomegaMatcher {
-	if len(systemChannel) == 0 {
-		return BeNil()
-	}
-	return PointTo(channelInfoShortMatcher(systemChannel[0]))
-}
-
-func channelInfoShortMatcher(channel string) types.GomegaMatcher {
-	return MatchFields(IgnoreExtras, Fields{
-		"Name": Equal(channel),
-		"URL":  Equal(fmt.Sprintf("/participation/v1/channels/%s", channel)),
-	})
-}
-
-type channelInfo struct {
-	Name            string `json:"name"`
-	URL             string `json:"url"`
-	Status          string `json:"status"`
-	ClusterRelation string `json:"clusterRelation"`
-	Height          uint64 `json:"height"`
-}
-
-func channelParticipationListOne(n *nwo.Network, o *nwo.Orderer, channelURL string, expectedChannelInfo *channelInfo) {
-	authClient, _ := OrdererOperationalClients(n, o)
-	listChannelURL := fmt.Sprintf("https://127.0.0.1:%d/%s", n.OrdererPort(o, nwo.OperationsPort), channelURL)
-
-	By("using the channel participation API to list the details of a single channel")
-	body := getBody(authClient, listChannelURL)()
-	c := &channelInfo{}
-	err := json.Unmarshal([]byte(body), c)
-	Expect(err).NotTo(HaveOccurred())
-
-	Expect(c).To(Equal(expectedChannelInfo))
 }

--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -40,7 +40,6 @@ import (
 	"github.com/hyperledger/fabric/internal/pkg/identity"
 	"github.com/hyperledger/fabric/msp"
 	"github.com/hyperledger/fabric/orderer/common/bootstrap/file"
-	"github.com/hyperledger/fabric/orderer/common/channelparticipation"
 	"github.com/hyperledger/fabric/orderer/common/cluster"
 	"github.com/hyperledger/fabric/orderer/common/localconfig"
 	"github.com/hyperledger/fabric/orderer/common/metadata"
@@ -237,10 +236,6 @@ func Main() {
 		tlsCallback,
 	)
 
-	opsSystem.RegisterHandler(
-		channelparticipation.URLBaseV1,
-		channelparticipation.NewHTTPHandler(conf.ChannelParticipation, manager),
-	)
 	if err = opsSystem.Start(); err != nil {
 		logger.Panicf("failed to start operations subsystem: %s", err)
 	}

--- a/sampleconfig/orderer.yaml
+++ b/sampleconfig/orderer.yaml
@@ -343,24 +343,6 @@ Metrics:
 
 ################################################################################
 #
-#   Channel participation API Configuration
-#
-#   - This provides the channel participation API configuration for the orderer.
-#   - Channel participation uses the same ListenAddress and TLS settings of the
-#     Operations service.
-#
-################################################################################
-ChannelParticipation:
-    # Channel participation API is enabled.
-    Enabled: false
-
-    # Permanently remove storage resources when a channel is removed.
-    # Defines the default behavior of channel removal.
-    RemoveStorage: false
-
-
-################################################################################
-#
 #   Consensus Configuration
 #
 #   - This section contains config options for a consensus plugin. It is opaque


### PR DESCRIPTION
#### Type of change

- Test update
- Documentation update

#### Description

The channel participation API is not a supported feature in v2.2.x and should be disabled.

#### Related issues

[FAB-18037](https://jira.hyperledger.org/browse/FAB-18037)