### PR TITLE
FAB-18076 Ch.Part.API: registrar init with followers

### DIFF
--- a/integration/raft/channel_participation_test.go
+++ b/integration/raft/channel_participation_test.go
@@ -71,7 +71,8 @@ var _ = Describe("ChannelParticipation", func() {
 			ordererRunner := network.OrdererRunner(o)
 			ordererProcess := ifrit.Invoke(ordererRunner)
 			Eventually(ordererProcess.Ready(), network.EventuallyTimeout).Should(BeClosed())
-			Eventually(ordererRunner.Err(), network.EventuallyTimeout).Should(gbytes.Say("Registrar initializing without a system channel, number of application channels: 0"))
+			Eventually(ordererRunner.Err(), network.EventuallyTimeout).Should(gbytes.Say(
+				"Registrar initializing without a system channel, number of application channels: 0, with 0 consensus.Chain\\(s\\) and 0 follower.Chain\\(s\\)"))
 			ordererProcesses = append(ordererProcesses, ordererProcess)
 			ordererRunners = append(ordererRunners, ordererRunner)
 		}

--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 
 	cb "github.com/hyperledger/fabric-protos-go/common"
-	ab "github.com/hyperledger/fabric-protos-go/orderer"
 	"github.com/hyperledger/fabric/bccsp"
 	"github.com/hyperledger/fabric/common/channelconfig"
 	"github.com/hyperledger/fabric/common/configtx"
@@ -64,9 +63,9 @@ type Registrar struct {
 	joinBlockFileRepo *filerepo.Repo
 }
 
-// ConfigBlock retrieves the last configuration block from the given ledger.
+// ConfigBlockOrPanic retrieves the last configuration block from the given ledger.
 // Panics on failure.
-func ConfigBlock(reader blockledger.Reader) *cb.Block {
+func ConfigBlockOrPanic(reader blockledger.Reader) *cb.Block {
 	lastBlock := blockledger.GetBlock(reader, reader.Height()-1)
 	index, err := protoutil.GetLastConfigIndexFromBlock(lastBlock)
 	if err != nil {
@@ -81,7 +80,7 @@ func ConfigBlock(reader blockledger.Reader) *cb.Block {
 }
 
 func configTx(reader blockledger.Reader) *cb.Envelope {
-	return protoutil.ExtractEnvelopeOrPanic(ConfigBlock(reader), 0)
+	return protoutil.ExtractEnvelopeOrPanic(ConfigBlockOrPanic(reader), 0)
 }
 
 // NewRegistrar produces an instance of a *Registrar.
@@ -129,94 +128,217 @@ func (r *Registrar) initializeJoinBlockFileRepo() {
 func (r *Registrar) Initialize(consenters map[string]consensus.Consenter) {
 	r.consenters = consenters
 
-	//TODO reconcile existing channel ledgers with join blocks
+	// Discover and load join-blocks. If there is a join-block, there must be a ledger; if there is none, create it.
+	// channelsWithJoinBlock maps channelID to a join-block.
+	channelsWithJoinBlock := r.loadJoinBlocks()
+
+	// Discover all ledgers. This should already include all channels with join blocks as well.
 	existingChannels := r.ledgerFactory.ChannelIDs()
 
-	// TODO first scan for and initialize the system channel, if it exists.
-	// TODO then initialize application channels, by creating either consensus.Chain or follower.Chain.
-	// TODO start all channels
+	// Scan for and initialize the system channel, if it exists.
+	// Make sure there are no empty ledgers without a corresponding join-block.
+	// Note that there may be channels with empty ledgers, but always with a join block.
+	r.initSystemChannel(existingChannels, channelsWithJoinBlock)
 
+	// Initialize application channels, by creating either a consensus.Chain or a follower.Chain.
+	r.initAppChannels(existingChannels, channelsWithJoinBlock)
+
+	r.startChannels()
+}
+
+// startChannels starts internal go-routines in chains and followers.
+// Since these go-routines may call-back on the Registrar, this must be protected with a lock.
+func (r *Registrar) startChannels() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for _, chainSupport := range r.chains {
+		chainSupport.start()
+	}
+	for _, fChain := range r.followers {
+		fChain.Start()
+	}
+
+	if r.systemChannelID == "" {
+		logger.Infof("Registrar initializing without a system channel, number of application channels: %d, with %d consensus.Chain(s) and %d follower.Chain(s)",
+			len(r.chains)+len(r.followers), len(r.chains), len(r.followers))
+	}
+}
+
+func (r *Registrar) initSystemChannel(existingChannels []string, channelsWithJoinBlock map[string]*cb.Block) {
 	for _, channelID := range existingChannels {
 		rl, err := r.ledgerFactory.GetOrCreate(channelID)
 		if err != nil {
 			logger.Panicf("Ledger factory reported channelID %s but could not retrieve it: %s", channelID, err)
 		}
-		configTx := configTx(rl)
-		if configTx == nil {
-			logger.Panic("Programming error, configTx should never be nil here")
+
+		if rl.Height() == 0 {
+			if _, ok := channelsWithJoinBlock[channelID]; !ok {
+				logger.Warnf("Channel '%s' has an empty ledger without a join-block, removing it", channelID)
+				if err := r.ledgerFactory.Remove(channelID); err != nil {
+					logger.Panicf("Ledger factory failed to remove empty ledger '%s', error: %s", channelID, err)
+				}
+			}
+			//TODO currently the system channel cannot be a follower, i.e. start with height==0 and a join-block.
+			// This may change in FAB-17911, when we allow a system channel to join via the channel participation API.
+			continue // Skip application channels
 		}
-		ledgerResources, err := r.newLedgerResources(configTx)
+
+		configTransaction := configTx(rl)
+		if configTransaction == nil {
+			logger.Panic("Programming error, configTransaction should never be nil here")
+		}
+		ledgerResources, err := r.newLedgerResources(configTransaction)
 		if err != nil {
 			logger.Panicf("Error creating ledger resources: %s", err)
 		}
 		channelID := ledgerResources.ConfigtxValidator().ChannelID()
 
-		if _, ok := ledgerResources.ConsortiumsConfig(); ok {
-			if r.systemChannelID != "" {
-				logger.Panicf("There appear to be two system channels %s and %s", r.systemChannelID, channelID)
-			}
+		if _, ok := ledgerResources.ConsortiumsConfig(); !ok {
+			continue // Skip application channels
+		}
 
-			chain, err := newChainSupport(
-				r,
-				ledgerResources,
-				r.consenters,
-				r.signer,
-				r.blockcutterMetrics,
-				r.bccsp,
-			)
-			if err != nil {
-				logger.Panicf("Error creating chain support: %s", err)
-			}
-			r.templator = msgprocessor.NewDefaultTemplator(chain, r.bccsp)
-			chain.Processor = msgprocessor.NewSystemChannel(
-				chain,
-				r.templator,
-				msgprocessor.CreateSystemChannelFilters(r.config, r, chain, chain.MetadataValidator),
-				r.bccsp,
-			)
+		if r.systemChannelID != "" {
+			logger.Panicf("There appear to be two system channels %s and %s", r.systemChannelID, channelID)
+		}
 
-			// Retrieve genesis block to log its hash. See FAB-5450 for the purpose
-			iter, pos := rl.Iterator(&ab.SeekPosition{Type: &ab.SeekPosition_Oldest{Oldest: &ab.SeekOldest{}}})
-			defer iter.Close()
-			if pos != uint64(0) {
-				logger.Panicf("Error iterating over system channel: '%s', expected position 0, got %d", channelID, pos)
-			}
-			genesisBlock, status := iter.Next()
-			if status != cb.Status_SUCCESS {
-				logger.Panicf("Error reading genesis block of system channel '%s'", channelID)
-			}
-			logger.Infof("Starting system channel '%s' with genesis block hash %x and orderer type %s",
-				channelID, protoutil.BlockHeaderHash(genesisBlock.Header), chain.SharedConfig().ConsensusType())
+		chain, err := newChainSupport(r, ledgerResources, r.consenters, r.signer, r.blockcutterMetrics, r.bccsp)
+		if err != nil {
+			logger.Panicf("Error creating chain support: %s", err)
+		}
+		r.templator = msgprocessor.NewDefaultTemplator(chain, r.bccsp)
+		chain.Processor = msgprocessor.NewSystemChannel(
+			chain,
+			r.templator,
+			msgprocessor.CreateSystemChannelFilters(r.config, r, chain, chain.MetadataValidator),
+			r.bccsp,
+		)
 
-			r.chains[channelID] = chain
-			r.systemChannelID = channelID
-			r.systemChannel = chain
-			// We delay starting this channel, as it might try to copy and replace the channels map via newChannel before the map is fully built
-			defer chain.start()
+		// Retrieve genesis block to log its hash. See FAB-5450 for the purpose
+		genesisBlock := ledgerResources.Block(0)
+		if genesisBlock == nil {
+			logger.Panicf("Error reading genesis block of system channel '%s'", channelID)
+		}
+		logger.Infof("Starting system channel '%s' with genesis block hash %x and orderer type %s",
+			channelID, protoutil.BlockHeaderHash(genesisBlock.Header), chain.SharedConfig().ConsensusType())
+
+		r.chains[channelID] = chain
+		r.systemChannelID = channelID
+		r.systemChannel = chain
+	}
+}
+
+func (r *Registrar) initAppChannels(existingChannels []string, channelsWithJoinBlock map[string]*cb.Block) {
+	var appChannelsWithoutJoinBlock []string
+	for _, channelID := range existingChannels {
+		if _, withJoinBlock := channelsWithJoinBlock[channelID]; channelID == r.systemChannelID || withJoinBlock {
+			continue
+		}
+		appChannelsWithoutJoinBlock = append(appChannelsWithoutJoinBlock, channelID)
+	}
+
+	for channelID, joinBlock := range channelsWithJoinBlock {
+		ledgerRes, clusterConsenter, err := r.initLedgerResourcesClusterConsenter(joinBlock)
+		if err != nil {
+			logger.Panicf("Error: %s, channel: %s", err, channelID)
+		}
+
+		isMember, err := clusterConsenter.IsChannelMember(joinBlock)
+		if err != nil {
+			logger.Panicf("Failed to determine cluster membership from join-block, channel: %s, error: %s", channelID, err)
+		}
+
+		if joinBlock.Header.Number == 0 && isMember {
+			if _, _, err := r.createAsMember(ledgerRes, joinBlock, channelID); err != nil {
+				logger.Panicf("Failed to createAsMember, error: %s", err)
+			}
+			// TODO remove the join block
 		} else {
-			logger.Debugf("Starting channel: %s", channelID)
-			chain, err := newChainSupport(
-				r,
-				ledgerResources,
-				r.consenters,
-				r.signer,
-				r.blockcutterMetrics,
-				r.bccsp,
-			)
-			if err != nil {
-				logger.Panicf("Error creating chain support: %s", err)
+			if _, _, err = r.createFollower(ledgerRes, clusterConsenter, joinBlock, channelID); err != nil {
+				logger.Panicf("Failed to createFollower, error: %s", err)
 			}
-			r.chains[channelID] = chain
-			chain.start()
 		}
 	}
 
-	if r.systemChannelID == "" {
-		logger.Infof("Registrar initializing without a system channel, number of application channels: %d", len(r.chains))
-		if _, etcdRaftFound := r.consenters["etcdraft"]; !etcdRaftFound {
-			logger.Panicf("Error initializing without a system channel: failed to find an etcdraft clusterConsenter")
+	for _, channelID := range appChannelsWithoutJoinBlock {
+		rl, err := r.ledgerFactory.GetOrCreate(channelID)
+		if err != nil {
+			logger.Panicf("Ledger factory reported channelID %s but could not retrieve it: %s", channelID, err)
+		}
+
+		configBlock := ConfigBlockOrPanic(rl)
+		configTx := protoutil.ExtractEnvelopeOrPanic(configBlock, 0)
+		if configTx == nil {
+			logger.Panic("Programming error, configTx should never be nil here")
+		}
+		ledgerRes, err := r.newLedgerResources(configTx)
+		if err != nil {
+			logger.Panicf("Error creating ledger resources: %s", err)
+		}
+
+		if r.systemChannel != nil {
+			chainSupport, err := newChainSupport(r, ledgerRes, r.consenters, r.signer, r.blockcutterMetrics, r.bccsp)
+			if err != nil {
+				logger.Panicf("Failed to create chain support for channel '%s', error: %s", channelID, err)
+			}
+			r.chains[channelID] = chainSupport
+			continue
+		}
+
+		ordererConfig, _ := ledgerRes.OrdererConfig()
+		consenter, foundConsenter := r.consenters[ordererConfig.ConsensusType()]
+		if !foundConsenter {
+			logger.Panicf("Failed to find a consenter for consensus type: %s", ordererConfig.ConsensusType())
+		}
+
+		clusterConsenter, ok := consenter.(consensus.ClusterConsenter)
+		if !ok {
+			logger.Panic("clusterConsenter is not a consensus.ClusterConsenter")
+		}
+
+		isMember, err := clusterConsenter.IsChannelMember(configBlock)
+		if err != nil {
+			logger.Panicf("Failed to determine cluster membership from config-block, error: %s", err)
+		}
+
+		if isMember {
+			chainSupport, err := newChainSupport(r, ledgerRes, r.consenters, r.signer, r.blockcutterMetrics, r.bccsp)
+			if err != nil {
+				logger.Panicf("Failed to create chain support for channel '%s', error: %s", channelID, err)
+			}
+			r.chains[channelID] = chainSupport
+		} else {
+			_, _, err := r.createFollower(ledgerRes, clusterConsenter, nil, channelID)
+			if err != nil {
+				logger.Panicf("Failed to create follower for channel '%s', error: %s", channelID, err)
+			}
 		}
 	}
+}
+
+func (r *Registrar) initLedgerResourcesClusterConsenter(configBlock *cb.Block) (*ledgerResources, consensus.ClusterConsenter, error) {
+	configEnv, err := protoutil.ExtractEnvelope(configBlock, 0)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed extracting config envelope from block")
+	}
+
+	ledgerRes, err := r.newLedgerResources(configEnv)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed creating ledger resources")
+	}
+
+	ordererConfig, _ := ledgerRes.OrdererConfig()
+	consenter, foundConsenter := r.consenters[ordererConfig.ConsensusType()]
+	if !foundConsenter {
+		return nil, nil, errors.Errorf("failed to find a consenter for consensus type: %s", ordererConfig.ConsensusType())
+	}
+
+	clusterConsenter, ok := consenter.(consensus.ClusterConsenter)
+	if !ok {
+		return nil, nil, errors.New("failed cast: clusterConsenter is not a consensus.ClusterConsenter")
+	}
+
+	return ledgerRes, clusterConsenter, nil
 }
 
 // SystemChannelID returns the ChannelID for the system channel.
@@ -343,10 +465,12 @@ func (r *Registrar) newChain(configtx *cb.Envelope) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	r.createNewChain(configtx)
+	cs := r.createNewChain(configtx)
+	cs.start()
+	logger.Infof("Created and started new channel %s", cs.ChannelID())
 }
 
-func (r *Registrar) createNewChain(configtx *cb.Envelope) {
+func (r *Registrar) createNewChain(configtx *cb.Envelope) *ChainSupport {
 	ledgerResources, err := r.newLedgerResources(configtx)
 	if err != nil {
 		logger.Panicf("Error creating ledger resources: %s", err)
@@ -366,8 +490,7 @@ func (r *Registrar) createNewChain(configtx *cb.Envelope) {
 	chainID := ledgerResources.ConfigtxValidator().ChannelID()
 	r.chains[chainID] = cs
 
-	logger.Infof("Created and starting new channel %s", chainID)
-	cs.start()
+	return cs
 }
 
 // SwitchFollowerToChain creates a consensus.Chain from the tip of the ledger, and removes the follower.
@@ -388,7 +511,9 @@ func (r *Registrar) SwitchFollowerToChain(chainName string) {
 
 	delete(r.followers, chainName)
 	logger.Debugf("Removed follower for channel %s", chainName)
-	r.createNewChain(configTx(lf))
+	cs := r.createNewChain(configTx(lf))
+	cs.start()
+	logger.Infof("Created and started channel %s", cs.ChannelID())
 }
 
 // ChannelsCount returns the count of the current total number of channels.
@@ -479,36 +604,26 @@ func (r *Registrar) JoinChannel(channelID string, configBlock *cb.Block, isAppCh
 		return types.ChannelInfo{}, types.ErrAppChannelsAlreadyExists
 	}
 
-	configEnv, err := protoutil.ExtractEnvelope(configBlock, 0)
+	ledgerRes, clusterConsenter, err := r.initLedgerResourcesClusterConsenter(configBlock)
 	if err != nil {
-		return types.ChannelInfo{}, errors.Wrap(err, "failed extracting config envelope from block")
+		return types.ChannelInfo{}, err
 	}
 
 	//TODO save the join-block in the file repo to make this action crash tolerant.
 	//TODO remove join block & ledger if things go bad below, (using defer that identifies an error?)
 
-	ledgerRes, err := r.newLedgerResources(configEnv)
-	if err != nil {
-		return types.ChannelInfo{}, errors.Wrap(err, "failed creating ledger resources")
-	}
-
-	ordererConfig, _ := ledgerRes.OrdererConfig()
-	consenter, foundConsenter := r.consenters[ordererConfig.ConsensusType()]
-	if !foundConsenter {
-		return types.ChannelInfo{}, errors.Errorf("failed to find a consenter for consensus type: %s", ordererConfig.ConsensusType())
-	}
-
-	clusterConsenter, ok := consenter.(consensus.ClusterConsenter)
-	if !ok {
-		return types.ChannelInfo{}, errors.New("clusterConsenter is not a consensus.ClusterConsenter")
-	}
 	isMember, err := clusterConsenter.IsChannelMember(configBlock)
 	if err != nil {
 		return types.ChannelInfo{}, errors.Wrap(err, "failed to determine cluster membership from join-block ")
 	}
 
 	if configBlock.Header.Number == 0 && isMember {
-		return r.joinAsMember(ledgerRes, configBlock, channelID)
+		chain, info, err := r.createAsMember(ledgerRes, configBlock, channelID)
+		if err == nil {
+			//TODO remove the join block
+			chain.start()
+		}
+		return info, err
 	}
 
 	fChain, info, err := r.createFollower(ledgerRes, clusterConsenter, configBlock, channelID)
@@ -521,10 +636,11 @@ func (r *Registrar) JoinChannel(channelID string, configBlock *cb.Block, isAppCh
 	return info, err
 }
 
-func (r *Registrar) joinAsMember(ledgerRes *ledgerResources, configBlock *cb.Block, channelID string) (types.ChannelInfo, error) {
-	err := ledgerRes.Append(configBlock)
-	if err != nil {
-		return types.ChannelInfo{}, errors.Wrap(err, "error appending join block to the ledger")
+func (r *Registrar) createAsMember(ledgerRes *ledgerResources, configBlock *cb.Block, channelID string) (*ChainSupport, types.ChannelInfo, error) {
+	if ledgerRes.Height() == 0 {
+		if err := ledgerRes.Append(configBlock); err != nil {
+			return nil, types.ChannelInfo{}, errors.Wrap(err, "error appending join block to the ledger")
+		}
 	}
 	chain, err := newChainSupport(
 		r,
@@ -535,7 +651,7 @@ func (r *Registrar) joinAsMember(ledgerRes *ledgerResources, configBlock *cb.Blo
 		r.bccsp,
 	)
 	if err != nil {
-		return types.ChannelInfo{}, errors.Wrap(err, "error creating chain")
+		return nil, types.ChannelInfo{}, errors.Wrap(err, "error creating chain support")
 	}
 
 	info := types.ChannelInfo{
@@ -544,12 +660,10 @@ func (r *Registrar) joinAsMember(ledgerRes *ledgerResources, configBlock *cb.Blo
 		Height: ledgerRes.Height(),
 	}
 	info.ClusterRelation, info.Status = chain.StatusReport()
-
 	r.chains[channelID] = chain
-	chain.start()
 
 	logger.Infof("Joining channel: %v", info)
-	return info, nil
+	return chain, info, nil
 }
 
 // createFollower created a follower.Chain, puts it in the map, but does not start it.
@@ -559,9 +673,9 @@ func (r *Registrar) createFollower(
 	joinBlock *cb.Block,
 	channelID string,
 ) (*follower.Chain, types.ChannelInfo, error) {
-	logger := flogging.MustGetLogger("orderer.commmon.follower").With("channel", channelID)
+	fLog := flogging.MustGetLogger("orderer.commmon.follower")
 	blockPullerCreator, err := follower.NewBlockPullerCreator(
-		channelID, logger, r.signer, r.clusterDialer, r.config.General.Cluster, r.bccsp)
+		channelID, fLog, r.signer, r.clusterDialer, r.config.General.Cluster, r.bccsp)
 	if err != nil {
 		return nil, types.ChannelInfo{}, errors.Wrapf(err, "failed to create BlockPullerFactory for channel %s", channelID)
 	}
@@ -571,7 +685,7 @@ func (r *Registrar) createFollower(
 		clusterConsenter,
 		joinBlock,
 		follower.Options{
-			Logger: logger,
+			Logger: fLog,
 		},
 		blockPullerCreator,
 		r,
@@ -614,9 +728,9 @@ func (r *Registrar) RemoveChannel(channelID string, removeStorage bool) error {
 		return r.removeMember(channelID, cs)
 	}
 
-	follower, ok := r.followers[channelID]
+	fChain, ok := r.followers[channelID]
 	if ok {
-		return r.removeFollower(channelID, follower)
+		return r.removeFollower(channelID, fChain)
 	}
 
 	return types.ErrChannelNotExist
@@ -652,4 +766,38 @@ func (r *Registrar) removeFollower(channelID string, follower *follower.Chain) e
 	logger.Infof("Removed channel: %s", channelID)
 
 	return nil
+}
+
+func (r *Registrar) loadJoinBlocks() map[string]*cb.Block {
+	channelToBlockMap := make(map[string]*cb.Block)
+	if !r.config.ChannelParticipation.Enabled {
+		return channelToBlockMap
+	}
+	channelsList, err := r.joinBlockFileRepo.List()
+	if err != nil {
+		logger.Panicf("Error listing join block file repo: %s", err)
+	}
+
+	logger.Debugf("Loading join-blocks for %d channels: %s", len(channelsList), channelsList)
+	for _, fileName := range channelsList {
+		channelName := r.joinBlockFileRepo.FileToBaseName(fileName)
+		blockBytes, err := r.joinBlockFileRepo.Read(channelName)
+		if err != nil {
+			logger.Panicf("Error reading join block file: '%s', error: %s", fileName, err)
+		}
+		block, err := protoutil.UnmarshalBlock(blockBytes)
+		if err != nil {
+			logger.Panicf("Error unmarshalling join block file: '%s', error: %s", fileName, err)
+		}
+		channelToBlockMap[channelName] = block
+	}
+
+	logger.Debug("Reconciling join-blocks and ledger by creating any missing ledger")
+	for channelID := range channelToBlockMap {
+		if _, err := r.ledgerFactory.GetOrCreate(channelID); err != nil {
+			logger.Panicf("Failed to create a ledger for channel: '%s', error: %s", channelID, err)
+		}
+	}
+
+	return channelToBlockMap
 }

--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -323,7 +323,7 @@ func extractSysChanLastConfig(lf blockledger.Factory, bootstrapBlock *cb.Block) 
 		logger.Panicf("Failed getting system channel ledger: %v", err)
 	}
 	height := systemChannelLedger.Height()
-	lastConfigBlock := multichannel.ConfigBlock(systemChannelLedger)
+	lastConfigBlock := multichannel.ConfigBlockOrPanic(systemChannelLedger)
 	logger.Infof("System channel: name=%s, height=%d, last config block number=%d",
 		systemChannelName, height, lastConfigBlock.Header.Number)
 	return lastConfigBlock
@@ -338,7 +338,7 @@ func extractSystemChannel(lf blockledger.Factory, bccsp bccsp.BCCSP) *cb.Block {
 		if err != nil {
 			logger.Panicf("Failed getting channel %v's ledger: %v", cID, err)
 		}
-		channelConfigBlock := multichannel.ConfigBlock(channelLedger)
+		channelConfigBlock := multichannel.ConfigBlockOrPanic(channelLedger)
 
 		err = onboarding.ValidateBootstrapBlock(channelConfigBlock, bccsp)
 		if err == nil {
@@ -767,7 +767,7 @@ func initializeEtcdraftConsenter(
 		logger.Panicf("Failed obtaining system channel (%s) ledger: %v", systemChannelName, err)
 	}
 	getConfigBlock := func() *cb.Block {
-		return multichannel.ConfigBlock(systemLedger)
+		return multichannel.ConfigBlockOrPanic(systemLedger)
 	}
 
 	icr := onboarding.NewInactiveChainReplicator(ri, getConfigBlock, ri.RegisterChain, conf.General.Cluster.ReplicationBackgroundRefreshInterval)


### PR DESCRIPTION
 FAB-18076 Ch.Part.API: Registrar init with followers
    
    Rewrite the Registrar.Initialize() flow:
    
    - Discover and load join-blocks. If there is a join-block,
      there must be a ledger; if there is none, create it.
    
    - Discover all ledgers. This should already include all channels
      with join blocks as well.
    
    - Scan for and initialize the system channel, if it exists.
    
    - Make sure there are no empty ledgers without a corresponding
      join-block. Note that there may be channels with empty ledgers,
      but always with a join block.
    
    - Initialize application channels, by creating either a
      consensus.Chain or a follower.Chain.
    
    - Start all channels.


Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: I41b7cffc4224b154cfd2acea64a2435789837766


#### Type of change
- New feature

#### Related issues

Task  FAB-18076
Epic  FAB-17712
