### PR TITLE
Reuse PKCS11 objects for keys

### DIFF
--- a/bccsp/pkcs11/ecdsa.go
+++ b/bccsp/pkcs11/ecdsa.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hyperledger/fabric/bccsp/utils"
 )
 
-func (csp *impl) signECDSA(k ecdsaPrivateKey, digest []byte, opts bccsp.SignerOpts) ([]byte, error) {
-	r, s, err := csp.signP11ECDSA(k.ski, digest)
+func (csp *impl) signECDSA(k *ecdsaPrivateKey, digest []byte, opts bccsp.SignerOpts) ([]byte, error) {
+	r, s, err := csp.signP11ECDSA(k.handle, digest)
 	if err != nil {
 		return nil, err
 	}
@@ -46,6 +46,6 @@ func (csp *impl) verifyECDSA(k ecdsaPublicKey, signature, digest []byte, opts bc
 	if csp.softVerify {
 		return ecdsa.Verify(k.pub, digest, r, s), nil
 	}
-	return csp.verifyP11ECDSA(k.ski, digest, r, s, k.pub.Curve.Params().BitSize/8)
+	return csp.verifyP11ECDSA(k.handle, digest, r, s, k.pub.Curve.Params().BitSize/8)
 
 }

--- a/bccsp/pkcs11/ecdsakey.go
+++ b/bccsp/pkcs11/ecdsakey.go
@@ -21,12 +21,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/miekg/pkcs11"
+
 	"github.com/hyperledger/fabric/bccsp"
 )
 
 type ecdsaPrivateKey struct {
-	ski []byte
-	pub ecdsaPublicKey
+	ski    []byte
+	pub    ecdsaPublicKey
+	handle pkcs11.ObjectHandle
 }
 
 // Bytes converts this key to its byte representation,
@@ -59,8 +62,9 @@ func (k *ecdsaPrivateKey) PublicKey() (bccsp.Key, error) {
 }
 
 type ecdsaPublicKey struct {
-	ski []byte
-	pub *ecdsa.PublicKey
+	ski    []byte
+	pub    *ecdsa.PublicKey
+	handle pkcs11.ObjectHandle
 }
 
 // Bytes converts this key to its byte representation,

--- a/bccsp/pkcs11/impl.go
+++ b/bccsp/pkcs11/impl.go
@@ -94,27 +94,51 @@ func (csp *impl) KeyGen(opts bccsp.KeyGenOpts) (k bccsp.Key, err error) {
 	// Parse algorithm
 	switch opts.(type) {
 	case *bccsp.ECDSAKeyGenOpts:
-		ski, pub, err := csp.generateECKey(csp.conf.ellipticCurve, opts.Ephemeral())
+		ski, privHandle, pubHandle, pubKey, err := csp.generateECKey(csp.conf.ellipticCurve, opts.Ephemeral())
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed generating ECDSA key")
 		}
-		k = &ecdsaPrivateKey{ski, ecdsaPublicKey{ski, pub}}
+		k = &ecdsaPrivateKey{
+			ski: ski,
+			pub: ecdsaPublicKey{
+				ski:    ski,
+				pub:    pubKey,
+				handle: pubHandle,
+			},
+			handle: privHandle,
+		}
 
 	case *bccsp.ECDSAP256KeyGenOpts:
-		ski, pub, err := csp.generateECKey(oidNamedCurveP256, opts.Ephemeral())
+		ski, privHandle, pubHandle, pubKey, err := csp.generateECKey(oidNamedCurveP256, opts.Ephemeral())
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed generating ECDSA P256 key")
 		}
 
-		k = &ecdsaPrivateKey{ski, ecdsaPublicKey{ski, pub}}
+		k = &ecdsaPrivateKey{
+			ski: ski,
+			pub: ecdsaPublicKey{
+				ski:    ski,
+				pub:    pubKey,
+				handle: pubHandle,
+			},
+			handle: privHandle,
+		}
 
 	case *bccsp.ECDSAP384KeyGenOpts:
-		ski, pub, err := csp.generateECKey(oidNamedCurveP384, opts.Ephemeral())
+		ski, privHandle, pubHandle, pubKey, err := csp.generateECKey(oidNamedCurveP384, opts.Ephemeral())
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed generating ECDSA P384 key")
 		}
 
