### PR TITLE
Stop pulling Builder and Runtime Images

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -104,12 +104,8 @@ pullDockerImages() {
     if [ "${NODOCKER}" == 0 ]; then
         FABRIC_IMAGES=(peer orderer ccenv tools)
         case "$VERSION" in
-        1.*)
-            FABRIC_IMAGES+=(javaenv)
-            shift
-            ;;
         2.*)
-            FABRIC_IMAGES+=(nodeenv baseos javaenv)
+            FABRIC_IMAGES+=(baseos)
             shift
             ;;
         esac


### PR DESCRIPTION
Since Builder and Runtime images now diverge
on versions, we will allow the the Peer
to pull them at runtime using the tag set in
core.yaml

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
