### PR TITLE
Revert "Reuse PKCS11 objects for keys (#1669)"

### DIFF
--- a/bccsp/pkcs11/ecdsa.go
+++ b/bccsp/pkcs11/ecdsa.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hyperledger/fabric/bccsp/utils"
 )
 
-func (csp *impl) signECDSA(k *ecdsaPrivateKey, digest []byte, opts bccsp.SignerOpts) ([]byte, error) {
-	r, s, err := csp.signP11ECDSA(k.handle, digest)
+func (csp *impl) signECDSA(k ecdsaPrivateKey, digest []byte, opts bccsp.SignerOpts) ([]byte, error) {
+	r, s, err := csp.signP11ECDSA(k.ski, digest)
 	if err != nil {
 		return nil, err
 	}
@@ -46,6 +46,6 @@ func (csp *impl) verifyECDSA(k ecdsaPublicKey, signature, digest []byte, opts bc
 	if csp.softVerify {
 		return ecdsa.Verify(k.pub, digest, r, s), nil
 	}
-	return csp.verifyP11ECDSA(k.handle, digest, r, s, k.pub.Curve.Params().BitSize/8)
+	return csp.verifyP11ECDSA(k.ski, digest, r, s, k.pub.Curve.Params().BitSize/8)
 
 }

--- a/bccsp/pkcs11/ecdsakey.go
+++ b/bccsp/pkcs11/ecdsakey.go
@@ -22,13 +22,11 @@ import (
 	"fmt"
 
 	"github.com/hyperledger/fabric/bccsp"
-	"github.com/miekg/pkcs11"
 )
 
 type ecdsaPrivateKey struct {
-	ski    []byte
-	pub    ecdsaPublicKey
-	handle pkcs11.ObjectHandle
+	ski []byte
+	pub ecdsaPublicKey
 }
 
 // Bytes converts this key to its byte representation,
@@ -61,9 +59,8 @@ func (k *ecdsaPrivateKey) PublicKey() (bccsp.Key, error) {
 }
 
 type ecdsaPublicKey struct {
-	ski    []byte
-	pub    *ecdsa.PublicKey
-	handle pkcs11.ObjectHandle
+	ski []byte
+	pub *ecdsa.PublicKey
 }
 
 // Bytes converts this key to its byte representation,

--- a/bccsp/pkcs11/impl_test.go
+++ b/bccsp/pkcs11/impl_test.go
@@ -946,7 +946,7 @@ func TestECDSALowS(t *testing.T) {
 
 	// Ensure that signature with high-S are rejected.
 	for {
-		R, S, err = currentBCCSP.(*impl).signP11ECDSA(k.(*ecdsaPrivateKey).handle, digest)
+		R, S, err = currentBCCSP.(*impl).signP11ECDSA(k.SKI(), digest)
 		if err != nil {
 			t.Fatalf("Failed generating signature [%s]", err)
 		}

--- a/bccsp/pkcs11/pkcs11_test.go
+++ b/bccsp/pkcs11/pkcs11_test.go
@@ -123,18 +123,22 @@ func TestPKCS11ECKeySignVerify(t *testing.T) {
 		oid = oidNamedCurveP384
 	}
 
-	_, privHandle, pubHandle, pubKey, err := currentBCCSP.(*impl).generateECKey(oid, true)
+	key, pubKey, err := currentBCCSP.(*impl).generateECKey(oid, true)
 	if err != nil {
 		t.Fatalf("Failed generating Key [%s]", err)
 	}
 
-	R, S, err := currentBCCSP.(*impl).signP11ECDSA(privHandle, hash1)
+	R, S, err := currentBCCSP.(*impl).signP11ECDSA(key, hash1)
 
 	if err != nil {
 		t.Fatalf("Failed signing message [%s]", err)
 	}
 
-	pass, err := currentBCCSP.(*impl).verifyP11ECDSA(pubHandle, hash1, R, S, currentTestConfig.securityLevel/8)
+	_, _, err = currentBCCSP.(*impl).signP11ECDSA(nil, hash1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Private key not found")
+
+	pass, err := currentBCCSP.(*impl).verifyP11ECDSA(key, hash1, R, S, currentTestConfig.securityLevel/8)
 	if err != nil {
 		t.Fatalf("Error verifying message 1 [%s]", err)
 	}
@@ -147,7 +151,7 @@ func TestPKCS11ECKeySignVerify(t *testing.T) {
 		t.Fatal("Signature should match with software verification!")
 	}
 
-	pass, err = currentBCCSP.(*impl).verifyP11ECDSA(pubHandle, hash2, R, S, currentTestConfig.securityLevel/8)
+	pass, err = currentBCCSP.(*impl).verifyP11ECDSA(key, hash2, R, S, currentTestConfig.securityLevel/8)
 	if err != nil {
 		t.Fatalf("Error verifying message 2 [%s]", err)
 	}


### PR DESCRIPTION
This reverts commit 9364c6fa98ad729f277e95c9fc4825c3261d1175.

See comments in #1670 for background on revert

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
