### PR TITLE
Remove Thirdparty Images From Bootstrap Script

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -45,15 +45,14 @@ the binaries and images.
 
   curl -sSL https://bit.ly/2ysbOFE | bash -s
 
-.. note:: If you want a specific release, pass a version identifier for Fabric,
-          Fabric-ca and thirdparty Docker images.
+.. note:: If you want a specific release, pass a version identifier for Fabric and Fabric-CA docker images.
           The command below demonstrates how to download the latest production releases -
           **Fabric v2.1.1** and **Fabric CA v1.4.7**
 
 .. code:: bash
 
-  curl -sSL https://bit.ly/2ysbOFE | bash -s -- <fabric_version> <fabric-ca_version> <thirdparty_version>
-  curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.1.1 1.4.7 0.4.20
+  curl -sSL https://bit.ly/2ysbOFE | bash -s -- <fabric_version> <fabric-ca_version>
+  curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.1.1 1.4.7
 
 .. note:: If you get an error running the above curl command, you may
           have too old a version of curl that does not handle

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -9,13 +9,11 @@
 VERSION=2.1.1
 # if ca version not passed in, default to latest released version
 CA_VERSION=1.4.7
-# current version of thirdparty images (couchdb, kafka and zookeeper) released
-THIRDPARTY_IMAGE_VERSION=0.4.20
 ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m | sed 's/x86_64/amd64/g')")
 MARCH=$(uname -m)
 
 printHelp() {
-    echo "Usage: bootstrap.sh [version [ca_version [thirdparty_version]]] [options]"
+    echo "Usage: bootstrap.sh [version [ca_version]] [options]"
     echo
     echo "options:"
     echo "-h : this help"
@@ -23,8 +21,8 @@ printHelp() {
     echo "-s : bypass fabric-samples repo clone"
     echo "-b : bypass download of platform-specific binaries"
     echo
-    echo "e.g. bootstrap.sh 2.1.1 1.4.7 0.4.20 -s"
-    echo "would download docker images and binaries for Fabric v2.1.1 and Fabric CA v1.4.7"
+    echo "e.g. bootstrap.sh 2.1.1 1.4.7 -s"
+    echo "will download docker images and binaries for Fabric v2.1.1 and Fabric CA v1.4.7"
 }
 
 # dockerPull() pulls docker images from fabric and chaincode repositories
@@ -121,10 +119,6 @@ pullDockerImages() {
         echo "===> Pulling fabric ca Image"
         CA_IMAGE=(ca)
         dockerPull "${CA_TAG}" "${CA_IMAGE[@]}"
-        echo "===> Pulling thirdparty docker images"
-        THIRDPARTY_IMAGES=(zookeeper kafka couchdb)
-        dockerPull "${THIRDPARTY_TAG}" "${THIRDPARTY_IMAGES[@]}"
-        echo
         echo "===> List out hyperledger docker images"
         docker images | grep hyperledger
     else


### PR DESCRIPTION
As Fabric 2.x no longer uses the official hyperledger couchdb. Fabric Samples has been shifted to use the official images as well. As such, Samples no longer relies on any of the images published in the baseimage repo.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
