### PR TITLE
Clarify private data policy doc

### DIFF
--- a/docs/source/private-data-arch.rst
+++ b/docs/source/private-data-arch.rst
@@ -28,15 +28,21 @@ Collection definitions are composed of the following properties:
 * ``name``: Name of the collection.
 
 * ``policy``: The private data collection distribution policy defines which
-  organizations' peers are allowed to persist the collection data expressed using
+  organizations' peers are allowed to retrieve and persist the collection data expressed using
   the ``Signature`` policy syntax, with each member being included in an ``OR``
   signature policy list. To support read/write transactions, the private data
-  distribution policy must define a broader set of organizations than the chaincode
+  distribution policy must define a broader set of organizations than the
   endorsement policy, as peers must have the private data in order to endorse
   proposed transactions. For example, in a channel with ten organizations,
   five of the organizations might be included in a private data collection
   distribution policy, but the endorsement policy might call for any three
-  of the organizations to endorse.
+  of the organizations in the channel to endorse a read/write transaction.
+  For write-only transactions, organizations that are not members of the
+  collection distribution policy but are included in the chaincode level
+  endorsement policy may endorse transactions that write to the private data
+  collection. If this is not desirable, utilize a collection level
+  ``endorsementPolicy`` to restrict the set of allowed endorsers to the private data
+  distribution policy members.
 
 * ``requiredPeerCount``: Minimum number of peers (across authorized organizations)
   that each endorsing peer must successfully disseminate private data to before the


### PR DESCRIPTION
Clarify that private data collection non-member peers may
endorse writes to private data collections, and to
utilize collection level endorsement policy if this
is not desirable.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
