### PR TITLE
Move implicit collection name construction

### DIFF
--- a/core/chaincode/implicitcollection/name.go
+++ b/core/chaincode/implicitcollection/name.go
@@ -1,0 +1,29 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package implicitcollection
+
+import (
+	"strings"
+)
+
+const (
+	prefix = "_implicit_org_"
+)
+
+// NameForOrg constructs the name of the implicit collection for the specified org
+func NameForOrg(mspid string) string {
+	return prefix + mspid
+}
+
+// MspIDIfImplicitCollection returns <true, mspid> if the specified name is a valid implicit collection name
+// else it returns <false, "">
+func MspIDIfImplicitCollection(collectionName string) (isImplicitCollection bool, mspid string) {
+	if !strings.HasPrefix(collectionName, prefix) {
+		return false, ""
+	}
+	return true, collectionName[len(prefix):]
+}

--- a/core/chaincode/implicitcollection/name_test.go
+++ b/core/chaincode/implicitcollection/name_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package implicitcollection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNameForOrg(t *testing.T) {
+	require.Equal(t, "_implicit_org_mspID1", NameForOrg("mspID1"))
+}
+
+func TestMspIDIfImplicitCollection(t *testing.T) {
+	testCases := []struct {
+		name                       string
+		inputCollectionName        string
+		outputIsImplicitCollection bool
+		outputMspID                string
+	}{
+		{
+			name:                       "valid-implicit-collection",
+			inputCollectionName:        "_implicit_org_mspID1",
+			outputIsImplicitCollection: true,
+			outputMspID:                "mspID1",
+		},
+
+		{
+			name:                       "valid-implicit-collection",
+			inputCollectionName:        "_implicit_org_",
+			outputIsImplicitCollection: true,
+			outputMspID:                "",
+		},
+
+		{
+			name:                       "invalid-implicit-collection",
+			inputCollectionName:        "explicit_collection",
+			outputIsImplicitCollection: false,
+			outputMspID:                "",
+		},
+	}
+
+	for _, testcase := range testCases {
+		t.Run(testcase.name, func(t *testing.T) {
+			isImplicitCollection, mspID := MspIDIfImplicitCollection(testcase.inputCollectionName)
+			require.Equal(t, testcase.outputIsImplicitCollection, isImplicitCollection)
+			require.Equal(t, testcase.outputMspID, mspID)
+		})
+	}
+}

--- a/core/chaincode/lifecycle/lifecycle.go
+++ b/core/chaincode/lifecycle/lifecycle.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hyperledger/fabric/common/chaincode"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/common/policydsl"
+	"github.com/hyperledger/fabric/core/chaincode/implicitcollection"
 	"github.com/hyperledger/fabric/core/chaincode/persistence"
 	"github.com/hyperledger/fabric/core/container"
 	"github.com/hyperledger/fabric/protoutil"
@@ -652,7 +653,7 @@ func (ef *ExternalFunctions) QueryOrgApprovals(name string, cd *ChaincodeDefinit
 			return nil, errors.WithMessagef(err, "serialization check failed for key %s", privateName)
 		}
 
-		org := OrgFromImplicitCollectionName(orgState.CollectionName())
+		_, org := implicitcollection.MspIDIfImplicitCollection(orgState.CollectionName())
 		approvals[org] = match
 	}
 

--- a/core/chaincode/lifecycle/scc.go
+++ b/core/chaincode/lifecycle/scc.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/fabric/common/chaincode"
 	"github.com/hyperledger/fabric/common/channelconfig"
 	"github.com/hyperledger/fabric/core/aclmgmt"
+	"github.com/hyperledger/fabric/core/chaincode/implicitcollection"
 	"github.com/hyperledger/fabric/core/chaincode/persistence"
 	"github.com/hyperledger/fabric/core/dispatcher"
 	"github.com/hyperledger/fabric/core/ledger"
