### PR TITLE
Remove commented out type definition

### DIFF
--- a/orderer/consensus/etcdraft/util.go
+++ b/orderer/consensus/etcdraft/util.go
@@ -271,8 +271,6 @@ type ConsenterCertificate struct {
 	CryptoProvider       bccsp.BCCSP
 }
 
-// type ConsenterCertificate []byte
-
 // IsConsenterOfChannel returns whether the caller is a consenter of a channel
 // by inspecting the given configuration block.
 // It returns nil if true, else returns an error.


### PR DESCRIPTION
This change removes the commented out type `ConsenterCertificate []byte` as it was replaced in the past by a struct and commented out instead of deleted

Change-Id: Ia18f25ab2a75e1eb385cf488ae697b3181d4b006
Signed-off-by: yacovm <yacovm@il.ibm.com>
