### PR TITLE
Cache PKCS11 ObjectHandles

### DIFF
--- a/bccsp/pkcs11/cache.go
+++ b/bccsp/pkcs11/cache.go
@@ -1,0 +1,47 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pkcs11
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"sync"
+
+	"github.com/miekg/pkcs11"
+)
+
+type p11Key struct {
+	privH  pkcs11.ObjectHandle
+	pubH   pkcs11.ObjectHandle
+	pubKey *ecdsa.PublicKey
+}
+
+type keyCache struct {
+	mu      sync.RWMutex
+	p11Keys map[string]p11Key
+}
+
+func (k *keyCache) get(ski []byte) (p11Key, bool) {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+
+	h, ok := k.p11Keys[hex.EncodeToString(ski)]
+	return h, ok
+}
+
+func (k *keyCache) set(ski []byte, key p11Key) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.p11Keys[hex.EncodeToString(ski)] = key
+
+}
+
+func (k *keyCache) clear() {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.p11Keys = make(map[string]p11Key)
+}

--- a/bccsp/pkcs11/cache_test.go
+++ b/bccsp/pkcs11/cache_test.go
@@ -1,0 +1,62 @@
+// +build pkcs11
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pkcs11
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"testing"
+
+	"github.com/miekg/pkcs11"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyCache(t *testing.T) {
+
+	kc := &keyCache{
+		p11Keys: make(map[string]p11Key),
+	}
+
+	k, ok := kc.get([]byte("ski"))
+	assert.Equal(t, false, ok)
+
+	k1 := p11Key{
+		privH: pkcs11.ObjectHandle(1),
+		pubH:  pkcs11.ObjectHandle(1),
+		pubKey: &ecdsa.PublicKey{
+			Curve: elliptic.P256(),
+		},
+	}
+
+	kc.set([]byte("ski"), k1)
+	k, ok = kc.get([]byte("ski"))
+	assert.Equal(t, true, ok)
+	assert.Equal(t, k1, k)
+
+	k2 := p11Key{
+		privH: pkcs11.ObjectHandle(2),
+		pubH:  pkcs11.ObjectHandle(2),
+		pubKey: &ecdsa.PublicKey{
+			Curve: elliptic.P384(),
+		},
+	}
+
+	kc.set([]byte("ski2"), k2)
+	k, ok = kc.get([]byte("ski2"))
+	assert.Equal(t, true, ok)
+	assert.Equal(t, k2, k)
+
+	kc.clear()
+	assert.Equal(t, 0, len(kc.p11Keys))
+	k, ok = kc.get([]byte("ski"))
+	assert.Equal(t, false, ok)
+	k, ok = kc.get([]byte("ski2"))
+	assert.Equal(t, false, ok)
+
+}

--- a/bccsp/pkcs11/impl.go
+++ b/bccsp/pkcs11/impl.go
@@ -54,10 +54,13 @@ func New(opts PKCS11Opts, keyStore bccsp.KeyStore) (bccsp.BCCSP, error) {
 
 	sessions := make(chan pkcs11.SessionHandle, sessionCacheSize)
 	csp := &impl{
-		BCCSP:      swCSP,
-		conf:       conf,
-		ctx:        ctx,
-		sessions:   sessions,
+		BCCSP:    swCSP,
+		conf:     conf,
+		ctx:      ctx,
+		sessions: sessions,
+		p11Keys: &keyCache{
+			p11Keys: make(map[string]p11Key),
+		},
 		slot:       slot,
 		pin:        pin,
 		lib:        lib,
@@ -75,6 +78,7 @@ type impl struct {
 
 	ctx      *pkcs11.Ctx
 	sessions chan pkcs11.SessionHandle
+	p11Keys  *keyCache
 	slot     uint
 	pin      string
 


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (performance)

#### Description

The pkcs11 implementation currently invokes
a find key operation for each sign and verify
operation.  This can be quite expensive especially
when communicating with network HSMs.

This change caches the ObjectHandle for private and
public keys as they should be valid across the current
PKCS11 session.

As ObjectHandles are only valid for the current session
context, if a stale session is found, the cache is cleared
as well.

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->