### PR TITLE
FAB-18051 Ch.Part.API: direct POST to /channels

### DIFF
--- a/integration/nwo/channel_participation.go
+++ b/integration/nwo/channel_participation.go
@@ -24,7 +24,7 @@ import (
 func ChannelParticipationJoin(n *Network, o *Orderer, channel string, block *common.Block, expectedChannelInfo ChannelInfo) {
 	blockBytes, err := proto.Marshal(block)
 	Expect(err).NotTo(HaveOccurred())
-	url := fmt.Sprintf("https://127.0.0.1:%d/participation/v1/channels/%s", n.OrdererPort(o, OperationsPort), channel)
+	url := fmt.Sprintf("https://127.0.0.1:%d/participation/v1/channels", n.OrdererPort(o, OperationsPort))
 	req := generateJoinRequest(url, channel, blockBytes)
 	authClient, _ := OrdererOperationalClients(n, o)
 

--- a/orderer/common/channelparticipation/validator.go
+++ b/orderer/common/channelparticipation/validator.go
@@ -8,47 +8,41 @@ package channelparticipation
 
 import (
 	"errors"
-	"fmt"
-
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/bccsp/factory"
 	"github.com/hyperledger/fabric/common/channelconfig"
 	"github.com/hyperledger/fabric/protoutil"
 )
 
-// ValidateJoinBlock returns whether this block can be used as a join block for the channel participation API
-// and whether it is an system channel if it contains consortiums, or otherwise
-// and application channel if an application group exists.
-func ValidateJoinBlock(channelID string, configBlock *cb.Block) (isAppChannel bool, err error) {
+// ValidateJoinBlock checks whether this block can be used as a join block for the channel participation API.
+// It returns the channel ID, and whether it is an system channel if it contains consortiums, or otherwise
+// an application channel if an application group exists. It returns an error when it cannot be used as a join-block.
+func ValidateJoinBlock(configBlock *cb.Block) (channelID string, isAppChannel bool, err error) {
 	if !protoutil.IsConfigBlock(configBlock) {
-		return false, errors.New("block is not a config block")
+		return "", false, errors.New("block is not a config block")
 	}
 
 	envelope, err := protoutil.ExtractEnvelope(configBlock, 0)
 	if err != nil {
-		return false, err
+		return "", false, err
 	}
 
 	cryptoProvider := factory.GetDefault()
 	bundle, err := channelconfig.NewBundleFromEnvelope(envelope, cryptoProvider)
 	if err != nil {
-		return false, err
+		return "", false, err
 	}
 
-	// Check channel id from join block matches
-	if bundle.ConfigtxValidator().ChannelID() != channelID {
-		return false, fmt.Errorf("config block channelID [%s] does not match passed channelID [%s]",
-			bundle.ConfigtxValidator().ChannelID(), channelID)
-	}
+	channelID = bundle.ConfigtxValidator().ChannelID()
 
 	// Check channel type
 	_, isSystemChannel := bundle.ConsortiumsConfig()
 	if !isSystemChannel {
 		_, isAppChannel = bundle.ApplicationConfig()
 		if !isAppChannel {
-			return false, errors.New("invalid config: must have at least one of application or consortiums")
+			return "", false, errors.New("invalid config: must have at least one of application or consortiums")
 		}
 	}
 
-	return isAppChannel, err
+	return channelID, isAppChannel, err
 }


### PR DESCRIPTION
Currently the `Join channel` command does
  `POST /channels/my-channel`.
Since the channel is created, the right thing to do is to
  `POST /channels`,
while extracting the channel name from the block channel header.

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: Ia464eddd67be35a12aa52ee1c0b7abe3d3a4e681

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Related issues

Task: FAB-18051
Epic: FAB-17712