### PR TITLE
Add LTS release status to What's New doc

### DIFF
--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -9,6 +9,9 @@ governance around smart contracts, and new options for operating nodes.
 Each v2.x minor release builds on the v2.0 release with minor features,
 improvements, and bug fixes.
 
+v2.2 is the first long-term support (LTS) release of Fabric v2.x.
+Fixes will be provided on the v2.2.x release stream until after the next LTS release is announced.
+
 Let's take a look at some of the highlights of the Fabric v2.0 release...
 
 Decentralized governance for smart contracts


### PR DESCRIPTION
Add v2.2 LTS release status to What's New doc.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
