### PR TITLE
Add Raft metrics to Raft config doc

### DIFF
--- a/docs/source/raft_configuration.md
+++ b/docs/source/raft_configuration.md
@@ -317,6 +317,12 @@ monitor:
    they can be shared with the consenter set. If this value begins to climb, this
    node may not be able to participate in consensus (which could lead to a
    service interruption for this node and possibly the network).
+* `consensus_etcdraft_cluster_size` and `consensus_etcdraft_active_nodes`: these
+   channel metrics help track the "active" nodes (which, as it sounds, are the nodes that
+   are currently contributing to the cluster, as compared to the total number of
+   nodes in the cluster). If the number of active nodes falls below a majority of
+   the nodes in the cluster, quorum will be lost and the ordering service will
+   stop processing blocks on the channel.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Adding two metrics to Raft configuration doc to encourage
users to monitor their active nodes as compared to the
total number of nodes in the cluster

Change-Id: Ica35ee1a0a2feea6511cfd56fcee1bdf429b1334
Signed-off-by: joe-alewine <Joe.Alewine@ibm.com>

#### Type of change

- Documentation update

#### Description

Adding two metrics to Raft configuration doc to encourage
users to monitor their active nodes as compared to the
total number of nodes in the cluster