### PR TITLE
Require orderer file ledger location to be set

### DIFF
--- a/integration/nwo/fabricconfig/orderer.go
+++ b/integration/nwo/fabricconfig/orderer.go
@@ -72,7 +72,6 @@ type OrdererTopic struct {
 
 type FileLedger struct {
 	Location string `yaml:"Location,omitempty"`
-	Prefix   string `yaml:"Prefix,omitempty"`
 }
 
 type Kafka struct {

--- a/integration/nwo/orderer_template.go
+++ b/integration/nwo/orderer_template.go
@@ -53,7 +53,6 @@ General:
     TimeWindow: 15m
 FileLedger:
   Location: {{ .OrdererDir Orderer }}/system
-  Prefix: hyperledger-fabric-ordererledger
 {{ if eq .Consensus.Type "kafka" -}}
 Kafka:
   Retry:

--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -110,7 +110,6 @@ type Profile struct {
 // FileLedger contains configuration for the file-based ledger.
 type FileLedger struct {
 	Location string
-	Prefix   string
 }
 
 // Kafka contains configuration for the Kafka-based orderer.
@@ -236,7 +235,6 @@ var Defaults = TopLevel{
 	},
 	FileLedger: FileLedger{
 		Location: "/var/hyperledger/production/orderer",
-		Prefix:   "hyperledger-fabric-ordererledger",
 	},
 	Kafka: Kafka{
 		Retry: Retry{
@@ -432,10 +430,6 @@ func (c *TopLevel) completeInitialization(configDir string) {
 		case c.General.Authentication.TimeWindow == 0:
 			logger.Infof("General.Authentication.TimeWindow unset, setting to %s", Defaults.General.Authentication.TimeWindow)
 			c.General.Authentication.TimeWindow = Defaults.General.Authentication.TimeWindow
-
-		case c.FileLedger.Prefix == "":
-			logger.Infof("FileLedger.Prefix unset, setting to %s", Defaults.FileLedger.Prefix)
-			c.FileLedger.Prefix = Defaults.FileLedger.Prefix
 
 		case c.Kafka.Retry.ShortInterval == 0:
 			logger.Infof("Kafka.Retry.ShortInterval unset, setting to %v", Defaults.Kafka.Retry.ShortInterval)

--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -107,7 +107,7 @@ func Main() {
 		clientRootCAs:         serverConfig.SecOpts.ClientRootCAs,
 	}
 
-	lf, _, err := createLedgerFactory(conf, metricsProvider)
+	lf, err := createLedgerFactory(conf, metricsProvider)
 	if err != nil {
 		logger.Panicf("Failed to create ledger factory: %v", err)
 	}

--- a/orderer/common/server/testdata/orderer.yaml
+++ b/orderer/common/server/testdata/orderer.yaml
@@ -128,19 +128,13 @@ General:
 #
 #   SECTION: File Ledger
 #
-#   - This section applies to the configuration of the file or json ledgers.
+#   - This section applies to the configuration of the file ledger.
 #
 ################################################################################
 FileLedger:
 
     # Location: The directory to store the blocks in.
-    # NOTE: If this is unset, a new temporary location will be chosen every time
-    # the orderer is restarted, using the prefix specified by Prefix.
     Location: /var/hyperledger/production/orderer
-
-    # The prefix to use when generating a ledger directory in temporary space.
-    # Otherwise, this value is ignored.
-    Prefix: hyperledger-fabric-ordererledger
 
 ################################################################################
 #

--- a/orderer/common/server/util.go
+++ b/orderer/common/server/util.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package server
 
 import (
-	"io/ioutil"
-
 	"github.com/hyperledger/fabric/common/ledger/blockledger"
 	"github.com/hyperledger/fabric/common/ledger/blockledger/fileledger"
 	"github.com/hyperledger/fabric/common/metrics"
@@ -16,19 +14,16 @@ import (
 	"github.com/pkg/errors"
 )
 
-func createLedgerFactory(conf *config.TopLevel, metricsProvider metrics.Provider) (blockledger.Factory, string, error) {
+func createLedgerFactory(conf *config.TopLevel, metricsProvider metrics.Provider) (blockledger.Factory, error) {
 	ld := conf.FileLedger.Location
-	var err error
 	if ld == "" {
-		if ld, err = ioutil.TempDir("", conf.FileLedger.Prefix); err != nil {
-			logger.Panic("Error creating temp dir:", err)
-		}
+		logger.Panic("Orderer.FileLedger.Location must be set")
 	}
 
 	logger.Debug("Ledger dir:", ld)
 	lf, err := fileledger.New(ld, metricsProvider)
 	if err != nil {
-		return nil, "", errors.WithMessage(err, "Error in opening ledger factory")
+		return nil, errors.WithMessage(err, "Error in opening ledger factory")
 	}
-	return lf, ld, nil
+	return lf, nil
 }

--- a/orderer/common/server/util_test.go
+++ b/orderer/common/server/util_test.go
@@ -21,13 +21,20 @@ func TestCreateLedgerFactory(t *testing.T) {
 	cleanup := configtest.SetDevFabricConfigPath(t)
 	defer cleanup()
 	testCases := []struct {
-		name            string
-		ledgerDir       string
-		ledgerDirPrefix string
-		expectPanic     bool
+		name        string
+		ledgerDir   string
+		expectPanic bool
 	}{
-		{"FilewithPathSet", filepath.Join(os.TempDir(), "test-dir"), "", false},
-		{"FilewithPathUnset", "", "test-prefix", false},
+		{
+			name:        "PathSet",
+			ledgerDir:   filepath.Join(os.TempDir(), "test-dir"),
+			expectPanic: false,
+		},
+		{
+			name:        "PathUnset",
+			ledgerDir:   "",
+			expectPanic: true,
+		},
 	}
 
 	conf, err := config.Load()
@@ -37,27 +44,15 @@ func TestCreateLedgerFactory(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer func() {
-				r := recover()
-				if tc.expectPanic && r == nil {
-					t.Fatal("Should have panicked")
-				}
-				if !tc.expectPanic && r != nil {
-					t.Fatal("Should not have panicked")
-				}
-			}()
-
 			conf.FileLedger.Location = tc.ledgerDir
-			conf.FileLedger.Prefix = tc.ledgerDirPrefix
-			lf, ld, err := createLedgerFactory(conf, &disabled.Provider{})
-			require.NoError(t, err)
-			defer func() {
-				if ld != "" {
-					os.RemoveAll(ld)
-					t.Log("Removed temp dir:", ld)
-				}
-			}()
-			lf.ChannelIDs()
+			if tc.expectPanic {
+				require.PanicsWithValue(t, "Orderer.FileLedger.Location must be set", func() { createLedgerFactory(conf, &disabled.Provider{}) })
+			} else {
+				lf, err := createLedgerFactory(conf, &disabled.Provider{})
+				require.NoError(t, err)
+				defer os.RemoveAll(tc.ledgerDir)
+				require.Equal(t, []string{}, lf.ChannelIDs())
+			}
 		})
 	}
 }

--- a/orderer/consensus/etcdraft/validator_test.go
+++ b/orderer/consensus/etcdraft/validator_test.go
@@ -8,6 +8,7 @@ package etcdraft_test
 
 import (
 	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -75,6 +76,10 @@ var _ = Describe("Metadata Validation", func() {
 		c.init()
 		chain = c.Chain
 		chain.ActiveNodes.Store([]uint64{1, 2, 3})
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(dataDir)
 	})
 
 	When("determining parameter well-formedness", func() {

--- a/sampleconfig/orderer.yaml
+++ b/sampleconfig/orderer.yaml
@@ -148,19 +148,13 @@ General:
 #
 #   SECTION: File Ledger
 #
-#   - This section applies to the configuration of the file or json ledgers.
+#   - This section applies to the configuration of the file ledger.
 #
 ################################################################################
 FileLedger:
 
     # Location: The directory to store the blocks in.
-    # NOTE: If this is unset, a new temporary location will be chosen every time
-    # the orderer is restarted, using the prefix specified by Prefix.
     Location: /var/hyperledger/production/orderer
-
-    # The prefix to use when generating a ledger directory in temporary space.
-    # Otherwise, this value is ignored.
-    Prefix: hyperledger-fabric-ordererledger
 
 ################################################################################
 #


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

The orderer currently allows starting with a configuration that does not specify the Orderer.FileLedger.Location. When this occurs, the orderer uses the Orderer.FileLedger.Prefix and creates a temporary directory using this prefix. In order to handle crash fault tolerance, the orderer needs a configured directory and should not generate a temporary directory. The orderer now panics if a location is not provided.

#### Related issues

[FAB-18066](https://jira.hyperledger.org/browse/FAB-18066)

#### Release Note
Orderer.FileLedger.Location must now be set. The orderer will panic if it is not.