-		k = &ecdsaPrivateKey{ski, ecdsaPublicKey{ski, pub}}
+		k = &ecdsaPrivateKey{
+			ski: ski,
+			pub: ecdsaPublicKey{
+				ski:    ski,
+				pub:    pubKey,
+				handle: pubHandle,
+			},
+			handle: privHandle,
+		}
 
 	default:
 		return csp.BCCSP.KeyGen(opts)
@@ -161,15 +185,28 @@ func (csp *impl) KeyImport(raw interface{}, opts bccsp.KeyImportOpts) (k bccsp.K
 // GetKey returns the key this CSP associates to
 // the Subject Key Identifier ski.
 func (csp *impl) GetKey(ski []byte) (bccsp.Key, error) {
-	pubKey, isPriv, err := csp.getECKey(ski)
+	privHandle, pubHandle, pubKey, err := csp.getECKey(ski)
 	if err != nil {
 		logger.Warnf("Key not found using PKCS11: %v", err)
 		return csp.BCCSP.GetKey(ski)
 	}
-	if isPriv {
-		return &ecdsaPrivateKey{ski, ecdsaPublicKey{ski, pubKey}}, nil
+	if privHandle > 0 {
+		return &ecdsaPrivateKey{
+				ski: ski,
+				pub: ecdsaPublicKey{
+					ski:    ski,
+					pub:    pubKey,
+					handle: pubHandle,
+				},
+				handle: privHandle,
+			},
+			nil
 	}
-	return &ecdsaPublicKey{ski, pubKey}, nil
+	return &ecdsaPublicKey{
+		ski:    ski,
+		pub:    pubKey,
+		handle: pubHandle,
+	}, nil
 }
 
 // Sign signs digest using key k.
@@ -190,7 +227,7 @@ func (csp *impl) Sign(k bccsp.Key, digest []byte, opts bccsp.SignerOpts) ([]byte
 	// Check key type
 	switch key := k.(type) {
 	case *ecdsaPrivateKey:
-		return csp.signECDSA(*key, digest, opts)
+		return csp.signECDSA(key, digest, opts)
 	default:
 		return csp.BCCSP.Sign(key, digest, opts)
 	}

--- a/bccsp/pkcs11/impl_test.go
+++ b/bccsp/pkcs11/impl_test.go
@@ -946,7 +946,7 @@ func TestECDSALowS(t *testing.T) {
 
 	// Ensure that signature with high-S are rejected.
 	for {
-		R, S, err = currentBCCSP.(*impl).signP11ECDSA(k.SKI(), digest)
+		R, S, err = currentBCCSP.(*impl).signP11ECDSA(k.(*ecdsaPrivateKey).handle, digest)
 		if err != nil {
 			t.Fatalf("Failed generating signature [%s]", err)
 		}

--- a/bccsp/pkcs11/pkcs11.go
+++ b/bccsp/pkcs11/pkcs11.go
@@ -120,48 +120,46 @@ func (csp *impl) returnSession(session pkcs11.SessionHandle) {
 }
 
 // Look for an EC key by SKI, stored in CKA_ID
-func (csp *impl) getECKey(ski []byte) (pubKey *ecdsa.PublicKey, isPriv bool, err error) {
+func (csp *impl) getECKey(ski []byte) (privHandle, pubHandle pkcs11.ObjectHandle, pubKey *ecdsa.PublicKey, err error) {
 	p11lib := csp.ctx
 	session, err := csp.getSession()
 	if err != nil {
-		return nil, false, err
+		return privHandle, pubHandle, nil, err
 	}
 	defer csp.returnSession(session)
 
-	isPriv = true
-	_, err = findKeyPairFromSKI(p11lib, session, ski, privateKeyType)
+	privHandle, err = findKeyPairFromSKI(p11lib, session, ski, privateKeyType)
 	if err != nil {
-		isPriv = false
 		logger.Debugf("Private key not found [%s] for SKI [%s], looking for Public key", err, hex.EncodeToString(ski))
 	}
 
-	publicKey, err := findKeyPairFromSKI(p11lib, session, ski, publicKeyType)
+	pubHandle, err = findKeyPairFromSKI(p11lib, session, ski, publicKeyType)
 	if err != nil {
-		return nil, false, fmt.Errorf("public key not found [%s] for SKI [%s]", err, hex.EncodeToString(ski))
+		return privHandle, pubHandle, nil, fmt.Errorf("public key not found [%s] for SKI [%s]", err, hex.EncodeToString(ski))
 	}
 
-	ecpt, marshaledOid, err := ecPoint(p11lib, session, *publicKey)
+	ecpt, marshaledOid, err := ecPoint(p11lib, session, pubHandle)
 	if err != nil {
-		return nil, false, fmt.Errorf("public key not found [%s] for SKI [%s]", err, hex.EncodeToString(ski))
+		return privHandle, pubHandle, nil, fmt.Errorf("public key not found [%s] for SKI [%s]", err, hex.EncodeToString(ski))
 	}
 
 	curveOid := new(asn1.ObjectIdentifier)
 	_, err = asn1.Unmarshal(marshaledOid, curveOid)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed Unmarshaling Curve OID [%s]\n%s", err.Error(), hex.EncodeToString(marshaledOid))
+		return privHandle, pubHandle, nil, fmt.Errorf("failed Unmarshaling Curve OID [%s]\n%s", err.Error(), hex.EncodeToString(marshaledOid))
 	}
 
 	curve := namedCurveFromOID(*curveOid)
 	if curve == nil {
-		return nil, false, fmt.Errorf("could not recognize Curve from OID")
+		return privHandle, pubHandle, nil, fmt.Errorf("could not recognize Curve from OID")
 	}
 	x, y := elliptic.Unmarshal(curve, ecpt)
 	if x == nil {
-		return nil, false, fmt.Errorf("failed Unmarshaling Public Key")
+		return privHandle, pubHandle, nil, fmt.Errorf("failed Unmarshaling Public Key")
 	}
 
 	pubKey = &ecdsa.PublicKey{Curve: curve, X: x, Y: y}
-	return pubKey, isPriv, nil
+	return privHandle, pubHandle, pubKey, nil
 }
 
 // RFC 5480, 2.1.1.1. Named Curve
@@ -200,11 +198,17 @@ func namedCurveFromOID(oid asn1.ObjectIdentifier) elliptic.Curve {
 	return nil
 }
 
-func (csp *impl) generateECKey(curve asn1.ObjectIdentifier, ephemeral bool) (ski []byte, pubKey *ecdsa.PublicKey, err error) {
+func (csp *impl) generateECKey(curve asn1.ObjectIdentifier, ephemeral bool) (
+	ski []byte,
+	privHandle,
+	pubHandle pkcs11.ObjectHandle,
+	pubKey *ecdsa.PublicKey,
+	err error,
+) {
 	p11lib := csp.ctx
 	session, err := csp.getSession()
 	if err != nil {
-		return nil, nil, err
+		return nil, privHandle, pubHandle, nil, err
 	}
 	defer csp.returnSession(session)
 
@@ -214,7 +218,7 @@ func (csp *impl) generateECKey(curve asn1.ObjectIdentifier, ephemeral bool) (ski
 
 	marshaledOID, err := asn1.Marshal(curve)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Could not marshal OID [%s]", err.Error())
+		return nil, privHandle, pubHandle, nil, fmt.Errorf("Could not marshal OID [%s]", err.Error())
 	}
 
 	pubkeyT := []*pkcs11.Attribute{
@@ -242,17 +246,20 @@ func (csp *impl) generateECKey(curve asn1.ObjectIdentifier, ephemeral bool) (ski
 		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, true),
 	}
 
-	pub, prv, err := p11lib.GenerateKeyPair(session,
+	pubHandle, privHandle, err = p11lib.GenerateKeyPair(
+		session,
 		[]*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_EC_KEY_PAIR_GEN, nil)},
-		pubkeyT, prvkeyT)
+		pubkeyT,
+		prvkeyT,
+	)
 
 	if err != nil {
-		return nil, nil, fmt.Errorf("P11: keypair generate failed [%s]", err)
+		return nil, privHandle, pubHandle, nil, fmt.Errorf("P11: keypair generate failed [%s]", err)
 	}
 
-	ecpt, _, err := ecPoint(p11lib, session, pub)
+	ecpt, _, err := ecPoint(p11lib, session, pubHandle)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Error querying EC-point: [%s]", err)
+		return nil, privHandle, pubHandle, nil, fmt.Errorf("Error querying EC-point: [%s]", err)
 	}
 	hash := sha256.Sum256(ecpt)
 	ski = hash[:]
@@ -264,14 +271,14 @@ func (csp *impl) generateECKey(curve asn1.ObjectIdentifier, ephemeral bool) (ski
 	}
 
 	logger.Infof("Generated new P11 key, SKI %x\n", ski)
-	err = p11lib.SetAttributeValue(session, pub, setskiT)
+	err = p11lib.SetAttributeValue(session, pubHandle, setskiT)
 	if err != nil {
-		return nil, nil, fmt.Errorf("P11: set-ID-to-SKI[public] failed [%s]", err)
+		return nil, privHandle, pubHandle, nil, fmt.Errorf("P11: set-ID-to-SKI[public] failed [%s]", err)
 	}
 
-	err = p11lib.SetAttributeValue(session, prv, setskiT)
+	err = p11lib.SetAttributeValue(session, privHandle, setskiT)
 	if err != nil {
-		return nil, nil, fmt.Errorf("P11: set-ID-to-SKI[private] failed [%s]", err)
+		return nil, privHandle, pubHandle, nil, fmt.Errorf("P11: set-ID-to-SKI[private] failed [%s]", err)
 	}
 
 	//Set CKA_Modifible to false for both public key and private keys
@@ -280,46 +287,46 @@ func (csp *impl) generateECKey(curve asn1.ObjectIdentifier, ephemeral bool) (ski
 			pkcs11.NewAttribute(pkcs11.CKA_MODIFIABLE, false),
 		}
 
-		_, pubCopyerror := p11lib.CopyObject(session, pub, setCKAModifiable)
+		pubHandle, pubCopyerror := p11lib.CopyObject(session, pubHandle, setCKAModifiable)
 		if pubCopyerror != nil {
-			return nil, nil, fmt.Errorf("P11: Public Key copy failed with error [%s] . Please contact your HSM vendor", pubCopyerror)
+			return nil, privHandle, pubHandle, nil, fmt.Errorf("P11: Public Key copy failed with error [%s] . Please contact your HSM vendor", pubCopyerror)
 		}
 
-		pubKeyDestroyError := p11lib.DestroyObject(session, pub)
+		pubKeyDestroyError := p11lib.DestroyObject(session, pubHandle)
 		if pubKeyDestroyError != nil {
-			return nil, nil, fmt.Errorf("P11: Public Key destroy failed with error [%s]. Please contact your HSM vendor", pubCopyerror)
+			return nil, privHandle, pubHandle, nil, fmt.Errorf("P11: Public Key destroy failed with error [%s]. Please contact your HSM vendor", pubCopyerror)
 		}
 
-		_, prvCopyerror := p11lib.CopyObject(session, prv, setCKAModifiable)
+		privHandle, prvCopyerror := p11lib.CopyObject(session, privHandle, setCKAModifiable)
 		if prvCopyerror != nil {
-			return nil, nil, fmt.Errorf("P11: Private Key copy failed with error [%s]. Please contact your HSM vendor", prvCopyerror)
+			return nil, privHandle, pubHandle, nil, fmt.Errorf("P11: Private Key copy failed with error [%s]. Please contact your HSM vendor", prvCopyerror)
 		}
-		prvKeyDestroyError := p11lib.DestroyObject(session, prv)
+		prvKeyDestroyError := p11lib.DestroyObject(session, privHandle)
 		if pubKeyDestroyError != nil {
-			return nil, nil, fmt.Errorf("P11: Private Key destroy failed with error [%s]. Please contact your HSM vendor", prvKeyDestroyError)
+			return nil, privHandle, pubHandle, nil, fmt.Errorf("P11: Private Key destroy failed with error [%s]. Please contact your HSM vendor", prvKeyDestroyError)
 		}
 	}
 
 	nistCurve := namedCurveFromOID(curve)
 	if curve == nil {
-		return nil, nil, fmt.Errorf("Cound not recognize Curve from OID")
+		return nil, privHandle, pubHandle, nil, fmt.Errorf("Cound not recognize Curve from OID")
 	}
 	x, y := elliptic.Unmarshal(nistCurve, ecpt)
 	if x == nil {
-		return nil, nil, fmt.Errorf("Failed Unmarshaling Public Key")
+		return nil, privHandle, pubHandle, nil, fmt.Errorf("Failed Unmarshaling Public Key")
 	}
 
 	pubGoKey := &ecdsa.PublicKey{Curve: nistCurve, X: x, Y: y}
 
 	if logger.IsEnabledFor(zapcore.DebugLevel) {
-		listAttrs(p11lib, session, prv)
-		listAttrs(p11lib, session, pub)
+		listAttrs(p11lib, session, privHandle)
+		listAttrs(p11lib, session, pubHandle)
 	}
 
-	return ski, pubGoKey, nil
+	return ski, privHandle, pubHandle, pubGoKey, nil
 }
 
-func (csp *impl) signP11ECDSA(ski []byte, msg []byte) (R, S *big.Int, err error) {
+func (csp *impl) signP11ECDSA(handle pkcs11.ObjectHandle, msg []byte) (R, S *big.Int, err error) {
 	p11lib := csp.ctx
 	session, err := csp.getSession()
 	if err != nil {
@@ -327,12 +334,11 @@ func (csp *impl) signP11ECDSA(ski []byte, msg []byte) (R, S *big.Int, err error)
 	}
 	defer csp.returnSession(session)
 
-	privateKey, err := findKeyPairFromSKI(p11lib, session, ski, privateKeyType)
-	if err != nil {
-		return nil, nil, fmt.Errorf("Private key not found [%s]", err)
-	}
-
-	err = p11lib.SignInit(session, []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_ECDSA, nil)}, *privateKey)
+	err = p11lib.SignInit(
+		session,
+		[]*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_ECDSA, nil)},
+		handle,
+	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Sign-initialize  failed [%s]", err)
 	}
