### PR TITLE
add Delete() method to confighistory mgr

### DIFF
--- a/core/ledger/confighistory/mgr.go
+++ b/core/ledger/confighistory/mgr.go
@@ -158,6 +158,15 @@ func (m *Mgr) ImportConfigHistory(ledgerID string, dir string) error {
 	return db.WriteBatch(batch, true)
 }
 
+// Delete deletes all collection config entries associated with
+// a given ledgerID. Currently, the Delete method would be called
+// only when a failure occurs during an import from snapshot files.
+// Hence, we do not need synchronization with other methods on the Mgr.
+func (m *Mgr) Delete(ledgerID string) error {
+	db := m.dbProvider.getDB(ledgerID)
+	return db.DeleteAll()
+}
+
 // GetRetriever returns an implementation of `ledger.ConfigHistoryRetriever` for the given ledger id.
 func (m *Mgr) GetRetriever(ledgerID string, ledgerInfoRetriever LedgerInfoRetriever) *Retriever {
 	return &Retriever{

--- a/core/ledger/confighistory/mgr_test.go
+++ b/core/ledger/confighistory/mgr_test.go
@@ -167,6 +167,22 @@ func TestMgr(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, maxBlockNumberInLedger, typedErr.MaxBlockNumCommitted)
 	})
+
+	t.Run("delete all entries associated with a ledgerID", func(t *testing.T) {
+		db := mgr.dbProvider.getDB("ledgerid1")
+		empty, err := db.isEmpty()
+		require.NoError(t, err)
+		require.False(t, empty)
+
+		require.NoError(t, mgr.Delete("ledgerid1"))
+		empty, err = db.isEmpty()
+		require.NoError(t, err)
+		require.True(t, empty)
+
+		require.NoError(t, mgr.Delete("ledgerid1"))
+		mgr.dbProvider.Close()
+		require.EqualError(t, mgr.Delete("ledgerid1"), "internal leveldb error while obtaining db iterator: leveldb: closed")
+	})
 }
 
 func TestWithImplicitColls(t *testing.T) {


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

This PR adds `Delete()` method to `confighistory` mgr to delete all collection config entries associated with a given ledgerID.

#### Additional details

The `Delete()` method would be used by `kvledger` pkg when a failure occurs during an import from snapshot files.