### PR TITLE
[FAB-17906] Add a new category to bookkeeping provider

### DIFF
--- a/core/ledger/kvledger/bookkeeping/provider.go
+++ b/core/ledger/kvledger/bookkeeping/provider.go
@@ -20,6 +20,8 @@ const (
 	PvtdataExpiry Category = iota
 	// MetadataPresenceIndicator maintains the bookkeeping about whether metadata is ever set for a namespace
 	MetadataPresenceIndicator
+	// SnapshotRequest maintains the information for snapshot requests
+	SnapshotRequest
 )
 
 // Provider provides handle to different bookkeepers for the given ledger
@@ -57,10 +59,12 @@ func (provider *provider) Close() {
 
 // Drop drops channel-specific data from the config history db
 func (provider *provider) Drop(ledgerID string) error {
-	if err := provider.dbProvider.Drop(dbName(ledgerID, PvtdataExpiry)); err != nil {
-		return err
+	for _, cat := range []Category{PvtdataExpiry, MetadataPresenceIndicator, SnapshotRequest} {
+		if err := provider.dbProvider.Drop(dbName(ledgerID, cat)); err != nil {
+			return err
+		}
 	}
-	return provider.dbProvider.Drop(dbName(ledgerID, MetadataPresenceIndicator))
+	return nil
 }
 
 func dbName(ledgerID string, cat Category) string {

--- a/core/ledger/kvledger/bookkeeping/provider_test.go
+++ b/core/ledger/kvledger/bookkeeping/provider_test.go
@@ -29,12 +29,21 @@ func TestProvider(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte("value2"), val)
 
+	snapshotRequestDB := p.GetDBHandle("TestLedger", SnapshotRequest)
+	require.NoError(t, snapshotRequestDB.Put([]byte("key3"), []byte("value3"), true))
+	val, err = snapshotRequestDB.Get([]byte("key3"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("value3"), val)
+
 	require.NoError(t, p.Drop("TestLedger"))
 
 	val, err = pvtdataExpiryDB.Get([]byte("key1"))
 	require.NoError(t, err)
 	require.Nil(t, val)
 	val, err = metadataIndicatorDB.Get([]byte("key2"))
+	require.NoError(t, err)
+	require.Nil(t, val)
+	val, err = snapshotRequestDB.Get([]byte("key3"))
 	require.NoError(t, err)
 	require.Nil(t, val)
 

--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -51,6 +51,7 @@ type kvLedger struct {
 	txmgr                  *txmgr.LockBasedTxMgr
 	historyDB              *history.DB
 	configHistoryRetriever *confighistory.Retriever
+	bookkeepingProvider    bookkeeping.Provider
 	blockAPIsRWLock        *sync.RWMutex
 	stats                  *ledgerStats
 	commitHash             []byte
@@ -83,13 +84,14 @@ func newKVLedger(initializer *lgrInitializer) (*kvLedger, error) {
 	ledgerID := initializer.ledgerID
 	logger.Debugf("Creating KVLedger ledgerID=%s: ", ledgerID)
 	l := &kvLedger{
-		ledgerID:        ledgerID,
-		blockStore:      initializer.blockStore,
-		pvtdataStore:    initializer.pvtdataStore,
-		historyDB:       initializer.historyDB,
-		hashProvider:    initializer.hashProvider,
-		config:          initializer.config,
-		blockAPIsRWLock: &sync.RWMutex{},
+		ledgerID:            ledgerID,
+		blockStore:          initializer.blockStore,
+		pvtdataStore:        initializer.pvtdataStore,
+		historyDB:           initializer.historyDB,
+		bookkeepingProvider: initializer.bookkeeperProvider,
+		hashProvider:        initializer.hashProvider,
+		config:              initializer.config,
+		blockAPIsRWLock:     &sync.RWMutex{},
 	}
 
 	btlPolicy := pvtdatapolicy.ConstructBTLPolicy(&collectionInfoRetriever{ledgerID, l, initializer.ccInfoProvider})


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- New feature

#### Description
Ledger snapshot management will store snapshot requests in bookkeepingDB.
Therefore, add a new category to bookkeeping provider  and also add
bookkeepingProvider to kvledger.

#### Additional details
This PR will be used by the snapshot management code to submit/query/list snapshot requests.

#### Related issues
Story: https://jira.hyperledger.org/browse/FAB-17688
Sub-task: https://jira.hyperledger.org/browse/FAB-17906
