### PR TITLE
Change string cast of int value to rune cast

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb_test.go
@@ -706,10 +706,10 @@ func TestPrefixScan(t *testing.T) {
 	require.Equal(t, database, dbResp.DbName)
 
 	//Save documents
-	for i := 0; i < 20; i++ {
-		id1 := string(0) + string(i) + string(0)
-		id2 := string(0) + string(i) + string(1)
-		id3 := string(0) + string(i) + string(utf8.MaxRune-1)
+	for i := rune(0); i < 20; i++ {
+		id1 := string([]rune{0, i, 0})
+		id2 := string([]rune{0, i, 1})
+		id3 := string([]rune{0, i, utf8.MaxRune - 1})
 		_, saveerr := db.saveDoc(id1, "", &couchDoc{jsonValue: assetJSON, attachments: nil})
 		require.NoError(t, saveerr, "Error when trying to save a document")
 		_, saveerr = db.saveDoc(id2, "", &couchDoc{jsonValue: assetJSON, attachments: nil})
@@ -718,7 +718,7 @@ func TestPrefixScan(t *testing.T) {
 		require.NoError(t, saveerr, "Error when trying to save a document")
 
 	}
-	startKey := string(0) + string(10)
+	startKey := string([]rune{0, 10})
 	endKey := startKey + string(utf8.MaxRune)
 	_, _, geterr := db.readDoc(endKey)
 	require.NoError(t, geterr, "Error when trying to get lastkey")
@@ -728,9 +728,9 @@ func TestPrefixScan(t *testing.T) {
 	require.NotNil(t, resultsPtr)
 	results := resultsPtr
 	require.Equal(t, 3, len(results))
-	require.Equal(t, string(0)+string(10)+string(0), results[0].id)
-	require.Equal(t, string(0)+string(10)+string(1), results[1].id)
-	require.Equal(t, string(0)+string(10)+string(utf8.MaxRune-1), results[2].id)
+	require.Equal(t, string([]rune{0, 10, 0}), results[0].id)
+	require.Equal(t, string([]rune{0, 10, 1}), results[1].id)
+	require.Equal(t, string([]rune{0, 10, utf8.MaxRune - 1}), results[2].id)
 
 	//Drop the database
 	errdbdrop := db.dropDatabase()

--- a/gossip/gossip/algo/pull_test.go
+++ b/gossip/gossip/algo/pull_test.go
@@ -187,7 +187,7 @@ func TestPullEngine_Stop(t *testing.T) {
 	inst2.setNextPeerSelection([]string{"p1"})
 	go func() {
 		for i := 0; i < 100; i++ {
-			inst1.Add(string(i))
+			inst1.Add(strconv.Itoa(i))
 			time.Sleep(time.Duration(10) * time.Millisecond)
 		}
 	}()
@@ -210,7 +210,7 @@ func TestPullEngineAll2AllWithIncrementalSpawning(t *testing.T) {
 
 	for i := 0; i < instanceCount; i++ {
 		inst := newPushPullTestInstance(fmt.Sprintf("p%d", i+1), peers)
-		inst.Add(string(i + 1))
+		inst.Add(strconv.Itoa(i + 1))
 		time.Sleep(time.Duration(50) * time.Millisecond)
 	}
 	for i := 0; i < instanceCount; i++ {

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -838,7 +838,6 @@ func hostIPv4Addrs() []net.IP {
 // bootstrapIdemix creates the idemix-related crypto material
 func (n *Network) bootstrapIdemix() {
 	for j, org := range n.IdemixOrgs() {
-
 		output := n.IdemixOrgMSPDir(org)
 		// - ca-keygen
 		sess, err := n.Idemixgen(commands.CAKeyGen{
@@ -849,13 +848,13 @@ func (n *Network) bootstrapIdemix() {
 
 		// - signerconfig
 		usersOutput := filepath.Join(n.IdemixOrgMSPDir(org), "users")
-		userOutput := filepath.Join(usersOutput, fmt.Sprintf("User%d@%s", 1, org.Domain))
+		userOutput := filepath.Join(usersOutput, "User1@"+org.Domain)
 		sess, err = n.Idemixgen(commands.SignerConfig{
 			CAInput:          output,
 			Output:           userOutput,
 			OrgUnit:          org.Domain,
-			EnrollmentID:     "User" + string(1),
-			RevocationHandle: fmt.Sprintf("1%d%d", 1, j),
+			EnrollmentID:     "User1",
+			RevocationHandle: fmt.Sprintf("11%d", j),
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))


### PR DESCRIPTION
Future versions of go will likely remove the explicit conversion of integer types (other than byte and rune) to string and with go 1.15, vet flags these as issues.

This change changes valid uses to use rune slices and updates other occurrences to use proper string conversions. 

See https://github.com/golang/go/issues/32479