### PR TITLE
[FAB-18009] Ch.Part.API: Initialize file repos during registrar initialization

### DIFF
--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -120,6 +120,7 @@ var _ = Describe("EndToEnd", func() {
 				core.VM = nil
 				network.WritePeerConfig(peer, core)
 			}
+
 			network.Bootstrap()
 
 			networkRunner := network.NetworkGroupRunner()


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

* Only used when channel participation API is enabled
* Initializes a joinblock file repo for the channel participation api

#### Related issues

Task: [FAB-18009](https://jira.hyperledger.org/browse/FAB-18009)
Story: [FAB-15711](https://jira.hyperledger.org/browse/FAB-15711)
Epic: [FAB-17712](https://jira.hyperledger.org/browse/FAB-17712)