### PR TITLE
Pass initializer to pvtdatastorage OpenStore to indicate ledger is cr…

### DIFF
--- a/core/ledger/kvledger/kv_ledger_provider.go
+++ b/core/ledger/kvledger/kv_ledger_provider.go
@@ -334,7 +334,12 @@ func (p *Provider) open(ledgerID string, bootSnapshotMetadata *snapshotMetadata)
 		return nil, err
 	}
 
-	pvtdataStore, err := p.pvtdataStoreProvider.OpenStore(ledgerID)
+	storeInitializer := &pvtdatastorage.Initializer{}
+	if bootSnapshotMetadata != nil {
+		storeInitializer.CreatedFromSnapshot = true
+		storeInitializer.LastBlockInSnapshot = bootSnapshotMetadata.ChannelHeight - 1
+	}
+	pvtdataStore, err := p.pvtdataStoreProvider.OpenStore(ledgerID, storeInitializer)
 	if err != nil {
 		return nil, err
 	}

--- a/core/ledger/pvtdatastorage/test_exports.go
+++ b/core/ledger/pvtdatastorage/test_exports.go
@@ -50,7 +50,7 @@ func NewTestStoreEnv(
 	conf.StorePath = storeDir
 	testStoreProvider, err := NewProvider(conf)
 	require.NoError(t, err)
-	testStore, err := testStoreProvider.OpenStore(ledgerid)
+	testStore, err := testStoreProvider.OpenStore(ledgerid, &Initializer{})
 	testStore.Init(btlPolicy)
 	require.NoError(t, err)
 	return &StoreEnv{t, testStoreProvider, testStore, ledgerid, btlPolicy, conf}
@@ -62,7 +62,7 @@ func (env *StoreEnv) CloseAndReopen() {
 	env.TestStoreProvider.Close()
 	env.TestStoreProvider, err = NewProvider(env.conf)
 	require.NoError(env.t, err)
-	env.TestStore, err = env.TestStoreProvider.OpenStore(env.ledgerid)
+	env.TestStore, err = env.TestStoreProvider.OpenStore(env.ledgerid, &Initializer{})
 	env.TestStore.Init(env.btlPolicy)
 	require.NoError(env.t, err)
 }

--- a/core/ledger/pvtdatastorage/v11_V12_test.go
+++ b/core/ledger/pvtdatastorage/v11_V12_test.go
@@ -51,7 +51,7 @@ func TestV11v12(t *testing.T) {
 	p, err := NewProvider(conf)
 	require.NoError(t, err)
 	defer p.Close()
-	s, err := p.OpenStore(ledgerid)
+	s, err := p.OpenStore(ledgerid, &Initializer{})
 	require.NoError(t, err)
 	s.Init(btlPolicy)
 


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- New feature

#### Description
This is a temporary workaround to enable system tests to run end2end snapshot tests. It will be removed after FAB-18033 is implemented.

#### Related issues
https://jira.hyperledger.org/browse/FAB-18033