### PR TITLE
deprioritize unreconcilable missingPvtData

### DIFF
--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -754,7 +754,7 @@ func (l *kvLedger) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.Reconcil
 
 	logger.Debugf("[%s:] Committing pvtData of [%d] old blocks to the pvtdatastore", l.ledgerID, len(reconciledPvtdata))
 
-	err = l.pvtdataStore.CommitPvtDataOfOldBlocks(hashVerifiedPvtData)
+	err = l.pvtdataStore.CommitPvtDataOfOldBlocks(hashVerifiedPvtData, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/core/ledger/pvtdatastorage/helper.go
+++ b/core/ledger/pvtdatastorage/helper.go
@@ -69,8 +69,10 @@ func prepareMissingDataEntries(
 				},
 			}
 
-			missingDataEntries = elgMissingDataEntries
-			if !nsColl.IsEligible {
+			switch nsColl.IsEligible {
+			case true:
+				missingDataEntries = elgMissingDataEntries
+			default:
 				missingDataEntries = inelgMissingDataEntries
 			}
 

--- a/core/ledger/pvtdatastorage/helper.go
+++ b/core/ledger/pvtdatastorage/helper.go
@@ -57,8 +57,6 @@ func prepareMissingDataEntries(
 	elgMissingDataEntries := make(map[missingDataKey]*bitset.BitSet)
 	inelgMissingDataEntries := make(map[missingDataKey]*bitset.BitSet)
 
-	var missingDataEntries map[missingDataKey]*bitset.BitSet
-
 	for txNum, missingData := range missingPvtData {
 		for _, nsColl := range missingData {
 			key := missingDataKey{
@@ -71,17 +69,16 @@ func prepareMissingDataEntries(
 
 			switch nsColl.IsEligible {
 			case true:
-				missingDataEntries = elgMissingDataEntries
+				if _, ok := elgMissingDataEntries[key]; !ok {
+					elgMissingDataEntries[key] = &bitset.BitSet{}
+				}
+				elgMissingDataEntries[key].Set(uint(txNum))
 			default:
-				missingDataEntries = inelgMissingDataEntries
+				if _, ok := inelgMissingDataEntries[key]; !ok {
+					inelgMissingDataEntries[key] = &bitset.BitSet{}
+				}
+				inelgMissingDataEntries[key].Set(uint(txNum))
 			}
-
-			if _, ok := missingDataEntries[key]; !ok {
-				missingDataEntries[key] = &bitset.BitSet{}
-			}
-			bitmap := missingDataEntries[key]
-
-			bitmap.Set(uint(txNum))
 		}
 	}
 

--- a/core/ledger/pvtdatastorage/kv_encoding_test.go
+++ b/core/ledger/pvtdatastorage/kv_encoding_test.go
@@ -56,8 +56,7 @@ func TestEligibleMissingDataRange(t *testing.T) {
 	startKey, endKey := eligibleMissingdatakeyRange(blockNum)
 	var txNum uint64
 	for txNum = 0; txNum < 100; txNum++ {
-		keyOfBlock := encodeElgMissingDataKey(
-			elgPrioritizedMissingDataGroup,
+		keyOfBlock := encodeElgPrioMissingDataKey(
 			&missingDataKey{
 				nsCollBlk: nsCollBlk{
 					ns:     "ns",
@@ -66,8 +65,7 @@ func TestEligibleMissingDataRange(t *testing.T) {
 				},
 			},
 		)
-		keyOfPreviousBlock := encodeElgMissingDataKey(
-			elgPrioritizedMissingDataGroup,
+		keyOfPreviousBlock := encodeElgPrioMissingDataKey(
 			&missingDataKey{
 				nsCollBlk: nsCollBlk{
 					ns:     "ns",
@@ -76,8 +74,7 @@ func TestEligibleMissingDataRange(t *testing.T) {
 				},
 			},
 		)
-		keyOfNextBlock := encodeElgMissingDataKey(
-			elgPrioritizedMissingDataGroup,
+		keyOfNextBlock := encodeElgPrioMissingDataKey(
 			&missingDataKey{
 				nsCollBlk: nsCollBlk{
 					ns:     "ns",
@@ -121,7 +118,7 @@ func testEncodeDecodeMissingdataKey(t *testing.T, blkNum uint64) {
 	t.Run("eligiblePrioritizedKey",
 		func(t *testing.T) {
 			decodedKey := decodeElgMissingDataKey(
-				encodeElgMissingDataKey(elgPrioritizedMissingDataGroup, key),
+				encodeElgPrioMissingDataKey(key),
 			)
 			require.Equal(t, key, decodedKey)
 		},
@@ -130,7 +127,7 @@ func testEncodeDecodeMissingdataKey(t *testing.T, blkNum uint64) {
 	t.Run("eligibleDeprioritizedKey",
 		func(t *testing.T) {
 			decodedKey := decodeElgMissingDataKey(
-				encodeElgMissingDataKey(elgDeprioritizedMissingDataGroup, key),
+				encodeElgDeprioMissingDataKey(key),
 			)
 			require.Equal(t, key, decodedKey)
 		},

--- a/core/ledger/pvtdatastorage/kv_encoding_test.go
+++ b/core/ledger/pvtdatastorage/kv_encoding_test.go
@@ -21,7 +21,7 @@ func TestDataKeyEncoding(t *testing.T) {
 	require.Equal(t, dataKey1, datakey2)
 }
 
-func TestDatakeyRange(t *testing.T) {
+func TestDataKeyRange(t *testing.T) {
 	blockNum := uint64(20)
 	startKey, endKey := datakeyRange(blockNum)
 	var txNum uint64
@@ -51,27 +51,39 @@ func TestDatakeyRange(t *testing.T) {
 	}
 }
 
-func TestEligibleMissingdataRange(t *testing.T) {
+func TestEligibleMissingDataRange(t *testing.T) {
 	blockNum := uint64(20)
 	startKey, endKey := eligibleMissingdatakeyRange(blockNum)
 	var txNum uint64
 	for txNum = 0; txNum < 100; txNum++ {
-		keyOfBlock := encodeMissingDataKey(
+		keyOfBlock := encodeElgMissingDataKey(
+			elgPrioritizedMissingDataGroup,
 			&missingDataKey{
-				nsCollBlk:  nsCollBlk{ns: "ns", coll: "coll", blkNum: blockNum},
-				isEligible: true,
+				nsCollBlk: nsCollBlk{
+					ns:     "ns",
+					coll:   "coll",
+					blkNum: blockNum,
+				},
 			},
 		)
-		keyOfPreviousBlock := encodeMissingDataKey(
+		keyOfPreviousBlock := encodeElgMissingDataKey(
+			elgPrioritizedMissingDataGroup,
 			&missingDataKey{
-				nsCollBlk:  nsCollBlk{ns: "ns", coll: "coll", blkNum: blockNum - 1},
-				isEligible: true,
+				nsCollBlk: nsCollBlk{
+					ns:     "ns",
+					coll:   "coll",
+					blkNum: blockNum - 1,
+				},
 			},
 		)
-		keyOfNextBlock := encodeMissingDataKey(
+		keyOfNextBlock := encodeElgMissingDataKey(
+			elgPrioritizedMissingDataGroup,
 			&missingDataKey{
-				nsCollBlk:  nsCollBlk{ns: "ns", coll: "coll", blkNum: blockNum + 1},
-				isEligible: true,
+				nsCollBlk: nsCollBlk{
+					ns:     "ns",
+					coll:   "coll",
+					blkNum: blockNum + 1,
+				},
 			},
 		)
 		require.Equal(t, bytes.Compare(keyOfNextBlock, startKey), -1)
@@ -99,19 +111,26 @@ func testEncodeDecodeMissingdataKey(t *testing.T, blkNum uint64) {
 
 	t.Run("ineligibileKey",
 		func(t *testing.T) {
-			key.isEligible = false
-			decodedKey := decodeMissingDataKey(
-				encodeMissingDataKey(key),
+			decodedKey := decodeInelgMissingDataKey(
+				encodeInelgMissingDataKey(key),
 			)
 			require.Equal(t, key, decodedKey)
 		},
 	)
 
-	t.Run("ineligibileKey",
+	t.Run("eligiblePrioritizedKey",
 		func(t *testing.T) {
-			key.isEligible = true
-			decodedKey := decodeMissingDataKey(
-				encodeMissingDataKey(key),
+			decodedKey := decodeElgMissingDataKey(
+				encodeElgMissingDataKey(elgPrioritizedMissingDataGroup, key),
+			)
+			require.Equal(t, key, decodedKey)
+		},
+	)
+
+	t.Run("eligibleDeprioritizedKey",
+		func(t *testing.T) {
+			decodedKey := decodeElgMissingDataKey(
+				encodeElgMissingDataKey(elgDeprioritizedMissingDataGroup, key),
 			)
 			require.Equal(t, key, decodedKey)
 		},

--- a/core/ledger/pvtdatastorage/reconcile_missing_pvtdata_test.go
+++ b/core/ledger/pvtdatastorage/reconcile_missing_pvtdata_test.go
@@ -7,196 +7,568 @@ SPDX-License-Identifier: Apache-2.0
 package pvtdatastorage
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/ledger"
 	btltestutil "github.com/hyperledger/fabric/core/ledger/pvtdatapolicy/testutil"
 	"github.com/stretchr/testify/require"
+	"github.com/willf/bitset"
 )
+
+type blockTxPvtDataInfoForTest struct {
+	blkNum         uint64
+	txNum          uint64
+	pvtDataPresent map[string][]string
+	pvtDataMissing map[string][]string
+}
+
+type pvtDataForTest struct {
+	blockNum        uint64
+	pvtData         []*ledger.TxPvtData
+	dataKeys        []*dataKey
+	missingDataInfo ledger.TxMissingPvtData
+}
 
 func TestCommitPvtDataOfOldBlocks(t *testing.T) {
 	btlPolicy := btltestutil.SampleBTLPolicy(
 		map[[2]string]uint64{
-			{"ns-1", "coll-1"}: 3,
-			{"ns-1", "coll-2"}: 1,
+			{"ns-1", "coll-1"}: 0,
+			{"ns-1", "coll-2"}: 0,
 			{"ns-2", "coll-1"}: 0,
-			{"ns-2", "coll-2"}: 1,
-			{"ns-3", "coll-1"}: 0,
-			{"ns-3", "coll-2"}: 3,
-			{"ns-4", "coll-1"}: 0,
-			{"ns-4", "coll-2"}: 0,
+			{"ns-2", "coll-2"}: 0,
 		},
 	)
 	env := NewTestStoreEnv(t, "TestCommitPvtDataOfOldBlocks", btlPolicy, pvtDataConf())
 	defer env.Cleanup()
 	store := env.TestStore
 
-	testData := []*ledger.TxPvtData{
-		produceSamplePvtdata(t, 2, []string{"ns-2:coll-1", "ns-2:coll-2"}),
-		produceSamplePvtdata(t, 4, []string{"ns-1:coll-1", "ns-1:coll-2", "ns-2:coll-1", "ns-2:coll-2"}),
+	blockTxPvtDataInfo := []*blockTxPvtDataInfoForTest{
+		{
+			blkNum: 1,
+			txNum:  1,
+			pvtDataMissing: map[string][]string{
+				"ns-1": {"coll-1", "coll-2"},
+				"ns-2": {"coll-1", "coll-2"},
+			},
+		},
+		{
+			blkNum: 1,
+			txNum:  2,
+			pvtDataPresent: map[string][]string{
+				"ns-2": {"coll-1", "coll-2"},
+			},
+			pvtDataMissing: map[string][]string{
+				"ns-1": {"coll-1", "coll-2"},
+			},
+		},
+		{
+			blkNum: 1,
+			txNum:  4,
+			pvtDataPresent: map[string][]string{
+				"ns-1": {"coll-1", "coll-2"},
+				"ns-2": {"coll-1", "coll-2"},
+			},
+		},
+		{
+			blkNum: 2,
+			txNum:  1,
+			pvtDataMissing: map[string][]string{
+				"ns-1": {"coll-1", "coll-2"},
+			},
+		},
+		{
+			blkNum: 2,
+			txNum:  3,
+			pvtDataMissing: map[string][]string{
+				"ns-1": {"coll-1"},
+			},
+		},
 	}
 
-	// CONSTRUCT MISSING DATA FOR BLOCK 1
-	blk1MissingData := make(ledger.TxMissingPvtData)
+	blocksPvtData, missingDataSummary := constructPvtDataForTest(t, blockTxPvtDataInfo)
 
-	// eligible missing data in tx1
-	blk1MissingData.Add(1, "ns-1", "coll-1", true)
-	blk1MissingData.Add(1, "ns-1", "coll-2", true)
-	blk1MissingData.Add(1, "ns-2", "coll-1", true)
-	blk1MissingData.Add(1, "ns-2", "coll-2", true)
-	// eligible missing data in tx2
-	blk1MissingData.Add(2, "ns-1", "coll-1", true)
-	blk1MissingData.Add(2, "ns-1", "coll-2", true)
-	blk1MissingData.Add(2, "ns-3", "coll-1", true)
-	blk1MissingData.Add(2, "ns-3", "coll-2", true)
-
-	// CONSTRUCT MISSING DATA FOR BLOCK 2
-	blk2MissingData := make(ledger.TxMissingPvtData)
-	// eligible missing data in tx1
-	blk2MissingData.Add(1, "ns-1", "coll-1", true)
-	blk2MissingData.Add(1, "ns-1", "coll-2", true)
-	// eligible missing data in tx3
-	blk2MissingData.Add(3, "ns-1", "coll-1", true)
-
-	// COMMIT BLOCK 0 WITH NO DATA
 	require.NoError(t, store.Commit(0, nil, nil))
+	require.NoError(t, store.Commit(1, blocksPvtData[1].pvtData, blocksPvtData[1].missingDataInfo))
+	require.NoError(t, store.Commit(2, blocksPvtData[2].pvtData, blocksPvtData[2].missingDataInfo))
 
-	// COMMIT BLOCK 1 WITH PVTDATA AND MISSINGDATA
-	require.NoError(t, store.Commit(1, testData, blk1MissingData))
+	assertMissingDataInfo(t, store, missingDataSummary, 2)
 
-	// COMMIT BLOCK 2 WITH PVTDATA AND MISSINGDATA
-	require.NoError(t, store.Commit(2, nil, blk2MissingData))
-
-	// CHECK MISSINGDATA ENTRIES ARE CORRECTLY STORED
-	expectedMissingPvtDataInfo := make(ledger.MissingPvtDataInfo)
-	// missing data in block1, tx1
-	expectedMissingPvtDataInfo.Add(1, 1, "ns-1", "coll-1")
-	expectedMissingPvtDataInfo.Add(1, 1, "ns-1", "coll-2")
-	expectedMissingPvtDataInfo.Add(1, 1, "ns-2", "coll-1")
-	expectedMissingPvtDataInfo.Add(1, 1, "ns-2", "coll-2")
-
-	// missing data in block1, tx2
-	expectedMissingPvtDataInfo.Add(1, 2, "ns-1", "coll-1")
-	expectedMissingPvtDataInfo.Add(1, 2, "ns-1", "coll-2")
-	expectedMissingPvtDataInfo.Add(1, 2, "ns-3", "coll-1")
-	expectedMissingPvtDataInfo.Add(1, 2, "ns-3", "coll-2")
-
-	// missing data in block2, tx1
-	expectedMissingPvtDataInfo.Add(2, 1, "ns-1", "coll-1")
-	expectedMissingPvtDataInfo.Add(2, 1, "ns-1", "coll-2")
-	// missing data in block2, tx3
-	expectedMissingPvtDataInfo.Add(2, 3, "ns-1", "coll-1")
-
-	missingPvtDataInfo, err := store.GetMissingPvtDataInfoForMostRecentBlocks(2)
-	require.NoError(t, err)
-	require.Equal(t, expectedMissingPvtDataInfo, missingPvtDataInfo)
-
-	// COMMIT THE MISSINGDATA IN BLOCK 1 AND BLOCK 2
-	oldBlocksPvtData := make(map[uint64][]*ledger.TxPvtData)
-	oldBlocksPvtData[1] = []*ledger.TxPvtData{
-		produceSamplePvtdata(t, 1, []string{"ns-1:coll-1", "ns-2:coll-1"}),
-		produceSamplePvtdata(t, 2, []string{"ns-1:coll-1", "ns-3:coll-1"}),
-	}
-	oldBlocksPvtData[2] = []*ledger.TxPvtData{
-		produceSamplePvtdata(t, 3, []string{"ns-1:coll-1"}),
-	}
-
-	err = store.CommitPvtDataOfOldBlocks(oldBlocksPvtData)
-	require.NoError(t, err)
-
-	// ENSURE THAT THE PREVIOUSLY MISSING PVTDATA OF BLOCK 1 & 2 EXIST IN THE STORE
-	ns1Coll1Blk1Tx1 := &dataKey{nsCollBlk: nsCollBlk{ns: "ns-1", coll: "coll-1", blkNum: 1}, txNum: 1}
-	ns2Coll1Blk1Tx1 := &dataKey{nsCollBlk: nsCollBlk{ns: "ns-2", coll: "coll-1", blkNum: 1}, txNum: 1}
-	ns1Coll1Blk1Tx2 := &dataKey{nsCollBlk: nsCollBlk{ns: "ns-1", coll: "coll-1", blkNum: 1}, txNum: 2}
-	ns3Coll1Blk1Tx2 := &dataKey{nsCollBlk: nsCollBlk{ns: "ns-3", coll: "coll-1", blkNum: 1}, txNum: 2}
-	ns1Coll1Blk2Tx3 := &dataKey{nsCollBlk: nsCollBlk{ns: "ns-1", coll: "coll-1", blkNum: 2}, txNum: 3}
-
-	require.True(t, testDataKeyExists(t, store, ns1Coll1Blk1Tx1))
-	require.True(t, testDataKeyExists(t, store, ns2Coll1Blk1Tx1))
-	require.True(t, testDataKeyExists(t, store, ns1Coll1Blk1Tx2))
-	require.True(t, testDataKeyExists(t, store, ns3Coll1Blk1Tx2))
-	require.True(t, testDataKeyExists(t, store, ns1Coll1Blk2Tx3))
-
-	// pvt data retrieval for block 2 should return the just committed pvtdata
-	var nilFilter ledger.PvtNsCollFilter
-	retrievedData, err := store.GetPvtDataByBlockNum(2, nilFilter)
-	require.NoError(t, err)
-	for i, data := range retrievedData {
-		require.Equal(t, data.SeqInBlock, oldBlocksPvtData[2][i].SeqInBlock)
-		require.True(t, proto.Equal(data.WriteSet, oldBlocksPvtData[2][i].WriteSet))
+	// COMMIT some of the missing data in the block 1 and block 2
+	oldBlockTxPvtDataInfo := []*blockTxPvtDataInfoForTest{
+		{
+			blkNum: 1,
+			txNum:  1,
+			pvtDataPresent: map[string][]string{
+				"ns-1": {"coll-1"},
+				"ns-2": {"coll-1"},
+			},
+			pvtDataMissing: map[string][]string{
+				"ns-1": {"coll-2"},
+				"ns-2": {"coll-2"},
+			},
+		},
+		{
+			blkNum: 1,
+			txNum:  2,
+			pvtDataPresent: map[string][]string{
+				"ns-1": {"coll-1"},
+			},
+			pvtDataMissing: map[string][]string{
+				"ns-1": {"coll-2"},
+			},
+		},
+		{
+			blkNum: 2,
+			txNum:  1,
+			pvtDataMissing: map[string][]string{
+				"ns-1": {"coll-1", "coll-2"},
+			},
+		},
+		{
+			blkNum: 2,
+			txNum:  3,
+			pvtDataPresent: map[string][]string{
+				"ns-1": {"coll-1"},
+			},
+		},
 	}
 
-	expectedMissingPvtDataInfo = make(ledger.MissingPvtDataInfo)
-	// missing data in block1, tx1
-	expectedMissingPvtDataInfo.Add(1, 1, "ns-1", "coll-2")
-	expectedMissingPvtDataInfo.Add(1, 1, "ns-2", "coll-2")
+	blocksPvtData, missingDataSummary = constructPvtDataForTest(t, oldBlockTxPvtDataInfo)
+	oldBlocksPvtData := map[uint64][]*ledger.TxPvtData{
+		1: blocksPvtData[1].pvtData,
+		2: blocksPvtData[2].pvtData,
+	}
+	require.NoError(t, store.CommitPvtDataOfOldBlocks(oldBlocksPvtData, nil))
 
-	// missing data in block1, tx2
-	expectedMissingPvtDataInfo.Add(1, 2, "ns-1", "coll-2")
-	expectedMissingPvtDataInfo.Add(1, 2, "ns-3", "coll-2")
+	for _, b := range blocksPvtData {
+		for _, dkey := range b.dataKeys {
+			require.True(t, testDataKeyExists(t, store, dkey))
+		}
+	}
+	assertMissingDataInfo(t, store, missingDataSummary, 2)
+}
 
-	// missing data in block2, tx1
-	expectedMissingPvtDataInfo.Add(2, 1, "ns-1", "coll-1")
-	expectedMissingPvtDataInfo.Add(2, 1, "ns-1", "coll-2")
+func TestCommitPvtDataOfOldBlocksWithBTL(t *testing.T) {
+	btlPolicy := btltestutil.SampleBTLPolicy(
+		map[[2]string]uint64{
+			{"ns-1", "coll-1"}: 1,
+			{"ns-2", "coll-1"}: 1,
+		},
+	)
+	env := NewTestStoreEnv(t, "TestCommitPvtDataOfOldBlocksWithBTL", btlPolicy, pvtDataConf())
+	defer env.Cleanup()
+	store := env.TestStore
 
-	missingPvtDataInfo, err = store.GetMissingPvtDataInfoForMostRecentBlocks(2)
-	require.NoError(t, err)
-	require.Equal(t, expectedMissingPvtDataInfo, missingPvtDataInfo)
+	blockTxPvtDataInfo := []*blockTxPvtDataInfoForTest{
+		{
+			blkNum: 1,
+			txNum:  1,
+			pvtDataMissing: map[string][]string{
+				"ns-1": {"coll-1"},
+				"ns-2": {"coll-1"},
+			},
+		},
+		{
+			blkNum: 1,
+			txNum:  2,
+			pvtDataMissing: map[string][]string{
+				"ns-1": {"coll-1"},
+				"ns-2": {"coll-1"},
+			},
+		},
+		{
+			blkNum: 1,
+			txNum:  3,
+			pvtDataMissing: map[string][]string{
+				"ns-1": {"coll-1"},
+				"ns-2": {"coll-1"},
+			},
+		},
+	}
 
-	// COMMIT BLOCK 3 WITH NO PVTDATA
+	blocksPvtData, missingDataSummary := constructPvtDataForTest(t, blockTxPvtDataInfo)
+
+	require.NoError(t, store.Commit(0, nil, nil))
+	require.NoError(t, store.Commit(1, blocksPvtData[1].pvtData, blocksPvtData[1].missingDataInfo))
+
+	assertMissingDataInfo(t, store, missingDataSummary, 1)
+
+	// COMMIT BLOCK 2 & 3 WITH NO PVTDATA
+	require.NoError(t, store.Commit(2, nil, nil))
 	require.NoError(t, store.Commit(3, nil, nil))
 
-	// IN BLOCK 1, NS-1:COLL-2 AND NS-2:COLL-2 SHOULD HAVE EXPIRED BUT NOT PURGED
-	// HENCE, THE FOLLOWING COMMIT SHOULD CREATE ENTRIES IN THE STORE
-	oldBlocksPvtData = make(map[uint64][]*ledger.TxPvtData)
-	oldBlocksPvtData[1] = []*ledger.TxPvtData{
-		produceSamplePvtdata(t, 1, []string{"ns-1:coll-2"}), // though expired, it
-		// would get committed to the store as it is not purged yet
-		produceSamplePvtdata(t, 2, []string{"ns-3:coll-2"}), // never expires
+	// in block 1, ns-1:coll-1 and ns-2:coll-2 should have expired but not purged.
+	// hence, the commit of pvtdata of block 1 transaction 1 should create entries
+	// in the store
+	oldBlockTxPvtDataInfo := []*blockTxPvtDataInfoForTest{
+		{
+			blkNum: 1,
+			txNum:  1,
+			pvtDataPresent: map[string][]string{
+				"ns-1": {"coll-1"},
+				"ns-2": {"coll-1"},
+			},
+		},
 	}
 
-	err = store.CommitPvtDataOfOldBlocks(oldBlocksPvtData)
-	require.NoError(t, err)
+	blocksPvtData, _ = constructPvtDataForTest(t, oldBlockTxPvtDataInfo)
+	oldBlocksPvtData := map[uint64][]*ledger.TxPvtData{
+		1: blocksPvtData[1].pvtData,
+	}
+	require.NoError(t, store.CommitPvtDataOfOldBlocks(oldBlocksPvtData, nil))
 
-	ns1Coll2Blk1Tx1 := &dataKey{nsCollBlk: nsCollBlk{ns: "ns-1", coll: "coll-2", blkNum: 1}, txNum: 1}
-	ns2Coll2Blk1Tx1 := &dataKey{nsCollBlk: nsCollBlk{ns: "ns-2", coll: "coll-2", blkNum: 1}, txNum: 1}
-	ns1Coll2Blk1Tx2 := &dataKey{nsCollBlk: nsCollBlk{ns: "ns-1", coll: "coll-2", blkNum: 1}, txNum: 2}
-	ns3Coll2Blk1Tx2 := &dataKey{nsCollBlk: nsCollBlk{ns: "ns-3", coll: "coll-2", blkNum: 1}, txNum: 2}
+	for _, b := range blocksPvtData {
+		for _, dkey := range b.dataKeys {
+			require.True(t, testDataKeyExists(t, store, dkey))
+		}
+	}
+	// as all missing data are expired, get missing info would return nil though
+	// it is not purged yet
+	assertMissingDataInfo(t, store, make(ledger.MissingPvtDataInfo), 1)
 
-	// though the pvtdata are expired but not purged yet, we do
-	// commit the data and hence the entries would exist in the
-	// store
-	require.True(t, testDataKeyExists(t, store, ns1Coll2Blk1Tx1))  // expired but committed
-	require.False(t, testDataKeyExists(t, store, ns2Coll2Blk1Tx1)) // expired but still missing
-	require.False(t, testDataKeyExists(t, store, ns1Coll2Blk1Tx2)) // expired still missing
-	require.True(t, testDataKeyExists(t, store, ns3Coll2Blk1Tx2))  // never expires
-
-	// COMMIT BLOCK 4 WITH NO PVTDATA
+	// while committing the next block, all entries related to expiry data are purged
 	require.NoError(t, store.Commit(4, nil, nil))
 
 	testWaitForPurgerRoutineToFinish(store)
-
-	// IN BLOCK 1, NS-1:COLL-2 AND NS-2:COLL-2 SHOULD HAVE EXPIRED BUT NOT PURGED
-	// HENCE, THE FOLLOWING COMMIT SHOULD NOT CREATE ENTRIES IN THE STORE
-	oldBlocksPvtData = make(map[uint64][]*ledger.TxPvtData)
-	oldBlocksPvtData[1] = []*ledger.TxPvtData{
-		// both data are expired and purged. hence, it won't be
-		// committed to the store
-		produceSamplePvtdata(t, 1, []string{"ns-2:coll-2"}),
-		produceSamplePvtdata(t, 2, []string{"ns-1:coll-2"}),
+	for _, b := range blocksPvtData {
+		for _, dkey := range b.dataKeys {
+			require.False(t, testDataKeyExists(t, store, dkey))
+		}
 	}
 
-	err = store.CommitPvtDataOfOldBlocks(oldBlocksPvtData)
+	// in block 1, ns-1:coll-1 and ns-2:coll-2 should have expired and purged.
+	// hence, the commit of pvtdata of block 1 transaction 2 should not create
+	// entries in the store
+	oldBlockTxPvtDataInfo = []*blockTxPvtDataInfoForTest{
+		{
+			blkNum: 1,
+			txNum:  2,
+			pvtDataPresent: map[string][]string{
+				"ns-1": {"coll-1"},
+				"ns-2": {"coll-1"},
+			},
+		},
+	}
+	oldBlocksPvtData = map[uint64][]*ledger.TxPvtData{
+		1: blocksPvtData[1].pvtData,
+	}
+	deprioritizedList := ledger.MissingPvtDataInfo{
+		1: ledger.MissingBlockPvtdataInfo{
+			3: {
+				{
+					Namespace:  "ns-1",
+					Collection: "coll-1",
+				},
+				{
+					Namespace:  "ns-2",
+					Collection: "coll-1",
+				},
+			},
+		},
+	}
+	require.NoError(t, store.CommitPvtDataOfOldBlocks(oldBlocksPvtData, deprioritizedList))
+
+	for _, b := range blocksPvtData {
+		for _, dkey := range b.dataKeys {
+			require.False(t, testDataKeyExists(t, store, dkey))
+		}
+	}
+	// deprioritized list should not be present
+	p := &oldBlockDataProcessor{
+		Store: store,
+	}
+	keys := []nsCollBlk{
+		{
+			ns:     "ns-1",
+			coll:   "coll-1",
+			blkNum: 1,
+		},
+		{
+			ns:     "ns-2",
+			coll:   "coll-1",
+			blkNum: 1,
+		},
+	}
+
+	for _, k := range keys {
+		bitmap, err := p.getMissingDataBitmapFromStore(elgDeprioritizedMissingDataGroup, k)
+		require.NoError(t, err)
+		require.Nil(t, bitmap)
+	}
+}
+
+func TestCommitPvtDataOfOldBlocksWithDeprioritization(t *testing.T) {
+	sampleDataForTest := func() (map[uint64]*pvtDataForTest, ledger.MissingPvtDataInfo) {
+		blockTxPvtDataInfo := []*blockTxPvtDataInfoForTest{
+			{
+				blkNum: 1,
+				txNum:  1,
+				pvtDataMissing: map[string][]string{
+					"ns-1": {"coll-1"},
+					"ns-2": {"coll-1"},
+				},
+			},
+			{
+				blkNum: 1,
+				txNum:  2,
+				pvtDataMissing: map[string][]string{
+					"ns-1": {"coll-1"},
+					"ns-2": {"coll-1"},
+				},
+			},
+			{
+				blkNum: 2,
+				txNum:  1,
+				pvtDataMissing: map[string][]string{
+					"ns-1": {"coll-1"},
+					"ns-2": {"coll-1"},
+				},
+			},
+			{
+				blkNum: 2,
+				txNum:  2,
+				pvtDataMissing: map[string][]string{
+					"ns-1": {"coll-1"},
+					"ns-2": {"coll-1"},
+				},
+			},
+		}
+
+		blocksPvtData, missingDataSummary := constructPvtDataForTest(t, blockTxPvtDataInfo)
+
+		return blocksPvtData, missingDataSummary
+	}
+
+	_, missingDataSummary := sampleDataForTest()
+
+	tests := []struct {
+		name                        string
+		deprioritizedList           ledger.MissingPvtDataInfo
+		expectedPrioMissingDataKeys ledger.MissingPvtDataInfo
+	}{
+		{
+			name:                        "all keys deprioritized",
+			deprioritizedList:           missingDataSummary,
+			expectedPrioMissingDataKeys: make(ledger.MissingPvtDataInfo),
+		},
+		{
+			name: "some keys deprioritized",
+			deprioritizedList: ledger.MissingPvtDataInfo{
+				1: ledger.MissingBlockPvtdataInfo{
+					2: {
+						{
+							Namespace:  "ns-1",
+							Collection: "coll-1",
+						},
+					},
+				},
+				2: ledger.MissingBlockPvtdataInfo{
+					2: {
+						{
+							Namespace:  "ns-1",
+							Collection: "coll-1",
+						},
+					},
+				},
+			},
+			expectedPrioMissingDataKeys: ledger.MissingPvtDataInfo{
+				1: ledger.MissingBlockPvtdataInfo{
+					1: {
+						{
+							Namespace:  "ns-1",
+							Collection: "coll-1",
+						},
+						{
+							Namespace:  "ns-2",
+							Collection: "coll-1",
+						},
+					},
+					2: {
+						{
+							Namespace:  "ns-2",
+							Collection: "coll-1",
+						},
+					},
+				},
+				2: ledger.MissingBlockPvtdataInfo{
+					1: {
+						{
+							Namespace:  "ns-1",
+							Collection: "coll-1",
+						},
+						{
+							Namespace:  "ns-2",
+							Collection: "coll-1",
+						},
+					},
+					2: {
+						{
+							Namespace:  "ns-2",
+							Collection: "coll-1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			btlPolicy := btltestutil.SampleBTLPolicy(
+				map[[2]string]uint64{
+					{"ns-1", "coll-1"}: 0,
+					{"ns-2", "coll-1"}: 0,
+				},
+			)
+			env := NewTestStoreEnv(t, "TestCommitPvtDataOfOldBlocksWithDeprio", btlPolicy, pvtDataConf())
+			defer env.Cleanup()
+			store := env.TestStore
+
+			blocksPvtData, missingDataSummary := sampleDataForTest()
+
+			// COMMIT BLOCK 0 WITH NO DATA
+			require.NoError(t, store.Commit(0, nil, nil))
+			require.NoError(t, store.Commit(1, blocksPvtData[1].pvtData, blocksPvtData[1].missingDataInfo))
+			require.NoError(t, store.Commit(2, blocksPvtData[2].pvtData, blocksPvtData[2].missingDataInfo))
+
+			assertMissingDataInfo(t, store, missingDataSummary, 2)
+
+			require.NoError(t, store.CommitPvtDataOfOldBlocks(nil, tt.deprioritizedList))
+
+			prioMissingData, err := store.getMissingData(elgPrioritizedMissingDataGroup, 3)
+			require.NoError(t, err)
+			require.Equal(t, len(tt.expectedPrioMissingDataKeys), len(prioMissingData))
+			for blkNum, txsMissingData := range tt.expectedPrioMissingDataKeys {
+				for txNum, expectedMissingData := range txsMissingData {
+					require.ElementsMatch(t, expectedMissingData, prioMissingData[blkNum][txNum])
+				}
+			}
+
+			deprioMissingData, err := store.getMissingData(elgDeprioritizedMissingDataGroup, 3)
+			require.NoError(t, err)
+			require.Equal(t, len(tt.deprioritizedList), len(deprioMissingData))
+			for blkNum, txsMissingData := range tt.deprioritizedList {
+				for txNum, expectedMissingData := range txsMissingData {
+					require.ElementsMatch(t, expectedMissingData, deprioMissingData[blkNum][txNum])
+				}
+			}
+
+			oldBlockTxPvtDataInfo := []*blockTxPvtDataInfoForTest{
+				{
+					blkNum: 1,
+					txNum:  1,
+					pvtDataPresent: map[string][]string{
+						"ns-1": {"coll-1"},
+						"ns-2": {"coll-1"},
+					},
+				},
+				{
+					blkNum: 1,
+					txNum:  2,
+					pvtDataPresent: map[string][]string{
+						"ns-1": {"coll-1"},
+						"ns-2": {"coll-1"},
+					},
+				},
+				{
+					blkNum: 2,
+					txNum:  1,
+					pvtDataPresent: map[string][]string{
+						"ns-1": {"coll-1"},
+						"ns-2": {"coll-1"},
+					},
+				},
+				{
+					blkNum: 2,
+					txNum:  2,
+					pvtDataPresent: map[string][]string{
+						"ns-1": {"coll-1"},
+						"ns-2": {"coll-1"},
+					},
+				},
+			}
+
+			blocksPvtData, _ = constructPvtDataForTest(t, oldBlockTxPvtDataInfo)
+			oldBlocksPvtData := map[uint64][]*ledger.TxPvtData{
+				1: blocksPvtData[1].pvtData,
+				2: blocksPvtData[2].pvtData,
+			}
+			require.NoError(t, store.CommitPvtDataOfOldBlocks(oldBlocksPvtData, nil))
+
+			prioMissingData, err = store.getMissingData(elgPrioritizedMissingDataGroup, 3)
+			require.NoError(t, err)
+			require.Equal(t, make(ledger.MissingPvtDataInfo), prioMissingData)
+
+			deprioMissingData, err = store.getMissingData(elgDeprioritizedMissingDataGroup, 3)
+			require.NoError(t, err)
+			require.Equal(t, make(ledger.MissingPvtDataInfo), deprioMissingData)
+		})
+	}
+}
+
+func constructPvtDataForTest(t *testing.T, blockInfo []*blockTxPvtDataInfoForTest) (map[uint64]*pvtDataForTest, ledger.MissingPvtDataInfo) {
+	blocksPvtData := make(map[uint64]*pvtDataForTest)
+	missingPvtDataInfoSummary := make(ledger.MissingPvtDataInfo)
+
+	for _, b := range blockInfo {
+		p, ok := blocksPvtData[b.blkNum]
+		if !ok {
+			p = &pvtDataForTest{
+				missingDataInfo: make(ledger.TxMissingPvtData),
+			}
+			blocksPvtData[b.blkNum] = p
+		}
+
+		for ns, colls := range b.pvtDataMissing {
+			for _, coll := range colls {
+				p.missingDataInfo.Add(b.txNum, ns, coll, true)
+				missingPvtDataInfoSummary.Add(b.blkNum, b.txNum, ns, coll)
+			}
+		}
+
+		var nsColls []string
+		for ns, colls := range b.pvtDataPresent {
+			for _, coll := range colls {
+				nsColls = append(nsColls, fmt.Sprintf("%s:%s", ns, coll))
+				p.dataKeys = append(p.dataKeys, &dataKey{
+					nsCollBlk: nsCollBlk{
+						ns:     ns,
+						coll:   coll,
+						blkNum: b.blkNum,
+					},
+					txNum: b.txNum,
+				})
+			}
+		}
+
+		if len(nsColls) == 0 {
+			continue
+		}
+		p.pvtData = append(
+			p.pvtData,
+			produceSamplePvtdata(t, b.txNum, nsColls),
+		)
+	}
+
+	return blocksPvtData, missingPvtDataInfoSummary
+}
+
+func assertMissingDataInfo(t *testing.T, store *Store, expected ledger.MissingPvtDataInfo, numRecentBlocks int) {
+	missingPvtDataInfo, err := store.GetMissingPvtDataInfoForMostRecentBlocks(numRecentBlocks)
 	require.NoError(t, err)
+	require.Equal(t, len(expected), len(missingPvtDataInfo))
+	for blkNum, txsMissingData := range expected {
+		for txNum, expectedMissingData := range txsMissingData {
+			require.ElementsMatch(t, expectedMissingData, missingPvtDataInfo[blkNum][txNum])
+		}
+	}
+}
 
-	ns1Coll2Blk1Tx1 = &dataKey{nsCollBlk: nsCollBlk{ns: "ns-1", coll: "coll-2", blkNum: 1}, txNum: 1}
-	ns2Coll2Blk1Tx1 = &dataKey{nsCollBlk: nsCollBlk{ns: "ns-2", coll: "coll-2", blkNum: 1}, txNum: 1}
-	ns1Coll2Blk1Tx2 = &dataKey{nsCollBlk: nsCollBlk{ns: "ns-1", coll: "coll-2", blkNum: 1}, txNum: 2}
-	ns3Coll2Blk1Tx2 = &dataKey{nsCollBlk: nsCollBlk{ns: "ns-3", coll: "coll-2", blkNum: 1}, txNum: 2}
-
-	require.False(t, testDataKeyExists(t, store, ns1Coll2Blk1Tx1)) // purged
-	require.False(t, testDataKeyExists(t, store, ns2Coll2Blk1Tx1)) // purged
-	require.False(t, testDataKeyExists(t, store, ns1Coll2Blk1Tx2)) // purged
-	require.True(t, testDataKeyExists(t, store, ns3Coll2Blk1Tx2))  // never expires
+func constructBitSetForTest(txNums ...uint) *bitset.BitSet {
+	bitmap := &bitset.BitSet{}
+	for _, txNum := range txNums {
+		bitmap.Set(txNum)
+	}
+	return bitmap
 }

--- a/core/ledger/pvtdatastorage/reconcile_missing_pvtdata_test.go
+++ b/core/ledger/pvtdatastorage/reconcile_missing_pvtdata_test.go
@@ -292,9 +292,10 @@ func TestCommitPvtDataOfOldBlocksWithBTL(t *testing.T) {
 	}
 
 	for _, k := range keys {
-		bitmap, err := p.getMissingDataBitmapFromStore(elgDeprioritizedMissingDataGroup, k)
+		encKey := encodeElgPrioMissingDataKey(&missingDataKey{k})
+		missingData, err := p.db.Get(encKey)
 		require.NoError(t, err)
-		require.Nil(t, bitmap)
+		require.Nil(t, missingData)
 	}
 }
 

--- a/core/ledger/pvtdatastorage/store.go
+++ b/core/ledger/pvtdatastorage/store.go
@@ -63,6 +63,9 @@ type Store struct {
 	// in the stateDB needs to be updated before finishing the
 	// recovery operation.
 	isLastUpdatedOldBlocksSet bool
+
+	iterSinceDeprioMissingDataAccess    int
+	deprioritizedMissingDataPeriodicity int
 }
 
 type blkTranNumKey []byte
@@ -140,6 +143,7 @@ func (p *Provider) OpenStore(ledgerid string) (*Store, error) {
 		return nil, err
 	}
 	s.launchCollElgProc()
+	s.deprioritizedMissingDataPeriodicity = 1000
 	logger.Debugf("Pvtdata store opened. Initial state: isEmpty [%t], lastCommittedBlock [%d]",
 		s.isEmpty, s.lastCommittedBlock)
 	return s, nil
@@ -212,7 +216,7 @@ func (s *Store) Commit(blockNum uint64, pvtData []*ledger.TxPvtData, missingPvtD
 
 	batch := s.db.NewUpdateBatch()
 	var err error
-	var keyBytes, valBytes []byte
+	var key, val []byte
 
 	storeEntries, err := prepareStoreEntries(blockNum, pvtData, s.btlPolicy, missingPvtData)
 	if err != nil {
@@ -220,27 +224,32 @@ func (s *Store) Commit(blockNum uint64, pvtData []*ledger.TxPvtData, missingPvtD
 	}
 
 	for _, dataEntry := range storeEntries.dataEntries {
-		keyBytes = encodeDataKey(dataEntry.key)
-		if valBytes, err = encodeDataValue(dataEntry.value); err != nil {
+		key = encodeDataKey(dataEntry.key)
+		if val, err = encodeDataValue(dataEntry.value); err != nil {
 			return err
 		}
-		batch.Put(keyBytes, valBytes)
+		batch.Put(key, val)
 	}
 
 	for _, expiryEntry := range storeEntries.expiryEntries {
-		keyBytes = encodeExpiryKey(expiryEntry.key)
-		if valBytes, err = encodeExpiryValue(expiryEntry.value); err != nil {
+		key = encodeExpiryKey(expiryEntry.key)
+		if val, err = encodeExpiryValue(expiryEntry.value); err != nil {
 			return err
 		}
-		batch.Put(keyBytes, valBytes)
+		batch.Put(key, val)
 	}
 
 	for missingDataKey, missingDataValue := range storeEntries.missingDataEntries {
-		keyBytes = encodeMissingDataKey(&missingDataKey)
-		if valBytes, err = encodeMissingDataValue(missingDataValue); err != nil {
+		switch {
+		case missingDataKey.isEligible:
+			key = encodeElgMissingDataKey(elgPrioritizedMissingDataGroup, &missingDataKey)
+		default:
+			key = encodeInelgMissingDataKey(&missingDataKey)
+		}
+		if val, err = encodeMissingDataValue(missingDataValue); err != nil {
 			return err
 		}
-		batch.Put(keyBytes, valBytes)
+		batch.Put(key, val)
 	}
 
 	committingBlockNum := s.nextBlockNum()
@@ -403,16 +412,27 @@ func (s *Store) GetMissingPvtDataInfoForMostRecentBlocks(maxBlock int) (ledger.M
 		return nil, nil
 	}
 
+	if s.iterSinceDeprioMissingDataAccess == s.deprioritizedMissingDataPeriodicity {
+		s.iterSinceDeprioMissingDataAccess = 0
+		return s.getMissingData(elgDeprioritizedMissingDataGroup, maxBlock)
+	}
+
+	s.iterSinceDeprioMissingDataAccess++
+	return s.getMissingData(elgPrioritizedMissingDataGroup, maxBlock)
+}
+
+func (s *Store) getMissingData(group []byte, maxBlock int) (ledger.MissingPvtDataInfo, error) {
 	missingPvtDataInfo := make(ledger.MissingPvtDataInfo)
 	numberOfBlockProcessed := 0
 	lastProcessedBlock := uint64(0)
 	isMaxBlockLimitReached := false
+
 	// as we are not acquiring a read lock, new blocks can get committed while we
 	// construct the MissingPvtDataInfo. As a result, lastCommittedBlock can get
 	// changed. To ensure consistency, we atomically load the lastCommittedBlock value
 	lastCommittedBlock := atomic.LoadUint64(&s.lastCommittedBlock)
 
-	startKey, endKey := createRangeScanKeysForEligibleMissingDataEntries(lastCommittedBlock)
+	startKey, endKey := createRangeScanKeysForElgMissingData(lastCommittedBlock, group)
 	dbItr, err := s.db.GetIterator(startKey, endKey)
 	if err != nil {
 		return nil, err
@@ -421,7 +441,7 @@ func (s *Store) GetMissingPvtDataInfoForMostRecentBlocks(maxBlock int) (ledger.M
 
 	for dbItr.Next() {
 		missingDataKeyBytes := dbItr.Key()
-		missingDataKey := decodeMissingDataKey(missingDataKeyBytes)
+		missingDataKey := decodeElgMissingDataKey(missingDataKeyBytes)
 
 		if isMaxBlockLimitReached && (missingDataKey.blkNum != lastProcessedBlock) {
 			// ensures that exactly maxBlock number
@@ -512,26 +532,38 @@ func (s *Store) performPurgeIfScheduled(latestCommittedBlk uint64) {
 }
 
 func (s *Store) purgeExpiredData(minBlkNum, maxBlkNum uint64) error {
-	batch := s.db.NewUpdateBatch()
 	expiryEntries, err := s.retrieveExpiryEntries(minBlkNum, maxBlkNum)
 	if err != nil || len(expiryEntries) == 0 {
 		return err
 	}
+
+	batch := s.db.NewUpdateBatch()
 	for _, expiryEntry := range expiryEntries {
-		// this encoding could have been saved if the function retrieveExpiryEntries also returns the encoded expiry keys.
-		// However, keeping it for better readability
 		batch.Delete(encodeExpiryKey(expiryEntry.key))
 		dataKeys, missingDataKeys := deriveKeys(expiryEntry)
+
 		for _, dataKey := range dataKeys {
 			batch.Delete(encodeDataKey(dataKey))
 		}
+
 		for _, missingDataKey := range missingDataKeys {
-			batch.Delete(encodeMissingDataKey(missingDataKey))
+			batch.Delete(
+				encodeElgMissingDataKey(elgPrioritizedMissingDataGroup, missingDataKey),
+			)
+			batch.Delete(
+				encodeElgMissingDataKey(elgDeprioritizedMissingDataGroup, missingDataKey),
+			)
+			batch.Delete(
+				encodeInelgMissingDataKey(missingDataKey),
+			)
 		}
+
 		if err := s.db.WriteBatch(batch, false); err != nil {
 			return err
 		}
+		batch.Reset()
 	}
+
 	logger.Infof("[%s] - [%d] Entries purged from private data storage till block number [%d]", s.ledgerid, len(expiryEntries), maxBlkNum)
 	return nil
 }
@@ -606,7 +638,7 @@ func (s *Store) processCollElgEvents() error {
 			var coll string
 			for _, coll = range colls.Entries {
 				logger.Infof("Converting missing data entries from ineligible to eligible for [ns=%s, coll=%s]", ns, coll)
-				startKey, endKey := createRangeScanKeysForIneligibleMissingData(blkNum, ns, coll)
+				startKey, endKey := createRangeScanKeysForInelgMissingData(blkNum, ns, coll)
 				collItr, err := s.db.GetIterator(startKey, endKey)
 				if err != nil {
 					return err
@@ -615,12 +647,15 @@ func (s *Store) processCollElgEvents() error {
 
 				for collItr.Next() { // each entry
 					originalKey, originalVal := collItr.Key(), collItr.Value()
-					modifiedKey := decodeMissingDataKey(originalKey)
+					modifiedKey := decodeInelgMissingDataKey(originalKey)
 					modifiedKey.isEligible = true
 					batch.Delete(originalKey)
 					copyVal := make([]byte, len(originalVal))
 					copy(copyVal, originalVal)
-					batch.Put(encodeMissingDataKey(modifiedKey), copyVal)
+					batch.Put(
+						encodeElgMissingDataKey(elgPrioritizedMissingDataGroup, modifiedKey),
+						copyVal,
+					)
 					collEntriesConverted++
 					if batch.Len() > s.maxBatchSize {
 						s.db.WriteBatch(batch, true)
@@ -709,30 +744,6 @@ func (c *collElgProcSync) done() {
 
 func (c *collElgProcSync) waitForDone() {
 	<-c.procComplete
-}
-
-func (s *Store) getBitmapOfMissingDataKey(missingDataKey *missingDataKey) (*bitset.BitSet, error) {
-	var v []byte
-	var err error
-	if v, err = s.db.Get(encodeMissingDataKey(missingDataKey)); err != nil {
-		return nil, err
-	}
-	if v == nil {
-		return nil, nil
-	}
-	return decodeMissingDataValue(v)
-}
-
-func (s *Store) getExpiryDataOfExpiryKey(expiryKey *expiryKey) (*ExpiryData, error) {
-	var v []byte
-	var err error
-	if v, err = s.db.Get(encodeExpiryKey(expiryKey)); err != nil {
-		return nil, err
-	}
-	if v == nil {
-		return nil, nil
-	}
-	return decodeExpiryValue(v)
 }
 
 // ErrIllegalCall is to be thrown by a store impl if the store does not expect a call to Prepare/Commit/Rollback/InitLastCommittedBlock

--- a/core/ledger/pvtdatastorage/store_test.go
+++ b/core/ledger/pvtdatastorage/store_test.go
@@ -245,7 +245,12 @@ func TestGetMissingDataInfo(t *testing.T) {
 		},
 	}
 
+	defaultVal := deprioritizedMissingDataPeriodicity
 	deprioritizedMissingDataPeriodicity = 10
+	defer func() {
+		deprioritizedMissingDataPeriodicity = defaultVal
+	}()
+
 	for i := 1; i <= 55; i++ {
 		if i%11 == 0 {
 			// after ever 10 iterations of accessing the prioritized list, the

--- a/core/ledger/pvtdatastorage/test_exports.go
+++ b/core/ledger/pvtdatastorage/test_exports.go
@@ -69,6 +69,8 @@ func (env *StoreEnv) CloseAndReopen() {
 
 // Cleanup cleansup the  store env after testing
 func (env *StoreEnv) Cleanup() {
+	env.TestStoreProvider.Close()
+	env.TestStore.db.Close()
 	if err := os.RemoveAll(env.conf.StorePath); err != nil {
 		env.t.Errorf("error while removing path %s, %v", env.conf.StorePath, err)
 	}


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

When a private data associated with a transaction is missing (i.e, the peer could not fetch it from other members during the commit time), the missing data info is recorded in the pvtdata store rather than stalling the block commit. A pvtdata reconciler task is to periodically try to fetch these missing private data. When the reconciler is not able to fetch a particular private data, it is necessary to deprioritize that missing private data so that the reconciler can fetch other missing private data rather than stalling the whole process by continuously retrying the same missing data. 

This PR enables differentiation of prioritized and deprioritized missing data. 

#### Additional details

This feature is necessary for the peer that bootstraps a channel using a snapshot. As the private is not dumped to a file, the new peer will use a reconciler to fetch the required private data. If a certain set of missing data could not be fetched, then the reconciler will get into a loop and does not progress further in a rare situation. 