### PR TITLE
reuse levelDB in-memory batch and fix batchSize reset

### DIFF
--- a/common/ledger/blkstorage/blockindex.go
+++ b/common/ledger/blkstorage/blockindex.go
@@ -343,7 +343,6 @@ func importTxIDsFromSnapshot(
 	lastBlockNumInSnapshot uint64,
 	db *leveldbhelper.DBHandle) error {
 
-	batch := db.NewUpdateBatch()
 	txIDsMetadata, err := snapshot.OpenFile(filepath.Join(snapshotDir, snapshotMetadataFileName), snapshotFileFormat)
 	if err != nil {
 		return err
@@ -356,6 +355,8 @@ func importTxIDsFromSnapshot(
 	if err != nil {
 		return err
 	}
+
+	batch := db.NewUpdateBatch()
 	for i := uint64(0); i < numTxIDs; i++ {
 		txID, err := txIDsData.DecodeString()
 		if err != nil {
@@ -369,7 +370,7 @@ func importTxIDsFromSnapshot(
 			if err := db.WriteBatch(batch, true); err != nil {
 				return err
 			}
-			batch = db.NewUpdateBatch()
+			batch.Reset()
 		}
 	}
 	batch.Put(indexSavePointKey, encodeBlockNum(lastBlockNumInSnapshot))

--- a/common/ledger/util/leveldbhelper/leveldb_provider.go
+++ b/common/ledger/util/leveldbhelper/leveldb_provider.go
@@ -195,7 +195,7 @@ func (h *DBHandle) DeleteAll() error {
 			}
 			logger.Infof("Have removed %d entries for channel %s in leveldb %s", numKeys, h.dbName, h.db.conf.DBPath)
 			batchSize = 0
-			batch = &leveldb.Batch{}
+			batch.Reset()
 		}
 	}
 	if batch.Len() > 0 {

--- a/core/ledger/confighistory/mgr.go
+++ b/core/ledger/confighistory/mgr.go
@@ -155,7 +155,8 @@ func (m *Mgr) ImportConfigHistory(ledgerID string, dir string) error {
 			if err := db.WriteBatch(batch, true); err != nil {
 				return err
 			}
-			batch = db.NewUpdateBatch()
+			currentBatchSize = 0
+			batch.Reset()
 		}
 	}
 	return db.WriteBatch(batch, true)

--- a/core/ledger/pvtdatastorage/store.go
+++ b/core/ledger/pvtdatastorage/store.go
@@ -870,7 +870,7 @@ func (s *Store) processCollElgEvents() error {
 					collEntriesConverted++
 					if batch.Len() > s.maxBatchSize {
 						s.db.WriteBatch(batch, true)
-						batch = s.db.NewUpdateBatch()
+						batch.Reset()
 						sleepTime := time.Duration(s.batchesInterval)
 						logger.Infof("Going to sleep for %d milliseconds between batches. Entries for [ns=%s, coll=%s] converted so far = %d",
 							sleepTime, ns, coll, collEntriesConverted)


### PR DESCRIPTION
#### Type of change

- Bug fix
- Improvement (improvement to code, performance, etc)

#### Description

This PR

(1) Enables the reuse of leveldb in-memory batch -- reduces the memory utilization and also the burden on GC.
(2) Fixes a missing logic of batchsize reset in confighistory store `ImportXXX()`
