### PR TITLE
Typos on i18n pages

### DIFF
--- a/docs/source/advice_for_writers.md
+++ b/docs/source/advice_for_writers.md
@@ -67,7 +67,7 @@ Each workgroup has a list of members and their contact information.
 
 Hyperledger Fabric has many other collaboration mechanisms such as mailing
 lists, contributor meetings and maintainer meetings. Find out about these and
-more [here](./contributing.html).
+more [here](contributing.html).
 
 Good luck getting started and thanks for your contribution.
 

--- a/docs/source/international_languages.md
+++ b/docs/source/international_languages.md
@@ -150,7 +150,7 @@ new language get started.
 
   This is your advert! Thanks to you, users can now see that the documentation
   is available in their language. It might not be complete yet, but its clear
-  you and your team are trying to achieve. Translating tis page will help you
+  you and your team are trying to achieve. Translating this page will help you
   recruit other translators.
 
 


### PR DESCRIPTION
Fixed a couple typos in the new i18n topics

Signed-off-by: pama-ibm <pama@ibm.com>


#### Type of change

- Documentation update

