### PR TITLE
[FAB-17374] Integration test for Chaincode as an External Service

### DIFF
--- a/integration/chaincode/extcc/main.go
+++ b/integration/chaincode/extcc/main.go
@@ -1,0 +1,53 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/hyperledger/fabric-chaincode-go/shim"
+	"github.com/hyperledger/fabric/integration/chaincode/simple"
+)
+
+func main() {
+	if len(os.Args) < 6 {
+		fmt.Println("usage: <package-id> <listener-address>")
+		os.Exit(1)
+	}
+
+	key, err := ioutil.ReadFile(os.Args[3])
+	if err != nil {
+		panic(fmt.Sprintf("Cannot read key file %s, error: %s", os.Args[3], err))
+	}
+	cert, err := ioutil.ReadFile(os.Args[4])
+	if err != nil {
+		panic(fmt.Sprintf("Cannot read cert file %s, error: %s", os.Args[3], err))
+	}
+	clientCACert, err := ioutil.ReadFile(os.Args[5])
+	if err != nil {
+		panic(fmt.Sprintf("Cannot read key file %s, error: %s", os.Args[3], err))
+	}
+
+	server := &shim.ChaincodeServer{
+		CCID:    os.Args[1],
+		Address: os.Args[2],
+		CC:      new(simple.SimpleChaincode),
+		TLSProps: shim.TLSProperties{
+			Key:           key,
+			Cert:          cert,
+			ClientCACerts: clientCACert,
+		},
+	}
+	// do not modify - needed for integration test
+	fmt.Printf("Starting chaincode %s at %s\n", server.CCID, server.Address)
+	err = server.Start()
+	if err != nil {
+		fmt.Printf("Error starting Simple chaincode: %s", err)
+	}
+}

