### PR TITLE
Directives are in comment text instead of groups

### DIFF
--- a/common/metrics/gendoc/options.go
+++ b/common/metrics/gendoc/options.go
@@ -42,10 +42,12 @@ func FileOptions(f *ast.File) ([]interface{}, error) {
 	var options []interface{}
 	var errors []error
 
-	// If the file contains gendoc:ignore, ignore the file
+	// If the file contains a gendoc:ignore directive, ignore the file
 	for _, c := range f.Comments {
-		if strings.Contains(c.Text(), "gendoc:ignore") {
-			return nil, nil
+		for _, c := range c.List {
+			if strings.HasPrefix(c.Text, "//gendoc:ignore") {
+				return nil, nil
+			}
 		}
 	}
 

--- a/common/metrics/gendoc/testdata/ignored.go
+++ b/common/metrics/gendoc/testdata/ignored.go
@@ -10,7 +10,7 @@ import "github.com/hyperledger/fabric/common/metrics"
 
 //gendoc:ignore
 
-// This should be ignored by doc generation because of the gendoc:ignore statement above.
+// This should be ignored by doc generation because of the directive above.
 
 var (
 	Ignored = metrics.CounterOpts{


### PR DESCRIPTION
It's been a long time coming but, as of go 1.15, the ast package is treating directives as a special case and removing them from comment groups.

See https://github.com/golang/go/issues/37974