### PR TITLE
PKCS11 test environment variables take precedence

### DIFF
--- a/bccsp/pkcs11/impl.go
+++ b/bccsp/pkcs11/impl.go
@@ -223,13 +223,10 @@ func (csp *impl) Decrypt(k bccsp.Key, ciphertext []byte, opts bccsp.DecrypterOpt
 }
 
 // FindPKCS11Lib IS ONLY USED FOR TESTING
-// This is a convenience function. Useful to self-configure, for tests where usual configuration is not
-// available
+// This is a convenience function. Useful to self-configure, for tests where
+// usual configuration is not available.
 func FindPKCS11Lib() (lib, pin, label string) {
-	lib = os.Getenv("PKCS11_LIB")
-	if lib == "" {
-		pin = "98765432"
-		label = "ForFabric"
+	if lib = os.Getenv("PKCS11_LIB"); lib == "" {
 		possibilities := []string{
 			"/usr/lib/softhsm/libsofthsm2.so",                  //Debian
 			"/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so", //Ubuntu
@@ -240,9 +237,13 @@ func FindPKCS11Lib() (lib, pin, label string) {
 				break
 			}
 		}
-	} else {
-		pin = os.Getenv("PKCS11_PIN")
-		label = os.Getenv("PKCS11_LABEL")
 	}
+	if pin = os.Getenv("PKCS11_PIN"); pin == "" {
+		pin = "98765432"
+	}
+	if label = os.Getenv("PKCS11_LABEL"); label == "" {
+		label = "ForFabric"
+	}
+
 	return lib, pin, label
 }

--- a/bccsp/pkcs11/impl_test.go
+++ b/bccsp/pkcs11/impl_test.go
@@ -141,25 +141,36 @@ func TestNew(t *testing.T) {
 func TestFindPKCS11LibEnvVars(t *testing.T) {
 	const (
 		dummy_PKCS11_LIB   = "/usr/lib/pkcs11"
-		dummy_PKCS11_PIN   = "98765432"
+		dummy_PKCS11_PIN   = "23456789"
 		dummy_PKCS11_LABEL = "testing"
 	)
 
 	// Set environment variables used for test and preserve
 	// original values for restoration after test completion
 	orig_PKCS11_LIB := os.Getenv("PKCS11_LIB")
-	os.Setenv("PKCS11_LIB", dummy_PKCS11_LIB)
-
 	orig_PKCS11_PIN := os.Getenv("PKCS11_PIN")
-	os.Setenv("PKCS11_PIN", dummy_PKCS11_PIN)
-
 	orig_PKCS11_LABEL := os.Getenv("PKCS11_LABEL")
-	os.Setenv("PKCS11_LABEL", dummy_PKCS11_LABEL)
 
-	lib, pin, label := FindPKCS11Lib()
-	assert.EqualValues(t, dummy_PKCS11_LIB, lib, "FindPKCS11Lib did not return expected library")
-	assert.EqualValues(t, dummy_PKCS11_PIN, pin, "FindPKCS11Lib did not return expected pin")
-	assert.EqualValues(t, dummy_PKCS11_LABEL, label, "FindPKCS11Lib did not return expected label")
+	t.Run("ExplicitEnvironment", func(t *testing.T) {
+		os.Setenv("PKCS11_LIB", dummy_PKCS11_LIB)
+		os.Setenv("PKCS11_PIN", dummy_PKCS11_PIN)
+		os.Setenv("PKCS11_LABEL", dummy_PKCS11_LABEL)
+
+		lib, pin, label := FindPKCS11Lib()
+		assert.EqualValues(t, dummy_PKCS11_LIB, lib, "FindPKCS11Lib did not return expected library")
+		assert.EqualValues(t, dummy_PKCS11_PIN, pin, "FindPKCS11Lib did not return expected pin")
+		assert.EqualValues(t, dummy_PKCS11_LABEL, label, "FindPKCS11Lib did not return expected label")
+	})
+
+	t.Run("MissingEnvironment", func(t *testing.T) {
+		os.Unsetenv("PKCS11_LIB")
+		os.Unsetenv("PKCS11_PIN")
+		os.Unsetenv("PKCS11_LABEL")
+
+		_, pin, label := FindPKCS11Lib()
+		assert.EqualValues(t, "98765432", pin, "FindPKCS11Lib did not return expected pin")
+		assert.EqualValues(t, "ForFabric", label, "FindPKCS11Lib did not return expected label")
+	})
 
 	os.Setenv("PKCS11_LIB", orig_PKCS11_LIB)
 	os.Setenv("PKCS11_PIN", orig_PKCS11_PIN)


### PR DESCRIPTION
The implementation of FindPKCS11Lib would not honor PKCS11_PIN or PKCS11_LABEL if the location of the library was not specified. This change enables the override for test when needed.