### PR TITLE
Channel Participation API: Orderer with system channel rejects application channel removal

### DIFF
--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -523,6 +523,8 @@ func (r *Registrar) joinAsFollower(ledgerRes *ledgerResources, clusterConsenter 
 // RemoveChannel instructs the orderer to remove a channel.
 // Depending on the removeStorage parameter, the storage resources are either removed or archived.
 func (r *Registrar) RemoveChannel(channelID string, removeStorage bool) error {
-	//TODO
+	if r.SystemChannelID() != "" && channelID != r.SystemChannelID() {
+		return types.ErrSystemChannelExists
+	}
 	return errors.New("Not implemented yet")
 }


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

When a system channel is defined, the channel participation API should reject requests to remove application channels.

#### Related issues

[FAB-18011](https://jira.hyperledger.org/browse/FAB-18011)