### PR TITLE
FAB-18177 Ch.Part.API: Flake in registrar unit test

### DIFF
--- a/orderer/common/follower/block_puller.go
+++ b/orderer/common/follower/block_puller.go
@@ -99,6 +99,7 @@ func (creator *BlockPullerCreator) BlockPuller(configBlock *common.Block) (Chann
 		Logger:              flogging.MustGetLogger("orderer.common.cluster.puller").With("channel", creator.channelID),
 		RetryTimeout:        creator.clusterConfig.ReplicationRetryTimeout,
 		MaxTotalBufferBytes: creator.clusterConfig.ReplicationBufferSize,
+		MaxPullBlockRetries: uint64(creator.clusterConfig.ReplicationMaxRetries),
 		FetchTimeout:        creator.clusterConfig.ReplicationPullTimeout,
 		Endpoints:           endpoints,
 		Signer:              creator.signer,


### PR DESCRIPTION
Both the registrar_test.go and the block_puller.go factory do not assign value to

```go
cluster.BlockPuller{
   MaxPullBlockRetries
   ...
}
```

which may cause an endless loop in cluster/deliver.go#L143.

Solution is to initialize a non zero value.

In addition, when a follower is started in registrar_test.go,
it must be stopped, otherwise the go-routine will run until  the process exits.

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: I4f20ebdaeb20e9dde24dc555c90e0684bfb5d720

#### Type of change

- Bug fix


#### Related issues

BUG: FAB-18177
EPIC: FAB-17712

