### PR TITLE
Update AZP Comment Trigger Workflow

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
     - name: Trigger Build
       run: |
-        author=$(jq -r ".issue.user.login" "${GITHUB_EVENT_PATH}")
-        commenter=$(jq -r ".comment.user.login" "${GITHUB_EVENT_PATH}")
         org=$(jq -r ".repository.owner.login" "${GITHUB_EVENT_PATH}")
         pr_number=$(jq -r ".issue.number" "${GITHUB_EVENT_PATH}")
         project=$(jq -r ".repository.name" "${GITHUB_EVENT_PATH}")
@@ -25,23 +23,16 @@ jobs:
         pr_url="https://api.github.com/repos/${repo}/pulls/${pr_number}"
 
         pr_resp=$(curl "${pr_url}")
-        isReviewer=$(echo "${pr_resp}" | jq -r .requested_reviewers | jq -c ".[] | select(.login | contains(\"${commenter}\"))" | wc -l)
+        sha=$(echo "${pr_resp}" | jq -r ".head.sha")
 
-        if [[ "${commenter}" = "${author}" ]] || [[ "${isReviewer}" -ne 0 ]]; then
-          sha=$(echo "${pr_resp}" | jq -r ".head.sha")
-
-          az extension add --name azure-devops
-          echo ${AZP_TOKEN} | az devops login --organization "https://dev.azure.com/${org}"
-
-          runs=$(az pipelines build list --project ${project} | jq -c ".[] | select(.sourceVersion | contains(\"${sha}\"))" | jq -r .status | grep -v completed | wc -l)
-          if [[ $runs -eq 0 ]]; then
-            az pipelines build queue --branch refs/pull/${pr_number}/merge --commit-id ${sha} --project ${project} --definition-name Pull-Request
-            curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d '{"body": "AZP build triggered!"}' "${comment_url}"
-          else
-            curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d '{"body": "AZP build already running!"}' "${comment_url}"
-          fi
+        az extension add --name azure-devops
+        echo ${AZP_TOKEN} | az devops login --organization "https://dev.azure.com/${org}"
+        runs=$(az pipelines build list --project ${project} | jq -c ".[] | select(.sourceVersion | contains(\"${sha}\"))" | jq -r .status | grep -v completed | wc -l)
+        if [[ $runs -eq 0 ]]; then
+          az pipelines build queue --branch refs/pull/${pr_number}/merge --commit-id ${sha} --project ${project} --definition-name Pull-Request
+          curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d '{"body": "AZP build triggered!"}' "${comment_url}"
         else
-          curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d '{"body": "You are not authorized to trigger builds for this pull request!"}' "${comment_url}"
+          curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d '{"body": "AZP build already running!"}' "${comment_url}"
         fi
       env:
         AZP_TOKEN: ${{ secrets.AZP_TOKEN }}


### PR DESCRIPTION
The existing implementation relied on the ability
to parse the assigned reviewers and compare them
to the commenter which is no longer available.
Instead we just remove this requirement since we
have a check to not start additional pipelines
if one is already running.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
