### PR TITLE
Only canonize ECDSA signatures in MSP:IsWellFormed

### DIFF
--- a/msp/mspimpl.go
+++ b/msp/mspimpl.go
@@ -847,6 +847,10 @@ func (msp *bccspmsp) IsWellFormed(identity *m.SerializedIdentity) error {
 		return err
 	}
 
+	if !isECDSASignedCert(cert) {
+		return nil
+	}
+
 	return isIdentitySignedInCanonicalForm(cert.Signature, identity.Mspid, identity.IdBytes)
 
 }


### PR DESCRIPTION
Currently, the MSP IsWellFormed function expects any signature to be
a valid ECDSA signature, however the certificate can be signed by
a non-ECDSA algorithm which will then yield a false negative.

This change set ensures the check only applies if the signature is ECDSA.

Change-Id: I0b14e3e9b87e860a3ca29cc233dc4810de1768ab
Signed-off-by: yacovm <yacovm@il.ibm.com>
