### PR TITLE
Fix: Missing addToWallet.js in ls command output

### DIFF
--- a/docs/source/tutorial/commercial_paper.md
+++ b/docs/source/tutorial/commercial_paper.md
@@ -606,7 +606,7 @@ separate terminal window for her, and in `fabric-samples` locate the MagnetoCorp
 (isabella)$ cd commercial-paper/organization/magnetocorp/application/
 (isabella)$ ls
 
-enrollUser.js		issue.js		package.json
+addToWallet.js		enrollUser.js		issue.js		package.json
 ```
 
 `addToWallet.js` is the program that Isabella is going to use to load her


### PR DESCRIPTION
### Fix: Missing addToWallet.js in ls command output

#### Type of change

- Documentation update

#### Description

`addToWallet.js` is being specified as being present in that folder but the output of the ls command doesn't list that file along with the other files.

<img width="722" alt="Screenshot 2020-07-22 at 10 10 53 PM" src="https://user-images.githubusercontent.com/36922376/88203961-37059800-cc68-11ea-86e5-6a941b5f802f.png">