### PR TITLE
Add org name to consortium error message

### DIFF
--- a/orderer/common/msgprocessor/systemchannel.go
+++ b/orderer/common/msgprocessor/systemchannel.go
@@ -333,7 +333,7 @@ func (dt *DefaultTemplator) NewChannelConfig(envConfigUpdate *cb.Envelope) (chan
 		for orgName := range configUpdate.WriteSet.Groups[channelconfig.ApplicationGroupKey].Groups {
 			consortiumGroup, ok := systemChannelGroup.Groups[channelconfig.ConsortiumsGroupKey].Groups[consortium.Name].Groups[orgName]
 			if !ok {
-				return nil, fmt.Errorf("Attempted to include a member which is not in the consortium")
+				return nil, fmt.Errorf("Attempted to include member %s which is not in the consortium", orgName)
 			}
 			applicationGroup.Groups[orgName] = proto.Clone(consortiumGroup).(*cb.ConfigGroup)
 		}

--- a/orderer/common/msgprocessor/systemchannel_test.go
+++ b/orderer/common/msgprocessor/systemchannel_test.go
@@ -737,7 +737,7 @@ func TestNewChannelConfig(t *testing.T) {
 					),
 				}),
 			},
-			"Attempted to include a member which is not in the consortium",
+			"Attempted to include member BadOrgName which is not in the consortium",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Improve troubleshooting by including org name in the error message:
"Attempted to include a member which is not in the consortium"

New message:
"Attempted to include member BadOrgName which is not in the consortium"

This will help users that have an incorrect config transaction pinpoint the reason for failure.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>