### PR TITLE
Add Debug and Debugf to vet printfuncs

### DIFF
--- a/core/ledger/kvledger/history/query_executer.go
+++ b/core/ledger/kvledger/history/query_executer.go
@@ -94,7 +94,7 @@ func (scanner *historyScanner) Close() {
 
 // getTxIDandKeyWriteValueFromTran inspects a transaction for writes to a given key
 func getKeyModificationFromTran(tranEnvelope *common.Envelope, namespace string, key string) (commonledger.QueryResult, error) {
-	logger.Debugf("Entering getKeyModificationFromTran()\n", namespace, key)
+	logger.Debugf("Entering getKeyModificationFromTran %s:%s", namespace, key)
 
 	// extract action from the envelope
 	payload, err := protoutil.UnmarshalPayload(tranEnvelope.Payload)

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
@@ -106,7 +106,6 @@ func readDataformatVersion(couchInstance *couchInstance) (string, error) {
 		return "", err
 	}
 	doc, _, err := db.readDoc(dataformatVersionDocID)
-	logger.Debugf("dataformatVersionDoc = %s", doc)
 	if err != nil || doc == nil {
 		return "", err
 	}
@@ -336,7 +335,7 @@ func (vdb *VersionedDB) LoadCommittedVersions(keys []*statedb.CompositeKey) erro
 
 	nsMetadataMap, err := vdb.retrieveMetadata(missingKeys)
 	logger.Debugf("missingKeys=%s", missingKeys)
-	logger.Debugf("nsMetadataMap=%s", nsMetadataMap)
+	logger.Debugf("nsMetadataMap=%v", nsMetadataMap)
 	if err != nil {
 		return err
 	}

--- a/gossip/privdata/pull.go
+++ b/gossip/privdata/pull.go
@@ -561,7 +561,7 @@ func (p *puller) getPurgedCollections(members []discovery.NetworkMember, dig2Fil
 	for dig := range dig2Filter {
 		purged, err := p.purgedFilter(dig)
 		if err != nil {
-			logger.Debug("Failed to obtain purged filter for digest %v", dig, "error", err)
+			logger.Debugf("Failed to obtain purged filter for digest %v error %v", dig, err)
 			continue
 		}
 

--- a/internal/configtxgen/genesisconfig/config.go
+++ b/internal/configtxgen/genesisconfig/config.go
@@ -443,7 +443,7 @@ func (c *configCache) load(config *viper.Viper, configPath string) (*TopLevel, e
 
 	conf := &TopLevel{}
 	serializedConf, ok := c.cache[configPath]
-	logger.Debug("Loading configuration from cache :%v", ok)
+	logger.Debugf("Loading configuration from cache: %t", ok)
 	if !ok {
 		err := viperutil.EnhancedExactUnmarshal(config, conf)
 		if err != nil {

--- a/internal/peer/chaincode/package.go
+++ b/internal/peer/chaincode/package.go
@@ -163,7 +163,7 @@ func (p *Packager) packageCC() error {
 		bytesToWrite = protoutil.MarshalOrPanic(cds)
 	}
 
-	logger.Debugf("Packaged chaincode into deployment spec of size <%d>, output file ", len(bytesToWrite), p.Input.OutputFile)
+	logger.Debugf("Packaged chaincode into deployment spec of size %d, output file %s", len(bytesToWrite), p.Input.OutputFile)
 	err = ioutil.WriteFile(p.Input.OutputFile, bytesToWrite, 0700)
 	if err != nil {
 		logger.Errorf("failed writing deployment spec to file [%s]: [%s]", p.Input.OutputFile, err)

--- a/orderer/common/channelparticipation/restapi.go
+++ b/orderer/common/channelparticipation/restapi.go
@@ -178,7 +178,7 @@ func (h *HTTPHandler) serveJoin(resp http.ResponseWriter, req *http.Request) {
 	info, err := h.registrar.JoinChannel(channelID, block, isAppChannel)
 	if err == nil {
 		info.URL = path.Join(URLBaseV1Channels, info.Name)
-		h.logger.Debugf("Successfully joined channel: %s", info)
+		h.logger.Debugf("Successfully joined channel: %s", info.URL)
 		h.sendResponseCreated(resp, info.URL, info)
 		return
 	}

--- a/scripts/golinter.sh
+++ b/scripts/golinter.sh
@@ -61,7 +61,7 @@ if [ -n "$OUTPUT" ]; then
 fi
 
 echo "Checking with go vet"
-PRINTFUNCS="Print,Printf,Info,Infof,Warning,Warningf,Error,Errorf,Critical,Criticalf,Sprint,Sprintf,Log,Logf,Panic,Panicf,Fatal,Fatalf,Notice,Noticef,Wrap,Wrapf,WithMessage"
+PRINTFUNCS="Debug,Debugf,Print,Printf,Info,Infof,Warning,Warningf,Error,Errorf,Critical,Criticalf,Sprint,Sprintf,Log,Logf,Panic,Panicf,Fatal,Fatalf,Notice,Noticef,Wrap,Wrapf,WithMessage"
 OUTPUT="$(go vet -all -printfuncs "$PRINTFUNCS" ./...)"
 if [ -n "$OUTPUT" ]; then
     echo "The following files contain go vet errors"


### PR DESCRIPTION
Add `Debug` and `Debugf` to the vet `-printfuncs` argument list and address the misuse flagged by vet in the current version of code.