### PR TITLE
construct unreconciled missing pvtdata

### DIFF
--- a/gossip/privdata/reconcile_test.go
+++ b/gossip/privdata/reconcile_test.go
@@ -512,3 +512,168 @@ func TestFailuresWhileReconcilingMissingPvtData(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, "failed get missing pvt data for recent blocks", err.Error())
 }
+
+func TestConstructUnreconciledMissingData(t *testing.T) {
+	requestedMissingData := func() privdatacommon.Dig2CollectionConfig {
+		return privdatacommon.Dig2CollectionConfig{
+			privdatacommon.DigKey{
+				TxId:       "tx1",
+				Namespace:  "ns1",
+				Collection: "coll1",
+				BlockSeq:   1,
+				SeqInBlock: 1,
+			}: nil,
+			privdatacommon.DigKey{
+				TxId:       "tx1",
+				Namespace:  "ns2",
+				Collection: "coll2",
+				BlockSeq:   1,
+				SeqInBlock: 1,
+			}: nil,
+			privdatacommon.DigKey{
+				TxId:       "tx1",
+				Namespace:  "ns3",
+				Collection: "coll3",
+				BlockSeq:   1,
+				SeqInBlock: 3,
+			}: nil,
+			privdatacommon.DigKey{
+				TxId:       "tx2",
+				Namespace:  "ns4",
+				Collection: "coll4",
+				BlockSeq:   4,
+				SeqInBlock: 4,
+			}: nil,
+		}
+	}
+
+	testCases := []struct {
+		description                     string
+		fetchedData                     []*gossip2.PvtDataElement
+		expectedUnreconciledMissingData ledger.MissingPvtDataInfo
+	}{
+		{
+			description: "none-reconciled",
+			fetchedData: nil,
+			expectedUnreconciledMissingData: ledger.MissingPvtDataInfo{
+				1: ledger.MissingBlockPvtdataInfo{
+					1: []*ledger.MissingCollectionPvtDataInfo{
+						{
+							Namespace:  "ns1",
+							Collection: "coll1",
+						},
+						{
+							Namespace:  "ns2",
+							Collection: "coll2",
+						},
+					},
+					3: []*ledger.MissingCollectionPvtDataInfo{
+						{
+							Namespace:  "ns3",
+							Collection: "coll3",
+						},
+					},
+				},
+				4: ledger.MissingBlockPvtdataInfo{
+					4: []*ledger.MissingCollectionPvtDataInfo{
+						{
+							Namespace:  "ns4",
+							Collection: "coll4",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "all-reconciled",
+			fetchedData: []*gossip2.PvtDataElement{
+				{
+					Digest: &gossip2.PvtDataDigest{
+						TxId:       "tx1",
+						Namespace:  "ns1",
+						Collection: "coll1",
+						BlockSeq:   1,
+						SeqInBlock: 1,
+					},
+				},
+				{
+					Digest: &gossip2.PvtDataDigest{
+						TxId:       "tx1",
+						Namespace:  "ns2",
+						Collection: "coll2",
+						BlockSeq:   1,
+						SeqInBlock: 1,
+					},
+				},
+				{
+					Digest: &gossip2.PvtDataDigest{
+						TxId:       "tx1",
+						Namespace:  "ns3",
+						Collection: "coll3",
+						BlockSeq:   1,
+						SeqInBlock: 3,
+					},
+				},
+				{
+					Digest: &gossip2.PvtDataDigest{
+						TxId:       "tx2",
+						Namespace:  "ns4",
+						Collection: "coll4",
+						BlockSeq:   4,
+						SeqInBlock: 4,
+					},
+				},
+			},
+			expectedUnreconciledMissingData: nil,
+		},
+		{
+			description: "some-unreconciled",
+			fetchedData: []*gossip2.PvtDataElement{
+				{
+					Digest: &gossip2.PvtDataDigest{
+						TxId:       "tx1",
+						Namespace:  "ns1",
+						Collection: "coll1",
+						BlockSeq:   1,
+						SeqInBlock: 1,
+					},
+				},
+				{
+					Digest: &gossip2.PvtDataDigest{
+						TxId:       "tx1",
+						Namespace:  "ns3",
+						Collection: "coll3",
+						BlockSeq:   1,
+						SeqInBlock: 3,
+					},
+				},
+				{
+					Digest: &gossip2.PvtDataDigest{
+						TxId:       "tx2",
+						Namespace:  "ns4",
+						Collection: "coll4",
+						BlockSeq:   4,
+						SeqInBlock: 4,
+					},
+				},
+			},
+			expectedUnreconciledMissingData: ledger.MissingPvtDataInfo{
+				1: ledger.MissingBlockPvtdataInfo{
+					1: []*ledger.MissingCollectionPvtDataInfo{
+						{
+							Namespace:  "ns2",
+							Collection: "coll2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			unreconciledData := constructUnreconciledMissingData(requestedMissingData(), testCase.fetchedData)
+			require.Equal(t, testCase.expectedUnreconciledMissingData, unreconciledData)
+		})
+	}
+}


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

This PR adds a utility function to construct unreconciled missing pvtdata. 

#### Additional details

This utility function would be used by the reconciler to inform ledger about the unreconciled missing pvtdata. This information would be used by the pvtdata store to deprioritize these missing pvtdata and retried after N iterations of reconciliation. 

TxId field present in some of the structs defined in the reconciler/puller is not used. As some involve proto messages, it is not straightforward to remove it (due to rolling upgrade and change in the message format). 