### PR TITLE
fix glossary.rst by reverting commit 21fa6480b161

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -25,7 +25,7 @@ For example, let's assume we have three organizations --- ``A``, ``B``, ``C`` --
 and a single anchor peer --- ``peer0.orgC`` --- defined for organization ``C``.
 When ``peer1.orgA`` (from organization ``A``) contacts ``peer0.orgC``, it will
 tell ``peer0.orgC`` about ``peer0.orgA``. And when at a later time ``peer1.orgB``
-contacts ``peer0.orgC``, the latter would tell the former about ``peer0.orgB``.
+contacts ``peer0.orgC``, the latter would tell the former about ``peer0.orgA``.
 From that point forward, organizations ``A`` and ``B`` would start exchanging
 membership information directly without any assistance from ``peer0.orgC``.
 


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Commit 21fa6480b161 converted the sentence "the latter would tell the
former about ``peer0.orgA``".  But this paragraph explains with example
that the info about peer0.orgA is transferred to peer1.orgB (referred to
as "the former") via peer0.orgC (referred to as "the latter").  So the
original text is totally correct. Let's revert the commit.

Signed-off-by: Naoya Horiguchi <naoya.horiguchi@nec.com>