@@ -352,7 +358,7 @@ func (csp *impl) signP11ECDSA(ski []byte, msg []byte) (R, S *big.Int, err error)
 	return R, S, nil
 }
 
-func (csp *impl) verifyP11ECDSA(ski []byte, msg []byte, R, S *big.Int, byteSize int) (bool, error) {
+func (csp *impl) verifyP11ECDSA(handle pkcs11.ObjectHandle, msg []byte, R, S *big.Int, byteSize int) (bool, error) {
 	p11lib := csp.ctx
 	session, err := csp.getSession()
 	if err != nil {
@@ -362,11 +368,6 @@ func (csp *impl) verifyP11ECDSA(ski []byte, msg []byte, R, S *big.Int, byteSize 
 
 	logger.Debugf("Verify ECDSA\n")
 
-	publicKey, err := findKeyPairFromSKI(p11lib, session, ski, publicKeyType)
-	if err != nil {
-		return false, fmt.Errorf("Public key not found [%s]", err)
-	}
-
 	r := R.Bytes()
 	s := S.Bytes()
 
@@ -375,8 +376,13 @@ func (csp *impl) verifyP11ECDSA(ski []byte, msg []byte, R, S *big.Int, byteSize 
 	copy(sig[byteSize-len(r):byteSize], r)
 	copy(sig[2*byteSize-len(s):], s)
 
-	err = p11lib.VerifyInit(session, []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_ECDSA, nil)},
-		*publicKey)
+	err = p11lib.VerifyInit(
+		session,
+		[]*pkcs11.Mechanism{
+			pkcs11.NewMechanism(pkcs11.CKM_ECDSA, nil),
+		},
+		handle,
+	)
 	if err != nil {
 		return false, fmt.Errorf("PKCS11: Verify-initialize [%s]", err)
 	}
@@ -398,7 +404,12 @@ const (
 	privateKeyType
 )
 
-func findKeyPairFromSKI(mod *pkcs11.Ctx, session pkcs11.SessionHandle, ski []byte, keyType keyType) (*pkcs11.ObjectHandle, error) {
+func findKeyPairFromSKI(
+	mod *pkcs11.Ctx,
+	session pkcs11.SessionHandle,
+	ski []byte,
+	keyType keyType,
+) (pkcs11.ObjectHandle, error) {
 	ktype := pkcs11.CKO_PUBLIC_KEY
 	if keyType == privateKeyType {
 		ktype = pkcs11.CKO_PRIVATE_KEY
@@ -409,23 +420,23 @@ func findKeyPairFromSKI(mod *pkcs11.Ctx, session pkcs11.SessionHandle, ski []byt
 		pkcs11.NewAttribute(pkcs11.CKA_ID, ski),
 	}
 	if err := mod.FindObjectsInit(session, template); err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	// single session instance, assume one hit only
 	objs, _, err := mod.FindObjects(session, 1)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	if err = mod.FindObjectsFinal(session); err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	if len(objs) == 0 {
-		return nil, fmt.Errorf("Key not found [%s]", hex.Dump(ski))
+		return 0, fmt.Errorf("Key not found [%s]", hex.Dump(ski))
 	}
 
-	return &objs[0], nil
+	return objs[0], nil
 }
 
 // Fairly straightforward EC-point query, other than opencryptoki

--- a/bccsp/pkcs11/pkcs11_test.go
+++ b/bccsp/pkcs11/pkcs11_test.go
@@ -123,22 +123,18 @@ func TestPKCS11ECKeySignVerify(t *testing.T) {
 		oid = oidNamedCurveP384
 	}
 
-	key, pubKey, err := currentBCCSP.(*impl).generateECKey(oid, true)
+	_, privHandle, pubHandle, pubKey, err := currentBCCSP.(*impl).generateECKey(oid, true)
 	if err != nil {
 		t.Fatalf("Failed generating Key [%s]", err)
 	}
 
-	R, S, err := currentBCCSP.(*impl).signP11ECDSA(key, hash1)
+	R, S, err := currentBCCSP.(*impl).signP11ECDSA(privHandle, hash1)
 
 	if err != nil {
 		t.Fatalf("Failed signing message [%s]", err)
 	}
 
-	_, _, err = currentBCCSP.(*impl).signP11ECDSA(nil, hash1)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "Private key not found")
-
-	pass, err := currentBCCSP.(*impl).verifyP11ECDSA(key, hash1, R, S, currentTestConfig.securityLevel/8)
+	pass, err := currentBCCSP.(*impl).verifyP11ECDSA(pubHandle, hash1, R, S, currentTestConfig.securityLevel/8)
 	if err != nil {
 		t.Fatalf("Error verifying message 1 [%s]", err)
 	}
@@ -151,7 +147,7 @@ func TestPKCS11ECKeySignVerify(t *testing.T) {
 		t.Fatal("Signature should match with software verification!")
 	}
 
-	pass, err = currentBCCSP.(*impl).verifyP11ECDSA(key, hash2, R, S, currentTestConfig.securityLevel/8)
+	pass, err = currentBCCSP.(*impl).verifyP11ECDSA(pubHandle, hash2, R, S, currentTestConfig.securityLevel/8)
 	if err != nil {
 		t.Fatalf("Error verifying message 2 [%s]", err)
 	}


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement

#### Description

Prior to this change, each invocation of Sign or
Verify actually made a PKCS11 call to find the
key object.  This is actually unnecessary as the
object handle is valid across multiple sessions.

This change adds a handle field to both the private
and public key objects and uses these handles across
multiple invocations of Sign and Verify for any given
key pair.

#### Additional details

This change should improve overall performance when using network HSMs as each Sign or Verify invocation now just make a single call to the HSM.