### PR TITLE
Fixed externalbuilder.Duration Marshalling/Unmashalling issue

### DIFF
--- a/core/container/externalbuilder/instance.go
+++ b/core/container/externalbuilder/instance.go
@@ -40,7 +40,7 @@ type Duration struct {
 }
 
 func (d Duration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.Seconds())
+	return json.Marshal(d.String())
 }
 
 func (d *Duration) UnmarshalJSON(b []byte) error {

--- a/core/container/externalbuilder/instance_test.go
+++ b/core/container/externalbuilder/instance_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package externalbuilder_test
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -233,6 +234,27 @@ var _ = Describe("Instance", func() {
 					Expect(err).To(MatchError("chaincode tls root cert not provided"))
 				})
 			})
+		})
+	})
+
+	Describe("Duration", func() {
+		It("validates that marshalled Duration is unmarshalled correctly", func() {
+			validateUnmarshalling := func(d time.Duration) {
+				duration := externalbuilder.Duration{d}
+
+				marshalled, err := json.Marshal(duration)
+
+				var unmarshalled externalbuilder.Duration
+				err = json.Unmarshal(marshalled, &unmarshalled)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(unmarshalled).To(Equal(duration))
+			}
+
+			validateUnmarshalling(10 * time.Millisecond)
+			validateUnmarshalling(10 * time.Second)
+			validateUnmarshalling(10 * time.Minute)
+			validateUnmarshalling(10 * time.Hour)
 		})
 	})
 


### PR DESCRIPTION
**Issue:**
During JSON marshalling, externalbuilder.Duration marshalls underlying Duration as seconds. While unmarshalling, it unmarshalls it as nano-seconds which is default format for time.Duration

**Fix:**
The fix marshalls externalbuilder.Duration as human readable string such as "10s", "1m10s" and unmarshalls it correctly.
