### PR TITLE
Import state from snapshotted data in stateleveldb

### DIFF
--- a/common/ledger/util/leveldbhelper/leveldb_provider.go
+++ b/common/ledger/util/leveldbhelper/leveldb_provider.go
@@ -204,6 +204,21 @@ func (h *DBHandle) DeleteAll() error {
 	return nil
 }
 
+// IsEmpty returns true if no data exists for the DBHandle
+func (h *DBHandle) IsEmpty() (bool, error) {
+	itr, err := h.GetIterator(nil, nil)
+	if err != nil {
+		return false, err
+	}
+	defer itr.Release()
+
+	if err := itr.Error(); err != nil {
+		return false, errors.WithMessagef(itr.Error(), "internal leveldb error while obtaining next entry from iterator")
+	}
+
+	return !itr.Next(), nil
+}
+
 // NewUpdateBatch returns a new UpdateBatch that can be used to update the db
 func (h *DBHandle) NewUpdateBatch() *UpdateBatch {
 	return &UpdateBatch{

--- a/core/ledger/confighistory/db_helper.go
+++ b/core/ledger/confighistory/db_helper.go
@@ -111,19 +111,6 @@ func (d *db) getNamespaceIterator(ns string) (*leveldbhelper.Iterator, error) {
 	return d.GetIterator(nsStartKey, nsEndKey)
 }
 
-func (d *db) isEmpty() (bool, error) {
-	itr, err := d.GetIterator(nil, nil)
-	if err != nil {
-		return false, err
-	}
-	defer itr.Release()
-	entryExist := itr.Next()
-	if err := itr.Error(); err != nil {
-		return false, errors.WithMessagef(err, "internal leveldb error while obtaining next entry from iterator")
-	}
-	return !entryExist, nil
-}
-
 func encodeCompositeKey(ns, key string, blockNum uint64) []byte {
 	b := []byte(keyPrefix + ns)
 	b = append(b, separatorByte)

--- a/core/ledger/confighistory/db_helper_test.go
+++ b/core/ledger/confighistory/db_helper_test.go
@@ -113,46 +113,6 @@ func TestGetNamespaceIterator(t *testing.T) {
 	})
 }
 
-func TestIsNotEmpty(t *testing.T) {
-	testDBPath := "/tmp/fabric/core/ledger/confighistory"
-	deleteTestPath(t, testDBPath)
-	provider, err := newDBProvider(testDBPath)
-	require.NoError(t, err)
-	defer deleteTestPath(t, testDBPath)
-
-	db := provider.getDB("ledger1")
-
-	t.Run("db is empty", func(t *testing.T) {
-		empty, err := db.isEmpty()
-		require.NoError(t, err)
-		require.True(t, empty)
-	})
-
-	t.Run("db is not empty", func(t *testing.T) {
-		sampleData := []*compositeKV{
-			{
-				&compositeKey{
-					ns:       "ns1",
-					key:      "key1",
-					blockNum: 40,
-				},
-				[]byte("val1_40"),
-			},
-		}
-		populateDBWithSampleData(t, db, sampleData)
-		empty, err := db.isEmpty()
-		require.NoError(t, err)
-		require.False(t, empty)
-	})
-
-	t.Run("iter error", func(t *testing.T) {
-		provider.Close()
-		empty, err := db.isEmpty()
-		require.EqualError(t, err, "internal leveldb error while obtaining db iterator: leveldb: closed")
-		require.False(t, empty)
-	})
-}
-
 func verifyNsEntries(t *testing.T, nsItr *leveldbhelper.Iterator, expectedEntries []*compositeKV) {
 	var retrievedEntries []*compositeKV
 	for nsItr.Next() {

--- a/core/ledger/confighistory/mgr.go
+++ b/core/ledger/confighistory/mgr.go
@@ -53,6 +53,7 @@ func (m *Mgr) Name() string {
 	return "collection configuration history listener"
 }
 
+// Initialize implements function from the interface ledger.StateListener
 func (m *Mgr) Initialize(ledgerID string, qe ledger.SimpleQueryExecutor) error {
 	// Noop
 	return nil
@@ -112,7 +113,7 @@ func (m *Mgr) HandleStateUpdates(trigger *ledger.StateUpdateTrigger) error {
 // ledgerID from the snapshot files present in the dir
 func (m *Mgr) ImportConfigHistory(ledgerID string, dir string) error {
 	db := m.dbProvider.getDB(ledgerID)
-	empty, err := db.isEmpty()
+	empty, err := db.IsEmpty()
 	if err != nil {
 		return err
 	}
@@ -175,6 +176,7 @@ func (m *Mgr) Close() {
 	m.dbProvider.Close()
 }
 
+// Retriever helps consumer retrieve collection config history
 type Retriever struct {
 	ledgerInfoRetriever    LedgerInfoRetriever
 	ledgerID               string

--- a/core/ledger/kvledger/txmgmt/statedb/mock/versioned_db.go
+++ b/core/ledger/kvledger/txmgmt/statedb/mock/versioned_db.go
@@ -165,6 +165,30 @@ type VersionedDB struct {
 		result1 *version.Height
 		result2 error
 	}
+	ImportStateStub        func(statedb.FullScanIterator, byte) error
+	importStateMutex       sync.RWMutex
+	importStateArgsForCall []struct {
+		arg1 statedb.FullScanIterator
+		arg2 byte
+	}
+	importStateReturns struct {
+		result1 error
+	}
+	importStateReturnsOnCall map[int]struct {
+		result1 error
+	}
+	IsEmptyStub        func() (bool, error)
+	isEmptyMutex       sync.RWMutex
+	isEmptyArgsForCall []struct {
+	}
+	isEmptyReturns struct {
+		result1 bool
+		result2 error
+	}
+	isEmptyReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	OpenStub        func() error
 	openMutex       sync.RWMutex
 	openArgsForCall []struct {
@@ -906,6 +930,122 @@ func (fake *VersionedDB) GetVersionReturnsOnCall(i int, result1 *version.Height,
 	}{result1, result2}
 }
 
+func (fake *VersionedDB) ImportState(arg1 statedb.FullScanIterator, arg2 byte) error {
+	fake.importStateMutex.Lock()
+	ret, specificReturn := fake.importStateReturnsOnCall[len(fake.importStateArgsForCall)]
+	fake.importStateArgsForCall = append(fake.importStateArgsForCall, struct {
+		arg1 statedb.FullScanIterator
+		arg2 byte
+	}{arg1, arg2})
+	fake.recordInvocation("ImportState", []interface{}{arg1, arg2})
+	fake.importStateMutex.Unlock()
+	if fake.ImportStateStub != nil {
+		return fake.ImportStateStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.importStateReturns
+	return fakeReturns.result1
+}
+
+func (fake *VersionedDB) ImportStateCallCount() int {
+	fake.importStateMutex.RLock()
+	defer fake.importStateMutex.RUnlock()
+	return len(fake.importStateArgsForCall)
+}
+
+func (fake *VersionedDB) ImportStateCalls(stub func(statedb.FullScanIterator, byte) error) {
+	fake.importStateMutex.Lock()
+	defer fake.importStateMutex.Unlock()
+	fake.ImportStateStub = stub
+}
+
+func (fake *VersionedDB) ImportStateArgsForCall(i int) (statedb.FullScanIterator, byte) {
+	fake.importStateMutex.RLock()
+	defer fake.importStateMutex.RUnlock()
+	argsForCall := fake.importStateArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *VersionedDB) ImportStateReturns(result1 error) {
+	fake.importStateMutex.Lock()
+	defer fake.importStateMutex.Unlock()
+	fake.ImportStateStub = nil
+	fake.importStateReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *VersionedDB) ImportStateReturnsOnCall(i int, result1 error) {
+	fake.importStateMutex.Lock()
+	defer fake.importStateMutex.Unlock()
+	fake.ImportStateStub = nil
+	if fake.importStateReturnsOnCall == nil {
+		fake.importStateReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.importStateReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *VersionedDB) IsEmpty() (bool, error) {
+	fake.isEmptyMutex.Lock()
+	ret, specificReturn := fake.isEmptyReturnsOnCall[len(fake.isEmptyArgsForCall)]
+	fake.isEmptyArgsForCall = append(fake.isEmptyArgsForCall, struct {
+	}{})
+	fake.recordInvocation("IsEmpty", []interface{}{})
+	fake.isEmptyMutex.Unlock()
+	if fake.IsEmptyStub != nil {
+		return fake.IsEmptyStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.isEmptyReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *VersionedDB) IsEmptyCallCount() int {
+	fake.isEmptyMutex.RLock()
+	defer fake.isEmptyMutex.RUnlock()
+	return len(fake.isEmptyArgsForCall)
+}
+
+func (fake *VersionedDB) IsEmptyCalls(stub func() (bool, error)) {
+	fake.isEmptyMutex.Lock()
+	defer fake.isEmptyMutex.Unlock()
+	fake.IsEmptyStub = stub
+}
+
+func (fake *VersionedDB) IsEmptyReturns(result1 bool, result2 error) {
+	fake.isEmptyMutex.Lock()
+	defer fake.isEmptyMutex.Unlock()
+	fake.IsEmptyStub = nil
+	fake.isEmptyReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *VersionedDB) IsEmptyReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.isEmptyMutex.Lock()
+	defer fake.isEmptyMutex.Unlock()
+	fake.IsEmptyStub = nil
+	if fake.isEmptyReturnsOnCall == nil {
+		fake.isEmptyReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.isEmptyReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *VersionedDB) Open() error {
 	fake.openMutex.Lock()
 	ret, specificReturn := fake.openReturnsOnCall[len(fake.openArgsForCall)]
@@ -1051,6 +1191,10 @@ func (fake *VersionedDB) Invocations() map[string][][]interface{} {
 	defer fake.getStateRangeScanIteratorWithPaginationMutex.RUnlock()
 	fake.getVersionMutex.RLock()
 	defer fake.getVersionMutex.RUnlock()
+	fake.importStateMutex.RLock()
+	defer fake.importStateMutex.RUnlock()
+	fake.isEmptyMutex.RLock()
+	defer fake.isEmptyMutex.RUnlock()
 	fake.openMutex.RLock()
 	defer fake.openMutex.RUnlock()
 	fake.validateKeyValueMutex.RLock()

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
@@ -868,6 +868,18 @@ func (vdb *VersionedDB) GetFullScanIterator(skipNamespace func(string) bool) (st
 	return newDBsScanner(dbsToScan, vdb.couchInstance.internalQueryLimit(), toSkipKeysFromEmptyNs)
 }
 
+// ImportState implements method in VersionedDB interface. The function is expected to be used
+// for importing the state from a previously snapshotted state. The parameter itr provides access to
+// the snapshotted state.
+func (vdb *VersionedDB) ImportState(itr statedb.FullScanIterator, dbValueFormat byte) error {
+	return errors.New("Not yet implemented")
+}
+
+// IsEmpty return true if the statedb does not have any content
+func (vdb *VersionedDB) IsEmpty() (bool, error) {
+	return false, errors.New("Not yet implemented")
+}
+
 // applyAdditionalQueryOptions will add additional fields to the query required for query processing
 func applyAdditionalQueryOptions(queryString string, queryLimit int32, queryBookmark string) (string, error) {
 	const jsonQueryFields = "fields"

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
@@ -1694,15 +1694,15 @@ func testRangeQueryWithPageSize(
 	require.Equal(t, expectedResults, results)
 }
 
-func TestFullScanIterator(t *testing.T) {
+func TestDataExportImport(t *testing.T) {
+	t.Skip("Skip this test until the import state function is implemented in statecouchdb")
 	vdbEnv.init(t, nil)
 	defer vdbEnv.cleanup()
 
-	commontests.TestFullScanIterator(
+	commontests.TestDataExportImport(
 		t,
 		vdbEnv.DBProvider,
 		byte(1),
-		constructVersionedValueForTest,
 	)
 }
 

--- a/core/ledger/kvledger/txmgmt/statedb/statedb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statedb.go
@@ -72,6 +72,11 @@ type VersionedDB interface {
 	// about the value bytes returned by the Next function in the returned FullScanIterator.
 	// The intended use of this iterator is to generate the snapshot files for the statedb.
 	GetFullScanIterator(skipNamespace func(string) bool) (FullScanIterator, byte, error)
+	// ImportState is expected to be used for importing the state from a previously snapshotted state.
+	// The parameter itr provides access to the snapshotted state.
+	ImportState(itr FullScanIterator, dbValueFormat byte) error
+	// IsEmpty return true if the statedb does not have any content
+	IsEmpty() (bool, error)
 	// Open opens the db
 	Open() error
 	// Close closes the db


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Description

This commit enables `statelevedb` for importing the state data for a channel from an iterator that is expected to read from previously snapshotted state data

#### Related issues
FAB-18042