### PR TITLE
Pass snapshot metadata to init pvtdatastorage store properly

### DIFF
--- a/core/ledger/kvledger/kv_ledger_provider.go
+++ b/core/ledger/kvledger/kv_ledger_provider.go
@@ -334,7 +334,12 @@ func (p *Provider) open(ledgerID string, bootSnapshotMetadata *snapshotMetadata)
 		return nil, err
 	}
 
-	pvtdataStore, err := p.pvtdataStoreProvider.OpenStore(ledgerID)
+	storeInitializer := &pvtdatastorage.Initializer{CreatedFromSnapshot: false}
+	if bootSnapshotMetadata != nil {
+		storeInitializer.CreatedFromSnapshot = true
+		storeInitializer.LastBlockInSnapshot = bootSnapshotMetadata.ChannelHeight - 1
+	}
+	pvtdataStore, err := p.pvtdataStoreProvider.OpenStore(ledgerID, storeInitializer)
 	if err != nil {
 		return nil, err
 	}

--- a/core/ledger/pvtdatastorage/reconcile_missing_pvtdata_test.go
+++ b/core/ledger/pvtdatastorage/reconcile_missing_pvtdata_test.go
@@ -28,7 +28,7 @@ func TestCommitPvtDataOfOldBlocks(t *testing.T) {
 			{"ns-4", "coll-2"}: 0,
 		},
 	)
-	env := NewTestStoreEnv(t, "TestCommitPvtDataOfOldBlocks", btlPolicy, pvtDataConf())
+	env := NewTestStoreEnv(t, "TestCommitPvtDataOfOldBlocks", btlPolicy, pvtDataConf(), &Initializer{})
 	defer env.Cleanup()
 	store := env.TestStore
 

--- a/core/ledger/pvtdatastorage/store_test.go
+++ b/core/ledger/pvtdatastorage/store_test.go
@@ -28,10 +28,22 @@ func TestMain(m *testing.M) {
 }
 
 func TestEmptyStore(t *testing.T) {
-	env := NewTestStoreEnv(t, "TestEmptyStore", nil, pvtDataConf())
+	env := NewTestStoreEnv(t, "TestEmptyStore", nil, pvtDataConf(), &Initializer{})
 	defer env.Cleanup()
 	store := env.TestStore
 	require.True(t, store.isEmpty)
+}
+
+func TestStoreCreatedFromSnapshot(t *testing.T) {
+	initializer := &Initializer{
+		CreatedFromSnapshot: true,
+		LastBlockInSnapshot: 100,
+	}
+	env := NewTestStoreEnv(t, "TestStoreCreatedFromSnapshot", nil, pvtDataConf(), initializer)
+	defer env.Cleanup()
+	store := env.TestStore
+	require.False(t, store.isEmpty)
+	require.Equal(t, initializer.LastBlockInSnapshot, store.lastCommittedBlock)
 }
 
 func TestStoreBasicCommitAndRetrieval(t *testing.T) {
@@ -47,7 +59,7 @@ func TestStoreBasicCommitAndRetrieval(t *testing.T) {
 		},
 	)
 
-	env := NewTestStoreEnv(t, "TestStoreBasicCommitAndRetrieval", btlPolicy, pvtDataConf())
+	env := NewTestStoreEnv(t, "TestStoreBasicCommitAndRetrieval", btlPolicy, pvtDataConf(), &Initializer{})
 	defer env.Cleanup()
 	store := env.TestStore
 	testData := []*ledger.TxPvtData{
@@ -154,7 +166,7 @@ func TestStoreBasicCommitAndRetrieval(t *testing.T) {
 }
 
 func TestStoreIteratorError(t *testing.T) {
-	env := NewTestStoreEnv(t, "TestStoreIteratorError", nil, pvtDataConf())
+	env := NewTestStoreEnv(t, "TestStoreIteratorError", nil, pvtDataConf(), &Initializer{})
 	defer env.Cleanup()
 	store := env.TestStore
 	require.NoError(t, store.Commit(0, nil, nil))
@@ -203,7 +215,7 @@ func TestExpiryDataNotIncluded(t *testing.T) {
 			{"ns-3", "coll-2"}: 0,
 		},
 	)
-	env := NewTestStoreEnv(t, ledgerid, btlPolicy, pvtDataConf())
+	env := NewTestStoreEnv(t, ledgerid, btlPolicy, pvtDataConf(), &Initializer{})
 	defer env.Cleanup()
 	store := env.TestStore
 
@@ -327,7 +339,7 @@ func TestStorePurge(t *testing.T) {
 			{"ns-3", "coll-2"}: 0,
 		},
 	)
