### PR TITLE
Remove Use of Manifest Tool

### DIFF
--- a/ci/scripts/publish_docker.sh
+++ b/ci/scripts/publish_docker.sh
@@ -6,14 +6,10 @@ set -euo pipefail
 
 make docker
 
-wget -qO "$PWD/manifest-tool" https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-amd64
-chmod +x ./manifest-tool
-
+docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_PASSWORD}"
 for image in baseos peer orderer ccenv tools; do
-  docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_PASSWORD}"
-  docker tag "hyperledger/fabric-${image}" "hyperledger/fabric-${image}:amd64-${RELEASE}"
-  docker push "hyperledger/fabric-${image}:amd64-${RELEASE}"
-
-  ./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-${image}:amd64-${RELEASE}" --target "hyperledger/fabric-${image}:${RELEASE}"
-  ./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-${image}:amd64-${RELEASE}" --target "hyperledger/fabric-${image}:${TWO_DIGIT_RELEASE}"
+  for release in ${RELEASE} ${TWO_DIGIT_RELEASE}; do
+    docker tag "hyperledger/fabric-${image}" "hyperledger/fabric-${image}:amd64-${release}"
+    docker push "hyperledger/fabric-${image}:amd64-${release}"
+  done
 done


### PR DESCRIPTION
Since we no longer publish multiple architectures to
Dockerhub, simplify the release process by pushing images
directly with Docker.

As Docker currently has an experimental utility as part
of the Docker CLI: https://docs.docker.com/docker-for-mac/multi-arch/
future multiarch implementation could make use of the `buildx`
tooling directly from Docker assuming it is out stable.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
