### PR TITLE
[FAB-18208] Do not sign gossip message if membership is empty

### DIFF
--- a/gossip/discovery/discovery_impl.go
+++ b/gossip/discovery/discovery_impl.go
@@ -232,16 +232,7 @@ func (d *gossipDiscoveryImpl) InitiateSync(peerNum int) {
 		return
 	}
 	var peers2SendTo []*NetworkMember
-	m, err := d.createMembershipRequest(true)
-	if err != nil {
-		d.logger.Warningf("Failed creating membership request: %+v", errors.WithStack(err))
-		return
-	}
-	memReq, err := m.NoopSign()
-	if err != nil {
-		d.logger.Warningf("Failed creating SignedGossipMessage: %+v", errors.WithStack(err))
-		return
-	}
+
 	d.lock.RLock()
 
 	n := d.aliveMembership.Size()
@@ -267,6 +258,22 @@ func (d *gossipDiscoveryImpl) InitiateSync(peerNum int) {
 	}
 
 	d.lock.RUnlock()
+
+	if len(peers2SendTo) == 0 {
+		d.logger.Debugf("No peers to send to, aborting membership sync")
+		return
+	}
+
+	m, err := d.createMembershipRequest(true)
+	if err != nil {
+		d.logger.Warningf("Failed creating membership request: %+v", errors.WithStack(err))
+		return
+	}
+	memReq, err := m.NoopSign()
+	if err != nil {
+		d.logger.Warningf("Failed creating SignedGossipMessage: %+v", errors.WithStack(err))
+		return
+	}
 
 	for _, netMember := range peers2SendTo {
 		d.comm.SendToPeer(netMember, memReq)
@@ -754,6 +761,10 @@ func (d *gossipDiscoveryImpl) periodicalSendAlive() {
 	for !d.toDie() {
 		d.logger.Debug("Sleeping", d.aliveTimeInterval)
 		time.Sleep(d.aliveTimeInterval)
+		if d.aliveMembership.Size() == 0 {
+			d.logger.Debugf("Empty membership, no one to send a heartbeat to")
+			continue
+		}
 		msg, err := d.createSignedAliveMessage(true)
 		if err != nil {
 			d.logger.Warningf("Failed creating alive message: %+v", errors.WithStack(err))

--- a/gossip/discovery/discovery_test.go
+++ b/gossip/discovery/discovery_test.go
@@ -102,6 +102,7 @@ type dummyCommModule struct {
 	shouldGossip      bool
 	disableComm       bool
 	mock              *mock.Mock
+	signCount         uint32
 }
 
 type gossipInstance struct {
@@ -138,6 +139,7 @@ func (comm *dummyCommModule) recordValidation(validatedMessages chan *proto.Sign
 }
 
 func (comm *dummyCommModule) SignMessage(am *proto.GossipMessage, internalEndpoint string) *proto.Envelope {
+	atomic.AddUint32(&comm.signCount, 1)
 	am.NoopSign()
 
 	secret := &proto.Secret{
@@ -561,6 +563,18 @@ func TestConnect(t *testing.T) {
 	for firstSentSelfMsg := range firstSentMemReqMsgs {
 		assert.Nil(t, firstSentSelfMsg.Envelope.SecretEnvelope)
 	}
+}
+
+func TestNoSigningIfNoMembership(t *testing.T) {
+	t.Parallel()
+
+	inst := createDiscoveryInstance(8931, "foreveralone", nil)
+	defer inst.Stop()
+	time.Sleep(defaultTestConfig.AliveTimeInterval * 10)
+	assert.Zero(t, atomic.LoadUint32(&inst.comm.signCount))
+
+	inst.InitiateSync(10000)
+	assert.Zero(t, atomic.LoadUint32(&inst.comm.signCount))
 }
 
 func TestValidation(t *testing.T) {
@@ -1587,22 +1601,27 @@ func TestMemRespDisclosurePol(t *testing.T) {
 	pol := func(remotePeer *NetworkMember) (Sieve, EnvelopeFilter) {
 		assert.Equal(t, remotePeer.InternalEndpoint, remotePeer.Endpoint)
 		return func(_ *proto.SignedGossipMessage) bool {
-				return remotePeer.Endpoint == "localhost:7880"
+				return remotePeer.Endpoint != "localhost:7879"
 			}, func(m *proto.SignedGossipMessage) *proto.Envelope {
 				return m.Envelope
 			}
 	}
+
+	wasMembershipResponseReceived := func(msg *proto.SignedGossipMessage) {
+		assert.Nil(t, msg.GetMemRes())
+	}
+
 	d1 := createDiscoveryInstanceThatGossips(7878, "d1", []string{}, true, pol, defaultTestConfig)
 	defer d1.Stop()
-	d2 := createDiscoveryInstanceThatGossips(7879, "d2", []string{"localhost:7878"}, true, noopPolicy, defaultTestConfig)
+	d2 := createDiscoveryInstanceThatGossipsWithInterceptors(7879, "d2", []string{"localhost:7878"}, true, noopPolicy, wasMembershipResponseReceived, defaultTestConfig)
 	defer d2.Stop()
-	d3 := createDiscoveryInstanceThatGossips(7880, "d3", []string{"localhost:7878"}, true, noopPolicy, defaultTestConfig)
+	d3 := createDiscoveryInstanceThatGossips(7880, "d3", []string{"localhost:7878"}, true, pol, defaultTestConfig)
 	defer d3.Stop()
-	// Both d1 and d3 know each other, and also about d2
-	assertMembership(t, []*gossipInstance{d1, d3}, 2)
-	// d2 doesn't know about any one because the bootstrap peer is ignoring it due to custom policy
-	assertMembership(t, []*gossipInstance{d2}, 0)
-	assert.Zero(t, d2.receivedMsgCount())
+
+	// all peers know each other
+	assertMembership(t, []*gossipInstance{d1, d2, d3}, 2)
+	// d2 received some messages, but we asserted that none of them are membership responses.
+	assert.NotZero(t, d2.receivedMsgCount())
 	assert.NotZero(t, d2.sentMsgCount())
 }
 

--- a/gossip/gossip/channel/channel_test.go
+++ b/gossip/gossip/channel/channel_test.go
@@ -185,10 +185,12 @@ func (m *receivedMsg) GetConnectionInfo() *proto.ConnectionInfo {
 }
 
 type gossipAdapterMock struct {
+	signCallCount uint32
 	mock.Mock
 }
 
 func (ga *gossipAdapterMock) Sign(msg *proto.GossipMessage) (*proto.SignedGossipMessage, error) {
+	atomic.AddUint32(&ga.signCallCount, 1)
 	return msg.NoopSign()
 }
 
@@ -211,7 +213,12 @@ func (ga *gossipAdapterMock) DeMultiplex(msg interface{}) {
 
 func (ga *gossipAdapterMock) GetMembership() []discovery.NetworkMember {
 	args := ga.Called()
-	members := args.Get(0).([]discovery.NetworkMember)
+	val := args.Get(0)
+	if f, isFunc := val.(func() []discovery.NetworkMember); isFunc {
+		return f()
+	}
+
+	members := val.([]discovery.NetworkMember)
 
 	return members
 }
@@ -354,6 +361,7 @@ func TestMsgStoreNotExpire(t *testing.T) {
 	// Receive StateInfo messages from other peers
 	gc.HandleMessage(&receivedMsg{PKIID: pkiID2, msg: createStateInfoMsg(1, pkiID2, channelA)})
 	gc.HandleMessage(&receivedMsg{PKIID: pkiID3, msg: createStateInfoMsg(1, pkiID3, channelA)})
+	time.Sleep(adapter.GetConf().PublishStateInfoInterval * 2)
 
 	simulateStateInfoRequest := func(pkiID []byte, outChan chan *proto.SignedGossipMessage) {
 		sentMessages := make(chan *proto.GossipMessage, 1)
@@ -497,8 +505,14 @@ func TestChannelPeriodicalPublishStateInfo(t *testing.T) {
 	cs := &cryptoService{}
 	cs.On("VerifyBlock", mock.Anything).Return(nil)
 
+	peerA := discovery.NetworkMember{
+		PKIid:            pkiIDInOrg1,
+		Endpoint:         "a",
+		InternalEndpoint: "a",
+	}
+
 	adapter := new(gossipAdapterMock)
-	configureAdapter(adapter)
+	configureAdapter(adapter, peerA)
 	adapter.On("Send", mock.Anything, mock.Anything)
 	adapter.On("Gossip", mock.Anything).Run(func(arg mock.Arguments) {
 		if atomic.LoadInt32(&receivedMsg) == int32(1) {
@@ -1082,6 +1096,55 @@ func TestChannelBadBlocks(t *testing.T) {
 	cs.On("VerifyBlock", mock.Anything).Return(errors.New("Bad signature"))
 	gc.HandleMessage(&receivedMsg{msg: createDataMsg(4, channelA), PKIID: pkiIDInOrg1})
 	assert.Len(t, receivedMessages, 0)
+}
+
+func TestNoGossipOrSigningWhenEmptyMembership(t *testing.T) {
+	t.Parallel()
+
+	var gossipedWG sync.WaitGroup
+	gossipedWG.Add(1)
+
+	var emptyMembership []discovery.NetworkMember
+	nonEmptyMembership := []discovery.NetworkMember{{PKIid: pkiIDInOrg1}}
+
+	var dynamicMembership atomic.Value
+	dynamicMembership.Store(nonEmptyMembership)
+
+	cs := &cryptoService{}
+	adapter := new(gossipAdapterMock)
+	// Override configuration and disable outgoing state info requests
+	conf := conf
+	conf.PublishStateInfoInterval = time.Second
+	conf.RequestStateInfoInterval = time.Hour
+	conf.TimeForMembershipTracker = time.Hour
+	adapter.On("GetConf").Return(conf)
+	adapter.On("GetOrgOfPeer", pkiIDInOrg1).Return(orgInChannelA)
+	adapter.On("Gossip", mock.Anything).Run(func(arg mock.Arguments) {
+		gossipedWG.Done()
+	})
+	adapter.On("GetMembership").Return(func() []discovery.NetworkMember {
+		return dynamicMembership.Load().([]discovery.NetworkMember)
+	})
+
+	gc := NewGossipChannel(pkiIDInOrg1, orgInChannelA, cs, channelA, adapter, &joinChanMsg{}, disabledMetrics)
+	// We have signed only once at creation time
+	assert.Equal(t, uint32(1), atomic.LoadUint32(&adapter.signCallCount))
+	defer gc.Stop()
+	gc.UpdateLedgerHeight(1)
+
+	// The first time we have membership, so we should gossip and sign
+	gossipedWG.Wait()
+	// So far we have signed twice: Once at creation time, and once before we gossiped
+	assert.Equal(t, uint32(2), atomic.LoadUint32(&adapter.signCallCount))
+
+	// Membership is now empty
+	dynamicMembership.Store(emptyMembership)
+	// Set the required conditions for gossiping and signing
+	gc.UpdateLedgerHeight(2)
+	// Wait some time and ensure we do not sign because membership is now empty
+	time.Sleep(conf.PublishStateInfoInterval * 3)
+	// We haven't signed anything
+	assert.Equal(t, uint32(2), atomic.LoadUint32(&adapter.signCallCount))
 }
 
 func TestChannelPulledBadBlocks(t *testing.T) {
@@ -1725,17 +1788,21 @@ func TestOnDemandGossip(t *testing.T) {
 
 	// Scenario: update the metadata and ensure only 1 dissemination
 	// takes place when membership is not empty
+	peerA := discovery.NetworkMember{
+		PKIid:            pkiIDInOrg1,
+		Endpoint:         "a",
+		InternalEndpoint: "a",
+	}
 
 	cs := &cryptoService{}
 	adapter := new(gossipAdapterMock)
-	configureAdapter(adapter)
+	configureAdapter(adapter, peerA)
 
 	gossipedEvents := make(chan struct{})
 
 	conf := conf
 	conf.PublishStateInfoInterval = time.Millisecond * 200
 	adapter.On("GetConf").Return(conf)
-	adapter.On("GetMembership").Return([]discovery.NetworkMember{})
 	adapter.On("Gossip", mock.Anything).Run(func(mock.Arguments) {
 		gossipedEvents <- struct{}{}
 	})
@@ -1748,19 +1815,13 @@ func TestOnDemandGossip(t *testing.T) {
 		assert.Fail(t, "Should not have gossiped because metadata has not been updated yet")
 	case <-time.After(time.Millisecond * 500):
 	}
-	gc.UpdateLedgerHeight(0)
+	gc.UpdateLedgerHeight(1)
 	select {
 	case <-gossipedEvents:
 	case <-time.After(time.Second):
 		assert.Fail(t, "Didn't gossip within a timely manner")
 	}
-	select {
-	case <-gossipedEvents:
-	case <-time.After(time.Second):
-		assert.Fail(t, "Should have gossiped a second time, because membership is empty")
-	}
-	adapter = new(gossipAdapterMock)
-	configureAdapter(adapter, []discovery.NetworkMember{{}}...)
+	gc.UpdateLedgerHeight(2)
 	adapter.On("Gossip", mock.Anything).Run(func(mock.Arguments) {
 		gossipedEvents <- struct{}{}
 	})
@@ -1776,7 +1837,7 @@ func TestOnDemandGossip(t *testing.T) {
 		assert.Fail(t, "Should not have gossiped a fourth time, because dirty flag should have been turned off")
 	case <-time.After(time.Millisecond * 500):
 	}
-	gc.UpdateLedgerHeight(1)
+	gc.UpdateLedgerHeight(3)
 	select {
 	case <-gossipedEvents:
 	case <-time.After(time.Second):


### PR DESCRIPTION
This change set makes gossip discovery and channel modules only sign (and gossip)
alive messages and state info messages if the membership is non empty.

Change-Id: Id4de507cdccaa5860ba4b67cf059defc98545bd9
Signed-off-by: yacovm <yacovm@il.ibm.com>
