### PR TITLE
Improve peer CLI error message when no orderer address passed

### DIFF
--- a/internal/peer/chaincode/common.go
+++ b/internal/peer/chaincode/common.go
@@ -492,7 +492,7 @@ func InitCmdFactory(cmdName string, isEndorserRequired, isOrdererRequired bool, 
 				return nil, errors.WithMessagef(err, "error getting channel (%s) orderer endpoint", channelID)
 			}
 			if len(orderingEndpoints) == 0 {
-				return nil, errors.Errorf("no orderer endpoints retrieved for channel %s", channelID)
+				return nil, errors.Errorf("no orderer endpoints retrieved for channel %s, pass orderer endpoint with -o flag instead", channelID)
 			}
 			logger.Infof("Retrieved channel (%s) orderer endpoint: %s", channelID, orderingEndpoints[0])
 			// override viper env

--- a/internal/peer/lifecycle/chaincode/client_connections.go
+++ b/internal/peer/lifecycle/chaincode/client_connections.go
@@ -184,7 +184,7 @@ func (c *ClientConnections) setOrdererClient() error {
 			return errors.WithMessagef(err, "error getting channel (%s) orderer endpoint", channelID)
 		}
 		if len(orderingEndpoints) == 0 {
-			return errors.Errorf("no orderer endpoints retrieved for channel %s", channelID)
+			return errors.Errorf("no orderer endpoints retrieved for channel %s, pass orderer endpoint with -o flag instead", channelID)
 		}
 
 		logger.Infof("Retrieved channel (%s) orderer endpoint: %s", channelID, orderingEndpoints[0])


### PR DESCRIPTION
For peer CLI commands that require an orderer address, the peer
command does best effort attempt to retrieve orderer address from channel
config if the orderer address is not passed (it currently only
checks the deprecated Orderer.Addresses, not the org level
OrdererEndpoints). The best effort attempt may be removed in
a future release, so for now improve the error message
to indicate that orderer address should be passed using
-o flag.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>