-	env := NewTestStoreEnv(t, ledgerid, btlPolicy, pvtDataConf())
+	env := NewTestStoreEnv(t, ledgerid, btlPolicy, pvtDataConf(), &Initializer{})
 	defer env.Cleanup()
 	s := env.TestStore
 
@@ -426,7 +438,7 @@ func TestStoreState(t *testing.T) {
 			{"ns-1", "coll-2"}: 0,
 		},
 	)
-	env := NewTestStoreEnv(t, "TestStoreState", btlPolicy, pvtDataConf())
+	env := NewTestStoreEnv(t, "TestStoreState", btlPolicy, pvtDataConf(), &Initializer{})
 	defer env.Cleanup()
 	store := env.TestStore
 	testData := []*ledger.TxPvtData{
@@ -443,7 +455,7 @@ func TestPendingBatch(t *testing.T) {
 			{"ns-1", "coll-2"}: 0,
 		},
 	)
-	env := NewTestStoreEnv(t, "TestPendingBatch", btlPolicy, pvtDataConf())
+	env := NewTestStoreEnv(t, "TestPendingBatch", btlPolicy, pvtDataConf(), &Initializer{})
 	defer env.Cleanup()
 	s := env.TestStore
 	existingLastBlockNum := uint64(25)
@@ -529,7 +541,7 @@ func TestDrop(t *testing.T) {
 		},
 	)
 
-	env := NewTestStoreEnv(t, ledgerid, btlPolicy, pvtDataConf())
+	env := NewTestStoreEnv(t, ledgerid, btlPolicy, pvtDataConf(), &Initializer{})
 	defer env.Cleanup()
 	store := env.TestStore
 
@@ -601,7 +613,7 @@ func testCollElgEnabled(t *testing.T, conf *PrivateDataConfig) {
 			{"ns-2", "coll-2"}: 0,
 		},
 	)
-	env := NewTestStoreEnv(t, ledgerid, btlPolicy, conf)
+	env := NewTestStoreEnv(t, ledgerid, btlPolicy, conf, &Initializer{})
 	defer env.Cleanup()
 	testStore := env.TestStore
 

--- a/core/ledger/pvtdatastorage/test_exports.go
+++ b/core/ledger/pvtdatastorage/test_exports.go
@@ -42,7 +42,8 @@ func NewTestStoreEnv(
 	t *testing.T,
 	ledgerid string,
 	btlPolicy pvtdatapolicy.BTLPolicy,
-	conf *PrivateDataConfig) *StoreEnv {
+	conf *PrivateDataConfig,
+	initializer *Initializer) *StoreEnv {
 	storeDir, err := ioutil.TempDir("", "pdstore")
 	if err != nil {
 		t.Fatalf("Failed to create private data storage directory: %s", err)
@@ -50,7 +51,7 @@ func NewTestStoreEnv(
 	conf.StorePath = storeDir
 	testStoreProvider, err := NewProvider(conf)
 	require.NoError(t, err)
-	testStore, err := testStoreProvider.OpenStore(ledgerid)
+	testStore, err := testStoreProvider.OpenStore(ledgerid, initializer)
 	testStore.Init(btlPolicy)
 	require.NoError(t, err)
 	return &StoreEnv{t, testStoreProvider, testStore, ledgerid, btlPolicy, conf}
@@ -62,7 +63,7 @@ func (env *StoreEnv) CloseAndReopen() {
 	env.TestStoreProvider.Close()
 	env.TestStoreProvider, err = NewProvider(env.conf)
 	require.NoError(env.t, err)
-	env.TestStore, err = env.TestStoreProvider.OpenStore(env.ledgerid)
+	env.TestStore, err = env.TestStoreProvider.OpenStore(env.ledgerid, &Initializer{})
 	env.TestStore.Init(env.btlPolicy)
 	require.NoError(env.t, err)
 }

--- a/core/ledger/pvtdatastorage/v11_V12_test.go
+++ b/core/ledger/pvtdatastorage/v11_V12_test.go
@@ -51,7 +51,7 @@ func TestV11v12(t *testing.T) {
 	p, err := NewProvider(conf)
 	require.NoError(t, err)
 	defer p.Close()
-	s, err := p.OpenStore(ledgerid)
+	s, err := p.OpenStore(ledgerid, &Initializer{})
 	require.NoError(t, err)
 	s.Init(btlPolicy)
 


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Bug fix

#### Description
Add an initializer to pass snapshot metadata to open pvtdatastorage store so that it can init state properly.

#### Related issues
https://jira.hyperledger.org/browse/FAB-17689