### PR TITLE
[FAB-18171] Disregard certificate validity period in intra-orderer communication

### DIFF
--- a/common/crypto/expiration.go
+++ b/common/crypto/expiration.go
@@ -7,12 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 package crypto
 
 import (
+	"bytes"
 	"crypto/x509"
 	"encoding/pem"
 	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/msp"
+	"github.com/pkg/errors"
 )
 
 // ExpiresAt returns when the given identity expires, or a zero time.Time
@@ -94,4 +96,47 @@ func trackCertExpiration(rawCert []byte, certRole string, warn WarnFunc, now tim
 	sched(timeLeftUntilOneWeekBeforeExpiration, func() {
 		warn("The %s certificate will expire within one week", certRole)
 	})
+}
+
+var (
+	// ErrPubKeyMismatch is used by CertificatesWithSamePublicKey to indicate the two public keys mismatch
+	ErrPubKeyMismatch = errors.New("public keys do not match")
+)
+
+// LogNonPubKeyMismatchErr logs an error which is not an ErrPubKeyMismatch error
+func LogNonPubKeyMismatchErr(log func(template string, args ...interface{}), err error, cert1DER, cert2DER []byte) {
+	cert1PEM := &pem.Block{Type: "CERTIFICATE", Bytes: cert1DER}
+	cert2PEM := &pem.Block{Type: "CERTIFICATE", Bytes: cert2DER}
+	log("Failed determining if public key of %s matches public key of %s: %s",
+		string(pem.EncodeToMemory(cert1PEM)),
+		string(pem.EncodeToMemory(cert2PEM)),
+		err)
+}
+
+// CertificatesWithSamePublicKey returns nil if both byte slices
+// are valid DER encoding of certificates with the same public key.
+func CertificatesWithSamePublicKey(der1, der2 []byte) error {
+	cert1canonized, err := publicKeyFromCertificate(der1)
+	if err != nil {
+		return err
+	}
+
+	cert2canonized, err := publicKeyFromCertificate(der2)
+	if err != nil {
+		return err
+	}
+
+	if bytes.Equal(cert1canonized, cert2canonized) {
+		return nil
+	}
+	return ErrPubKeyMismatch
+}
+
+// publicKeyFromCertificate returns the public key of the given ASN1 DER certificate.
+func publicKeyFromCertificate(der []byte) ([]byte, error) {
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, err
+	}
+	return x509.MarshalPKIXPublicKey(cert.PublicKey)
 }

