### PR TITLE
Unexport ClientAuthEnabled and ConnectsToOrderer functions from nwo

### DIFF
--- a/integration/nwo/command.go
+++ b/integration/nwo/command.go
@@ -24,24 +24,6 @@ type WorkingDirer interface {
 	WorkingDir() string
 }
 
-func ConnectsToOrderer(c Command) bool {
-	for _, arg := range c.Args() {
-		if arg == "--orderer" {
-			return true
-		}
-	}
-	return false
-}
-
-func ClientAuthEnabled(c Command) bool {
-	for _, arg := range c.Args() {
-		if arg == "--clientauth" {
-			return true
-		}
-	}
-	return false
-}
-
 func NewCommand(path string, command Command) *exec.Cmd {
 	cmd := exec.Command(path, command.Args()...)
 	cmd.Env = os.Environ()

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -1298,12 +1298,13 @@ func (n *Network) NetworkGroupRunner() ifrit.Runner {
 func (n *Network) peerCommand(command Command, tlsDir string, env ...string) *exec.Cmd {
 	cmd := NewCommand(n.Components.Peer(), command)
 	cmd.Env = append(cmd.Env, env...)
-	if ConnectsToOrderer(command) {
+
+	if connectsToOrderer(command) {
 		cmd.Args = append(cmd.Args, "--tls")
 		cmd.Args = append(cmd.Args, "--cafile", n.CACertsBundlePath())
 	}
 
-	if ClientAuthEnabled(command) {
+	if clientAuthEnabled(command) {
 		certfilePath := filepath.Join(tlsDir, "client.crt")
 		keyfilePath := filepath.Join(tlsDir, "client.key")
 
@@ -1321,6 +1322,24 @@ func (n *Network) peerCommand(command Command, tlsDir string, env ...string) *ex
 		cmd.Args = append(cmd.Args, n.CACertsBundlePath())
 	}
 	return cmd
+}
+
+func connectsToOrderer(c Command) bool {
+	for _, arg := range c.Args() {
+		if arg == "--orderer" {
+			return true
+		}
+	}
+	return false
+}
+
+func clientAuthEnabled(c Command) bool {
+	for _, arg := range c.Args() {
+		if arg == "--clientauth" {
+			return true
+		}
+	}
+	return false
 }
 
 func flagCount(flag string, args []string) int {


### PR DESCRIPTION
`clientAuthEnabled` and `connectsToOrderer` are details of `peerCommand` which is also not exported.