@@ -363,7 +364,7 @@ func (i *Invocation) ApproveChaincodeDefinitionForMyOrg(input *lb.ApproveChainco
 	if err := i.validateInput(input.Name, input.Version, input.Collections); err != nil {
 		return nil, errors.WithMessage(err, "error validating chaincode definition")
 	}
-	collectionName := ImplicitCollectionNameForOrg(i.SCC.OrgMSPID)
+	collectionName := implicitcollection.NameForOrg(i.SCC.OrgMSPID)
 	var collectionConfig []*pb.CollectionConfig
 	if input.Collections != nil {
 		collectionConfig = input.Collections.Config
@@ -423,7 +424,7 @@ func (i *Invocation) QueryApprovedChaincodeDefinition(input *lb.QueryApprovedCha
 		i.Stub.GetChannelID(),
 		input.Name,
 	)
-	collectionName := ImplicitCollectionNameForOrg(i.SCC.OrgMSPID)
+	collectionName := implicitcollection.NameForOrg(i.SCC.OrgMSPID)
 
 	ca, err := i.SCC.Functions.QueryApprovedChaincodeDefinition(
 		i.Stub.GetChannelID(),
@@ -510,7 +511,7 @@ func (i *Invocation) CommitChaincodeDefinition(input *lb.CommitChaincodeDefiniti
 	var myOrg string
 	for _, org := range orgs {
 		opaqueStates = append(opaqueStates, &ChaincodePrivateLedgerShim{
-			Collection: ImplicitCollectionNameForOrg(org.MSPID()),
+			Collection: implicitcollection.NameForOrg(org.MSPID()),
 			Stub:       i.Stub,
 		})
 		if org.MSPID() == i.SCC.OrgMSPID {
@@ -894,7 +895,7 @@ func (i *Invocation) createOpaqueStates() ([]OpaqueState, error) {
 	opaqueStates := make([]OpaqueState, 0, len(orgs))
 	for _, org := range orgs {
 		opaqueStates = append(opaqueStates, &ChaincodePrivateLedgerShim{
-			Collection: ImplicitCollectionNameForOrg(org.MSPID()),
+			Collection: implicitcollection.NameForOrg(org.MSPID()),
 			Stub:       i.Stub,
 		})
 	}

--- a/core/ledger/kvledger/tests/v20_test.go
+++ b/core/ledger/kvledger/tests/v20_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger/fabric/common/ledger/testutil"
-	"github.com/hyperledger/fabric/core/chaincode/lifecycle"
+	"github.com/hyperledger/fabric/core/chaincode/implicitcollection"
 	"github.com/hyperledger/fabric/core/ledger/kvledger"
 	"github.com/stretchr/testify/require"
 )
@@ -113,7 +113,7 @@ func (d *v20SampleDataHelper) marbleCollConf1(ccName string) []*collConf {
 	collConfigs = append(collConfigs, &collConf{name: "collectionMarbles", btl: 1000000, members: []string{"Org1MSP", "Org2MSP"}})
 	collConfigs = append(collConfigs, &collConf{name: "collectionMarblePrivateDetails", btl: 1000000, members: []string{"Org2MSP", "Org3MSP"}})
 	for _, mspID := range d.mspIDsInChannelConfig() {
-		collConfigs = append(collConfigs, &collConf{name: lifecycle.ImplicitCollectionNameForOrg(mspID), btl: 0, members: []string{mspID}})
+		collConfigs = append(collConfigs, &collConf{name: implicitcollection.NameForOrg(mspID), btl: 0, members: []string{mspID}})
 	}
 	return collConfigs
 }
@@ -124,7 +124,7 @@ func (d *v20SampleDataHelper) marbleCollConf2(ccName string) []*collConf {
 	collConfigs = append(collConfigs, &collConf{name: "collectionMarbles", btl: 1000000, members: []string{"Org2MSP", "Org3MSP"}})
 	collConfigs = append(collConfigs, &collConf{name: "collectionMarblePrivateDetails", btl: 1000000, members: []string{"Org1MSP", "Org2MSP", "Org3MSP"}})
 	for _, mspID := range d.mspIDsInChannelConfig() {
-		collConfigs = append(collConfigs, &collConf{name: lifecycle.ImplicitCollectionNameForOrg(mspID), btl: 0, members: []string{mspID}})
+		collConfigs = append(collConfigs, &collConf{name: implicitcollection.NameForOrg(mspID), btl: 0, members: []string{mspID}})
 	}
 	return collConfigs
 }


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- Improvement (improvement to code)

#### Description
This PR moves the implicit collection name construction logic outside the `chaincode/lifecycle` package. 
So that the other packages do not have incur dependency on entire lifecycle package for this small need.

<!--- Describe your changes in detail, including motivation. -->

#### Additional details
- While loading data during creation of a ledger from a snapshot, we need to figure out whether a collection is implicit collection or explicit collection. It's not good to keep adding these functions to existing interface `DeployedChaincodeInfoProvider` where these functions are meaningless for the legacy chaincode (lscc).

- In general, the functions related to implicit collections had grown over time and are added to the existing interface `DeployedChaincodeInfoProvider`, As a further improvement, the functions related to the generation of collection config for the implicit collection can also be moved to this new package as these functions do not depend on with persisted chaincode data and rather they simply generate collection config on the fly.