### PR TITLE
[FAB-18109] Update peer chaincode invoke

### DIFF
--- a/docs/source/commands/peerchaincode.md
+++ b/docs/source/commands/peerchaincode.md
@@ -382,6 +382,18 @@ Here is an example of the `peer chaincode invoke` command:
     successfully. The transaction will then be added to a block and, finally, validated
     or invalidated by each peer on the channel.
 
+Here is an example of how to format the `peer chaincode invoke` command when the chaincode package includes multiple smart contracts.
+
+  * If you are using the [contract-api](https://www.npmjs.com/package/fabric-contract-api), the name you pass to `super("MyContract")` can be used as a prefix.
+
+    ```
+    peer chaincode invoke -C $CHANNEL_NAME -n $CHAINCODE_NAME -c '{ "Args": ["MyContract:methodName", "{}"] }'
+
+    peer chaincode invoke -C $CHANNEL_NAME -n $CHAINCODE_NAME -c '{ "Args": ["MyOtherContract:methodName", "{}"] }'
+
+    ```
+
+
 ### peer chaincode list example
 
 Here are some examples of the `peer chaincode list ` command:

--- a/docs/source/write_first_app.rst
+++ b/docs/source/write_first_app.rst
@@ -340,8 +340,15 @@ to the Contract using the contract name and channel name via Gateway:
     // Build a network instance based on the channel where the smart contract is deployed
     const network = await gateway.getNetwork(channelName);
 
+
     // Get the contract from the network.
     const contract = network.getContract(chaincodeName);
+
+When a chaincode package includes multiple smart contracts, on the `getContract() API <https://hyperledger.github.io/fabric-sdk-node/release-2.2/module-fabric-network.Network.html#getContract>`__ you can specify both the name of the chaincode package and a specific smart contract to target. For example:
+
+.. code:: bash
+
+  const contract = await network.getContract('chaincodeName', 'smartContractName');
 
 Fourth, the application initializes the ledger with some sample data
 --------------------------------------------------------------------

--- a/docs/wrappers/peer_chaincode_postscript.md
+++ b/docs/wrappers/peer_chaincode_postscript.md
@@ -66,6 +66,18 @@ Here is an example of the `peer chaincode invoke` command:
     successfully. The transaction will then be added to a block and, finally, validated
     or invalidated by each peer on the channel.
 
+Here is an example of how to format the `peer chaincode invoke` command when the chaincode package includes multiple smart contracts.
+
+  * If you are using the [contract-api](https://www.npmjs.com/package/fabric-contract-api), the name you pass to `super("MyContract")` can be used as a prefix.
+
+    ```
+    peer chaincode invoke -C $CHANNEL_NAME -n $CHAINCODE_NAME -c '{ "Args": ["MyContract:methodName", "{}"] }'
+
+    peer chaincode invoke -C $CHANNEL_NAME -n $CHAINCODE_NAME -c '{ "Args": ["MyOtherContract:methodName", "{}"] }'
+
+    ```
+
+
 ### peer chaincode list example
 
 Here are some examples of the `peer chaincode list ` command:


### PR DESCRIPTION
Need to describe how to target a specific smart contract inside
a chaincode package.
- Added a new example to peer chaincode invoke
- Added instructions to writing your first application tutorial.

Content is already included in the Developing Apps documentation.

Signed-off-by: pama-ibm <pama@ibm.com>


#### Type of change

- Documentation update

#### Description

User feedback that they could not find instructions for how to use the peer chaincode invoke
command when chaincode package includes multiple smart contracts.

- Added a new example to peer chaincode invoke
- Added instructions to writing your first application tutorial.

(Content is already included in the Developing Apps documentation.)

#### Additional details

#### Related issues
#### Release Note
