### PR TITLE
[FAB-18054] Remove default value for top level orderer addresses if unset in config

### DIFF
--- a/common/channelconfig/realconfig_test.go
+++ b/common/channelconfig/realconfig_test.go
@@ -33,6 +33,7 @@ func TestWithRealConfigtx(t *testing.T) {
 func TestOrgSpecificOrdererEndpoints(t *testing.T) {
 	t.Run("Without_Capability", func(t *testing.T) {
 		conf := genesisconfig.Load(genesisconfig.SampleDevModeSoloProfile, configtest.GetDevConfigDir())
+		conf.Orderer.Addresses = []string{"127.0.0.1:7050"}
 		conf.Capabilities = map[string]bool{"V1_3": true}
 
 		cg, err := encoder.NewChannelGroup(conf)

--- a/discovery/support/config/support_test.go
+++ b/discovery/support/config/support_test.go
@@ -391,7 +391,10 @@ func injectGlobalOrdererEndpoint(t *testing.T, block *common.Block, endpoint str
 	confEnv, err := configtx.UnmarshalConfigEnvelope(payload.Data)
 	assert.NoError(t, err)
 	// Replace the orderer addresses
-	confEnv.Config.ChannelGroup.Values[ordererAddresses.Key()].Value = protoutil.MarshalOrPanic(ordererAddresses.Value())
+	confEnv.Config.ChannelGroup.Values[ordererAddresses.Key()] = &common.ConfigValue{
+		Value:     protoutil.MarshalOrPanic(ordererAddresses.Value()),
+		ModPolicy: "/Channel/Orderer/Admins",
+	}
 	// Remove the per org addresses, if applicable
 	ordererGrps := confEnv.Config.ChannelGroup.Groups[channelconfig.OrdererGroupKey].Groups
 	for _, grp := range ordererGrps {

--- a/internal/configtxgen/genesisconfig/config.go
+++ b/internal/configtxgen/genesisconfig/config.go
@@ -169,7 +169,6 @@ type Kafka struct {
 var genesisDefaults = TopLevel{
 	Orderer: &Orderer{
 		OrdererType:  "solo",
-		Addresses:    []string{"127.0.0.1:7050"},
 		BatchTimeout: 2 * time.Second,
 		BatchSize: BatchSize{
 			MaxMessageCount:   500,
@@ -302,9 +301,6 @@ loop:
 		case ord.OrdererType == "":
 			logger.Infof("Orderer.OrdererType unset, setting to %v", genesisDefaults.Orderer.OrdererType)
 			ord.OrdererType = genesisDefaults.Orderer.OrdererType
-		case ord.Addresses == nil:
-			logger.Infof("Orderer.Addresses unset, setting to %s", genesisDefaults.Orderer.Addresses)
-			ord.Addresses = genesisDefaults.Orderer.Addresses
 		case ord.BatchTimeout == 0:
 			logger.Infof("Orderer.BatchTimeout unset, setting to %s", genesisDefaults.Orderer.BatchTimeout)
 			ord.BatchTimeout = genesisDefaults.Orderer.BatchTimeout

--- a/internal/peer/chaincode/common_test.go
+++ b/internal/peer/chaincode/common_test.go
@@ -175,8 +175,7 @@ func TestGetOrdererEndpointFromConfigTx(t *testing.T) {
 	ordererEndpoints, err := common.GetOrdererEndpointOfChain(mockchain, signer, mockEndorserClient, cryptoProvider)
 	assert.NoError(t, err, "GetOrdererEndpointOfChain from genesis block")
 
-	assert.Equal(t, len(ordererEndpoints), 1)
-	assert.Equal(t, ordererEndpoints[0], "127.0.0.1:7050")
+	assert.Equal(t, len(ordererEndpoints), 0)
 }
 
 func TestGetOrdererEndpointFail(t *testing.T) {

--- a/orderer/common/cluster/replication_test.go
+++ b/orderer/common/cluster/replication_test.go
@@ -1086,7 +1086,10 @@ func injectGlobalOrdererEndpoint(t *testing.T, block *common.Block, endpoint str
 	confEnv, err := configtx.UnmarshalConfigEnvelope(payload.Data)
 	assert.NoError(t, err)
 	// Replace the orderer addresses
-	confEnv.Config.ChannelGroup.Values[ordererAddresses.Key()].Value = protoutil.MarshalOrPanic(ordererAddresses.Value())
+	confEnv.Config.ChannelGroup.Values[ordererAddresses.Key()] = &common.ConfigValue{
+		Value:     protoutil.MarshalOrPanic(ordererAddresses.Value()),
+		ModPolicy: "/Channel/Orderer/Admins",
+	}
 	// Remove the per org addresses, if applicable
 	ordererGrps := confEnv.Config.ChannelGroup.Groups[channelconfig.OrdererGroupKey].Groups
 	for _, grp := range ordererGrps {


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Top level orderer addresses are deprecated in 2.2 so this commit
removes the default value for consumers that pass a config with no
orderer addresses value

#### Related issues

[FAB-18054](https://jira.hyperledger.org/browse/FAB-18054)