### PR TITLE
[FAB-18053] Make values for ACL policies in sample/test configs consi…

### DIFF
--- a/docs/source/enable_cc_lifecycle.md
+++ b/docs/source/enable_cc_lifecycle.md
@@ -116,10 +116,10 @@ Note that the `enable_lifecycle.json` uses sample values, for example `org1Polic
 			"policy_ref": "/Channel/Application/Writers"
 		},
 		"_lifecycle/QueryChaincodeDefinition": {
-			"policy_ref": "/Channel/Application/Readers"
+			"policy_ref": "/Channel/Application/Writers"
 		},
 		"_lifecycle/QueryChaincodeDefinitions": {
-			"policy_ref": "/Channel/Application/Readers"
+			"policy_ref": "/Channel/Application/Writers"
 		}
    }
 }

--- a/docs/source/policies/policies.md
+++ b/docs/source/policies/policies.md
@@ -111,11 +111,11 @@ In that file, ACLs are expressed using the following format:
 
 ```
 # ACL policy for chaincode to chaincode invocation
-peer/ChaincodeToChaincode: /Channel/Application/Readers
+peer/ChaincodeToChaincode: /Channel/Application/Writers
 ```
 
 Where `peer/ChaincodeToChaincode` represents the resource being secured and
-`/Channel/Application/Readers` refers to the policy which must be satisfied for
+`/Channel/Application/Writers` refers to the policy which must be satisfied for
 the associated transaction to be considered valid.
 
 For a deeper dive into ACLS, refer to the topic in the Operations Guide on [ACLs](../access_control.html).

--- a/orderer/common/onboarding/testdata/configtx.yaml
+++ b/orderer/common/onboarding/testdata/configtx.yaml
@@ -48,7 +48,7 @@ Application: &ApplicationDefaults
         cscc/GetConfigTree: /Channel/Application/Readers
         cscc/SimulateConfigTreeUpdate: /Channel/Application/Readers
         peer/Propose: /Channel/Application/Writers
-        peer/ChaincodeToChaincode: /Channel/Application/Readers
+        peer/ChaincodeToChaincode: /Channel/Application/Writers
         event/Block: /Channel/Application/Readers
         event/FilteredBlock: /Channel/Application/Readers
     Organizations:

--- a/orderer/common/server/testdata/configtx.yaml
+++ b/orderer/common/server/testdata/configtx.yaml
@@ -48,7 +48,7 @@ Application: &ApplicationDefaults
         cscc/GetConfigTree: /Channel/Application/Readers
         cscc/SimulateConfigTreeUpdate: /Channel/Application/Readers
         peer/Propose: /Channel/Application/Writers
-        peer/ChaincodeToChaincode: /Channel/Application/Readers
+        peer/ChaincodeToChaincode: /Channel/Application/Writers
         event/Block: /Channel/Application/Readers
         event/FilteredBlock: /Channel/Application/Readers
     Organizations:

--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -153,10 +153,10 @@ Application: &ApplicationDefaults
         _lifecycle/CommitChaincodeDefinition: /Channel/Application/Writers
 
         # ACL policy for _lifecycle's "QueryChaincodeDefinition" function
-        _lifecycle/QueryChaincodeDefinition: /Channel/Application/Readers
+        _lifecycle/QueryChaincodeDefinition: /Channel/Application/Writers
 
         # ACL policy for _lifecycle's "QueryChaincodeDefinitions" function
-        _lifecycle/QueryChaincodeDefinitions: /Channel/Application/Readers
+        _lifecycle/QueryChaincodeDefinitions: /Channel/Application/Writers
 
         #---Lifecycle System Chaincode (lscc) function to policy mapping for access control---#
 
@@ -206,7 +206,7 @@ Application: &ApplicationDefaults
         peer/Propose: /Channel/Application/Writers
 
         # ACL policy for chaincode to chaincode invocation
-        peer/ChaincodeToChaincode: /Channel/Application/Readers
+        peer/ChaincodeToChaincode: /Channel/Application/Writers
 
         #---Events resource to policy mapping for access control###---#
 


### PR DESCRIPTION
…stent with default values in source

#### Type of change

- Improvement (improvement to code, performance, etc)
- Documentation update

#### Description

Values for some ACL polices used in sample/test configurations are different from default values in source code (`core/aclmgmt/defaultaclprovider.go`).

For example, the following gaps from source code can be found in sampleconfig/configtx.yaml:
- _lifecycle/QueryChaincodeDefinition: /Channel/Application/Readers
- _lifecycle/QueryChaincodeDefinitions: /Channel/Application/Readers
- peer/ChaincodeToChaincode: /Channel/Application/Readers

In `core/aclmgmt/defaultaclprovider.go`, they are set to `/Channel/Application/Writers` as the default values.

Although the values in the sample configuration may be just examples,  Fabric users may expect them as default values as there is no documentation on ACL default values.

To prevent misunderstandings, if there is no specific intention, I think that it is desirable to have consistent default values.

So, this patch makes the values used in samples consistent with default values in source code.

#### Related issues

- https://jira.hyperledger.org/browse/FAB-18053
