### PR TITLE
Do not export client struct in snapshot CLI cmds

### DIFF
--- a/internal/peer/snapshot/cancelrequest.go
+++ b/internal/peer/snapshot/cancelrequest.go
@@ -17,13 +17,13 @@ import (
 )
 
 // cancelRequestCmd returns the cobra command for snapshot cancelrequest command
-func cancelRequestCmd(client *Client, cryptoProvider bccsp.BCCSP) *cobra.Command {
+func cancelRequestCmd(cl *client, cryptoProvider bccsp.BCCSP) *cobra.Command {
 	snapshotCancelRequestCmd := &cobra.Command{
 		Use:   "cancelrequest",
 		Short: "Cancel a request for a snapshot at the specified block.",
 		Long:  "Cancel a request for a snapshot at the specified block.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cancelRequest(cmd, client, cryptoProvider)
+			return cancelRequest(cmd, cl, cryptoProvider)
 		},
 	}
 
@@ -38,7 +38,7 @@ func cancelRequestCmd(client *Client, cryptoProvider bccsp.BCCSP) *cobra.Command
 	return snapshotCancelRequestCmd
 }
 
-func cancelRequest(cmd *cobra.Command, client *Client, cryptoProvider bccsp.BCCSP) error {
+func cancelRequest(cmd *cobra.Command, cl *client, cryptoProvider bccsp.BCCSP) error {
 	if err := validateCancelRequest(); err != nil {
 		return err
 	}
@@ -47,9 +47,9 @@ func cancelRequest(cmd *cobra.Command, client *Client, cryptoProvider bccsp.BCCS
 	cmd.SilenceUsage = true
 
 	// create a client if not provided
-	if client == nil {
+	if cl == nil {
 		var err error
-		client, err = NewClient(cryptoProvider)
+		cl, err = newClient(cryptoProvider)
 		if err != nil {
 			return err
 		}
@@ -59,17 +59,17 @@ func cancelRequest(cmd *cobra.Command, client *Client, cryptoProvider bccsp.BCCS
 		ChannelId: channelID,
 		Height:    blockNumber,
 	}
-	signedRequest, err := signSnapshotRequest(client.Signer, request)
+	signedRequest, err := signSnapshotRequest(cl.signer, request)
 	if err != nil {
 		return err
 	}
 
-	_, err = client.SnapshotClient.Cancel(context.Background(), signedRequest)
+	_, err = cl.snapshotClient.Cancel(context.Background(), signedRequest)
 	if err != nil {
 		return errors.WithMessage(err, "failed to cancel the request")
 	}
 
-	fmt.Fprint(client.Writer, "Snapshot request cancelled successfully\n")
+	fmt.Fprint(cl.writer, "Snapshot request cancelled successfully\n")
 	return nil
 }
 

--- a/internal/peer/snapshot/cancelrequest_test.go
+++ b/internal/peer/snapshot/cancelrequest_test.go
@@ -22,7 +22,7 @@ func TestCancelRequestCmd(t *testing.T) {
 	mockSnapshotClient := &mock.SnapshotClient{}
 	mockSnapshotClient.CancelReturns(&empty.Empty{}, nil)
 	buffer := gbytes.NewBuffer()
-	mockClient := &Client{mockSnapshotClient, mockSigner, buffer}
+	mockClient := &client{mockSnapshotClient, mockSigner, buffer}
 
 	resetFlags()
 	cmd := cancelRequestCmd(mockClient, nil)

--- a/internal/peer/snapshot/client.go
+++ b/internal/peer/snapshot/client.go
@@ -17,15 +17,15 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Client holds client side dependency for the snapshot commands
-type Client struct {
-	SnapshotClient pb.SnapshotClient
-	Signer         common.Signer
-	Writer         io.Writer
+// client holds client side dependency for the snapshot commands
+type client struct {
+	snapshotClient pb.SnapshotClient
+	signer         common.Signer
+	writer         io.Writer
 }
 
-// NewClient creates a client instance
-func NewClient(cryptoProvider bccsp.BCCSP) (*Client, error) {
+// newClient creates a client instance
+func newClient(cryptoProvider bccsp.BCCSP) (*client, error) {
 	if err := validatePeerConnectionParameters(); err != nil {
 		return nil, err
 	}
@@ -40,10 +40,10 @@ func NewClient(cryptoProvider bccsp.BCCSP) (*Client, error) {
 		return nil, errors.WithMessage(err, "failed to retrieve default signer")
 	}
 
-	return &Client{
-		Signer:         signer,
-		SnapshotClient: snapshotClient,
-		Writer:         os.Stdout,
+	return &client{
+		signer:         signer,
+		snapshotClient: snapshotClient,
+		writer:         os.Stdout,
 	}, nil
 }
 

--- a/internal/peer/snapshot/listpending_test.go
+++ b/internal/peer/snapshot/listpending_test.go
@@ -22,7 +22,7 @@ func TestListPendingCmd(t *testing.T) {
 	mockSnapshotClient := &mock.SnapshotClient{}
 	mockSnapshotClient.QueryPendingsReturns(&pb.QueryPendingSnapshotsResponse{Heights: []uint64{100, 200}}, nil)
 	buffer := gbytes.NewBuffer()
-	mockClient := &Client{mockSnapshotClient, mockSigner, buffer}
+	mockClient := &client{mockSnapshotClient, mockSigner, buffer}
 
 	resetFlags()
 	cmd := listPendingCmd(mockClient, nil)

--- a/internal/peer/snapshot/snapshot.go
+++ b/internal/peer/snapshot/snapshot.go
@@ -73,12 +73,7 @@ func attachFlags(cmd *cobra.Command, names []string) {
 	}
 }
 
-// Signer defines the interface needed for signing messages
-type Signer interface {
-	Sign(msg []byte) ([]byte, error)
-}
-
-func signSnapshotRequest(signer Signer, request proto.Message) (*pb.SignedSnapshotRequest, error) {
+func signSnapshotRequest(signer common.Signer, request proto.Message) (*pb.SignedSnapshotRequest, error) {
 	requestBytes := protoutil.MarshalOrPanic(request)
 	signature, err := signer.Sign(requestBytes)
 	if err != nil {

--- a/internal/peer/snapshot/submitrequest.go
+++ b/internal/peer/snapshot/submitrequest.go
@@ -17,13 +17,13 @@ import (
 )
 
 // submitRequestCmd returns the cobra command for snapshot submitrequest command
-func submitRequestCmd(client *Client, cryptoProvider bccsp.BCCSP) *cobra.Command {
+func submitRequestCmd(cl *client, cryptoProvider bccsp.BCCSP) *cobra.Command {
 	snapshotSubmitRequestCmd := &cobra.Command{
 		Use:   "submitrequest",
 		Short: "Submit a request for a snapshot at the specified block.",
 		Long:  "Submit a request for a snapshot at the specified block. When the blockNumber parameter is set to 0 or not provided, it will submit a request for the last committed block.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return submitRequest(cmd, client, cryptoProvider)
+			return submitRequest(cmd, cl, cryptoProvider)
 		},
 	}
 
@@ -38,7 +38,7 @@ func submitRequestCmd(client *Client, cryptoProvider bccsp.BCCSP) *cobra.Command
 	return snapshotSubmitRequestCmd
 }
 
-func submitRequest(cmd *cobra.Command, client *Client, cryptoProvider bccsp.BCCSP) error {
+func submitRequest(cmd *cobra.Command, cl *client, cryptoProvider bccsp.BCCSP) error {
 	if err := validateSubmitRequest(); err != nil {
 		return err
 	}
@@ -47,9 +47,9 @@ func submitRequest(cmd *cobra.Command, client *Client, cryptoProvider bccsp.BCCS
 	cmd.SilenceUsage = true
 
 	// create a client if not provided
-	if client == nil {
+	if cl == nil {
 		var err error
-		client, err = NewClient(cryptoProvider)
+		cl, err = newClient(cryptoProvider)
 		if err != nil {
 			return err
 		}
@@ -59,17 +59,17 @@ func submitRequest(cmd *cobra.Command, client *Client, cryptoProvider bccsp.BCCS
 		ChannelId: channelID,
 		Height:    blockNumber,
 	}
-	signedRequest, err := signSnapshotRequest(client.Signer, request)
+	signedRequest, err := signSnapshotRequest(cl.signer, request)
 	if err != nil {
 		return err
 	}
 
-	_, err = client.SnapshotClient.Generate(context.Background(), signedRequest)
+	_, err = cl.snapshotClient.Generate(context.Background(), signedRequest)
 	if err != nil {
 		return errors.WithMessage(err, "failed to submit the request")
 	}
 
-	fmt.Fprint(client.Writer, "Snapshot request submitted successfully\n")
+	fmt.Fprint(cl.writer, "Snapshot request submitted successfully\n")
 	return nil
 }
 

--- a/internal/peer/snapshot/submitrequest_test.go
+++ b/internal/peer/snapshot/submitrequest_test.go
@@ -22,7 +22,7 @@ func TestSubmitRequestCmd(t *testing.T) {
 	mockSnapshotClient := &mock.SnapshotClient{}
 	mockSnapshotClient.GenerateReturns(&empty.Empty{}, nil)
 	buffer := gbytes.NewBuffer()
-	mockClient := &Client{mockSnapshotClient, mockSigner, buffer}
+	mockClient := &client{mockSnapshotClient, mockSigner, buffer}
 
 	resetFlags()
 	cmd := submitRequestCmd(mockClient, nil)
@@ -32,7 +32,7 @@ func TestSubmitRequestCmd(t *testing.T) {
 
 	// use a new buffer to verify new command execution
 	buffer2 := gbytes.NewBuffer()
-	mockClient.Writer = buffer2
+	mockClient.writer = buffer2
 	resetFlags()
 	cmd = submitRequestCmd(mockClient, nil)
 	cmd.SetArgs([]string{"-C", "mychannel", "-b", "100"})


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
The client struct is used internally to help unit tests for snapshot CLI cmds. Do not need to export it.

#### Related issues
https://jira.hyperledger.org/browse/FAB-18145