### PR TITLE
Remove unused 'Ephemeral' member from Pkcs11Opts

### DIFF
--- a/bccsp/factory/pkcs11_test.go
+++ b/bccsp/factory/pkcs11_test.go
@@ -60,7 +60,6 @@ func TestGetBCCSPFromOpts(t *testing.T) {
 		Pkcs11Opts: &pkcs11.PKCS11Opts{
 			SecLevel:   256,
 			HashFamily: "SHA2",
-			Ephemeral:  true,
 			Library:    lib,
 			Pin:        pin,
 			Label:      label,

--- a/bccsp/factory/pkcs11factory_test.go
+++ b/bccsp/factory/pkcs11factory_test.go
@@ -70,7 +70,6 @@ func TestPKCS11FactoryGet(t *testing.T) {
 		Pkcs11Opts: &pkcs11.PKCS11Opts{
 			SecLevel:   256,
 			HashFamily: "SHA2",
-			Ephemeral:  true,
 			Library:    lib,
 			Pin:        pin,
 			Label:      label,

--- a/bccsp/pkcs11/conf.go
+++ b/bccsp/pkcs11/conf.go
@@ -72,9 +72,6 @@ type PKCS11Opts struct {
 	SecLevel   int    `mapstructure:"security" json:"security"`
 	HashFamily string `mapstructure:"hash" json:"hash"`
 
-	// Keystore options
-	Ephemeral bool `mapstructure:"tempkeys,omitempty" json:"tempkeys,omitempty"`
-
 	// PKCS11 options
 	Library    string `mapstructure:"library" json:"library"`
 	Label      string `mapstructure:"label" json:"label"`


### PR DESCRIPTION
`Ephemeral` was not referenced by any code.