### PR TITLE
Make BCCSP configuration field names match the configuration keys used by config files and overrides

### DIFF
--- a/bccsp/factory/factory_test.go
+++ b/bccsp/factory/factory_test.go
@@ -61,8 +61,8 @@ BCCSP:
 
 	cfgVariations := []*FactoryOpts{
 		{},
-		{ProviderName: "SW"},
-		{ProviderName: "SW", SwOpts: &SwOpts{HashFamily: "SHA2", SecLevel: 256}},
+		{Default: "SW"},
+		{Default: "SW", SW: &SwOpts{Hash: "SHA2", Security: 256}},
 		yamlBCCSP,
 	}
 

--- a/bccsp/factory/nopkcs11.go
+++ b/bccsp/factory/nopkcs11.go
@@ -17,8 +17,8 @@ const pkcs11Enabled = false
 
 // FactoryOpts holds configuration information used to initialize factory implementations
 type FactoryOpts struct {
-	ProviderName string  `mapstructure:"default" json:"default" yaml:"Default"`
-	SwOpts       *SwOpts `mapstructure:"SW,omitempty" json:"SW,omitempty" yaml:"SW,omitempty"`
+	Default string  `json:"default" yaml:"Default"`
+	SW      *SwOpts `json:"SW,omitempty" yaml:"SW,omitempty"`
 }
 
 // InitFactories must be called before using factory interfaces
@@ -39,16 +39,16 @@ func initFactories(config *FactoryOpts) error {
 		config = GetDefaultOpts()
 	}
 
