### PR TITLE
Additional cleanup of viperutil

### DIFF
--- a/common/viperutil/config_test.go
+++ b/common/viperutil/config_test.go
@@ -20,7 +20,10 @@ import (
 	"github.com/hyperledger/fabric/orderer/mocks/util"
 )
 
-const Prefix = "VIPERUTIL"
+const (
+	testConfigName = "viperutil"
+	testEnvPrefix  = "VIPERUTIL"
+)
 
 func TestEnvSlice(t *testing.T) {
 	type testSlice struct {
@@ -29,19 +32,19 @@ func TestEnvSlice(t *testing.T) {
 		}
 	}
 
-	envVar := "VIPERUTIL_INNER_SLICE"
+	envVar := testEnvPrefix + "_INNER_SLICE"
 	envVal := "[a, b, c]"
 	os.Setenv(envVar, envVal)
 	defer os.Unsetenv(envVar)
 	config := New()
-	config.SetEnvPrefix(Prefix)
+	config.SetConfigName(testConfigName)
 
 	data := "---\nInner:\n    Slice: [d,e,f]"
 
 	err := config.ReadConfig(bytes.NewReader([]byte(data)))
 
 	if err != nil {
-		t.Fatalf("Error reading %s plugin config: %s", Prefix, err)
+		t.Fatalf("Error reading %s plugin config: %s", testConfigName, err)
 	}
 
 	var uconf testSlice
@@ -324,18 +327,17 @@ func TestPEMBlocksFromFileEnv(t *testing.T) {
 	}{
 		{"Override", "---\nInner:\n  Multiple:\n    File: wrong_file"},
 		{"NoFileElement", "---\nInner:\n  Multiple:\n"},
-		// {"NoElementAtAll", "---\nInner:\n"}, test case for another time
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			envVar := "VIPERUTIL_INNER_MULTIPLE_FILE"
+			envVar := testEnvPrefix + "_INNER_MULTIPLE_FILE"
 			envVal := file.Name()
 			os.Setenv(envVar, envVal)
 			defer os.Unsetenv(envVar)
 			config := New()
-			config.SetEnvPrefix(Prefix)
+			config.SetConfigName(testConfigName)
 
 			if err := config.ReadConfig(bytes.NewReader([]byte(tc.data))); err != nil {
 				t.Fatalf("Error reading config: %v", err)
@@ -391,15 +393,15 @@ func TestStringFromFileEnv(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			envVar := "VIPERUTIL_INNER_SINGLE_FILE"
+			envVar := testEnvPrefix + "_INNER_SINGLE_FILE"
 			envVal := file.Name()
 			os.Setenv(envVar, envVal)
 			defer os.Unsetenv(envVar)
 			config := New()
-			config.SetEnvPrefix(Prefix)
+			config.SetConfigName(testConfigName)
 
 			if err = config.ReadConfig(bytes.NewReader([]byte(tc.data))); err != nil {
-				t.Fatalf("Error reading %s plugin config: %s", Prefix, err)
+				t.Fatalf("Error reading %s plugin config: %s", testConfigName, err)
 			}
 
 			var uconf stringFromFileConfig
@@ -453,9 +455,9 @@ BCCSP:
 `
 
 	config := New()
-	config.SetEnvPrefix("VIPERUTIL")
+	config.SetConfigName(testConfigName)
 
-	overrideVar := "VIPERUTIL_BCCSP_SW_SECURITY"
+	overrideVar := testEnvPrefix + "_BCCSP_SW_SECURITY"
 	os.Setenv(overrideVar, "1111")
 	defer os.Unsetenv(overrideVar)
 	if err := config.ReadConfig(strings.NewReader(yaml)); err != nil {

--- a/common/viperutil/config_util.go
+++ b/common/viperutil/config_util.go
@@ -81,12 +81,6 @@ func (c *ConfigParser) SetConfigName(in string) {
 	c.configName = in
 }
 
-// SetConfigFile sets the full config file name.
-// In this case, configPaths search shall not be done.
-func (c *ConfigParser) SetConfigFile(in string) {
-	c.configFile = in
-}
-
 // ConfigFileUsed returns the used configFile.
 func (c *ConfigParser) ConfigFileUsed() string {
 	return c.configFile

--- a/common/viperutil/config_util.go
+++ b/common/viperutil/config_util.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package viperutil
 
 import (
-	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -184,15 +183,6 @@ func getKeysRecursively(base string, getenv envGetter, nodeKeys map[string]inter
 		}
 
 		switch val := val.(type) {
-		case string:
-			logger.Debugf("Found string value for %s", fqKey)
-			if val, ok := unmarshalJSON(val); ok {
-				logger.Debugf("Found real value for %s setting to map[string]string %v", fqKey, val)
-				result[key] = val
-				continue
-			}
-			result[key] = val
-
 		case map[string]interface{}:
 			logger.Debugf("Found map[string]interface{} value for %s", fqKey)
 			result[key] = getKeysRecursively(fqKey+".", getenv, val, subTypes[key])
@@ -211,17 +201,6 @@ func getKeysRecursively(base string, getenv envGetter, nodeKeys map[string]inter
 		}
 	}
 	return result
-}
-
-func unmarshalJSON(s string) (map[string]string, bool) {
-	// TODO(mjs): I think this code may be dead. Nothing fails when the JSON path
-	// is replaced with a panic.
-	mp := map[string]string{}
-	if err := json.Unmarshal([]byte(s), &mp); err != nil {
-		logger.Debugf("Unmarshal JSON: value cannot be unmarshalled: %s", err)
-		return nil, false
-	}
-	return mp, true
 }
 
 func toMapStringInterface(m map[interface{}]interface{}) map[string]interface{} {

--- a/common/viperutil/config_util.go
+++ b/common/viperutil/config_util.go
@@ -52,9 +52,6 @@ type ConfigParser struct {
 	configName  string
 	configFile  string
 
-	// env variable prefix
-	envPrefix string
-
 	// parsed config
 	config map[string]interface{}
 }
@@ -69,14 +66,12 @@ func New() *ConfigParser {
 // AddConfigPaths keeps a list of path to search the relevant
 // config file. Multiple paths can be provided.
 func (c *ConfigParser) AddConfigPaths(cfgPaths ...string) {
-	if len(cfgPaths) > 0 {
-		for _, p := range cfgPaths {
-			c.configPaths = append(c.configPaths, p)
-		}
-	}
+	c.configPaths = append(c.configPaths, cfgPaths...)
 }
 
-// SetConfigName initializes config file name. The extension is not included.
+// SetConfigName provides the configuration file name stem. The upper-cased
+// version of this value also serves as the environment variable override
+// prefix.
 func (c *ConfigParser) SetConfigName(in string) {
 	c.configName = in
 }
@@ -84,13 +79,6 @@ func (c *ConfigParser) SetConfigName(in string) {
 // ConfigFileUsed returns the used configFile.
 func (c *ConfigParser) ConfigFileUsed() string {
 	return c.configFile
-}
-
-// SetEnvPrefix initializes the envPrefix.
-// For example, if "peer" is set here, all environment variable
-// searches shall be prefixed with "PEER_"
-func (c *ConfigParser) SetEnvPrefix(in string) {
-	c.envPrefix = in
 }
 
 // Search for the existence of filename for all supported extensions
@@ -154,9 +142,10 @@ func (c *ConfigParser) ReadConfig(in io.Reader) error {
 // Get value for the key by searching environment variables.
 func (c *ConfigParser) getFromEnv(key string) string {
 	envKey := key
-	if c.envPrefix != "" {
-		envKey = strings.ToUpper(c.envPrefix + "_" + envKey)
+	if c.configName != "" {
+		envKey = c.configName + "_" + envKey
 	}
+	envKey = strings.ToUpper(envKey)
 	envKey = strings.ReplaceAll(envKey, ".", "_")
 	return os.Getenv(envKey)
 }

--- a/internal/peer/common/common_test.go
+++ b/internal/peer/common/common_test.go
@@ -92,31 +92,35 @@ func TestInitCrypto(t *testing.T) {
 func TestSetBCCSPKeystorePath(t *testing.T) {
 	cfgKey := "peer.BCCSP.SW.FileKeyStore.KeyStore"
 	cfgPath := "./testdata"
-	absPath, _ := filepath.Abs(cfgPath)
+	absPath, err := filepath.Abs(cfgPath)
+	assert.NoError(t, err)
+
 	keystorePath := "/msp/keystore"
+	defer os.Unsetenv("FABRIC_CFG_PATH")
 
 	os.Setenv("FABRIC_CFG_PATH", cfgPath)
 	viper.Reset()
-	_ = common.InitConfig("notset")
+	err = common.InitConfig("notset")
 	common.SetBCCSPKeystorePath()
 	t.Log(viper.GetString(cfgKey))
 	assert.Equal(t, "", viper.GetString(cfgKey))
+	assert.Nil(t, viper.Get(cfgKey))
 
 	viper.Reset()
-	_ = common.InitConfig("absolute")
+	err = common.InitConfig("absolute")
+	assert.NoError(t, err)
 	common.SetBCCSPKeystorePath()
 	t.Log(viper.GetString(cfgKey))
 	assert.Equal(t, keystorePath, viper.GetString(cfgKey))
 
 	viper.Reset()
-	_ = common.InitConfig("relative")
+	err = common.InitConfig("relative")
+	assert.NoError(t, err)
 	common.SetBCCSPKeystorePath()
 	t.Log(viper.GetString(cfgKey))
-	assert.Equal(t, filepath.Join(absPath, keystorePath),
-		viper.GetString(cfgKey))
+	assert.Equal(t, filepath.Join(absPath, keystorePath), viper.GetString(cfgKey))
 
 	viper.Reset()
-	os.Unsetenv("FABRIC_CFG_PATH")
 }
 
 func TestCheckLogLevel(t *testing.T) {

--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -17,9 +17,6 @@ import (
 	coreconfig "github.com/hyperledger/fabric/core/config"
 )
 
-// Prefix for environment variables.
-const Prefix = "ORDERER"
-
 var logger = flogging.MustGetLogger("localconfig")
 
 // TopLevel directly corresponds to the orderer config YAML.
@@ -314,7 +311,6 @@ func (c *configCache) load() (*TopLevel, error) {
 
 	config := viperutil.New()
 	config.SetConfigName("orderer")
-	config.SetEnvPrefix(Prefix)
 
 	if err := config.ReadInConfig(); err != nil {
 		return nil, fmt.Errorf("Error reading configuration: %s", err)


### PR DESCRIPTION
These commits remove unnecessary methods from `ConfigParser`, aggregate "config name" and "environment prefix", update tests to use `testify/require`, and refactors the heart of `getKeysRecursively` to clarify the code.