### PR TITLE
[FAB-17508] Removing viper library from viperutil

### DIFF
--- a/common/viperutil/config_test.go
+++ b/common/viperutil/config_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/hyperledger/fabric/bccsp/factory"
 	"github.com/hyperledger/fabric/orderer/mocks/util"
-	"github.com/spf13/viper"
 )
 
 const Prefix = "VIPERUTIL"
@@ -34,12 +33,8 @@ func TestEnvSlice(t *testing.T) {
 	envVal := "[a, b, c]"
 	os.Setenv(envVar, envVal)
 	defer os.Unsetenv(envVar)
-	config := viper.New()
+	config := New()
 	config.SetEnvPrefix(Prefix)
-	config.AutomaticEnv()
-	replacer := strings.NewReplacer(".", "_")
-	config.SetEnvKeyReplacer(replacer)
-	config.SetConfigType("yaml")
 
 	data := "---\nInner:\n    Slice: [d,e,f]"
 
@@ -50,7 +45,7 @@ func TestEnvSlice(t *testing.T) {
 	}
 
 	var uconf testSlice
-	if err := EnhancedExactUnmarshal(config, &uconf); err != nil {
+	if err := config.EnhancedExactUnmarshal(&uconf); err != nil {
 		t.Fatalf("Failed to unmarshal with: %s", err)
 	}
 
@@ -67,8 +62,7 @@ func TestKafkaVersionDecode(t *testing.T) {
 		}
 	}
 
-	config := viper.New()
-	config.SetConfigType("yaml")
+	config := New()
 
 	testCases := []struct {
 		data        string
@@ -114,7 +108,7 @@ func TestKafkaVersionDecode(t *testing.T) {
 			}
 
 			var uconf testKafkaVersion
-			err = EnhancedExactUnmarshal(config, &uconf)
+			err = config.EnhancedExactUnmarshal(&uconf)
 
 			if tc.errExpected {
 				if err == nil {
@@ -141,8 +135,7 @@ type testByteSize struct {
 }
 
 func TestByteSize(t *testing.T) {
-	config := viper.New()
-	config.SetConfigType("yaml")
+	config := New()
 
 	testCases := []struct {
 		data     string
@@ -178,7 +171,7 @@ func TestByteSize(t *testing.T) {
 				t.Fatalf("Error reading config: %s", err)
 			}
 			var uconf testByteSize
-			err = EnhancedExactUnmarshal(config, &uconf)
+			err = config.EnhancedExactUnmarshal(&uconf)
 			if err != nil {
 				t.Fatalf("Failed to unmarshal with: %s", err)
 			}
@@ -190,8 +183,7 @@ func TestByteSize(t *testing.T) {
 }
 
 func TestByteSizeOverflow(t *testing.T) {
-	config := viper.New()
-	config.SetConfigType("yaml")
+	config := New()
 
 	data := "---\nInner:\n    ByteSize: 4GB"
 	err := config.ReadConfig(bytes.NewReader([]byte(data)))
@@ -199,7 +191,7 @@ func TestByteSizeOverflow(t *testing.T) {
 		t.Fatalf("Error reading config: %s", err)
 	}
 	var uconf testByteSize
-	err = EnhancedExactUnmarshal(config, &uconf)
+	err = config.EnhancedExactUnmarshal(&uconf)
 	if err == nil {
 		t.Fatalf("Should have failed to unmarshal")
 	}
@@ -217,15 +209,14 @@ func TestStringNotFromFile(t *testing.T) {
 	expectedValue := "expected_value"
 	yaml := fmt.Sprintf("---\nInner:\n  Single: %s\n", expectedValue)
 
-	config := viper.New()
-	config.SetConfigType("yaml")
+	config := New()
 
 	if err := config.ReadConfig(bytes.NewReader([]byte(yaml))); err != nil {
 		t.Fatalf("Error reading config: %s", err)
 	}
 
 	var uconf stringFromFileConfig
-	if err := EnhancedExactUnmarshal(config, &uconf); err != nil {
+	if err := config.EnhancedExactUnmarshal(&uconf); err != nil {
 		t.Fatalf("Failed to unmarshall: %s", err)
 	}
 
@@ -253,14 +244,13 @@ func TestStringFromFile(t *testing.T) {
 
 	yaml := fmt.Sprintf("---\nInner:\n  Single:\n    File: %s", file.Name())
 
-	config := viper.New()
-	config.SetConfigType("yaml")
+	config := New()
 
 	if err = config.ReadConfig(bytes.NewReader([]byte(yaml))); err != nil {
 		t.Fatalf("Error reading config: %s", err)
 	}
 	var uconf stringFromFileConfig
-	if err = EnhancedExactUnmarshal(config, &uconf); err != nil {
+	if err = config.EnhancedExactUnmarshal(&uconf); err != nil {
 		t.Fatalf("Failed to unmarshall: %s", err)
 	}
 
@@ -292,14 +282,13 @@ func TestPEMBlocksFromFile(t *testing.T) {
 
 	yaml := fmt.Sprintf("---\nInner:\n  Multiple:\n    File: %s", file.Name())
 
-	config := viper.New()
-	config.SetConfigType("yaml")
+	config := New()
 
 	if err := config.ReadConfig(bytes.NewReader([]byte(yaml))); err != nil {
 		t.Fatalf("Error reading config: %v", err)
 	}
 	var uconf stringFromFileConfig
-	if err := EnhancedExactUnmarshal(config, &uconf); err != nil {
+	if err := config.EnhancedExactUnmarshal(&uconf); err != nil {
 		t.Fatalf("Failed to unmarshall: %v", err)
 	}
 
@@ -345,18 +334,14 @@ func TestPEMBlocksFromFileEnv(t *testing.T) {
 			envVal := file.Name()
 			os.Setenv(envVar, envVal)
 			defer os.Unsetenv(envVar)
-			config := viper.New()
+			config := New()
 			config.SetEnvPrefix(Prefix)
-			config.AutomaticEnv()
-			replacer := strings.NewReplacer(".", "_")
-			config.SetEnvKeyReplacer(replacer)
-			config.SetConfigType("yaml")
 
 			if err := config.ReadConfig(bytes.NewReader([]byte(tc.data))); err != nil {
 				t.Fatalf("Error reading config: %v", err)
 			}
 			var uconf stringFromFileConfig
-			if err := EnhancedExactUnmarshal(config, &uconf); err != nil {
+			if err := config.EnhancedExactUnmarshal(&uconf); err != nil {
 				t.Fatalf("Failed to unmarshall: %v", err)
 			}
 
@@ -370,14 +355,13 @@ func TestPEMBlocksFromFileEnv(t *testing.T) {
 func TestStringFromFileNotSpecified(t *testing.T) {
 	yaml := "---\nInner:\n  Single:\n    File:\n"
 
-	config := viper.New()
-	config.SetConfigType("yaml")
+	config := New()
 
 	if err := config.ReadConfig(bytes.NewReader([]byte(yaml))); err != nil {
 		t.Fatalf("Error reading config: %s", err)
 	}
 	var uconf stringFromFileConfig
-	if err := EnhancedExactUnmarshal(config, &uconf); err == nil {
+	if err := config.EnhancedExactUnmarshal(&uconf); err == nil {
 		t.Fatalf("Should of failed to unmarshall.")
 	}
 }
@@ -411,12 +395,8 @@ func TestStringFromFileEnv(t *testing.T) {
 			envVal := file.Name()
 			os.Setenv(envVar, envVal)
 			defer os.Unsetenv(envVar)
-			config := viper.New()
+			config := New()
 			config.SetEnvPrefix(Prefix)
-			config.AutomaticEnv()
-			replacer := strings.NewReplacer(".", "_")
-			config.SetEnvKeyReplacer(replacer)
-			config.SetConfigType("yaml")
 
 			if err = config.ReadConfig(bytes.NewReader([]byte(tc.data))); err != nil {
 				t.Fatalf("Error reading %s plugin config: %s", Prefix, err)
@@ -424,7 +404,7 @@ func TestStringFromFileEnv(t *testing.T) {
 
 			var uconf stringFromFileConfig
 
-			err = EnhancedExactUnmarshal(config, &uconf)
+			err = config.EnhancedExactUnmarshal(&uconf)
 			if err != nil {
 				t.Fatalf("Failed to unmarshal with: %s", err)
 			}
@@ -444,8 +424,7 @@ Foo: bar
 Hello:
   World: 42
 `
-	config := viper.New()
-	config.SetConfigType("yaml")
+	config := New()
 	if err := config.ReadConfig(bytes.NewReader([]byte(yaml))); err != nil {
 		t.Fatalf("Error reading config: %s", err)
 	}
@@ -453,7 +432,7 @@ Hello:
 		Foo   string
 		Hello struct{ World int }
 	}
-	if err := EnhancedExactUnmarshal(config, &conf); err != nil {
+	if err := config.EnhancedExactUnmarshal(&conf); err != nil {
 		t.Fatalf("Error unmarshalling: %s", err)
 	}
 
@@ -473,12 +452,8 @@ BCCSP:
     Security: 999
 `
 
-	config := viper.New()
+	config := New()
 	config.SetEnvPrefix("VIPERUTIL")
-	config.AutomaticEnv()
-	replacer := strings.NewReplacer(".", "_")
-	config.SetEnvKeyReplacer(replacer)
-	config.SetConfigType("yaml")
 
 	overrideVar := "VIPERUTIL_BCCSP_SW_SECURITY"
 	os.Setenv(overrideVar, "1111")
@@ -488,7 +463,7 @@ BCCSP:
 	}
 
 	var tc testConfig
-	if err := EnhancedExactUnmarshal(config, &tc); err != nil {
+	if err := config.EnhancedExactUnmarshal(&tc); err != nil {
 		t.Fatalf("Error unmarshaling: %s", err)
 	}
 

--- a/common/viperutil/config_util.go
+++ b/common/viperutil/config_util.go
@@ -10,8 +10,11 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math"
+	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -24,14 +27,150 @@ import (
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
 )
 
 var logger = flogging.MustGetLogger("viperutil")
 
-type viperGetter func(key string) interface{}
+// ConfigPaths returns the paths from environment and
+// defaults which are CWD and /etc/hyperledger/fabric.
+func ConfigPaths() []string {
+	var paths []string
+	if p := os.Getenv("FABRIC_CFG_PATH"); p != "" {
+		paths = append(paths, p)
+	}
+	return append(paths, ".", "/etc/hyperledger/fabric")
+}
 
-func getKeysRecursively(base string, getKey viperGetter, nodeKeys map[string]interface{}, oType reflect.Type) map[string]interface{} {
+// ConfigParser holds the configuration file locations.
+// It keeps the config file directory locations and env variables.
+// From the file the config is unmarshalled and stored.
+// Currently "yaml" is supported.
+type ConfigParser struct {
+	// configuration file to process
+	configPaths []string
+	configName  string
+	configFile  string
+
+	// env variable prefix
+	envPrefix string
+
+	// parsed config
+	config map[string]interface{}
+}
+
+// New creates a ConfigParser instance
+func New() *ConfigParser {
+	return &ConfigParser{
+		config: map[string]interface{}{},
+	}
+}
+
+// AddConfigPaths keeps a list of path to search the relevant
+// config file. Multiple paths can be provided.
+func (c *ConfigParser) AddConfigPaths(cfgPaths ...string) {
+	if len(cfgPaths) > 0 {
+		for _, p := range cfgPaths {
+			c.configPaths = append(c.configPaths, p)
+		}
+	}
+}
+
+// SetConfigName initializes config file name. The extension is not included.
+func (c *ConfigParser) SetConfigName(in string) {
+	c.configName = in
+}
+
+// SetConfigFile sets the full config file name.
+// In this case, configPaths search shall not be done.
+func (c *ConfigParser) SetConfigFile(in string) {
+	c.configFile = in
+}
+
+// ConfigFileUsed returns the used configFile.
+func (c *ConfigParser) ConfigFileUsed() string { return c.configFile }
+
+// SetEnvPrefix initializes the envPrefix.
+// For example, if "peer" is set here, all environment variable
+// searches shall be prefixed with "PEER_"
+func (c *ConfigParser) SetEnvPrefix(in string) {
+	c.envPrefix = in
+}
+
+// Search for the existence of filename for all supported extensions
+func (c *ConfigParser) searchInPath(in string) (filename string) {
+	var supportedExts []string = []string{"yaml", "yml"}
+	for _, ext := range supportedExts {
+		fullPath := filepath.Join(in, c.configName+"."+ext)
+		_, err := os.Stat(fullPath)
+		if err == nil {
+			return fullPath
+		}
+	}
+	return ""
+}
+
+// Search for the configName in all configPaths
+func (c *ConfigParser) findConfigFile() string {
+	paths := c.configPaths
+	if len(paths) == 0 {
+		paths = ConfigPaths()
+	}
+	for _, cp := range paths {
+		file := c.searchInPath(cp)
+		if file != "" {
+			return file
+		}
+	}
+	return ""
+}
+
+// Get the valid and present config file
+func (c *ConfigParser) getConfigFile() string {
+	// if explicitly set, then use it
+	if c.configFile != "" {
+		return c.configFile
+	}
+
+	c.configFile = c.findConfigFile()
+	return c.configFile
+}
+
+// ReadInConfig reads and unmarshals the config file.
+func (c *ConfigParser) ReadInConfig() error {
+	cf := c.getConfigFile()
+	logger.Debugf("Attempting to open the config file : %s", cf)
+	file, err := os.Open(cf)
+	if err != nil {
+		logger.Errorf("Unable to open the config file : %s", cf)
+		return err
+	}
+	defer file.Close()
+
+	return c.ReadConfig(file)
+}
+
+// ReadConfig parses the buffer and initializes the config.
+func (c *ConfigParser) ReadConfig(in io.Reader) error {
+	dec := yaml.NewDecoder(in)
+	return dec.Decode(c.config)
+}
+
+// Get value for the key by searching
+// environment variables
+func (c *ConfigParser) getFromEnv(key string) interface{} {
+	envKey := key
+	if c.envPrefix != "" {
+		envKey = strings.ToUpper(c.envPrefix + "_" + envKey)
+	}
+	envKey = strings.ReplaceAll(envKey, ".", "_")
+	return os.Getenv(envKey)
+}
+
+// Prototype declaration for getFromEnv function.
+type envGetter func(key string) interface{}
+
+func getKeysRecursively(base string, getKey envGetter, nodeKeys map[string]interface{}, oType reflect.Type) map[string]interface{} {
 	subTypes := map[string]reflect.Type{}
 
 	if oType != nil && oType.Kind() == reflect.Struct {
@@ -56,7 +195,12 @@ func getKeysRecursively(base string, getKey viperGetter, nodeKeys map[string]int
 	for key := range nodeKeys {
 		fqKey := base + key
 
-		val := getKey(fqKey)
+		var val interface{}
+		val = nodeKeys[key]
+		// overwrite val, if an environment is available
+		if envVal := getKey(fqKey); envVal != "" {
+			val = envVal
+		}
 		if m, ok := val.(map[interface{}]interface{}); ok {
 			logger.Debugf("Found map[interface{}]interface{} value for %s", fqKey)
 			tmp := make(map[string]interface{})
@@ -76,8 +220,11 @@ func getKeysRecursively(base string, getKey viperGetter, nodeKeys map[string]int
 			result[key] = m
 		} else {
 			if val == nil {
+				var fileVal interface{}
 				fileSubKey := fqKey + ".File"
-				fileVal := getKey(fileSubKey)
+				if envVal := getKey(fileSubKey); envVal != "" {
+					fileVal = envVal
+				}
 				if fileVal != nil {
 					result[key] = map[string]interface{}{"File": fileVal}
 					continue
@@ -315,7 +462,7 @@ func bccspHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, e
 // EnhancedExactUnmarshal is intended to unmarshal a config file into a structure
 // producing error when extraneous variables are introduced and supporting
 // the time.Duration type
-func EnhancedExactUnmarshal(v *viper.Viper, output interface{}) error {
+func (c *ConfigParser) EnhancedExactUnmarshal(output interface{}) error {
 	oType := reflect.TypeOf(output)
 	if oType.Kind() != reflect.Ptr {
 		return errors.Errorf("supplied output argument must be a pointer to a struct but is not pointer")
@@ -325,10 +472,8 @@ func EnhancedExactUnmarshal(v *viper.Viper, output interface{}) error {
 		return errors.Errorf("supplied output argument must be a pointer to a struct, but it is pointer to something else")
 	}
 
-	baseKeys := v.AllSettings()
-
-	getterWithClass := func(key string) interface{} { return v.Get(key) } // hide receiver
-	leafKeys := getKeysRecursively("", getterWithClass, baseKeys, eType)
+	baseKeys := c.config
+	leafKeys := getKeysRecursively("", c.getFromEnv, baseKeys, eType)
 
 	logger.Debugf("%+v", leafKeys)
 	config := &mapstructure.DecoderConfig{

--- a/internal/configtxgen/genesisconfig/config.go
+++ b/internal/configtxgen/genesisconfig/config.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hyperledger/fabric/common/viperutil"
 	cf "github.com/hyperledger/fabric/core/config"
 	"github.com/hyperledger/fabric/msp"
-	"github.com/spf13/viper"
 )
 
 const (
@@ -199,15 +198,9 @@ var genesisDefaults = TopLevel{
 // Note, for environment overrides to work properly within a profile, Load
 // should be used instead.
 func LoadTopLevel(configPaths ...string) *TopLevel {
-	config := viper.New()
-	if len(configPaths) > 0 {
-		for _, p := range configPaths {
-			config.AddConfigPath(p)
-		}
-		config.SetConfigName("configtx")
-	} else {
-		cf.InitViper(config, "configtx")
-	}
+	config := viperutil.New()
+	config.AddConfigPaths(configPaths...)
+	config.SetConfigName("configtx")
 
 	err := config.ReadInConfig()
 	if err != nil {
@@ -229,15 +222,9 @@ func LoadTopLevel(configPaths ...string) *TopLevel {
 // a given profile. Config paths may optionally be provided and will be used
 // in place of the FABRIC_CFG_PATH env variable.
 func Load(profile string, configPaths ...string) *Profile {
-	config := viper.New()
-	if len(configPaths) > 0 {
-		for _, p := range configPaths {
-			config.AddConfigPath(p)
-		}
-		config.SetConfigName("configtx")
-	} else {
-		cf.InitViper(config, "configtx")
-	}
+	config := viperutil.New()
+	config.AddConfigPaths(configPaths...)
+	config.SetConfigName("configtx")
 
 	err := config.ReadInConfig()
 	if err != nil {
@@ -437,7 +424,7 @@ var cache = &configCache{
 // load loads the TopLevel config structure from configCache.
 // if not successful, it unmarshal a config file, and populate configCache
 // with marshaled TopLevel struct.
-func (c *configCache) load(config *viper.Viper, configPath string) (*TopLevel, error) {
+func (c *configCache) load(config *viperutil.ConfigParser, configPath string) (*TopLevel, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -445,7 +432,7 @@ func (c *configCache) load(config *viper.Viper, configPath string) (*TopLevel, e
 	serializedConf, ok := c.cache[configPath]
 	logger.Debugf("Loading configuration from cache: %t", ok)
 	if !ok {
-		err := viperutil.EnhancedExactUnmarshal(config, conf)
+		err := config.EnhancedExactUnmarshal(conf)
 		if err != nil {
 			return nil, fmt.Errorf("Error unmarshaling config into struct: %s", err)
 		}

--- a/internal/configtxgen/genesisconfig/config_test.go
+++ b/internal/configtxgen/genesisconfig/config_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 
 	"github.com/hyperledger/fabric-protos-go/orderer/etcdraft"
+	"github.com/hyperledger/fabric/common/viperutil"
 	"github.com/hyperledger/fabric/core/config/configtest"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -274,31 +274,31 @@ func TestLoadConfigCache(t *testing.T) {
 	cleanup := configtest.SetDevFabricConfigPath(t)
 	defer cleanup()
 
-	v := viper.New()
+	cfg := viperutil.New()
 	devConfigDir := configtest.GetDevConfigDir()
-	v.AddConfigPath(devConfigDir)
-	v.SetConfigName("configtx")
-	err := v.ReadInConfig()
+	cfg.AddConfigPaths(devConfigDir)
+	cfg.SetConfigName("configtx")
+	err := cfg.ReadInConfig()
 	assert.NoError(t, err)
 
-	configPath := v.ConfigFileUsed()
+	configPath := cfg.ConfigFileUsed()
 	c := &configCache{
 		cache: make(map[string][]byte),
 	}
 
 	// Load the initial config, update the environment, and load again.
 	// With the caching behavior, the update should not be reflected.
-	initial, err := c.load(v, configPath)
+	initial, err := c.load(cfg, configPath)
 	assert.NoError(t, err)
 	os.Setenv("ORDERER_KAFKA_RETRY_SHORTINTERVAL", "120s")
-	updated, err := c.load(v, configPath)
+	updated, err := c.load(cfg, configPath)
 	assert.NoError(t, err)
 	assert.Equal(t, initial, updated, "expected %#v to equal %#v", updated, initial)
 
 	// Change the configuration we got back and load again.
 	// The  new value should not contain the updated to the initial
 	initial.Orderer.OrdererType = "bad-Orderer-Type"
-	updated, err = c.load(v, configPath)
+	updated, err = c.load(cfg, configPath)
 	assert.NoError(t, err)
 	assert.NotEqual(t, initial, updated, "expected %#v to not equal %#v", updated, initial)
 }

--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/common/viperutil"
 	coreconfig "github.com/hyperledger/fabric/core/config"
-	"github.com/spf13/viper"
 )
 
 // Prefix for environment variables.
@@ -314,12 +312,9 @@ var cache = &configCache{}
 func (c *configCache) load() (*TopLevel, error) {
 	var uconf TopLevel
 
-	config := viper.New()
-	coreconfig.InitViper(config, "orderer")
+	config := viperutil.New()
+	config.SetConfigName("orderer")
 	config.SetEnvPrefix(Prefix)
-	config.AutomaticEnv()
-	replacer := strings.NewReplacer(".", "_")
-	config.SetEnvKeyReplacer(replacer)
 
 	if err := config.ReadInConfig(); err != nil {
 		return nil, fmt.Errorf("Error reading configuration: %s", err)
@@ -329,7 +324,7 @@ func (c *configCache) load() (*TopLevel, error) {
 	defer c.mutex.Unlock()
 	serializedConf, ok := c.cache[config.ConfigFileUsed()]
 	if !ok {
-		err := viperutil.EnhancedExactUnmarshal(config, &uconf)
+		err := config.EnhancedExactUnmarshal(&uconf)
 		if err != nil {
 			return nil, fmt.Errorf("Error unmarshaling config into struct: %s", err)
 		}


### PR DESCRIPTION
Type of change

Improvement (improvement to code by avoiding viper library that is not
needed in this context)

Description

Avoiding the overlap in the implementation of getKeysRecursively and
viper.Get() function. The sub-keys needed by getKeysRecursively is
readily available and the usage of viper.Get() can be avoided.

The reference to viper library is removed from the following modules
1. orderer/common/localconfig
2. internal/configtxgen/genesisconfig
3. common/viperutil

A ConfigParser class is created in viperutil/config_utils.go to achieve
the needed funtionality.

Additional details

Unit tests done are the following

go test -race -count 1 -v -run Test github.com/hyperledger/fabric/orderer/common/localconfig | tail -2
PASS
ok      github.com/hyperledger/fabric/orderer/common/localconfig
1.260s
go test -race -count 1 -v -run Test github.com/hyperledger/fabric/internal/configtxgen/genesisconfig | tail -2
PASS
ok      github.com/hyperledger/fabric/internal/configtxgen/genesisconfig
1.115s
go test -race -count 1 -v -run Test github.com/hyperledger/fabric/common/viperutil | tail -2
PASS
ok      github.com/hyperledger/fabric/common/viperutil  0.793s
go test -race -count 1 -v -run Test github.com/hyperledger/fabric/orderer/consensus/etcdraft | tail -2
PASS
ok      github.com/hyperledger/fabric/orderer/consensus/etcdraft
52.528s
go test -race -count 1 -v -run Test github.com/hyperledger/fabric/orderer/consensus/etcdraft | grep SUCCESS!
SUCCESS! -- 107 Passed | 0 Failed | 0 Pending | 0 Skipped

Related issues

https://jira.hyperledger.org/browse/FAB-17508

Signed-off-by: NicholasB <nbasker@gmail.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

- Improvement (improvement to code, performance, etc)


#### Description

Avoiding the overlap in the implementation of getKeysRecursively and
viper.Get() function. 

#### Additional details

Unit Tests Done

#### Related issues

https://jira.hyperledger.org/browse/FAB-17508

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
