### PR TITLE
Increase iterations for raft active nodes to be considered stable

### DIFF
--- a/orderer/consensus/etcdraft/tracker.go
+++ b/orderer/consensus/etcdraft/tracker.go
@@ -66,9 +66,9 @@ func (t *Tracker) Check(status *raft.Status) {
 		return
 	}
 
-	// consider active nodes to be stable if it holds for 3 iterations, to avoid glitch
+	// consider active nodes to be stable if it holds for 5 iterations, to avoid glitch
 	// in this value when the recent status is reset on leader election intervals
-	if t.counter < 3 {
+	if t.counter < 5 {
 		t.counter++
 		return
 	}


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

At times, the active nodes reported by Raft are temporarily unstable. I've noticed this while working on an integration test where I add an OSN as a follower, wait for it to catch up, and then add it to the consenters set. 

You can see the leader initially reports the active nodes as [1 2 3] and then follows it up by reporting the active nodes of [1 2]. This causes problems when attempting to determine when a newly added consenter is truly active. Subsequent attempts to, for example, remove a consenter result in an incorrect failure:

#### Related issues

[FAB-18167](https://jira.hyperledger.org/browse/FAB-18167)