### PR TITLE
Use correct gossip SecretEnvelope reference

### DIFF
--- a/gossip/discovery/discovery_impl.go
+++ b/gossip/discovery/discovery_impl.go
@@ -339,8 +339,8 @@ func (d *gossipDiscoveryImpl) handleMsgFromComm(msg protoext.ReceivedMessage) {
 		}
 
 		var internalEndpoint string
-		if m.Envelope.SecretEnvelope != nil {
-			internalEndpoint = protoext.InternalEndpoint(m.Envelope.SecretEnvelope)
+		if memReq.SelfInformation.SecretEnvelope != nil {
+			internalEndpoint = protoext.InternalEndpoint(memReq.SelfInformation.SecretEnvelope)
 		}
 
 		// Sending a membership response to a peer may block this routine

--- a/gossip/discovery/discovery_test.go
+++ b/gossip/discovery/discovery_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hyperledger/fabric/gossip/gossip/msgstore"
 	"github.com/hyperledger/fabric/gossip/protoext"
 	"github.com/hyperledger/fabric/gossip/util"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -1582,6 +1583,7 @@ func TestAliveMsgStore(t *testing.T) {
 
 func TestMemRespDisclosurePol(t *testing.T) {
 	pol := func(remotePeer *NetworkMember) (Sieve, EnvelopeFilter) {
+		assert.Equal(t, remotePeer.InternalEndpoint, remotePeer.Endpoint)
 		return func(_ *protoext.SignedGossipMessage) bool {
 				return remotePeer.Endpoint == "localhost:7880"
 			}, func(m *protoext.SignedGossipMessage) *proto.Envelope {


### PR DESCRIPTION
In case a membership request is received, it contains an inner
alive message envelope (which has a secret envelope).

The function handleMsgFromComm extracts an internal endpoint from
that secret envelope, however it was referencing the wrong envelope.

Instead of referencing the inner envelope of the alive message, it referenced
the outer envelope of the membership request, however, only alive messages
carry internal endpoints inside their secret envelopes.

As a result, all internal endpoints were always empty.

While this has no semantic effect, because the consumer of the internal endpoint doesn't
make use of the field, the field might still be logged, and we should use the correct
envelope which contains the internal endpoint and not the incorrect envelope.

Change-Id: I2452269e627e3444485425b0df5aced527d5149c
Signed-off-by: yacovm <yacovm@il.ibm.com>
