### PR TITLE
Improve private data logging

### DIFF
--- a/core/transientstore/store.go
+++ b/core/transientstore/store.go
@@ -316,6 +316,8 @@ func (scanner *RwsetScanner) Next() (*EndorserPvtSimulationResults, error) {
 			return nil, err
 		}
 
+		// trim the tx rwset based on the current collection filter,
+		// nil will be returned to filteredTxPvtRWSet if the transient store txid entry does not contain the data for the collection
 		filteredTxPvtRWSet = trimPvtWSet(txPvtRWSetWithConfig.GetPvtRwset(), scanner.filter)
 		configs, err := trimPvtCollectionConfigs(txPvtRWSetWithConfig.CollectionConfigs, scanner.filter)
 		if err != nil {

--- a/gossip/privdata/pvtdataprovider_test.go
+++ b/gossip/privdata/pvtdataprovider_test.go
@@ -1237,6 +1237,15 @@ func TestRetrievedPvtdataPurgeBelowHeight(t *testing.T) {
 	}
 }
 
+func TestFetchStats(t *testing.T) {
+	fetchStats := fetchStats{
+		fromLocalCache:     1,
+		fromTransientStore: 2,
+		fromRemotePeer:     3,
+	}
+	assert.Equal(t, "(1 from local cache, 2 from transient store, 3 from other peers)", fetchStats.String())
+}
+
 func testRetrievePvtdataSuccess(t *testing.T,
 	scenario string,
 	ts testSupport,


### PR DESCRIPTION
Changed following warning to debug message:
WARN The PvtRwset of PvtSimulationResultsWithConfig for txID [...] is nil. Skipping.
In v2.x peer attempts to retrieve private data from transient store one collection at a time.
If peer is eligible for multiple collections in a transaction,
and each transient store entry has one collection,
some of the retrieved records will have all collections filtered out and therefore the above message
is expected in v2.x and should not be a Warning (in v1.x this should not happen
since each transient store record was filtered against ALL eligible collections, therefore it
was a legitimate unexpected Warning message in v1.x).

Suppressed the following confusing message when there IS NO private data in a block:
INFO Successfully fetched all eligible collection private write sets for block [31]

When there IS private data in the block, replaced the message with a more useful message like this:
INFO Successfully fetched all 2 eligible collection private write sets for block [35] (0 from local cache, 1 from transient store, 1 from other peers)

And if peer can't fetch all the private data in a block, you'll now get this message:
WARN Could not fetch all 2 eligible collection private write sets for block [36] (0 from local cache, 1 from transient store, 0 from other peers).
     Will commit block with missing private write sets.

Finally, removed some of the redundant or not useful debug messages.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
