### PR TITLE
[FAB-18162] Add CreateLedgerFromSnapshot to LedgerMgr to enable join channel by snapshot

### DIFF
--- a/core/ledger/ledger_interface.go
+++ b/core/ledger/ledger_interface.go
@@ -130,10 +130,11 @@ type SnapshotsConfig struct {
 type PeerLedgerProvider interface {
 	// CreateFromGenesisBlock creates a new ledger with the given genesis block.
 	// This function guarantees that the creation of ledger and committing the genesis block would an atomic action
-	// The chain id retrieved from the genesis block is treated as a ledger id
+	// The channel id retrieved from the genesis block is treated as a ledger id
 	CreateFromGenesisBlock(genesisBlock *common.Block) (PeerLedger, error)
-	// CreateFromSnapshot creates a new ledger from a snapshot
-	CreateFromSnapshot(snapshotDir string) (PeerLedger, error)
+	// CreateFromSnapshot creates a new ledger from a snapshot and returns the ledger and channel id.
+	// The channel id retrieved from snapshot metadata is treated as a ledger id
+	CreateFromSnapshot(snapshotDir string) (PeerLedger, string, error)
 	// Open opens an already created ledger
 	Open(ledgerID string) (PeerLedger, error)
 	// Exists tells whether the ledger with given id exists


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- New feature

#### Description
- Add CreateLedgerFromSnapshot API to LedgerMgr
- Update PeerLedgerProvider.CreateFromSnapshot to return channel ID

#### Additional details

#### Related issues
https://jira.hyperledger.org/browse/FAB-18162