### PR TITLE
Remove Latest Tag Publishing

### DIFF
--- a/ci/scripts/publish_docker.sh
+++ b/ci/scripts/publish_docker.sh
@@ -16,5 +16,4 @@ for image in peer orderer ccenv tools; do
 
   ./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-${image}:amd64-${RELEASE}" --target "hyperledger/fabric-${image}:${RELEASE}"
   ./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-${image}:amd64-${RELEASE}" --target "hyperledger/fabric-${image}:$(sed 's/..$//' <<< ${RELEASE})"
-  ./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-${image}:amd64-${RELEASE}" --target "hyperledger/fabric-${image}:latest"
 done


### PR DESCRIPTION
We no longer publish the latest tag to dockerhub,
so removing the publishing of it.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
