### PR TITLE
Fix chaincode package example path

### DIFF
--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -361,11 +361,13 @@ A chaincode needs to be packaged before it can be installed on your peers.
 This example uses the `peer lifecycle chaincode package` command to package
 a Go chaincode.
 
+  * Use the `--path` flag to indicate the location of the chaincode.
+    The path must be a fully qualified path or a path relative to your present working directory.
   * Use the `--label` flag to provide a chaincode package label of `myccv1`
     that your organization will use to identify the package.
 
     ```
-    peer lifecycle chaincode package mycc.tar.gz --path github.com/hyperledger/fabric-samples/chaincode/abstore/go/ --lang golang --label myccv1
+    peer lifecycle chaincode package mycc.tar.gz --path $CHAINCODE_DIR --lang golang --label myccv1
     ```
 
 ### peer lifecycle chaincode install example

--- a/docs/source/deploy_chaincode.md
+++ b/docs/source/deploy_chaincode.md
@@ -149,7 +149,9 @@ You can now create the chaincode package using the [peer lifecycle chaincode pac
 peer lifecycle chaincode package fabcar.tar.gz --path ../chaincode/fabcar/go/ --lang golang --label fabcar_1
 ```
 
-This command will create a package named ``fabcar.tar.gz`` in your current directory. The `--lang` flag is used to specify the chaincode language and the `--path` flag provides the location of your smart contract code. The `--label` flag is used to specify a chaincode label that will identity your chaincode after it is installed. It is recommended that your label include the chaincode name and version.
+This command will create a package named ``fabcar.tar.gz`` in your current directory.
+The `--lang` flag is used to specify the chaincode language and the `--path` flag provides the location of your smart contract code. The path must be a fully qualified path or a path relative to your present working directory.
+The `--label` flag is used to specify a chaincode label that will identity your chaincode after it is installed. It is recommended that your label include the chaincode name and version.
 
 Now that we created the chaincode package, we can [install the chaincode](#install-the-chaincode-package) on the peers of the test network.
 

--- a/docs/wrappers/peer_lifecycle_chaincode_postscript.md
+++ b/docs/wrappers/peer_lifecycle_chaincode_postscript.md
@@ -7,11 +7,13 @@ A chaincode needs to be packaged before it can be installed on your peers.
 This example uses the `peer lifecycle chaincode package` command to package
 a Go chaincode.
 
+  * Use the `--path` flag to indicate the location of the chaincode.
+    The path must be a fully qualified path or a path relative to your present working directory.
   * Use the `--label` flag to provide a chaincode package label of `myccv1`
     that your organization will use to identify the package.
 
     ```
-    peer lifecycle chaincode package mycc.tar.gz --path github.com/hyperledger/fabric-samples/chaincode/abstore/go/ --lang golang --label myccv1
+    peer lifecycle chaincode package mycc.tar.gz --path $CHAINCODE_DIR --lang golang --label myccv1
     ```
 
 ### peer lifecycle chaincode install example


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

With the Fabric shift to Go modules, chaincode packaging no longer
honors local GOPATH when resolving the chaincode path. User needs
to utilize a fully qualified path or a path relative to PWD.

This change updates the doc example that made an assumption about GOPATH usage.

#### Related issues

https://github.com/hyperledger/fabric/pull/1064

#### Release Note

A release note will be added in v2.2 to make it clear that GOPATH is no longer utilized.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>