### PR TITLE
Increase timeouts for discovery CLI and raft tests

### DIFF
--- a/cmd/discover/main_test.go
+++ b/cmd/discover/main_test.go
@@ -9,6 +9,7 @@ package main
 import (
 	"os/exec"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -25,6 +26,6 @@ func TestMissingArguments(t *testing.T) {
 	cmd := exec.Command(discover, "--configFile", "conf.yaml", "--MSP", "SampleOrg", "saveConfig")
 	process, err := Start(cmd, nil, nil)
 	gt.Expect(err).NotTo(HaveOccurred())
-	gt.Eventually(process).Should(Exit(1))
+	gt.Eventually(process, 5*time.Second).Should(Exit(1))
 	gt.Expect(process.Err).To(gbytes.Say("empty string that is mandatory"))
 }

--- a/integration/raft/migration_test.go
+++ b/integration/raft/migration_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/onsi/gomega/gexec"
 	"github.com/tedsuo/ifrit"
 	"github.com/tedsuo/ifrit/ginkgomon"
-	"github.com/tedsuo/ifrit/grouper"
 )
 
 var _ = Describe("Kafka2RaftMigration", func() {
@@ -692,14 +691,14 @@ var _ = Describe("Kafka2RaftMigration", func() {
 
 			By("Launching the fourth orderer")
 			o4Runner := network.OrdererRunner(o4)
-			o4Process := ifrit.Invoke(grouper.Member{Name: o4.ID(), Runner: o4Runner})
+			o4Process := ifrit.Invoke(o4Runner)
 
 			defer func() {
 				o4Process.Signal(syscall.SIGTERM)
 				Eventually(o4Process.Wait(), network.EventuallyTimeout).Should(Receive())
 			}()
 
-			Eventually(o4Process.Ready()).Should(BeClosed())
+			Eventually(o4Process.Ready(), network.EventuallyTimeout).Should(BeClosed())
 
 			By("Waiting for the orderer to figure out it was migrated")
 			Eventually(o4Runner.Err(), time.Minute, time.Second).Should(gbytes.Say("This node was migrated from Kafka to Raft, skipping activation of Kafka chain"))


### PR DESCRIPTION
Locally, the discovery CLI test has been failing intermittently due to an eventually timeout of 1s. While this should be enough, bumping it to 5 seconds seems to have resolved it.

In the raft migration tests, when the new orderer is started, the network eventually timeout is not provided. This has resulted in a couple of timeouts while waiting for the process to initialize.

Also, the grouper.Member used when invoking the orderer was unnecessary so it's been removed.