### PR TITLE
[FAB-17906] Stop snapshot mgmt goroutine and close channels when ledger is closed

### DIFF
--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -769,10 +769,14 @@ func (l *kvLedger) GetMissingPvtDataTracker() (ledger.MissingPvtDataTracker, err
 	return l, nil
 }
 
-// Close closes `KVLedger`
+// Close closes `KVLedger`.
+// Currently this function is only used by test code. The caller should make sure no in-progress commit
+// or snapshot generation before calling this function. Otherwise, the ledger may have unknown behavior
+// and cause panic.
 func (l *kvLedger) Close() {
 	l.blockStore.Shutdown()
 	l.txmgr.Shutdown()
+	l.snapshotMgr.shutdown()
 }
 
 type blocksItr struct {


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- New feature

#### Description
Implement a snapshotMgr.shutdown function to stop process event goroutine
and close channels.  Call this function when the ledger is closed.

#### Additional details

#### Related issues
https://jira.hyperledger.org/browse/FAB-17906
