### PR TITLE
[FAB-18052] Remove ACL policies for non-existent functions from confi…

### DIFF
--- a/orderer/common/onboarding/testdata/configtx.yaml
+++ b/orderer/common/onboarding/testdata/configtx.yaml
@@ -45,8 +45,6 @@ Application: &ApplicationDefaults
         qscc/GetTransactionByID: /Channel/Application/Readers
         qscc/GetBlockByTxID: /Channel/Application/Readers
         cscc/GetConfigBlock: /Channel/Application/Readers
-        cscc/GetConfigTree: /Channel/Application/Readers
-        cscc/SimulateConfigTreeUpdate: /Channel/Application/Readers
         peer/Propose: /Channel/Application/Writers
         peer/ChaincodeToChaincode: /Channel/Application/Readers
         event/Block: /Channel/Application/Readers

--- a/orderer/common/server/testdata/configtx.yaml
+++ b/orderer/common/server/testdata/configtx.yaml
@@ -45,8 +45,6 @@ Application: &ApplicationDefaults
         qscc/GetTransactionByID: /Channel/Application/Readers
         qscc/GetBlockByTxID: /Channel/Application/Readers
         cscc/GetConfigBlock: /Channel/Application/Readers
-        cscc/GetConfigTree: /Channel/Application/Readers
-        cscc/SimulateConfigTreeUpdate: /Channel/Application/Readers
         peer/Propose: /Channel/Application/Writers
         peer/ChaincodeToChaincode: /Channel/Application/Readers
         event/Block: /Channel/Application/Readers

--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -194,12 +194,6 @@ Application: &ApplicationDefaults
         # ACL policy for cscc's "GetConfigBlock" function
         cscc/GetConfigBlock: /Channel/Application/Readers
 
-        # ACL policy for cscc's "GetConfigTree" function
-        cscc/GetConfigTree: /Channel/Application/Readers
-
-        # ACL policy for cscc's "SimulateConfigTreeUpdate" function
-        cscc/SimulateConfigTreeUpdate: /Channel/Application/Readers
-
         #---Miscellaneous peer function to policy mapping for access control---#
 
         # ACL policy for invoking chaincodes on peer


### PR DESCRIPTION
…gtx.yaml

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

SimulateConfigTreeUpdate() and GetConfigTree() in cscc have been removed after FAB-15348 was merged.
On the other hand, ACL policies to manage the removed functions still remains in some configtx.yaml.
They may confuse Fabric users, admins and contributors.

So, this patch removes the unnecessary policies.

#### Related issues

- https://jira.hyperledger.org/browse/FAB-18052