### PR TITLE
Update AZP --definition-name Flag With Current Pipeline Name

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -29,7 +29,7 @@ jobs:
         echo ${AZP_TOKEN} | az devops login --organization "https://dev.azure.com/${org}"
         runs=$(az pipelines build list --project ${project} | jq -c ".[] | select(.sourceVersion | contains(\"${sha}\"))" | jq -r .status | grep -v completed | wc -l)
         if [[ $runs -eq 0 ]]; then
-          az pipelines build queue --branch refs/pull/${pr_number}/merge --commit-id ${sha} --project ${project} --definition-name Pull-Request
+          az pipelines build queue --branch refs/pull/${pr_number}/merge --commit-id ${sha} --project ${project} --definition-name Fabric-Pull-Request
           curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d '{"body": "AZP build triggered!"}' "${comment_url}"
         else
           curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d '{"body": "AZP build already running!"}' "${comment_url}"


### PR DESCRIPTION
The pipeline added `Fabric` to its name to differentiate with other Pipelines. This was missed in the previous PR because this code can't actually be tested in my own personal repo because it targets my AZP org, rather than the Hyperledger AZP org. 

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
