### PR TITLE
Remove implicit collections logic from config history mgr

### DIFF
--- a/core/ledger/kvledger/snapshot_test.go
+++ b/core/ledger/kvledger/snapshot_test.go
@@ -740,9 +740,10 @@ func verifyCreatedLedger(t *testing.T,
 		require.NoError(t, err)
 		require.Equal(t, v, string(val))
 	}
-	for h, collConfigPkg := range e.collectionConfig {
-		collConfigInfo, err := l.configHistoryRetriever.CollectionConfigAt(h, e.namespace)
+	for committingBlock, collConfigPkg := range e.collectionConfig {
+		collConfigInfo, err := l.configHistoryRetriever.MostRecentCollectionConfigBelow(committingBlock+1, e.namespace)
 		require.NoError(t, err)
+		require.Equal(t, committingBlock, collConfigInfo.CommittingBlockNum)
 		require.True(t, proto.Equal(collConfigPkg, collConfigInfo.CollectionConfig))
 	}
 }

--- a/core/ledger/ledger_interface.go
+++ b/core/ledger/ledger_interface.go
@@ -530,7 +530,6 @@ type KVStateUpdates struct {
 
 // ConfigHistoryRetriever allow retrieving history of collection configs
 type ConfigHistoryRetriever interface {
-	CollectionConfigAt(blockNum uint64, chaincodeName string) (*CollectionConfigInfo, error)
 	MostRecentCollectionConfigBelow(blockNum uint64, chaincodeName string) (*CollectionConfigInfo, error)
 }
 


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- Improvement (improvement to code)

#### Description

- This PR cleans up existing code by removing the propagation of dependencies deep down to the level of config history mgr. Instead, now, the config history mgr manages only explicit collection configs and the code for combining the results from explicit and implicit collection configs is maintained at the higher level - in the package kvledger

- Also, removed an unused function

#### Additional details
We plan to retrieve the collection config information from collection-config-history-mgr for populating the stores related to private data (such as purgeMgr and pvtdata storage). For this purpose, we plan to pull only explicit collection config from collection-config-history-mgr. So, this clean up, in addition to preventing the dependencies deep down, makes the forthcoming usage a natural fit.