--- a/integration/e2e/chaincode_service_test.go
+++ b/integration/e2e/chaincode_service_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/hyperledger/fabric/common/crypto/tlsgen"
+	"github.com/hyperledger/fabric/core/container/externalbuilder"
+	"github.com/hyperledger/fabric/integration/nwo"
+	"github.com/hyperledger/fabric/integration/nwo/fabricconfig"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/tedsuo/ifrit"
+	"github.com/tedsuo/ifrit/ginkgomon"
+)
+
+var _ = Describe("ChaincodeAsExternalService", func() {
+	var (
+		testDir                 string
+		network                 *nwo.Network
+		extcc                   nwo.Chaincode
+		chaincodeServerAddrress string
+		certFiles               []string
+		process                 ifrit.Process
+		extbldr                 fabricconfig.ExternalBuilder
+		ccserver                ifrit.Process
+	)
+
+	BeforeEach(func() {
+		var err error
+		testDir, err = ioutil.TempDir("", "e2e-chaincode-service")
+		Expect(err).NotTo(HaveOccurred())
+		extcc = nwo.Chaincode{
+			Name:            "mycc",
+			Version:         "0.0",
+			Path:            components.Build("github.com/hyperledger/fabric/integration/chaincode/extcc"),
+			Lang:            "extcc",
+			PackageFile:     filepath.Join(testDir, "extcc.tar.gz"),
+			Ctor:            `{"Args":["init","a","100","b","200"]}`,
+			SignaturePolicy: `AND ('Org1MSP.member','Org2MSP.member')`,
+			Sequence:        "1",
+			Label:           "my_extcc_chaincode",
+		}
+
+		extbldr = fabricconfig.ExternalBuilder{
+			Path: filepath.Join("..", "externalbuilders", "extcc"),
+			Name: "extcc",
+		}
+
+		network = nwo.New(nwo.BasicSolo(), testDir, nil, StartPort(), components)
+
+		chaincodeServerAddrress = fmt.Sprintf("127.0.0.1:%d", network.ReservePort())
+
+		tlsCA, err := tlsgen.NewCA()
+		Expect(err).NotTo(HaveOccurred())
+		certFiles = generateCertKeysAndConnectionFiles(tlsCA, testDir, extcc.Name)
+		chaincodeConnectionsFile := generateClientConnectionFile(tlsCA, chaincodeServerAddrress, testDir, extcc.Name)
+
+		//add extcc builder
+		network.ExternalBuilders = append(network.ExternalBuilders, extbldr)
+
+		network.GenerateConfigTree()
+
+		// package connection.json
+		extcc.CodeFiles = map[string]string{
+			chaincodeConnectionsFile: "connection.json",
+		}
+
+		network.Bootstrap()
+
+		networkRunner := network.NetworkGroupRunner()
+		process = ifrit.Invoke(networkRunner)
+		Eventually(process.Ready(), network.EventuallyTimeout).Should(BeClosed())
+	})
+
+	AfterEach(func() {
+		if ccserver != nil {
+			ccserver.Signal(syscall.SIGTERM)
+			Eventually(ccserver.Wait(), network.EventuallyTimeout).Should(Receive())
+		}
+
+		if process != nil {
+			process.Signal(syscall.SIGTERM)
+			Eventually(process.Wait(), network.EventuallyTimeout).Should(Receive())
+		}
+		if network != nil {
+			network.Cleanup()
+		}
+		os.RemoveAll(testDir)
+	})
+
+	It("executes a basic solo network with 2 orgs and external chaincode service", func() {
+		orderer := network.Orderer("orderer")
+
+		By("setting up the channel")
+		network.CreateAndJoinChannel(orderer, "testchannel")
+		nwo.EnableCapabilities(network, "testchannel", "Application", "V2_0", orderer, network.Peer("Org1", "peer0"), network.Peer("Org2", "peer0"))
+
+		By("deploying the chaincode")
+		nwo.DeployChaincode(network, "testchannel", orderer, extcc)
+
+		By("starting the chaincode service")
+		extcc.SetPackageIDFromPackageFile()
+
+		// start external chain code service
+		ccrunner := chaincodeServerRunner(extcc.Path, extcc.PackageID, append([]string{extcc.PackageID, chaincodeServerAddrress}, certFiles...))
+		ccserver = ifrit.Invoke(ccrunner)
+		Eventually(ccserver.Ready(), network.EventuallyTimeout).Should(BeClosed())
+
+		peer := network.Peer("Org1", "peer0")
+
+		RunRespondWith(network, orderer, peer, "testchannel")
+	})
+})
+
+func generateCertKeysAndConnectionFiles(tlsCA tlsgen.CA, testDir string, chaincodeID string) []string {
+	certsDir := filepath.Join(testDir, "certs", chaincodeID)
+
+	// Generate key files for chaincode server
+	err := os.MkdirAll(certsDir, 0755)
+	Expect(err).NotTo(HaveOccurred())
+
+	serverKeyFile := filepath.Join(certsDir, "key.pem")
+	serverCertFile := filepath.Join(certsDir, "cert.pem")
+	clientCAFile := filepath.Join(certsDir, "clientCA.pem")
+
+	serverPair, err := tlsCA.NewServerCertKeyPair("127.0.0.1")
+	cert := serverPair.Cert
+	key := serverPair.Key
+
+	err = ioutil.WriteFile(serverKeyFile, key, 0644)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = ioutil.WriteFile(serverCertFile, cert, 0644)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = ioutil.WriteFile(clientCAFile, tlsCA.CertBytes(), 0644)
+	Expect(err).NotTo(HaveOccurred())
+
+	return []string{serverKeyFile, serverCertFile, clientCAFile}
+}
+
+func generateClientConnectionFile(tlsCA tlsgen.CA, chaincodeServerAddrress string, testDir string, chaincodeID string) string {
+	clientPair, err := tlsCA.NewClientCertKeyPair()
+	Expect(err).NotTo(HaveOccurred())
+	clientKey := clientPair.Key
+	clientCert := clientPair.Cert
+
+	connectionsDir := filepath.Join(testDir, "chaincode-connections", chaincodeID)
+	err = os.MkdirAll(connectionsDir, 0755)
+	Expect(err).NotTo(HaveOccurred())
+
+	data := externalbuilder.ChaincodeServerUserData{
+		Address:            chaincodeServerAddrress,
+		DialTimeout:        externalbuilder.Duration{Duration: 10 * time.Second},
+		TLSRequired:        true,
+		ClientAuthRequired: true,
+		ClientKey:          string(clientKey),
+		ClientCert:         string(clientCert),
+		RootCert:           string(tlsCA.CertBytes()),
+	}
+
+	bdata, err := json.Marshal(data)
+	Expect(err).NotTo(HaveOccurred())
+
+	chaincodeConnectionsFile := filepath.Join(connectionsDir, "connection.json")
+	ioutil.WriteFile(chaincodeConnectionsFile, bdata, 0644)
+	Expect(err).NotTo(HaveOccurred())
+
+	return chaincodeConnectionsFile
+}
+
+func chaincodeServerRunner(path string, packageID string, args []string) *ginkgomon.Runner {
+	cmd := exec.Command(path, args...)
+	cmd.Env = os.Environ()
+
+	return ginkgomon.New(ginkgomon.Config{
+		Name:              packageID,
+		Command:           cmd,
+		StartCheck:        `Starting chaincode .* at .*`,
+		StartCheckTimeout: 15 * time.Second,
+	})
+}

