### PR TITLE
Restore couchdb logger

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdbutil.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdbutil.go
@@ -106,7 +106,7 @@ func checkCouchDBVersion(version string) error {
 		return errors.Errorf("CouchDB v%s detected. CouchDB must be at least version 2.0.0", version)
 	}
 	if majorVersion != 3 || minorVersion < 1 {
-		logger.Warnf("CouchDB v%s detected. CouchDB versions before 3.1.0 are unsupported.", version)
+		couchdbLogger.Warnf("CouchDB v%s detected. CouchDB versions before 3.1.0 are unsupported.", version)
 	}
 	return nil
 }
@@ -116,7 +116,7 @@ func createCouchDatabase(couchInstance *couchInstance, dbName string) (*couchDat
 
 	databaseName, err := mapAndValidateDatabaseName(dbName)
 	if err != nil {
-		logger.Errorf("Error calling CouchDB CreateDatabaseIfNotExist() for dbName: %s, error: %s", dbName, err)
+		couchdbLogger.Errorf("Error calling CouchDB CreateDatabaseIfNotExist() for dbName: %s, error: %s", dbName, err)
 		return nil, err
 	}
 
@@ -125,7 +125,7 @@ func createCouchDatabase(couchInstance *couchInstance, dbName string) (*couchDat
 	// Create CouchDB database upon ledger startup, if it doesn't already exist
 	err = couchDBDatabase.createDatabaseIfNotExist()
 	if err != nil {
-		logger.Errorf("Error calling CouchDB CreateDatabaseIfNotExist() for dbName: %s, error: %s", dbName, err)
+		couchdbLogger.Errorf("Error calling CouchDB CreateDatabaseIfNotExist() for dbName: %s, error: %s", dbName, err)
 		return nil, err
 	}
 
@@ -139,7 +139,7 @@ func createSystemDatabasesIfNotExist(couchInstance *couchInstance) error {
 	systemCouchDBDatabase := couchDatabase{couchInstance: couchInstance, dbName: dbName, indexWarmCounter: 1}
 	err := systemCouchDBDatabase.createDatabaseIfNotExist()
 	if err != nil {
-		logger.Errorf("Error calling CouchDB createDatabaseIfNotExist() for system dbName: %s, error: %s", dbName, err)
+		couchdbLogger.Errorf("Error calling CouchDB createDatabaseIfNotExist() for system dbName: %s, error: %s", dbName, err)
 		return err
 	}
 
@@ -147,7 +147,7 @@ func createSystemDatabasesIfNotExist(couchInstance *couchInstance) error {
 	systemCouchDBDatabase = couchDatabase{couchInstance: couchInstance, dbName: dbName, indexWarmCounter: 1}
 	err = systemCouchDBDatabase.createDatabaseIfNotExist()
 	if err != nil {
-		logger.Errorf("Error calling CouchDB createDatabaseIfNotExist() for system dbName: %s, error: %s", dbName, err)
+		couchdbLogger.Errorf("Error calling CouchDB createDatabaseIfNotExist() for system dbName: %s, error: %s", dbName, err)
 		return err
 	}
 	if couchInstance.conf.CreateGlobalChangesDB {
@@ -155,7 +155,7 @@ func createSystemDatabasesIfNotExist(couchInstance *couchInstance) error {
 		systemCouchDBDatabase = couchDatabase{couchInstance: couchInstance, dbName: dbName, indexWarmCounter: 1}
 		err = systemCouchDBDatabase.createDatabaseIfNotExist()
 		if err != nil {
-			logger.Errorf("Error calling CouchDB createDatabaseIfNotExist() for system dbName: %s, error: %s", dbName, err)
+			couchdbLogger.Errorf("Error calling CouchDB createDatabaseIfNotExist() for system dbName: %s, error: %s", dbName, err)
 			return err
 		}
 	}
@@ -305,7 +305,7 @@ func escapeUpperCase(dbName string) string {
 
 // DropApplicationDBs drops all application databases.
 func DropApplicationDBs(config *ledger.CouchDBConfig) error {
-	logger.Info("Dropping CouchDB application databases ...")
+	couchdbLogger.Info("Dropping CouchDB application databases ...")
 	couchInstance, err := createCouchInstance(config, &disabled.Provider{})
 	if err != nil {
 		return err
@@ -316,7 +316,7 @@ func DropApplicationDBs(config *ledger.CouchDBConfig) error {
 	}
 	for _, dbName := range dbNames {
 		if _, err = dropDB(couchInstance, dbName); err != nil {
-			logger.Errorf("Error dropping CouchDB database %s", dbName)
+			couchdbLogger.Errorf("Error dropping CouchDB database %s", dbName)
 			return err
 		}
 	}


### PR DESCRIPTION
CouchDB client utility layer was recently refactored to be included in statecouchdb package.
This caused the traditional [couchdb] logger and [statecouchdb] logger
to log under a common [statecouchdb] logger.
Since administrators and support staff often want to see only the CouchDB interactions
in debug log, and since they are already accustomed to using the [couchdb] logger,
this change restores the separate [couchdb] logger for the CouchDB client code,
making it aligned with prior versions of Fabric.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
