### PR TITLE
Keep Orderer.FileLedger.Prefix in orderer localconfig

### DIFF
--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -110,6 +110,7 @@ type Profile struct {
 // FileLedger contains configuration for the file-based ledger.
 type FileLedger struct {
 	Location string
+	Prefix   string // For compatibility only. This setting is no longer supported.
 }
 
 // Kafka contains configuration for the Kafka-based orderer.


### PR DESCRIPTION

#### Type of change

- Bug fix

#### Description

This setting is no longer supported but, without it in the localconfig, existing orderer YAML files won't work and the orderer won't start.

#### Related issues

[FAB-18101](https://jira.hyperledger.org/browse/FAB-18101)