### PR TITLE
Change function signature for pvtdata hashes consumer

### DIFF
--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/db.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/db.go
@@ -62,7 +62,7 @@ func NewDBProvider(
 ) (*DBProvider, error) {
 
 	var vdbProvider statedb.VersionedDBProvider
-	var versionFromSnapshotValue func(snapshotValue []byte) ([]byte, error)
+	var versionFromSnapshotValue versionFromSnapshotValueFunc
 	var err error
 
 	if stateDBConf != nil && stateDBConf.StateDatabase == ledger.CouchDB {

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/mock/snapshot_pvtdatahashes_consumer.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/mock/snapshot_pvtdatahashes_consumer.go
@@ -3,16 +3,18 @@ package mock
 
 import (
 	"sync"
+
+	"github.com/hyperledger/fabric/core/ledger/internal/version"
 )
 
 type SnapshotPvtdataHashesConsumer struct {
-	ConsumeSnapshotDataStub        func(string, string, []byte, []byte) error
+	ConsumeSnapshotDataStub        func(string, string, []byte, *version.Height) error
 	consumeSnapshotDataMutex       sync.RWMutex
 	consumeSnapshotDataArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 []byte
-		arg4 []byte
+		arg4 *version.Height
 	}
 	consumeSnapshotDataReturns struct {
 		result1 error
@@ -24,16 +26,11 @@ type SnapshotPvtdataHashesConsumer struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *SnapshotPvtdataHashesConsumer) ConsumeSnapshotData(arg1 string, arg2 string, arg3 []byte, arg4 []byte) error {
+func (fake *SnapshotPvtdataHashesConsumer) ConsumeSnapshotData(arg1 string, arg2 string, arg3 []byte, arg4 *version.Height) error {
 	var arg3Copy []byte
 	if arg3 != nil {
 		arg3Copy = make([]byte, len(arg3))
 		copy(arg3Copy, arg3)
-	}
-	var arg4Copy []byte
-	if arg4 != nil {
-		arg4Copy = make([]byte, len(arg4))
-		copy(arg4Copy, arg4)
 	}
 	fake.consumeSnapshotDataMutex.Lock()
 	ret, specificReturn := fake.consumeSnapshotDataReturnsOnCall[len(fake.consumeSnapshotDataArgsForCall)]
@@ -41,9 +38,9 @@ func (fake *SnapshotPvtdataHashesConsumer) ConsumeSnapshotData(arg1 string, arg2
 		arg1 string
 		arg2 string
 		arg3 []byte
-		arg4 []byte
-	}{arg1, arg2, arg3Copy, arg4Copy})
-	fake.recordInvocation("ConsumeSnapshotData", []interface{}{arg1, arg2, arg3Copy, arg4Copy})
+		arg4 *version.Height
+	}{arg1, arg2, arg3Copy, arg4})
+	fake.recordInvocation("ConsumeSnapshotData", []interface{}{arg1, arg2, arg3Copy, arg4})
 	fake.consumeSnapshotDataMutex.Unlock()
 	if fake.ConsumeSnapshotDataStub != nil {
 		return fake.ConsumeSnapshotDataStub(arg1, arg2, arg3, arg4)
@@ -61,13 +58,13 @@ func (fake *SnapshotPvtdataHashesConsumer) ConsumeSnapshotDataCallCount() int {
 	return len(fake.consumeSnapshotDataArgsForCall)
 }
 
-func (fake *SnapshotPvtdataHashesConsumer) ConsumeSnapshotDataCalls(stub func(string, string, []byte, []byte) error) {
+func (fake *SnapshotPvtdataHashesConsumer) ConsumeSnapshotDataCalls(stub func(string, string, []byte, *version.Height) error) {
 	fake.consumeSnapshotDataMutex.Lock()
 	defer fake.consumeSnapshotDataMutex.Unlock()
 	fake.ConsumeSnapshotDataStub = stub
 }
 
-func (fake *SnapshotPvtdataHashesConsumer) ConsumeSnapshotDataArgsForCall(i int) (string, string, []byte, []byte) {
+func (fake *SnapshotPvtdataHashesConsumer) ConsumeSnapshotDataArgsForCall(i int) (string, string, []byte, *version.Height) {
 	fake.consumeSnapshotDataMutex.RLock()
 	defer fake.consumeSnapshotDataMutex.RUnlock()
 	argsForCall := fake.consumeSnapshotDataArgsForCall[i]

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/snapshot.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/snapshot.go
@@ -25,7 +25,7 @@ const (
 	pvtStateHashesMetadataFileName = "private_state_hashes.metadata"
 )
 
-type versionFromSnapshotValueFunc func(snapshotValue []byte) ([]byte, error)
+type versionFromSnapshotValueFunc func(snapshotValue []byte) (*version.Height, error)
 
 // ExportPubStateAndPvtStateHashes generates four files in the specified dir. The files, public_state.data and public_state.metadata
 // contains the exported public state and the files private_state_hashes.data and private_state_hashes.data contain the exported private state hashes.
@@ -469,5 +469,5 @@ func (c *cursor) currentNamespace() string {
 }
 
 type SnapshotPvtdataHashesConsumer interface {
-	ConsumeSnapshotData(namespace, coll string, keyHash []byte, version []byte) error
+	ConsumeSnapshotData(namespace, coll string, keyHash []byte, version *version.Height) error
 }

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/snapshot_test.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/snapshot_test.go
@@ -700,7 +700,7 @@ func TestSnapshotImportPvtdataHashesConsumer(t *testing.T) {
 			require.Equal(t, "ns-1", callArgNs)
 			require.Equal(t, "coll-1", callArgsColl)
 			require.Equal(t, []byte("key-hash-1"), callArgsKeyHash)
-			require.Equal(t, version.NewHeight(1, 1).ToBytes(), callArgsVer)
+			require.Equal(t, version.NewHeight(1, 1), callArgsVer)
 		}
 	})
 

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/snapshot_purge_mgr_builder.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/snapshot_purge_mgr_builder.go
@@ -32,13 +32,8 @@ func NewPurgeMgrBuilder(
 
 // ConsumeSnapshotData implements the function in the interface privacuenabledstate.SnapshotPvtdataHashesConsumer.
 // This is intended to be invoked for populating the expiry data in the purge manager for the keyhashses
-func (b *PurgeMgrBuilder) ConsumeSnapshotData(namespace, coll string, keyHash []byte, versionBytes []byte) error {
-	ver, _, err := version.NewHeightFromBytes(versionBytes)
-	if err != nil {
-		return errors.WithMessage(err, "invalid version bytes")
-	}
-
-	committingBlk := ver.BlockNum
+func (b *PurgeMgrBuilder) ConsumeSnapshotData(namespace, coll string, keyHash []byte, version *version.Height) error {
+	committingBlk := version.BlockNum
 	expiringBlock, err := b.btlPolicy.GetExpiringBlock(namespace, coll, committingBlk)
 	if err != nil {
 		return errors.WithMessage(err, "error from btlpolicy")

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/snapshot_purge_mgr_builder_test.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/snapshot_purge_mgr_builder_test.go
@@ -34,7 +34,7 @@ func TestPurgeMgrBuilder(t *testing.T) {
 	purgeMgrBuilder := NewPurgeMgrBuilder(ledgerID, btlPolicy, bookkeepingProvider)
 
 	require.NoError(t,
-		purgeMgrBuilder.ConsumeSnapshotData("ns1", "never-expiring-collection", []byte("key-hash-3"), version.NewHeight(5, 1).ToBytes()),
+		purgeMgrBuilder.ConsumeSnapshotData("ns1", "never-expiring-collection", []byte("key-hash-3"), version.NewHeight(5, 1)),
 	)
 	expiry, err := purgeMgrBuilder.expKeeper.retrieveByExpiryKey(
 		&expiryInfoKey{
@@ -47,14 +47,14 @@ func TestPurgeMgrBuilder(t *testing.T) {
 
 	// add data that expires at block-7
 	require.NoError(t,
-		purgeMgrBuilder.ConsumeSnapshotData("ns1", "coll1", []byte("key-hash-1"), version.NewHeight(5, 1).ToBytes()),
+		purgeMgrBuilder.ConsumeSnapshotData("ns1", "coll1", []byte("key-hash-1"), version.NewHeight(5, 1)),
 	)
 	require.NoError(t,
-		purgeMgrBuilder.ConsumeSnapshotData("ns1", "coll1", []byte("key-hash-2"), version.NewHeight(5, 1).ToBytes()),
+		purgeMgrBuilder.ConsumeSnapshotData("ns1", "coll1", []byte("key-hash-2"), version.NewHeight(5, 1)),
 	)
 	// add data that expires at block-8
 	require.NoError(t,
-		purgeMgrBuilder.ConsumeSnapshotData("ns2", "coll2", []byte("key-hash-2"), version.NewHeight(5, 1).ToBytes()),
+		purgeMgrBuilder.ConsumeSnapshotData("ns2", "coll2", []byte("key-hash-2"), version.NewHeight(5, 1)),
 	)
 
 	purgeMgr, err := InstantiatePurgeMgr(ledgerID, nil, btlPolicy, bookkeepingProvider)
@@ -162,20 +162,13 @@ func TestPurgeMgrBuilderErrorsPropagation(t *testing.T) {
 		t.Cleanup(bookkeepingEnv.Cleanup)
 	}
 
-	t.Run("wrong-version-bytes", func(t *testing.T) {
-		init()
-		purgeMgrBuilder := NewPurgeMgrBuilder("test-ledger", btlPolicy, bookkeepingProvider)
-		err := purgeMgrBuilder.ConsumeSnapshotData("ns", "coll", []byte("key-hash"), []byte("invalid-version-bytes"))
-		require.Contains(t, err.Error(), "invalid version bytes")
-	})
-
 	t.Run("btlpolicy-returns-error", func(t *testing.T) {
 		init()
 		btlPolicy = &btltestutil.ErrorCausingBTLPolicy{
 			Err: errors.New("btl-error"),
 		}
 		purgeMgrBuilder := NewPurgeMgrBuilder("test-ledger", btlPolicy, bookkeepingProvider)
-		err := purgeMgrBuilder.ConsumeSnapshotData("ns", "coll", []byte("key-hash"), version.NewHeight(1, 1).ToBytes())
+		err := purgeMgrBuilder.ConsumeSnapshotData("ns", "coll", []byte("key-hash"), version.NewHeight(1, 1))
 		require.EqualError(t, err, "error from btlpolicy: btl-error")
 	})
 
@@ -183,7 +176,7 @@ func TestPurgeMgrBuilderErrorsPropagation(t *testing.T) {
 		init()
 		bookkeepingProvider.Close()
 		purgeMgrBuilder := NewPurgeMgrBuilder("test-ledger", btlPolicy, bookkeepingProvider)
-		err := purgeMgrBuilder.ConsumeSnapshotData("ns", "coll", []byte("key-hash"), version.NewHeight(1, 1).ToBytes())
+		err := purgeMgrBuilder.ConsumeSnapshotData("ns", "coll", []byte("key-hash"), version.NewHeight(1, 1))
 		require.Contains(t, err.Error(), "error from bookkeeper")
 	})
 }

--- a/core/ledger/kvledger/txmgmt/statedb/commontests/test_common.go
+++ b/core/ledger/kvledger/txmgmt/statedb/commontests/test_common.go
@@ -1150,7 +1150,7 @@ func TestDataExportImport(
 
 func TestVersionFromSnapshotValue(t *testing.T,
 	dbProvider statedb.VersionedDBProvider,
-	versionExtractionFunc func(snapshotVal []byte) (versionBytes []byte, err error),
+	versionExtractionFunc func(snapshotVal []byte) (version *version.Height, err error),
 ) {
 	stateDB, err := dbProvider.GetDBHandle("source_ledger", nil)
 	require.NoError(t, err)
@@ -1168,11 +1168,9 @@ func TestVersionFromSnapshotValue(t *testing.T,
 	nextVersion := func() *version.Height {
 		_, snapshotVal, err := iter.Next()
 		require.NoError(t, err)
-		versionBytes, err := versionExtractionFunc(snapshotVal)
+		version, err := versionExtractionFunc(snapshotVal)
 		require.NoError(t, err)
-		ver, _, err := version.NewHeightFromBytes(versionBytes)
-		require.NoError(t, err)
-		return ver
+		return version
 	}
 
 	require.Equal(t, version.NewHeight(5, 5), nextVersion())

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/dbvalue_encoding.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/dbvalue_encoding.go
@@ -61,7 +61,7 @@ func decodeValueVersionMetadata(encodedMsg []byte) (*ValueVersionMetadata, error
 	return val, nil
 }
 
-func VersionFromSnapshotValue(snapshotValue []byte) ([]byte, error) {
+func VersionFromSnapshotValue(snapshotValue []byte) (*version.Height, error) {
 	v, err := decodeValueVersionMetadata(snapshotValue)
 	if err != nil {
 		return nil, err
@@ -74,5 +74,6 @@ func VersionFromSnapshotValue(snapshotValue []byte) ([]byte, error) {
 	if err = proto.Unmarshal(versionAndMetadataBytes, versionAndMetadata); err != nil {
 		return nil, err
 	}
-	return versionAndMetadata.Version, nil
+	version, _, err := version.NewHeightFromBytes(versionAndMetadata.Version)
+	return version, err
 }

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/value_encoding.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/value_encoding.go
@@ -43,11 +43,12 @@ func decodeValue(encodedValue []byte) (*statedb.VersionedValue, error) {
 	return &statedb.VersionedValue{Version: ver, Value: val, Metadata: metadata}, nil
 }
 
-func VersionFromSnapshotValue(snapshotValue []byte) ([]byte, error) {
+func VersionFromSnapshotValue(snapshotValue []byte) (*version.Height, error) {
 	dbValue := &DBValue{}
 	err := proto.Unmarshal(snapshotValue, dbValue)
 	if err != nil {
 		return nil, err
 	}
-	return dbValue.Version, nil
+	version, _, err := version.NewHeightFromBytes(dbValue.Version)
+	return version, err
 }


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
This PR changes the function signature for `SnapshotPvtdataHashesConsumer`. It now returns `version` struct instead of version bytes

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