-	if config.ProviderName == "" {
-		config.ProviderName = "SW"
+	if config.Default == "" {
+		config.Default = "SW"
 	}
 
-	if config.SwOpts == nil {
-		config.SwOpts = GetDefaultOpts().SwOpts
+	if config.SW == nil {
+		config.SW = GetDefaultOpts().SW
 	}
 
 	// Software-Based BCCSP
-	if config.ProviderName == "SW" && config.SwOpts != nil {
+	if config.Default == "SW" && config.SW != nil {
 		f := &SWFactory{}
 		var err error
 		defaultBCCSP, err = initBCCSP(f, config)
@@ -58,7 +58,7 @@ func initFactories(config *FactoryOpts) error {
 	}
 
 	if defaultBCCSP == nil {
-		return errors.Errorf("Could not find default `%s` BCCSP", config.ProviderName)
+		return errors.Errorf("Could not find default `%s` BCCSP", config.Default)
 	}
 
 	return nil
@@ -67,11 +67,11 @@ func initFactories(config *FactoryOpts) error {
 // GetBCCSPFromOpts returns a BCCSP created according to the options passed in input.
 func GetBCCSPFromOpts(config *FactoryOpts) (bccsp.BCCSP, error) {
 	var f BCCSPFactory
-	switch config.ProviderName {
+	switch config.Default {
 	case "SW":
 		f = &SWFactory{}
 	default:
-		return nil, errors.Errorf("Could not find BCCSP, no '%s' provider", config.ProviderName)
+		return nil, errors.Errorf("Could not find BCCSP, no '%s' provider", config.Default)
 	}
 
 	csp, err := f.Get(config)

--- a/bccsp/factory/nopkcs11_test.go
+++ b/bccsp/factory/nopkcs11_test.go
@@ -16,13 +16,13 @@ import (
 
 func TestInitFactories(t *testing.T) {
 	err := initFactories(&FactoryOpts{
-		ProviderName: "SW",
-		SwOpts:       &SwOpts{},
+		Default: "SW",
+		SW:      &SwOpts{},
 	})
 	require.EqualError(t, err, "Failed initializing BCCSP: Could not initialize BCCSP SW [Failed initializing configuration at [0,]: Hash Family not supported []]")
 
 	err = initFactories(&FactoryOpts{
-		ProviderName: "PKCS11",
+		Default: "PKCS11",
 	})
 	require.EqualError(t, err, "Could not find default `PKCS11` BCCSP")
 }

--- a/bccsp/factory/opts.go
+++ b/bccsp/factory/opts.go
@@ -20,15 +20,15 @@ package factory
 // returns a new instance every time
 func GetDefaultOpts() *FactoryOpts {
 	return &FactoryOpts{
-		ProviderName: "SW",
-		SwOpts: &SwOpts{
-			HashFamily: "SHA2",
-			SecLevel:   256,
+		Default: "SW",
+		SW: &SwOpts{
+			Hash:     "SHA2",
+			Security: 256,
 		},
 	}
 }
 
 // FactoryName returns the name of the provider
 func (o *FactoryOpts) FactoryName() string {
-	return o.ProviderName
+	return o.Default
 }

--- a/bccsp/factory/pkcs11.go
+++ b/bccsp/factory/pkcs11.go
@@ -18,9 +18,9 @@ const pkcs11Enabled = false
 
 // FactoryOpts holds configuration information used to initialize factory implementations
 type FactoryOpts struct {
-	ProviderName string             `mapstructure:"default" json:"default" yaml:"Default"`
-	SwOpts       *SwOpts            `mapstructure:"SW,omitempty" json:"SW,omitempty" yaml:"SW,omitempty"`
-	Pkcs11Opts   *pkcs11.PKCS11Opts `mapstructure:"PKCS11,omitempty" json:"PKCS11,omitempty" yaml:"PKCS11"`
+	Default string             `json:"default" yaml:"Default"`
+	SW      *SwOpts            `json:"SW,omitempty" yaml:"SW,omitempty"`
+	PKCS11  *pkcs11.PKCS11Opts `json:"PKCS11,omitempty" yaml:"PKCS11"`
 }
 
 // InitFactories must be called before using factory interfaces
@@ -41,16 +41,16 @@ func initFactories(config *FactoryOpts) error {
 		config = GetDefaultOpts()
 	}
 
-	if config.ProviderName == "" {
-		config.ProviderName = "SW"
+	if config.Default == "" {
+		config.Default = "SW"
 	}
 
-	if config.SwOpts == nil {
-		config.SwOpts = GetDefaultOpts().SwOpts
+	if config.SW == nil {
+		config.SW = GetDefaultOpts().SW
 	}
 
 	// Software-Based BCCSP
-	if config.ProviderName == "SW" && config.SwOpts != nil {
+	if config.Default == "SW" && config.SW != nil {
 		f := &SWFactory{}
 		var err error
 		defaultBCCSP, err = initBCCSP(f, config)
@@ -60,7 +60,7 @@ func initFactories(config *FactoryOpts) error {
 	}
 
 	// PKCS11-Based BCCSP
-	if config.ProviderName == "PKCS11" && config.Pkcs11Opts != nil {
+	if config.Default == "PKCS11" && config.PKCS11 != nil {
 		f := &PKCS11Factory{}
 		var err error
 		defaultBCCSP, err = initBCCSP(f, config)
@@ -70,7 +70,7 @@ func initFactories(config *FactoryOpts) error {
 	}
 
 	if defaultBCCSP == nil {
-		return errors.Errorf("Could not find default `%s` BCCSP", config.ProviderName)
+		return errors.Errorf("Could not find default `%s` BCCSP", config.Default)
 	}
 
 	return nil
@@ -79,13 +79,13 @@ func initFactories(config *FactoryOpts) error {
 // GetBCCSPFromOpts returns a BCCSP created according to the options passed in input.
 func GetBCCSPFromOpts(config *FactoryOpts) (bccsp.BCCSP, error) {
 	var f BCCSPFactory
-	switch config.ProviderName {
+	switch config.Default {
 	case "SW":
 		f = &SWFactory{}
 	case "PKCS11":
 		f = &PKCS11Factory{}
 	default:
-		return nil, errors.Errorf("Could not find BCCSP, no '%s' provider", config.ProviderName)
+		return nil, errors.Errorf("Could not find BCCSP, no '%s' provider", config.Default)
 	}
 
 	csp, err := f.Get(config)

--- a/bccsp/factory/pkcs11_test.go
+++ b/bccsp/factory/pkcs11_test.go
@@ -34,41 +34,41 @@ func TestInitFactories(t *testing.T) {
 
 func TestInitFactoriesInvalidArgs(t *testing.T) {
 	err := initFactories(&FactoryOpts{
-		ProviderName: "SW",
-		SwOpts:       &SwOpts{},
+		Default: "SW",
+		SW:      &SwOpts{},
 	})
 	require.EqualError(t, err, "Failed initializing SW.BCCSP: Could not initialize BCCSP SW [Failed initializing configuration at [0,]: Hash Family not supported []]")
 
 	err = initFactories(&FactoryOpts{
-		ProviderName: "PKCS11",
-		Pkcs11Opts:   &pkcs11.PKCS11Opts{},
+		Default: "PKCS11",
+		PKCS11:  &pkcs11.PKCS11Opts{},
 	})
 	require.EqualError(t, err, "Failed initializing PKCS11.BCCSP: Could not initialize BCCSP PKCS11 [Failed initializing configuration: Hash Family not supported []]")
 }
 
 func TestGetBCCSPFromOpts(t *testing.T) {
 	opts := GetDefaultOpts()
-	opts.SwOpts.FileKeystore = &FileKeystoreOpts{KeyStorePath: os.TempDir()}
+	opts.SW.FileKeystore = &FileKeystoreOpts{KeyStorePath: os.TempDir()}
 	csp, err := GetBCCSPFromOpts(opts)
 	require.NoError(t, err)
 	require.NotNil(t, csp)
 
 	lib, pin, label := pkcs11.FindPKCS11Lib()
 	csp, err = GetBCCSPFromOpts(&FactoryOpts{
-		ProviderName: "PKCS11",
-		Pkcs11Opts: &pkcs11.PKCS11Opts{
-			SecLevel:   256,
-			HashFamily: "SHA2",
-			Library:    lib,
-			Pin:        pin,
-			Label:      label,
+		Default: "PKCS11",
+		PKCS11: &pkcs11.PKCS11Opts{
+			Security: 256,
+			Hash:     "SHA2",
+			Library:  lib,
+			Pin:      pin,
+			Label:    label,
 		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, csp)
 
 	csp, err = GetBCCSPFromOpts(&FactoryOpts{
-		ProviderName: "BadName",
+		Default: "BadName",
 	})
 	require.EqualError(t, err, "Could not find BCCSP, no 'BadName' provider")
 	require.Nil(t, csp)

--- a/bccsp/factory/pkcs11factory.go
+++ b/bccsp/factory/pkcs11factory.go
@@ -31,11 +31,11 @@ func (f *PKCS11Factory) Name() string {
 // Get returns an instance of BCCSP using Opts.
 func (f *PKCS11Factory) Get(config *FactoryOpts) (bccsp.BCCSP, error) {
 	// Validate arguments
-	if config == nil || config.Pkcs11Opts == nil {
+	if config == nil || config.PKCS11 == nil {
 		return nil, errors.New("Invalid config. It must not be nil.")
 	}
 
-	p11Opts := config.Pkcs11Opts
+	p11Opts := config.PKCS11
 	ks := sw.NewDummyKeyStore()
 
 	return pkcs11.New(*p11Opts, ks)

--- a/bccsp/factory/pkcs11factory_test.go
+++ b/bccsp/factory/pkcs11factory_test.go
@@ -30,7 +30,7 @@ func TestPKCS11FactoryGetInvalidArgs(t *testing.T) {
 	require.Error(t, err, "Invalid config. It must not be nil.")
 
 	opts := &FactoryOpts{
-		Pkcs11Opts: &pkcs11.PKCS11Opts{},
+		PKCS11: &pkcs11.PKCS11Opts{},
 	}
 	_, err = f.Get(opts)
 	require.Error(t, err, "CSP:500 - Failed initializing configuration at [0,]")
@@ -41,12 +41,12 @@ func TestPKCS11FactoryGet(t *testing.T) {
 	lib, pin, label := pkcs11.FindPKCS11Lib()
 
 	opts := &FactoryOpts{
-		Pkcs11Opts: &pkcs11.PKCS11Opts{
-			SecLevel:   256,
-			HashFamily: "SHA2",
-			Library:    lib,
-			Pin:        pin,
-			Label:      label,
+		PKCS11: &pkcs11.PKCS11Opts{
+			Security: 256,
+			Hash:     "SHA2",
+			Library:  lib,
+			Pin:      pin,
+			Label:    label,
 		},
 	}
 	csp, err := f.Get(opts)
@@ -54,12 +54,12 @@ func TestPKCS11FactoryGet(t *testing.T) {
 	require.NotNil(t, csp)
 
 	opts = &FactoryOpts{
-		Pkcs11Opts: &pkcs11.PKCS11Opts{
-			SecLevel:   256,
-			HashFamily: "SHA2",
-			Library:    lib,
-			Pin:        pin,
-			Label:      label,
+		PKCS11: &pkcs11.PKCS11Opts{
+			Security: 256,
+			Hash:     "SHA2",
+			Library:  lib,
+			Pin:      pin,
+			Label:    label,
 		},
 	}
 	csp, err = f.Get(opts)
@@ -67,12 +67,12 @@ func TestPKCS11FactoryGet(t *testing.T) {
 	require.NotNil(t, csp)
 
 	opts = &FactoryOpts{
-		Pkcs11Opts: &pkcs11.PKCS11Opts{
-			SecLevel:   256,
-			HashFamily: "SHA2",
-			Library:    lib,
-			Pin:        pin,
-			Label:      label,
+		PKCS11: &pkcs11.PKCS11Opts{
+			Security: 256,
+			Hash:     "SHA2",
+			Library:  lib,
+			Pin:      pin,
+			Label:    label,
 		},
 	}
 	csp, err = f.Get(opts)
@@ -85,12 +85,12 @@ func TestPKCS11FactoryGetEmptyKeyStorePath(t *testing.T) {
 	lib, pin, label := pkcs11.FindPKCS11Lib()
 
 	opts := &FactoryOpts{
-		Pkcs11Opts: &pkcs11.PKCS11Opts{
-			SecLevel:   256,
-			HashFamily: "SHA2",
-			Library:    lib,
-			Pin:        pin,
-			Label:      label,
+		PKCS11: &pkcs11.PKCS11Opts{
+			Security: 256,
+			Hash:     "SHA2",
+			Library:  lib,
+			Pin:      pin,
+			Label:    label,
 		},
 	}
 	csp, err := f.Get(opts)
@@ -98,12 +98,12 @@ func TestPKCS11FactoryGetEmptyKeyStorePath(t *testing.T) {
 	require.NotNil(t, csp)
 
 	opts = &FactoryOpts{
-		Pkcs11Opts: &pkcs11.PKCS11Opts{
-			SecLevel:   256,
-			HashFamily: "SHA2",
-			Library:    lib,
-			Pin:        pin,
-			Label:      label,
+		PKCS11: &pkcs11.PKCS11Opts{
+			Security: 256,
+			Hash:     "SHA2",
+			Library:  lib,
+			Pin:      pin,
+			Label:    label,
 		},
 	}
 	csp, err = f.Get(opts)

--- a/bccsp/factory/swfactory.go
+++ b/bccsp/factory/swfactory.go
@@ -37,11 +37,11 @@ func (f *SWFactory) Name() string {
 // Get returns an instance of BCCSP using Opts.
 func (f *SWFactory) Get(config *FactoryOpts) (bccsp.BCCSP, error) {
 	// Validate arguments
-	if config == nil || config.SwOpts == nil {
+	if config == nil || config.SW == nil {
 		return nil, errors.New("Invalid config. It must not be nil.")
 	}
 
-	swOpts := config.SwOpts
+	swOpts := config.SW
 
 	var ks bccsp.KeyStore
 	switch {
@@ -56,18 +56,18 @@ func (f *SWFactory) Get(config *FactoryOpts) (bccsp.BCCSP, error) {
 		ks = sw.NewDummyKeyStore()
 	}
 
-	return sw.NewWithParams(swOpts.SecLevel, swOpts.HashFamily, ks)
+	return sw.NewWithParams(swOpts.Security, swOpts.Hash, ks)
 }
 
 // SwOpts contains options for the SWFactory
 type SwOpts struct {
 	// Default algorithms when not specified (Deprecated?)
-	SecLevel     int               `mapstructure:"security" json:"security" yaml:"Security"`
-	HashFamily   string            `mapstructure:"hash" json:"hash" yaml:"Hash"`
-	FileKeystore *FileKeystoreOpts `mapstructure:"filekeystore,omitempty" json:"filekeystore,omitempty" yaml:"FileKeyStore"`
+	Security     int               `json:"security" yaml:"Security"`
+	Hash         string            `json:"hash" yaml:"Hash"`
+	FileKeystore *FileKeystoreOpts `json:"filekeystore,omitempty" yaml:"FileKeyStore,omitempty"`
 }
 
 // Pluggable Keystores, could add JKS, P12, etc..
 type FileKeystoreOpts struct {
-	KeyStorePath string `mapstructure:"keystore" yaml:"KeyStore"`
+	KeyStorePath string `yaml:"KeyStore"`
 }

--- a/bccsp/factory/swfactory_test.go
+++ b/bccsp/factory/swfactory_test.go
@@ -37,7 +37,7 @@ func TestSWFactoryGetInvalidArgs(t *testing.T) {
 	require.Error(t, err, "Invalid config. It must not be nil.")
 
 	opts := &FactoryOpts{
-		SwOpts: &SwOpts{},
+		SW: &SwOpts{},
 	}
 	_, err = f.Get(opts)
 	require.Error(t, err, "CSP:500 - Failed initializing configuration at [0,]")
@@ -47,9 +47,9 @@ func TestSWFactoryGet(t *testing.T) {
 	f := &SWFactory{}
 
 	opts := &FactoryOpts{
-		SwOpts: &SwOpts{
-			SecLevel:   256,
-			HashFamily: "SHA2",
+		SW: &SwOpts{
+			Security: 256,
+			Hash:     "SHA2",
 		},
 	}
 	csp, err := f.Get(opts)
@@ -57,9 +57,9 @@ func TestSWFactoryGet(t *testing.T) {
 	require.NotNil(t, csp)
 
 	opts = &FactoryOpts{
-		SwOpts: &SwOpts{
-			SecLevel:     256,
-			HashFamily:   "SHA2",
+		SW: &SwOpts{
+			Security:     256,
+			Hash:         "SHA2",
 			FileKeystore: &FileKeystoreOpts{KeyStorePath: os.TempDir()},
 		},
 	}

--- a/bccsp/pkcs11/conf.go
+++ b/bccsp/pkcs11/conf.go
@@ -69,13 +69,13 @@ func (conf *config) setSecurityLevelSHA3(level int) (err error) {
 // PKCS11Opts contains options for the P11Factory
 type PKCS11Opts struct {
 	// Default algorithms when not specified (Deprecated?)
-	SecLevel   int    `mapstructure:"security" json:"security"`
-	HashFamily string `mapstructure:"hash" json:"hash"`
+	Security int    `json:"security"`
+	Hash     string `json:"hash"`
 
 	// PKCS11 options
-	Library    string `mapstructure:"library" json:"library"`
-	Label      string `mapstructure:"label" json:"label"`
-	Pin        string `mapstructure:"pin" json:"pin"`
-	SoftVerify bool   `mapstructure:"softwareverify,omitempty" json:"softwareverify,omitempty"`
-	Immutable  bool   `mapstructure:"immutable,omitempty" json:"immutable,omitempty"`
+	Library        string `json:"library"`
+	Label          string `json:"label"`
+	Pin            string `json:"pin"`
+	SoftwareVerify bool   `json:"softwareverify,omitempty"`
+	Immutable      bool   `json:"immutable,omitempty"`
 }

--- a/bccsp/pkcs11/impl.go
+++ b/bccsp/pkcs11/impl.go
@@ -28,7 +28,7 @@ var (
 func New(opts PKCS11Opts, keyStore bccsp.KeyStore) (bccsp.BCCSP, error) {
 	// Init config
 	conf := &config{}
-	err := conf.setSecurityLevel(opts.SecLevel, opts.HashFamily)
+	err := conf.setSecurityLevel(opts.Security, opts.Hash)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed initializing configuration")
 	}
@@ -38,7 +38,7 @@ func New(opts PKCS11Opts, keyStore bccsp.KeyStore) (bccsp.BCCSP, error) {
 		return nil, errors.New("Invalid bccsp.KeyStore instance. It must be different from nil")
 	}
 
-	swCSP, err := sw.NewWithParams(opts.SecLevel, opts.HashFamily, keyStore)
+	swCSP, err := sw.NewWithParams(opts.Security, opts.Hash, keyStore)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed initializing fallback SW BCCSP")
 	}
@@ -61,7 +61,7 @@ func New(opts PKCS11Opts, keyStore bccsp.KeyStore) (bccsp.BCCSP, error) {
 		slot:       slot,
 		pin:        pin,
 		lib:        lib,
-		softVerify: opts.SoftVerify,
+		softVerify: opts.SoftwareVerify,
 		immutable:  opts.Immutable,
 	}
 	csp.returnSession(*session)

--- a/bccsp/pkcs11/impl_test.go
+++ b/bccsp/pkcs11/impl_test.go
@@ -92,9 +92,9 @@ func testMain(m *testing.M) int {
 	for _, config := range tests {
 		currentTestConfig = config
 
-		opts.HashFamily = config.hashFamily
-		opts.SecLevel = config.securityLevel
-		opts.SoftVerify = config.softVerify
+		opts.Hash = config.hashFamily
+		opts.Security = config.securityLevel
+		opts.SoftwareVerify = config.softVerify
 		opts.Immutable = config.immutable
 		fmt.Printf("Immutable = [%v]\n", opts.Immutable)
 		currentBCCSP, err = New(opts, keyStore)
@@ -114,12 +114,12 @@ func testMain(m *testing.M) int {
 
 func TestNew(t *testing.T) {
 	opts := PKCS11Opts{
-		HashFamily: "SHA2",
-		SecLevel:   256,
-		SoftVerify: false,
-		Library:    "lib",
-		Label:      "ForFabric",
-		Pin:        "98765432",
+		Hash:           "SHA2",
+		Security:       256,
+		SoftwareVerify: false,
+		Library:        "lib",
+		Label:          "ForFabric",
+		Pin:            "98765432",
 	}
 
 	// Setup PKCS11 library and provide initial set of values
@@ -180,14 +180,14 @@ func TestFindPKCS11LibEnvVars(t *testing.T) {
 func TestInvalidNewParameter(t *testing.T) {
 	lib, pin, label := FindPKCS11Lib()
 	opts := PKCS11Opts{
-		Library:    lib,
-		Label:      label,
-		Pin:        pin,
-		SoftVerify: true,
+		Library:        lib,
+		Label:          label,
+		Pin:            pin,
+		SoftwareVerify: true,
 	}
 
-	opts.HashFamily = "SHA2"
-	opts.SecLevel = 0
+	opts.Hash = "SHA2"
+	opts.Security = 0
 	r, err := New(opts, currentKS)
 	if err == nil {
 		t.Fatal("Error should be different from nil in this case")
@@ -196,8 +196,8 @@ func TestInvalidNewParameter(t *testing.T) {
 		t.Fatal("Return value should be equal to nil in this case")
 	}
 
-	opts.HashFamily = "SHA8"
-	opts.SecLevel = 256
+	opts.Hash = "SHA8"
+	opts.Security = 256
 	r, err = New(opts, currentKS)
 	if err == nil {
 		t.Fatal("Error should be different from nil in this case")
@@ -206,8 +206,8 @@ func TestInvalidNewParameter(t *testing.T) {
 		t.Fatal("Return value should be equal to nil in this case")
 	}
 
-	opts.HashFamily = "SHA2"
-	opts.SecLevel = 256
+	opts.Hash = "SHA2"
+	opts.Security = 256
 	r, err = New(opts, nil)
 	if err == nil {
 		t.Fatal("Error should be different from nil in this case")
@@ -216,8 +216,8 @@ func TestInvalidNewParameter(t *testing.T) {
 		t.Fatal("Return value should be equal to nil in this case")
 	}
 
-	opts.HashFamily = "SHA3"
-	opts.SecLevel = 0
+	opts.Hash = "SHA3"
+	opts.Security = 0
 	r, err = New(opts, nil)
 	if err == nil {
 		t.Fatal("Error should be different from nil in this case")

--- a/bccsp/pkcs11/impl_test.go
+++ b/bccsp/pkcs11/impl_test.go
@@ -77,10 +77,7 @@ func testMain(m *testing.M) int {
 	}
 
 	if strings.Contains(lib, "softhsm") {
-		tests = append(tests, []testConfig{
-			{256, "SHA2", true, false},
-			{256, "SHA2", true, true},
-		}...)
+		tests = append(tests, testConfig{256, "SHA2", true, true})
 	}
 
 	opts := PKCS11Opts{

--- a/common/viperutil/config_test.go
+++ b/common/viperutil/config_test.go
@@ -369,6 +369,6 @@ func TestBCCSPDecodeHookOverride(t *testing.T) {
 	err = config.EnhancedExactUnmarshal(&tc)
 	require.NoError(t, err, "failed to unmarshal")
 	require.NotNil(t, tc.BCCSP)
-	require.NotNil(t, tc.BCCSP.SwOpts)
-	require.Equal(t, 1111, tc.BCCSP.SwOpts.SecLevel)
+	require.NotNil(t, tc.BCCSP.SW)
+	require.Equal(t, 1111, tc.BCCSP.SW.Security)
 }

--- a/common/viperutil/config_util.go
+++ b/common/viperutil/config_util.go
@@ -18,7 +18,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Shopify/sarama"
 	version "github.com/hashicorp/go-version"
@@ -215,18 +214,9 @@ func toMapStringInterface(m map[interface{}]interface{}) map[string]interface{} 
 	return result
 }
 
-// customDecodeHook adds the additional functions of parsing durations from strings
-// as well as parsing strings of the format "[thing1, thing2, thing3]" into string slices
-// Note that whitespace around slice elements is removed
+// customDecodeHook parses strings of the format "[thing1, thing2, thing3]"
+// into string slices. Note that whitespace around slice elements is removed.
 func customDecodeHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
-	durationHook := mapstructure.StringToTimeDurationHookFunc()
-	dur, err := mapstructure.DecodeHookExec(durationHook, f, t, data)
-	if err == nil {
-		if _, ok := dur.(time.Duration); ok {
-			return dur, nil
-		}
-	}
-
 	if f.Kind() != reflect.String {
 		return data, nil
 	}
@@ -444,6 +434,7 @@ func (c *ConfigParser) EnhancedExactUnmarshal(output interface{}) error {
 		WeaklyTypedInput: true,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			bccspHook,
+			mapstructure.StringToTimeDurationHookFunc(),
 			customDecodeHook,
 			byteSizeDecodeHook,
 			stringFromFileDecodeHook,

--- a/core/deliverservice/config.go
+++ b/core/deliverservice/config.go
@@ -47,9 +47,9 @@ type DeliverServiceConfig struct {
 }
 
 type AddressOverride struct {
-	From        string `mapstructure:"from"`
-	To          string `mapstructure:"to"`
-	CACertsFile string `mapstructure:"caCertsFile"`
+	From        string
+	To          string
+	CACertsFile string
 }
 
 // GlobalConfig obtains a set of configuration from viper, build and returns the config struct.

--- a/core/handlers/library/config.go
+++ b/core/handlers/library/config.go
@@ -14,10 +14,10 @@ import (
 // Config configures the factory methods
 // and plugins for the registry
 type Config struct {
-	AuthFilters []*HandlerConfig `mapstructure:"authFilters" yaml:"authFilters"`
-	Decorators  []*HandlerConfig `mapstructure:"decorators" yaml:"decorators"`
-	Endorsers   PluginMapping    `mapstructure:"endorsers" yaml:"endorsers"`
-	Validators  PluginMapping    `mapstructure:"validators" yaml:"validators"`
+	AuthFilters []*HandlerConfig `yaml:"authFilters"`
+	Decorators  []*HandlerConfig `yaml:"decorators"`
+	Endorsers   PluginMapping    `yaml:"endorsers"`
+	Validators  PluginMapping    `yaml:"validators"`
 }
 
 // PluginMapping stores a map between chaincode id to plugin config
@@ -25,8 +25,8 @@ type PluginMapping map[string]*HandlerConfig
 
 // HandlerConfig defines configuration for a plugin or compiled handler
 type HandlerConfig struct {
-	Name    string `mapstructure:"name" yaml:"name"`
-	Library string `mapstructure:"library" yaml:"library"`
+	Name    string `yaml:"name"`
+	Library string `yaml:"library"`
 }
 
 func LoadConfig() (Config, error) {

--- a/msp/configbuilder.go
+++ b/msp/configbuilder.go
@@ -137,15 +137,15 @@ func SetupBCCSPKeystoreConfig(bccspConfig *factory.FactoryOpts, keystoreDir stri
 		bccspConfig = factory.GetDefaultOpts()
 	}
 
-	if bccspConfig.ProviderName == "SW" || bccspConfig.SwOpts != nil {
-		if bccspConfig.SwOpts == nil {
-			bccspConfig.SwOpts = factory.GetDefaultOpts().SwOpts
+	if bccspConfig.Default == "SW" || bccspConfig.SW != nil {
+		if bccspConfig.SW == nil {
+			bccspConfig.SW = factory.GetDefaultOpts().SW
 		}
 
 		// Only override the KeyStorePath if it was left empty
-		if bccspConfig.SwOpts.FileKeystore == nil ||
-			bccspConfig.SwOpts.FileKeystore.KeyStorePath == "" {
-			bccspConfig.SwOpts.FileKeystore = &factory.FileKeystoreOpts{KeyStorePath: keystoreDir}
+		if bccspConfig.SW.FileKeystore == nil ||
+			bccspConfig.SW.FileKeystore.KeyStorePath == "" {
+			bccspConfig.SW.FileKeystore = &factory.FileKeystoreOpts{KeyStorePath: keystoreDir}
 		}
 	}
 

--- a/msp/configbuilder_test.go
+++ b/msp/configbuilder_test.go
@@ -23,63 +23,63 @@ func TestSetupBCCSPKeystoreConfig(t *testing.T) {
 	// Case 1 : Check with empty FactoryOpts
 	rtnConfig := SetupBCCSPKeystoreConfig(nil, keystoreDir)
 	require.NotNil(t, rtnConfig)
-	require.Equal(t, rtnConfig.ProviderName, "SW")
-	require.NotNil(t, rtnConfig.SwOpts)
-	require.NotNil(t, rtnConfig.SwOpts.FileKeystore)
-	require.Equal(t, rtnConfig.SwOpts.FileKeystore.KeyStorePath, keystoreDir)
+	require.Equal(t, rtnConfig.Default, "SW")
+	require.NotNil(t, rtnConfig.SW)
+	require.NotNil(t, rtnConfig.SW.FileKeystore)
+	require.Equal(t, rtnConfig.SW.FileKeystore.KeyStorePath, keystoreDir)
 
 	// Case 2 : Check with 'SW' as default provider
 	// Case 2-1 : without SwOpts
 	bccspConfig := &factory.FactoryOpts{
-		ProviderName: "SW",
+		Default: "SW",
 	}
 	rtnConfig = SetupBCCSPKeystoreConfig(bccspConfig, keystoreDir)
-	require.NotNil(t, rtnConfig.SwOpts)
-	require.NotNil(t, rtnConfig.SwOpts.FileKeystore)
-	require.Equal(t, rtnConfig.SwOpts.FileKeystore.KeyStorePath, keystoreDir)
+	require.NotNil(t, rtnConfig.SW)
+	require.NotNil(t, rtnConfig.SW.FileKeystore)
+	require.Equal(t, rtnConfig.SW.FileKeystore.KeyStorePath, keystoreDir)
 
 	// Case 2-2 : without SwOpts.FileKeystore
-	bccspConfig.SwOpts = &factory.SwOpts{
-		HashFamily: "SHA2",
-		SecLevel:   256,
+	bccspConfig.SW = &factory.SwOpts{
+		Hash:     "SHA2",
+		Security: 256,
 	}
 	rtnConfig = SetupBCCSPKeystoreConfig(bccspConfig, keystoreDir)
-	require.NotNil(t, rtnConfig.SwOpts.FileKeystore)
-	require.Equal(t, rtnConfig.SwOpts.FileKeystore.KeyStorePath, keystoreDir)
+	require.NotNil(t, rtnConfig.SW.FileKeystore)
+	require.Equal(t, rtnConfig.SW.FileKeystore.KeyStorePath, keystoreDir)
 
 	// Case 2-3 : without SwOpts.FileKeystore.KeyStorePath
-	bccspConfig.SwOpts = &factory.SwOpts{
-		HashFamily:   "SHA2",
-		SecLevel:     256,
+	bccspConfig.SW = &factory.SwOpts{
+		Hash:         "SHA2",
+		Security:     256,
 		FileKeystore: &factory.FileKeystoreOpts{},
 	}
 	rtnConfig = SetupBCCSPKeystoreConfig(bccspConfig, keystoreDir)
-	require.Equal(t, rtnConfig.SwOpts.FileKeystore.KeyStorePath, keystoreDir)
+	require.Equal(t, rtnConfig.SW.FileKeystore.KeyStorePath, keystoreDir)
 
 	// Case 2-4 : with empty SwOpts.FileKeystore.KeyStorePath
-	bccspConfig.SwOpts = &factory.SwOpts{
-		HashFamily:   "SHA2",
-		SecLevel:     256,
+	bccspConfig.SW = &factory.SwOpts{
+		Hash:         "SHA2",
+		Security:     256,
 		FileKeystore: &factory.FileKeystoreOpts{KeyStorePath: ""},
 	}
 	rtnConfig = SetupBCCSPKeystoreConfig(bccspConfig, keystoreDir)
-	require.Equal(t, rtnConfig.SwOpts.FileKeystore.KeyStorePath, keystoreDir)
+	require.Equal(t, rtnConfig.SW.FileKeystore.KeyStorePath, keystoreDir)
 
 	// Case 3 : Check with 'PKCS11' as default provider
 	// Case 3-1 : without SwOpts
-	bccspConfig.ProviderName = "PKCS11"
-	bccspConfig.SwOpts = nil
+	bccspConfig.Default = "PKCS11"
+	bccspConfig.SW = nil
 	rtnConfig = SetupBCCSPKeystoreConfig(bccspConfig, keystoreDir)
-	require.Nil(t, rtnConfig.SwOpts)
+	require.Nil(t, rtnConfig.SW)
 
 	// Case 3-2 : without SwOpts.FileKeystore
-	bccspConfig.SwOpts = &factory.SwOpts{
-		HashFamily: "SHA2",
-		SecLevel:   256,
+	bccspConfig.SW = &factory.SwOpts{
+		Hash:     "SHA2",
+		Security: 256,
 	}
 	rtnConfig = SetupBCCSPKeystoreConfig(bccspConfig, keystoreDir)
-	require.NotNil(t, rtnConfig.SwOpts.FileKeystore)
-	require.Equal(t, rtnConfig.SwOpts.FileKeystore.KeyStorePath, keystoreDir)
+	require.NotNil(t, rtnConfig.SW.FileKeystore)
+	require.Equal(t, rtnConfig.SW.FileKeystore.KeyStorePath, keystoreDir)
 }
 
 func TestGetLocalMspConfig(t *testing.T) {

--- a/msp/mspimpl.go
+++ b/msp/mspimpl.go
@@ -150,8 +150,8 @@ func NewBccspMspWithKeyStore(version MSPVersion, keyStore bccsp.KeyStore, bccsp 
 	}
 
 	csp, err := sw.NewWithParams(
-		factory.GetDefaultOpts().SwOpts.SecLevel,
-		factory.GetDefaultOpts().SwOpts.HashFamily,
+		factory.GetDefaultOpts().SW.Security,
+		factory.GetDefaultOpts().SW.Hash,
 		keyStore)
 	if err != nil {
 		return nil, err

--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -20,10 +20,6 @@ import (
 var logger = flogging.MustGetLogger("localconfig")
 
 // TopLevel directly corresponds to the orderer config YAML.
-// Note, for non 1-1 mappings, you may append
-// something like `mapstructure:"weirdFoRMat"` to
-// modify the default mapping, see the "Unmarshal"
-// section of https://github.com/spf13/viper for more info.
 type TopLevel struct {
 	General              General
 	FileLedger           FileLedger

--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -381,10 +381,10 @@ func TestLoadLocalMSP(t *testing.T) {
 					LocalMSPDir: localMSPDir,
 					LocalMSPID:  "SampleOrg",
 					BCCSP: &factory.FactoryOpts{
-						ProviderName: "SW",
-						SwOpts: &factory.SwOpts{
-							HashFamily: "SHA2",
-							SecLevel:   256,
+						Default: "SW",
+						SW: &factory.SwOpts{
+							Hash:     "SHA2",
+							Security: 256,
 						},
 					},
 				},
@@ -911,10 +911,10 @@ func genesisConfig(t *testing.T, genesisFile string) *localconfig.TopLevel {
 			LocalMSPDir:     localMSPDir,
 			LocalMSPID:      "SampleOrg",
 			BCCSP: &factory.FactoryOpts{
-				ProviderName: "SW",
-				SwOpts: &factory.SwOpts{
-					HashFamily: "SHA2",
-					SecLevel:   256,
+				Default: "SW",
+				SW: &factory.SwOpts{
+					Hash:     "SHA2",
+					Security: 256,
 				},
 			},
 		},


### PR DESCRIPTION
Rename configuration structure fields to match the keys used in configuration:
- Rename `SWOpts` to `SW`
- Rename `Pkcs11Opts` to `PKCS11`
- Rename `Provider` to `Default`
- Rename `HashFamily` to `Hash`
- Rename `SecLevel` to `Security`
- Rename `SoftVerify` to `SoftwareVerify`

Additional cleanup:
- Remove unnecessary `mapstructure` tags
- Reuse duration decode hook from the `mapstructure` package
- Add explicit duration handling tests to `viperutil`
- Remove duplicate PKCS11 configuration in test loop