### PR TITLE
Fix latest tag on ccenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ BUILD_DIR ?= .build
 
 EXTRA_VERSION ?= $(shell git rev-parse --short HEAD)
 PROJECT_VERSION=$(BASE_VERSION)-snapshot-$(EXTRA_VERSION)
+TWO_DIGIT_VERSION = $(shell echo $(BASE_VERSION) | cut -d '.' -f 1,2)
 
 PKGNAME = github.com/$(PROJECT_NAME)
 CGO_FLAGS = CGO_CFLAGS=" "
@@ -308,6 +309,7 @@ $(BUILD_DIR)/image/%/$(DUMMY): Makefile $(BUILD_DIR)/image/%/payload $(BUILD_DIR
 	$(DBUILD) -t $(DOCKER_NS)/fabric-$(TARGET) $(@D)
 	docker tag $(DOCKER_NS)/fabric-$(TARGET) $(DOCKER_NS)/fabric-$(TARGET):$(DOCKER_TAG)
 	docker tag $(DOCKER_NS)/fabric-$(TARGET) $(DOCKER_NS)/fabric-$(TARGET):$(ARCH)-latest
+	docker tag $(DOCKER_NS)/fabric-$(TARGET) $(DOCKER_NS)/fabric-$(TARGET)
 	@touch $@
 
 $(BUILD_DIR)/gotools.tar.bz2: $(BUILD_DIR)/docker/gotools

--- a/common/metadata/metadata.go
+++ b/common/metadata/metadata.go
@@ -9,7 +9,7 @@ package metadata
 // Variables defined by the Makefile and passed in with ldflags
 var Version string = "latest"
 var CommitSHA string = "development build"
-var BaseVersion string = "0.4.18"
+var BaseVersion string = "0.4.21"
 var BaseDockerLabel string = "org.hyperledger.fabric"
 var DockerNamespace string = "hyperledger"
 var BaseDockerNamespace string = "hyperledger"

--- a/core/chaincode/chaincodetest.yaml
+++ b/core/chaincode/chaincodetest.yaml
@@ -299,7 +299,7 @@ chaincode:
         name:
 
     # Generic builder environment, suitable for most chaincode types
-    builder: $(DOCKER_NS)/fabric-ccenv:$(ARCH)-$(PROJECT_VERSION)
+    builder: $(DOCKER_NS)/fabric-ccenv:$(TWO_DIGIT_VERSION)
 
     golang:
         # golang will never need more than baseos

--- a/examples/cluster/config/core.yaml
+++ b/examples/cluster/config/core.yaml
@@ -289,7 +289,7 @@ chaincode:
         name:
 
     # Generic builder environment, suitable for most chaincode types
-    builder: $(DOCKER_NS)/fabric-ccenv:$(ARCH)-$(PROJECT_VERSION)
+    builder: $(DOCKER_NS)/fabric-ccenv:$(TWO_DIGIT_VERSION)
 
     golang:
         # golang will never need more than baseos

--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -146,7 +146,7 @@ vm:
       Memory: 2147483648
 
 chaincode:
-  builder: $(DOCKER_NS)/fabric-ccenv:$(ARCH)-$(PROJECT_VERSION)
+  builder: $(DOCKER_NS)/fabric-ccenv:$(TWO_DIGIT_VERSION)
   pull: false
   golang:
     runtime: $(BASE_DOCKER_NS)/fabric-baseos:$(ARCH)-$(BASE_VERSION)

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -496,7 +496,7 @@ chaincode:
         name:
 
     # Generic builder environment, suitable for most chaincode types
-    builder: $(DOCKER_NS)/fabric-ccenv:latest
+    builder: $(DOCKER_NS)/fabric-ccenv:$(TWO_DIGIT_VERSION)
 
     # Enables/disables force pulling of the base docker images (listed below)
     # during user chaincode instantiation.


### PR DESCRIPTION
`latest` no longer exists. Defaulting to the standard tags

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