--- a/common/crypto/expiration_test.go
+++ b/common/crypto/expiration_test.go
@@ -7,6 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package crypto
 
 import (
+	"bytes"
+	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -179,4 +182,119 @@ func TestTrackExpiration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLogNonPubKeyMismatchErr(t *testing.T) {
+	ca, err := tlsgen.NewCA()
+	require.NoError(t, err)
+
+	aliceKeyPair, err := ca.NewClientCertKeyPair()
+	require.NoError(t, err)
+
+	bobKeyPair, err := ca.NewClientCertKeyPair()
+	require.NoError(t, err)
+
+	expected := &bytes.Buffer{}
+	expected.WriteString(fmt.Sprintf("Failed determining if public key of %s matches public key of %s: foo",
+		string(aliceKeyPair.Cert),
+		string(bobKeyPair.Cert)))
+
+	b := &bytes.Buffer{}
+	f := func(template string, args ...interface{}) {
+		fmt.Fprintf(b, template, args...)
+	}
+
+	LogNonPubKeyMismatchErr(f, errors.New("foo"), aliceKeyPair.TLSCert.Raw, bobKeyPair.TLSCert.Raw)
+
+	require.Equal(t, expected.String(), b.String())
+}
+
+func TestCertificatesWithSamePublicKey(t *testing.T) {
+	ca, err := tlsgen.NewCA()
+	require.NoError(t, err)
+
+	bobKeyPair, err := ca.NewClientCertKeyPair()
+	require.NoError(t, err)
+
+	bobCert := bobKeyPair.Cert
+	bob := pem2der(bobCert)
+
+	aliceCert := `-----BEGIN CERTIFICATE-----
+MIIBNjCB3KADAgECAgELMAoGCCqGSM49BAMCMBAxDjAMBgNVBAUTBUFsaWNlMB4X
+DTIwMDgxODIxMzU1NFoXDTIwMDgyMDIxMzU1NFowEDEOMAwGA1UEBRMFQWxpY2Uw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQjZP5VD/RaczoPFbA4gkt1qb54R6SP
+J/V5oxkhDboG9xWi0wpyghaMGwwxC7Q9wegEnyOVp9nXoLrQ8LUJ5BfZoycwJTAO
+BgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAwwCgYIKwYBBQUHAwIwCgYIKoZIzj0EAwID
+SQAwRgIhAK4le5XgH5edyhaQ9Sz7sFz3Zc4bbhPAzt9zQUYnoqK+AiEA5zcyLB/4
+Oqe93lroE6GF9W7UoCZFzD7lXsWku/dgFOU=
+-----END CERTIFICATE-----`
+
+	reIssuedAliceCert := `-----BEGIN CERTIFICATE-----
+MIIBNDCB3KADAgECAgELMAoGCCqGSM49BAMCMBAxDjAMBgNVBAUTBUFsaWNlMB4X
+DTIwMDgxODIxMzY1NFoXDTIwMDgyMDIxMzY1NFowEDEOMAwGA1UEBRMFQWxpY2Uw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQjZP5VD/RaczoPFbA4gkt1qb54R6SP
+J/V5oxkhDboG9xWi0wpyghaMGwwxC7Q9wegEnyOVp9nXoLrQ8LUJ5BfZoycwJTAO
+BgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAwwCgYIKwYBBQUHAwIwCgYIKoZIzj0EAwID
+RwAwRAIgDc8WyXFvsxCk97KS7D/LdYJxMpDKdHNFqpzJT9LddlsCIEr8KcMd/t5p
+cRv6rqxvy5M+t0DhRtiwCen70YCUsksb
+-----END CERTIFICATE-----`
+
+	alice := pem2der([]byte(aliceCert))
+	aliceMakesComeback := pem2der([]byte(reIssuedAliceCert))
+
+	for _, test := range []struct {
+		description string
+		errContains string
+		first       []byte
+		second      []byte
+	}{
+		{
+			description: "Bad first certificate",
+			errContains: "asn1:",
+			first:       []byte{1, 2, 3},
+			second:      bob,
+		},
+
+		{
+			description: "Bad second certificate",
+			errContains: "asn1:",
+			first:       alice,
+			second:      []byte{1, 2, 3},
+		},
+
+		{
+			description: "Different certificate",
+			errContains: ErrPubKeyMismatch.Error(),
+			first:       alice,
+			second:      bob,
+		},
+
+		{
+			description: "Same certificate",
+			first:       alice,
+			second:      alice,
+		},
+
+		{
+			description: "Same certificate but different validity period",
+			first:       alice,
+			second:      aliceMakesComeback,
+		},
+	} {
+		t.Run(test.description, func(t *testing.T) {
+			err := CertificatesWithSamePublicKey(test.first, test.second)
+			if test.errContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func pem2der(p []byte) []byte {
+	b, _ := pem.Decode(p)
+	return b.Bytes
 }

--- a/integration/raft/cft_test.go
+++ b/integration/raft/cft_test.go
@@ -378,7 +378,7 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 
 			By("Expiring orderer TLS certificates")
 			for filePath, certPEM := range serverTLSCerts {
-				expiredCert, earlyMadeCACert := expireCertificate(certPEM, ordererTLSCACert, ordererTLSCAKey)
+				expiredCert, earlyMadeCACert := expireCertificate(certPEM, ordererTLSCACert, ordererTLSCAKey, time.Now())
 				err = ioutil.WriteFile(filePath, expiredCert, 0600)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -513,6 +513,82 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			By("Waiting for a leader to be elected")
 			findLeader([]*ginkgomon.Runner{o1Runner, o2Runner, o3Runner})
 		})
+
+		It("disregards certificate renewal if only the validity period changed", func() {
+			config := nwo.MultiNodeEtcdRaft()
+			config.Channels = append(config.Channels, &nwo.Channel{Name: "foo", Profile: "TwoOrgsChannel"})
+			config.Channels = append(config.Channels, &nwo.Channel{Name: "bar", Profile: "TwoOrgsChannel"})
+			network = nwo.New(config, testDir, client, StartPort(), components)
+
+			network.GenerateConfigTree()
+			network.Bootstrap()
+
+			peer = network.Peer("Org1", "peer0")
+
+			o1 := network.Orderer("orderer1")
+			o2 := network.Orderer("orderer2")
+			o3 := network.Orderer("orderer3")
+
+			orderers := []*nwo.Orderer{o1, o2, o3}
+
+			o1Runner := network.OrdererRunner(o1)
+			o2Runner := network.OrdererRunner(o2)
+			o3Runner := network.OrdererRunner(o3)
+			ordererRunners := []*ginkgomon.Runner{o1Runner, o2Runner, o3Runner}
+
+			o1Proc = ifrit.Invoke(o1Runner)
+			o2Proc = ifrit.Invoke(o2Runner)
+			o3Proc = ifrit.Invoke(o3Runner)
+			ordererProcesses := []ifrit.Process{o1Proc, o2Proc, o3Proc}
+
+			Eventually(o1Proc.Ready(), network.EventuallyTimeout).Should(BeClosed())
+			Eventually(o2Proc.Ready(), network.EventuallyTimeout).Should(BeClosed())
+			Eventually(o3Proc.Ready(), network.EventuallyTimeout).Should(BeClosed())
+
+			By("Waiting for them to elect a leader")
+			findLeader(ordererRunners)
+
+			By("Creating a channel")
+			network.CreateChannel("foo", o1, peer)
+
+			assertBlockReception(map[string]int{
+				"foo":           0,
+				"systemchannel": 1,
+			}, []*nwo.Orderer{o1, o2, o3}, peer, network)
+
+			By("Killing all orderers")
+			for i := range orderers {
+				ordererProcesses[i].Signal(syscall.SIGTERM)
+				Eventually(ordererProcesses[i].Wait(), network.EventuallyTimeout).Should(Receive())
+			}
+
+			By("Renewing the certificates for all orderers")
+			renewOrdererCertificates(network, o1, o2, o3)
+
+			By("Starting the orderers again")
+			for i := range orderers {
+				ordererRunner := network.OrdererRunner(orderers[i])
+				ordererRunners[i] = ordererRunner
+				ordererProcesses[i] = ifrit.Invoke(ordererRunner)
+				Eventually(ordererProcesses[0].Ready(), network.EventuallyTimeout).Should(BeClosed())
+			}
+
+			o1Proc = ordererProcesses[0]
+			o2Proc = ordererProcesses[1]
+			o3Proc = ordererProcesses[2]
+
+			By("Waiting for them to elect a leader once again")
+			findLeader(ordererRunners)
+
+			By("Creating a channel again")
+			network.CreateChannel("bar", o1, peer)
+
+			assertBlockReception(map[string]int{
+				"foo":           0,
+				"bar":           0,
+				"systemchannel": 2,
+			}, []*nwo.Orderer{o1, o2, o3}, peer, network)
+		})
 	})
 
 	When("admin certificate expires", func() {
@@ -539,7 +615,7 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			originalAdminCert, err := ioutil.ReadFile(adminCertPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			expiredAdminCert, earlyCACert := expireCertificate(originalAdminCert, ordererCACert, ordererCAKey)
+			expiredAdminCert, earlyCACert := expireCertificate(originalAdminCert, ordererCACert, ordererCAKey, time.Now())
 			err = ioutil.WriteFile(adminCertPath, expiredAdminCert, 0600)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -688,7 +764,34 @@ func findLeader(ordererRunners []*ginkgomon.Runner) int {
 	return firstLeader
 }
 
-func expireCertificate(certPEM, caCertPEM, caKeyPEM []byte) (expiredcertPEM []byte, earlyMadeCACertPEM []byte) {
+func renewOrdererCertificates(network *nwo.Network, o1, o2, o3 *nwo.Orderer) {
+	ordererDomain := network.Organization(o1.Organization).Domain
+	ordererTLSCAKeyPath := filepath.Join(network.RootDir, "crypto", "ordererOrganizations",
+		ordererDomain, "tlsca", "priv_sk")
+
+	ordererTLSCAKey, err := ioutil.ReadFile(ordererTLSCAKeyPath)
+	Expect(err).NotTo(HaveOccurred())
+
+	ordererTLSCACertPath := filepath.Join(network.RootDir, "crypto", "ordererOrganizations",
+		ordererDomain, "tlsca", fmt.Sprintf("tlsca.%s-cert.pem", ordererDomain))
+	ordererTLSCACert, err := ioutil.ReadFile(ordererTLSCACertPath)
+	Expect(err).NotTo(HaveOccurred())
+
+	serverTLSCerts := make(map[string][]byte)
+	for _, orderer := range []*nwo.Orderer{o1, o2, o3} {
+		tlsCertPath := filepath.Join(network.OrdererLocalTLSDir(orderer), "server.crt")
+		serverTLSCerts[tlsCertPath], err = ioutil.ReadFile(tlsCertPath)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	for filePath, certPEM := range serverTLSCerts {
+		renewedCert, _ := expireCertificate(certPEM, ordererTLSCACert, ordererTLSCAKey, time.Now().Add(time.Hour))
+		err = ioutil.WriteFile(filePath, renewedCert, 0600)
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+func expireCertificate(certPEM, caCertPEM, caKeyPEM []byte, expirationTime time.Time) (expiredcertPEM []byte, earlyMadeCACertPEM []byte) {
 	keyAsDER, _ := pem.Decode(caKeyPEM)
 	caKeyWithoutType, err := x509.ParsePKCS8PrivateKey(keyAsDER.Bytes)
 	Expect(err).NotTo(HaveOccurred())
@@ -709,7 +812,7 @@ func expireCertificate(certPEM, caCertPEM, caKeyPEM []byte) (expiredcertPEM []by
 	// As well as the CA certificate
 	caCert.NotBefore = time.Now().Add((-1) * time.Hour)
 	// The certificate expires now
-	cert.NotAfter = time.Now()
+	cert.NotAfter = expirationTime
 
 	// The CA signs the certificate
 	certBytes, err := x509.CreateCertificate(rand.Reader, cert, caCert, cert.PublicKey, caKey)

--- a/orderer/common/cluster/comm_test.go
+++ b/orderer/common/cluster/comm_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/orderer"
+	"github.com/hyperledger/fabric/common/crypto"
 	"github.com/hyperledger/fabric/common/crypto/tlsgen"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/common/metrics"
@@ -266,6 +267,10 @@ func newTestNodeWithMetrics(t *testing.T, metrics cluster.MetricsProvider, tlsCo
 
 	tstSrv.freezeCond.L = &tstSrv.lock
 
+	compareCert := cluster.CachePublicKeyComparisons(func(a, b []byte) bool {
+		return crypto.CertificatesWithSamePublicKey(a, b) == nil
+	})
+
 	tstSrv.c = &cluster.Comm{
 		CertExpWarningThreshold: time.Hour,
 		SendBufferSize:          1,
@@ -275,6 +280,7 @@ func newTestNodeWithMetrics(t *testing.T, metrics cluster.MetricsProvider, tlsCo
 		ChanExt:                 channelExtractor,
 		Connections:             cluster.NewConnectionStore(dialer, tlsConnGauge),
 		Metrics:                 cluster.NewMetrics(metrics),
+		CompareCertificate:      compareCert,
 	}
 
 	orderer.RegisterClusterServer(gRPCServer.Server(), tstSrv)

--- a/orderer/common/cluster/connections.go
+++ b/orderer/common/cluster/connections.go
@@ -7,10 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package cluster
 
 import (
-	"bytes"
 	"crypto/x509"
 	"sync"
 
+	"github.com/hyperledger/fabric/common/crypto"
 	"github.com/hyperledger/fabric/common/metrics"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -57,10 +57,12 @@ func NewConnectionStore(dialer SecureDialer, tlsConnectionCount metrics.Gauge) *
 // itself with the given TLS certificate
 func (c *ConnectionStore) verifyHandshake(endpoint string, certificate []byte) RemoteVerifier {
 	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-		if bytes.Equal(certificate, rawCerts[0]) {
+		err := crypto.CertificatesWithSamePublicKey(certificate, rawCerts[0])
+		if err == nil {
 			return nil
 		}
-		return errors.Errorf("certificate presented by %s doesn't match any authorized certificate", endpoint)
+		return errors.Errorf("public key of server certificate presented by %s doesn't match the expected public key",
+			endpoint)
 	}
 }
 

--- a/orderer/common/cluster/util.go
+++ b/orderer/common/cluster/util.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -53,27 +54,47 @@ func (cbc ConnByCertMap) Remove(cert []byte) {
 	delete(cbc, string(cert))
 }
 
+// Size returns the size of the connections by certificate mapping
 func (cbc ConnByCertMap) Size() int {
 	return len(cbc)
 }
 
+// CertificateComparator returns whether some relation holds for two given certificates
+type CertificateComparator func([]byte, []byte) bool
+
 // MemberMapping defines NetworkMembers by their ID
-type MemberMapping map[uint64]*Stub
+// and enables to lookup stubs by a certificate
+type MemberMapping struct {
+	id2stub       map[uint64]*Stub
+	SamePublicKey CertificateComparator
+}
+
+// Foreach applies the given function on all stubs in the mapping
+func (mp *MemberMapping) Foreach(f func(id uint64, stub *Stub)) {
+	for id, stub := range mp.id2stub {
+		f(id, stub)
+	}
+}
 
 // Put inserts the given stub to the MemberMapping
-func (mp MemberMapping) Put(stub *Stub) {
-	mp[stub.ID] = stub
+func (mp *MemberMapping) Put(stub *Stub) {
+	mp.id2stub[stub.ID] = stub
+}
+
+// Remove removes the stub with the given ID from the MemberMapping
+func (mp *MemberMapping) Remove(ID uint64) {
+	delete(mp.id2stub, ID)
 }
 
 // ByID retrieves the Stub with the given ID from the MemberMapping
 func (mp MemberMapping) ByID(ID uint64) *Stub {
-	return mp[ID]
+	return mp.id2stub[ID]
 }
 
 // LookupByClientCert retrieves a Stub with the given client certificate
 func (mp MemberMapping) LookupByClientCert(cert []byte) *Stub {
-	for _, stub := range mp {
-		if bytes.Equal(stub.ClientTLSCert, cert) {
+	for _, stub := range mp.id2stub {
+		if mp.SamePublicKey(stub.ClientTLSCert, cert) {
 			return stub
 		}
 	}
@@ -84,7 +105,7 @@ func (mp MemberMapping) LookupByClientCert(cert []byte) *Stub {
 // represented as strings
 func (mp MemberMapping) ServerCertificates() StringSet {
 	res := make(StringSet)
-	for _, member := range mp {
+	for _, member := range mp.id2stub {
 		res[string(member.ServerTLSCert)] = struct{}{}
 	}
 	return res
@@ -703,4 +724,93 @@ func (exp *certificateExpirationCheck) checkExpiration(currentTime time.Time, ch
 	exp.alert("Certificate of %s from %s for channel %s expires in less than %v",
 		exp.nodeName, exp.endpoint, channel, timeLeft)
 	exp.lastWarning = currentTime
+}
+
+// CachePublicKeyComparisons creates CertificateComparator that caches invocations based on input arguments.
+// The given CertificateComparator must be a stateless function.
+func CachePublicKeyComparisons(f CertificateComparator) CertificateComparator {
+	m := &ComparisonMemoizer{
+		MaxEntries: 4096,
+		F:          f,
+	}
+	return m.Compare
+}
+
+// ComparisonMemoizer speeds up comparison computations by caching past invocations of a stateless function
+type ComparisonMemoizer struct {
+	// Configuration
+	F          func(a, b []byte) bool
+	MaxEntries uint16
+	// Internal state
+	cache map[arguments]bool
+	lock  sync.RWMutex
+	once  sync.Once
+	rand  *rand.Rand
+}
+
+type arguments struct {
+	a, b string
+}
+
+// Size returns the number of computations the ComparisonMemoizer currently caches.
+func (cm *ComparisonMemoizer) Size() int {
+	cm.lock.RLock()
+	defer cm.lock.RUnlock()
+	return len(cm.cache)
+}
+
+// Compare compares the given two byte slices.
+// It may return previous computations for the given two arguments,
+// otherwise it will compute the function F and cache the result.
+func (cm *ComparisonMemoizer) Compare(a, b []byte) bool {
+	cm.once.Do(cm.setup)
+	key := arguments{
+		a: string(a),
+		b: string(b),
+	}
+
+	cm.lock.RLock()
+	result, exists := cm.cache[key]
+	cm.lock.RUnlock()
+
+	if exists {
+		return result
+	}
+
+	result = cm.F(a, b)
+
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
+
+	cm.shrinkIfNeeded()
+	cm.cache[key] = result
+
+	return result
+}
+
+func (cm *ComparisonMemoizer) shrinkIfNeeded() {
+	for {
+		currentSize := uint16(len(cm.cache))
+		if currentSize < cm.MaxEntries {
+			return
+		}
+		cm.shrink()
+	}
+}
+
+func (cm *ComparisonMemoizer) shrink() {
+	// Shrink the cache by 25% by removing every fourth element (on average)
+	for key := range cm.cache {
+		if cm.rand.Int()%4 != 0 {
+			continue
+		}
+		delete(cm.cache, key)
+	}
+}
+
+func (cm *ComparisonMemoizer) setup() {
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
+	cm.rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+	cm.cache = make(map[arguments]bool)
 }

--- a/orderer/common/cluster/util_test.go
+++ b/orderer/common/cluster/util_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package cluster_test
 
 import (
+	"bytes"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
@@ -1186,4 +1187,42 @@ qz8bY+s6AiBvO0aOfE8M4ibjmRE4vSXo0+gkOIJKqZcmiRdnJSr8Xw==
 	actual := fmt.Sprint(epc)
 	expected := `{"CAs":[{"Expired":false,"Issuer":"self","Subject":"SERIALNUMBER=65764076798709079104397911007043976879"},{"Expired":true,"Issuer":"SERIALNUMBER=65764076798709079104397911007043976879","Subject":"SERIALNUMBER=187004237184026939685179573732217690720"}],"Endpoint":"orderer.example.com:7050"}`
 	require.Equal(t, expected, actual)
+}
+
+func TestComparisonMemoizer(t *testing.T) {
+	var invocations int
+
+	m := &cluster.ComparisonMemoizer{
+		MaxEntries: 5,
+		F: func(a, b []byte) bool {
+			invocations++
+			return bytes.Equal(a, b)
+		},
+	}
+
+	// Warm-up cache
+	for i := 0; i < 5; i++ {
+		notSame := m.Compare([]byte{byte(i)}, []byte{1, 2, 3})
+		require.False(t, notSame)
+		require.Equal(t, i+1, invocations)
+	}
+
+	// Ensure lookups are cached
+	for i := 0; i < 5; i++ {
+		notSame := m.Compare([]byte{byte(i)}, []byte{1, 2, 3})
+		require.False(t, notSame)
+		require.Equal(t, 5, invocations)
+	}
+
+	// Put a new entry which will cause a cache miss
+	same := m.Compare([]byte{5}, []byte{5})
+	require.True(t, same)
+	require.Equal(t, 6, invocations)
+
+	// Keep adding more and more elements to the cache and ensure it stays smaller than its size
+	for i := 0; i < 20; i++ {
+		odd := m.Compare([]byte{byte(1)}, []byte{byte(i % 2)})
+		require.Equal(t, i%2 != 0, odd)
+		require.LessOrEqual(t, m.Size(), int(m.MaxEntries))
+	}
 }

--- a/orderer/common/onboarding/onboarding.go
+++ b/orderer/common/onboarding/onboarding.go
@@ -109,6 +109,7 @@ func (ri *ReplicationInitiator) ReplicateIfNeeded(bootstrapBlock *common.Block) 
 
 func (ri *ReplicationInitiator) createReplicator(bootstrapBlock *common.Block, filter func(string) bool) *cluster.Replicator {
 	consenterCert := &etcdraft.ConsenterCertificate{
+		Logger:               ri.logger,
 		ConsenterCertificate: ri.secOpts.Certificate,
 		CryptoProvider:       ri.cryptoProvider,
 	}

--- a/orderer/consensus/etcdraft/chain.go
+++ b/orderer/consensus/etcdraft/chain.go
@@ -1347,6 +1347,7 @@ func (c *Chain) suspectEviction() bool {
 
 func (c *Chain) newEvictionSuspector() *evictionSuspector {
 	consenterCertificate := &ConsenterCertificate{
+		Logger:               c.logger,
 		ConsenterCertificate: c.opts.Cert,
 		CryptoProvider:       c.CryptoProvider,
 	}

--- a/orderer/consensus/etcdraft/util_test.go
+++ b/orderer/consensus/etcdraft/util_test.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hyperledger/fabric/common/flogging"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	etcdraftproto "github.com/hyperledger/fabric-protos-go/orderer/etcdraft"
@@ -38,6 +40,12 @@ func TestIsConsenterOfChannel(t *testing.T) {
 		"ZJQ0FURS0tLS0tCg==")
 	require.NoError(t, err)
 
+	ca, err := tlsgen.NewCA()
+	require.NoError(t, err)
+
+	kp, err := ca.NewClientCertKeyPair()
+	require.NoError(t, err)
+
 	validBlock := func() *common.Block {
 		b, err := ioutil.ReadFile(filepath.Join("testdata", "etcdraftgenesis.block"))
 		require.NoError(t, err)
@@ -54,18 +62,24 @@ func TestIsConsenterOfChannel(t *testing.T) {
 	}{
 		{
 			name:          "nil block",
-			expectedError: "nil block",
+			expectedError: "nil block or nil header",
+		},
+		{
+			name:          "nil header",
+			expectedError: "nil block or nil header",
+			configBlock:   &common.Block{},
 		},
 		{
 			name:          "no block data",
 			expectedError: "block data is nil",
-			configBlock:   &common.Block{},
+			configBlock:   &common.Block{Header: &common.BlockHeader{}},
 		},
 		{
 			name: "invalid envelope inside block",
 			expectedError: "failed to unmarshal payload from envelope:" +
 				" error unmarshaling Payload: proto: common.Payload: illegal tag 0 (wire type 1)",
 			configBlock: &common.Block{
+				Header: &common.BlockHeader{},
 				Data: &common.BlockData{
 					Data: [][]byte{protoutil.MarshalOrPanic(&common.Envelope{
 						Payload: []byte{1, 2, 3},
@@ -76,7 +90,7 @@ func TestIsConsenterOfChannel(t *testing.T) {
 		{
 			name:          "valid config block with cert mismatch",
 			configBlock:   validBlock(),
-			certificate:   certInsideConfigBlock[2:],
+			certificate:   kp.Cert,
 			expectedError: cluster.ErrNotInChannel.Error(),
 		},
 		{
@@ -90,6 +104,7 @@ func TestIsConsenterOfChannel(t *testing.T) {
 			require.NoError(t, err)
 
 			consenterCertificate := &ConsenterCertificate{
+				Logger:               flogging.MustGetLogger("test"),
 				ConsenterCertificate: testCase.certificate,
 				CryptoProvider:       cryptoProvider,
 			}


### PR DESCRIPTION
This change makes the orderer cluster authentication infrastructure
disregard validity periods when comparing certificates, and only regard public keys.

With this change, one can replace the TLS certificate of Raft,
by a certificate that has the same public key without issuing channel config updates.

This is to ensure that if a certificate of a consenter expired,
one can quickly renew it and start the orderer without performing
a config update per channel.

Change-Id: Id1b29e220d37aa33617b2143b702075bf5b01f6f
Signed-off-by: yacovm <yacovm@il.ibm.com>