--- a/integration/externalbuilders/extcc/bin/build
+++ b/integration/externalbuilders/extcc/bin/build
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+    >&2 echo "Expected 3 directories got $#"
+    exit 1
+fi
+
+SRC="$1"
+META="$2"
+BLD="$3"
+
+if [ ! -f "$SRC/connection.json" ]; then
+    >&2 echo "$SRC/connection.json not found"
+    exit 1
+fi
+
+cp $SRC/connection.json $BLD/connection.json
+
+if [ -e "$SRC/metadata" ] ; then
+  cp -a "$SRC/metadata" "$BLD"
+fi
+
+cp "$(jq -r .path "$META/metadata.json")" "$BLD/chaincode"

--- a/integration/externalbuilders/extcc/bin/detect
+++ b/integration/externalbuilders/extcc/bin/detect
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    >&2 echo "Expected 2 directories got $#"
+    exit 2
+fi
+
+if [ "$(jq -r .type "$2/metadata.json")" == "extcc" ]; then
+    exit 0
+fi
+
+>&2 echo "does not satisfy extcc builder"
+exit 1

--- a/integration/externalbuilders/extcc/bin/release
+++ b/integration/externalbuilders/extcc/bin/release
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    >&2 echo "Expected 2 directories got $#"
+    exit 2
+fi
+
+BLD="$1"
+RELEASE="$2"
+
+if [ -d "$BLD/metadata" ] ; then
+   cp -a "$BLD/metadata/"* "$RELEASE"
+fi
+
+if [ -f $BLD/connection.json ]; then
+   mkdir -p "$RELEASE"/chaincode/server
+   cp $BLD/connection.json "$RELEASE"/chaincode/server
+   exit 0
+fi
+
+exit 1

--- a/integration/nwo/deploy.go
+++ b/integration/nwo/deploy.go
@@ -134,7 +134,7 @@ func PackageAndInstallChaincode(n *Network, chaincode Chaincode, peers ...*Peer)
 	// only create chaincode package if it doesn't already exist
 	if _, err := os.Stat(chaincode.PackageFile); os.IsNotExist(err) {
 		switch chaincode.Lang {
-		case "binary":
+		case "binary", "extcc":
 			PackageChaincodeBinary(chaincode)
 		default:
 			PackageChaincode(n, chaincode, peers[0])


### PR DESCRIPTION
**Type of change**
Test update

**Details**
Fixes the issues reported in PR for Chaincode as External Service. The original PR with comments is here:
https://github.com/hyperledger/fabric/pull/552

The test is in integration/e2e/chaincode_service_test.go file
