### PR TITLE
Bug-fix for reading large values from snapshot files

### DIFF
--- a/common/ledger/snapshot/file.go
+++ b/common/ledger/snapshot/file.go
@@ -206,7 +206,7 @@ func (r *FileReader) decodeBytes() ([]byte, error) {
 	if len(r.reusableByteSlice) < size {
 		r.reusableByteSlice = make([]byte, size)
 	}
-	if _, err := r.bufReader.Read(r.reusableByteSlice[0:size]); err != nil {
+	if _, err := io.ReadFull(r.bufReader, r.reusableByteSlice[0:size]); err != nil {
 		return nil, errors.Wrapf(err, "error while reading from snapshot file: %s", r.file.Name())
 	}
 	return r.reusableByteSlice[0:size], nil


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- Bug fix

#### Description
The current code did not make sure to read the full length of data from the snapshot file. The bug was uncovered while testing with the real data and channel config is relatively large. Added a test with a large value.
