### PR TITLE
Add length check for dirsDepth

### DIFF
--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/db.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/db.go
@@ -426,7 +426,9 @@ func getIndexInfo(indexPath string) *indexInfo {
 		indexInfo.hasIndexForChaincode = true
 	case len(dirsDepth) > collectionDirDepth &&
 		dirsDepth[collectionDirDepth] == "collections" &&
-		dirsDepth[collectionIndexDirDepth] == "indexes":
+		len(dirsDepth) > collectionIndexDirDepth &&
+		dirsDepth[collectionIndexDirDepth] == "indexes" &&
+		len(dirsDepth) > collectionNameDepth:
 		indexInfo.hasIndexForCollection = true
 		indexInfo.collectionName = dirsDepth[collectionNameDepth]
 	}


### PR DESCRIPTION
This is a simple addition of a few bounds checks to ensure that the `dirsDepth` array is not accessed at an index beyond its size.

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

This change adds index checks before `dirDepths[collectionIndexDirDepth]` and `dirDepths[collectionNameDepth]` to avoid indexing beyond the end of the array. We *could* just check for the `collectionIndexDirDepth` and avoid the other two, but that would be more brittle in case the constants defined a few lines earlier were reordered. We could also just calculate `len(dirsDepth)` once as a small perf improvement.

#### Additional details

I have never used Hyperledger, and did not test this change in any way. I also don't know how likely it would be for `dirDepths` to short enough to cause the panic.

#### Related issues

This is related to the [suggestion](hyperledger#1080 (review)) from @manish-sethi in hyperledger#1080.