### PR TITLE
Use tcp for statsd and poll for metric arrival

### DIFF
--- a/integration/e2e/e2e_suite_test.go
+++ b/integration/e2e/e2e_suite_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package e2e
 
 import (
+	"bufio"
 	"encoding/json"
 	"io"
 	"net"
@@ -53,74 +54,80 @@ func StartPort() int {
 	return integration.E2EBasePort.StartPortForNode()
 }
 
-type DatagramReader struct {
+type MetricsReader struct {
 	buffer    *gbytes.Buffer
 	errCh     chan error
-	sock      *net.UDPConn
+	listener  net.Listener
 	doneCh    chan struct{}
 	closeOnce sync.Once
 	err       error
 }
 
-func NewDatagramReader() *DatagramReader {
-	udpAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	Expect(err).NotTo(HaveOccurred())
-	sock, err := net.ListenUDP("udp", udpAddr)
-	Expect(err).NotTo(HaveOccurred())
-	err = sock.SetReadBuffer(1024 * 1024)
+func NewMetricsReader() *MetricsReader {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	Expect(err).NotTo(HaveOccurred())
 
-	return &DatagramReader{
-		buffer: gbytes.NewBuffer(),
-		sock:   sock,
-		errCh:  make(chan error, 1),
-		doneCh: make(chan struct{}),
+	return &MetricsReader{
+		buffer:   gbytes.NewBuffer(),
+		listener: listener,
+		errCh:    make(chan error, 1),
+		doneCh:   make(chan struct{}),
 	}
 }
 
-func (dr *DatagramReader) Buffer() *gbytes.Buffer {
-	return dr.buffer
+func (mr *MetricsReader) Buffer() *gbytes.Buffer {
+	return mr.buffer
 }
 
-func (dr *DatagramReader) Address() string {
-	return dr.sock.LocalAddr().String()
+func (mr *MetricsReader) Address() string {
+	return mr.listener.Addr().String()
 }
 
-func (dr *DatagramReader) String() string {
-	return string(dr.buffer.Contents())
+func (mr *MetricsReader) String() string {
+	return string(mr.buffer.Contents())
 }
 
-func (dr *DatagramReader) Start() {
-	buf := make([]byte, 1024*1024)
+func (mr *MetricsReader) Start() {
+	for {
+		conn, err := mr.listener.Accept()
+		if err != nil {
+			mr.errCh <- err
+			return
+		}
+		go mr.handleConnection(conn)
+	}
+}
+
+func (mr *MetricsReader) handleConnection(c net.Conn) {
+	defer GinkgoRecover()
+	defer c.Close()
+
+	br := bufio.NewReader(c)
 	for {
 		select {
-		case <-dr.doneCh:
-			dr.errCh <- nil
-			return
-
+		case <-mr.doneCh:
+			c.Close()
 		default:
-			n, _, err := dr.sock.ReadFrom(buf)
-			if err != nil {
-				dr.errCh <- err
+			data, err := br.ReadBytes('\n')
+			if err == io.EOF {
 				return
 			}
-			_, err = dr.buffer.Write(buf[0:n])
-			if err != nil {
-				dr.errCh <- err
-				return
-			}
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = mr.buffer.Write(data)
+			Expect(err).NotTo(HaveOccurred())
 		}
 	}
 }
 
-func (dr *DatagramReader) Close() error {
-	dr.closeOnce.Do(func() {
-		close(dr.doneCh)
-		err := dr.sock.Close()
-		dr.err = <-dr.errCh
-		if dr.err == nil && err != nil && err != io.EOF {
-			dr.err = err
+func (mr *MetricsReader) Close() error {
+	mr.closeOnce.Do(func() {
+		close(mr.doneCh)
+		err := mr.listener.Close()
+		mr.err = <-mr.errCh
+		if mr.err == nil && err != nil && err != io.EOF {
+			mr.err = err
 		}
 	})
-	return dr.err
+	return mr.err
 }

--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -227,8 +227,13 @@ operations:
 metrics:
   provider: {{ .MetricsProvider }}
   statsd:
+    {{- if .StatsdEndpoint }}
+    network: tcp
+    address: {{ .StatsdEndpoint }}
+    {{- else }}
     network: udp
-    address: {{ if .StatsdEndpoint }}{{ .StatsdEndpoint }}{{ else }}127.0.0.1:8125{{ end }}
+    address: 127.0.0.1:8125
+    {{- end }}
     writeInterval: 5s
     prefix: {{ ReplaceAll (ToLower Peer.ID) "." "_" }}
 `

--- a/integration/nwo/orderer_template.go
+++ b/integration/nwo/orderer_template.go
@@ -107,8 +107,13 @@ Operations:
 Metrics:
   Provider: {{ .MetricsProvider }}
   Statsd:
+    {{- if .StatsdEndpoint }}
+    Network: tcp
+    Address: {{ .StatsdEndpoint }}
+    {{- else }}
     Network: udp
-    Address: {{ if .StatsdEndpoint }}{{ .StatsdEndpoint }}{{ else }}127.0.0.1:8125{{ end }}
+    Address: 127.0.0.1:8125
+    {{- end }}
     WriteInterval: 5s
     Prefix: {{ ReplaceAll (ToLower Orderer.ID) "." "_" }}
 {{- end }}


### PR DESCRIPTION
Have you heard the joke about UDP? Never mind. You probably won't get it.

The integration tests seem to be flaking out while making assertions on statsd metrics. There are two likely causes:

1. We wait for some sentinel and assume that when it arrives, all of the metrics we're looking for are ready. That's not necessarily true. This change replaces the single sentinel with assertions that all metrics are eventually available.
2. Even on good days and over the loopback adapter, UDP datagrams may not get to the intended target. To take that out of the equation, we'll move to TCP.