### PR TITLE
Peer deployment guide

### DIFF
--- a/docs/source/deployment_guide_overview.rst
+++ b/docs/source/deployment_guide_overview.rst
@@ -5,7 +5,7 @@ This deployment guide is a high level overview of the proper sequence for settin
 
 The process for deploying a Fabric network is complex and presumes an understanding of Public Key Infrastructure and managing distributed systems. If you are a smart contract or application developer, you should not need this level of expertise in deploying a production level Fabric network. However, you might need to be aware of how networks are deployed in order to develop effective smart contracts and applications.
 
-If all you need is a development environment to test chaincode, smart contracts, and applications against, check out :doc:`test_network`. It includes two organizations, each owning one peer, and a single ordering service organization that owns a single ordering node. **This test network is not meant to provide a blueprint for deploying production components, and should not be used as such, as it makes assumptions and decisions that production deployments will not make.**
+If all you need is a development environment to test chaincode, smart contracts, and applications against, check out :doc:`test_network`. The network you'll deploy will include two organizations, each owning one peer, and a single ordering service organization that owns a single ordering node. **This test network is not meant to provide a blueprint for deploying production components, and should not be used as such, as it makes assumptions and decisions that production deployments will not make.**
 
 The guide will give you an overview of the steps of setting up production components and a production network:
 
@@ -22,7 +22,7 @@ The guide will give you an overview of the steps of setting up production compon
 Step one: Decide on your network configuration
 ----------------------------------------------
 
-The structure of a blockchain network must be dictated by the use case. These fundamental business decisions will vary according to your use case, but let's consider a few scenarios.
+The structure of a blockchain network will be dictated by the use case it's serving. There are too many options to give definitive guidance on every point, but let's consider a few scenarios.
 
 In contrast to development environments or proofs of concept, security, resource management, and high availability become a priority when operating in production. How many nodes do you need to satisfy high availability, and in what data centers do you wish to deploy them in to satisfy both the needs of disaster recovery and data residency? How will you ensure that your private keys and roots of trust remain secure?
 
@@ -32,19 +32,19 @@ In addition to the above, here is a sampling of the decisions you will need to m
   As part of the overall decisions you have to make about your peers (how many, how many on each channel, and so on) and about your ordering service (how many nodes, who will own them), you also have to decide on how the CAs for your organization will be deployed. Production networks should be using Transport Layer Security (TLS), which will require setting up a TLS CA and using it to generate TLS certificates. This TLS CA will need to be deployed before your enrollment CA. We'll discuss this more in :ref:`dg-step-three-set-up-your-cas`.
 
 * **Use Organizational Units or not?**
-  Some organizations might find it necessary to establish Organizational Units to create a separation between certain identities and MSPs created by a single CA.
+  Some organizations might find it necessary to establish Organizational Units to create a separation between certain identities and MSPs created by a single CA. Note that this is separate from the concept of the "Node OU", in which identities can have roles coded into them (for example, "admin" or "peer").
 
 * **Database type.**
   Some channels in a network might require all data to be modeled in a way :doc:`couchdb_as_state_database` can understand, while other networks, prioritizing speed, might decide that all peers will use LevelDB. Note that channels should not have peers that use both CouchDB and LevelDB on them, as the two database types model data slightly differently.
 
 * **Channels and private data.**
-  Some networks might decide that :doc:`channels` are the best way to ensure privacy and isolation for certain transactions. Others might decide that a single channel, along with :doc:`private-data/private-data`, better serves their need for privacy.
+  Some networks might decide that :doc:`channels` are the best way to ensure privacy and isolation for certain transactions. Others might decide that fewer channels, supplemented where necessary with :doc:`private-data/private-data` collections, better serves their privacy needs.
 
 * **Container orchestration.**
-  Different users might also make different decisions about their container orchestration, creating separate containers for their peer process, logging for the peer, CouchDB, gRPC communications, and chaincode, while other users might decide to combine some of these processes.
+  Different users might also make different decisions about their container orchestration, creating separate containers for their peer process, logging, CouchDB, gRPC communications, and chaincode, while other users might decide to combine some of these processes.
 
 * **Chaincode deployment method.**
-  Users now have the option to deploy their chaincode using either the built in build and run support, a customized build and run using the :doc:`cc_launcher`, or using an :doc:`cc_service`.
+  Users have the option to deploy their chaincode using either the built in build and run support, a customized build and run using the :doc:`cc_launcher`, or using an :doc:`cc_service`.
 
 * **Using firewalls.**
   In a production deployment, components belonging to one organization might need access to components from other organizations, necessitating the use of firewalls and advanced networking configuration. For example, applications using the Fabric SDK require access to all endorsing peers from all organizations and the ordering services for all channels. Similarly, peers need access to the ordering service on the channels that they are receiving new blocks from.
@@ -53,17 +53,16 @@ However and wherever your components are deployed, you will need a high degree o
 
 This deployment guide will not go through every iteration and potential network configuration, but does give common guidelines and rules to consider.
 
-
 .. _dg-step-two-set-up-a-cluster-for-your-resources:
 
 Step two: Set up a cluster for your resources
 ---------------------------------------------
 
-Generally speaking, Fabric is agnostic to the method used to deploy and manage it. It is possible, for example, to deploy and manage a peer from a laptop. For a number of reasons, this is likely to be unadvisable, but there is nothing in Fabric that prohibits it.
+Generally speaking, Fabric is agnostic to the methods used to deploy and manage it. It is possible, for example, to deploy and manage a peer on a laptop. For a number of reasons, this is likely to be unadvisable, but there is nothing in Fabric that prohibits it.
 
 As long as you have the ability to deploy containers, whether locally (or behind a firewall), or in a cloud, it should be possible to stand up components and connect them to each other. However, Kubernetes features a number of helpful tools that have made it a popular container management platform for deploying and managing Fabric networks. For more information about Kubernetes, check out `the Kubernetes documentation <https://kubernetes.io/docs>`_. This topic will mostly limit its scope to the binaries and provide instructions that can be applied when using a Docker deployment or Kubernetes.
 
-However and wherever you choose to deploy your components, you will need to make sure you have enough resources for the components to run effectively. The sizes you need will largely depend on your use case. If you plan to join a single peer to several high volume channels, it will need much more CPU and memory than a peer a user plans to join to a single channel. As a rough estimate, plan to dedicate approximately three times the resources to a peer as you plan to allocate to a single ordering node (as you will see below, it is recommended to deploy at least three and optimally five nodes in an ordering service). Similarly, you should need approximately a tenth of the resources for a CA as you will for a peer. You will also need to add storage to your cluster (some cloud providers may provide storage) as you cannot configure Persistent Volumes and Persistent Volume Claims without storage being set up with your cloud provider first.
+However and wherever you choose to deploy your components, you will need to make sure you have enough resources for the components to run effectively. The sizes you need will largely depend on your use case. If you plan to join a single peer to several high volume channels, it will need much more CPU and memory than if you only plan to join to a single channel. As a rough estimate, plan to dedicate approximately three times the resources to a peer as you plan to allocate to a single ordering node (as you will see below, it is recommended to deploy at least three and optimally five nodes in an ordering service). Similarly, you should need approximately a tenth of the resources for a CA as you will for a peer. You will also need to add storage to your cluster (some cloud providers may provide storage) as you cannot configure Persistent Volumes and Persistent Volume Claims without storage being set up with your cloud provider first.
 
 By deploying a proof of concept network and testing it under load, you will have a better sense of the resources you will require.
 
@@ -93,6 +92,14 @@ While all of the non-TLS certificates associated with an organization can be cre
 
 For an example of how to setup an organization CA and a TLS CA and enroll their admin identity, check out the `Fabric CA Deployment Guide <https://hyperledger-fabric-ca.readthedocs.io/en/latest/deployguide/ca-deploy.html>`__.  The deploy guide uses the Fabric CA client to register and enroll the identities that are required when setting up CAs.
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Deploy a Production CA
+
+   Planning for a CA <https://hyperledger-fabric-ca.readthedocs.io/en/latest/deployguide/ca-deploy-topology.html>
+   Checklist for a production CA server <https://hyperledger-fabric-ca.readthedocs.io/en/latest/deployguide/ca-config.html>
+   CA deployment steps <https://hyperledger-fabric-ca.readthedocs.io/en/latest/deployguide/cadeploy.html>
+
 .. _dg-step-four-use-the-ca-to-create-identities-and-msps:
 
 Step four: Use the CA to create identities and MSPs
@@ -100,7 +107,7 @@ Step four: Use the CA to create identities and MSPs
 
 After you have created your CAs, you can use them to create the certificates for the identities and components related to your organization (which is represented by an MSP). For each organization, you will need to, at a minimum:
 
-* **Register and enroll an admin identity and create an MSP**. After the CA that will be associated with an organization has been created, it can be used to first register an identity and then enroll it. In the first step, a username and password for the identity is assigned by the admin of the CA. Attributes and affiliations can also be given to the identity (for example, a ``role`` of ``admin``, which is necessary for organization admins). After the identity has been registered, it can be enrolled by using the username and password. The CA will generate two certificates for this identity --- a public certificate (also known as a "signcert" or "public cert") known to the other members of the network, and the private key (stored in the ``keystore`` folder) used to sign actions taken by the identity. The CA will also generate a set of folders called an "MSP" containing the public certificate of the CA issuing the certificate and the root of trust for the CA (this may or may not be the same CA). This MSP can be thought of as defining the organization associated with the identity of the admin. In cases where the admin of the org will also be an admin of a node (which will be typical), **you must create the org admin identity before creating the local MSP of a node, since the certificate of the node admin must be used when creating the local MSP**.
+* **Register and enroll an admin identity and create an MSP**. After the CA that will be associated with an organization has been created, it can be used to first register a user and then enroll an identity (producing the certificate pair used by all entities on the network). In the first step, a username and password for the identity is assigned by the admin of the CA. Attributes and affiliations can also be given to the identity (for example, a ``role`` of ``admin``, which is necessary for organization admins). After the identity has been registered, it can be enrolled by using the username and password. The CA will generate two certificates for this identity --- a public certificate (also known as a "signcert" or "public cert") known to the other members of the network, and the private key (stored in the ``keystore`` folder) used to sign actions taken by the identity. The CA will also generate a set of folders called an "MSP" containing the public certificate of the CA issuing the certificate and the root of trust for the CA (this may or may not be the same CA). This MSP can be thought of as defining the organization associated with the identity of the admin. In cases where the admin of the org will also be an admin of a node (which will be typical), **you must create the org admin identity before creating the local MSP of a node, since the certificate of the node admin must be used when creating the local MSP**.
 * **Register and enroll node identities**. Just as an org admin identity is registered and enrolled, the identity of a node must be registered and enrolled with both an enrollment CA and a TLS CA (the latter generates certificates that are used to secure communications). Instead of giving a node a role of ``admin`` or ``user`` when registering it with the enrollment CA, give it a role of ``peer`` or ``orderer``. As with the admin, attributes and affiliations for this identity can also be assigned. The MSP structure for a node is known as a "local MSP", since the permissions assigned to the identities are only relevant at the local (node) level. This MSP is created when the node identity is created, and is used when bootstrapping the node.
 
 For more conceptual information about identities and permissions in a Fabric-based blockchain network, see :doc:`identity/identity` and :doc:`membership/membership`.
@@ -109,21 +116,14 @@ For more information about how to use a CA to register and enroll identities, in
 
 .. _dg-step-five-deploy-nodes:
 
-Step five: Deploy nodes
------------------------
+Step five: Deploy peers and ordering nodes
+------------------------------------------
 
 Once you have gathered all of the certificates and MSPs you need, you're almost ready to create a node. As discussed above, there are a number of valid ways to deploy nodes.
 
-.. _dg-create-a-peer:
+Before any node can be deployed, its configuration file must be customized. For the peer, this file is called ``core.yaml``, while the configuration file for ordering nodes is called ``orderer.yaml``.
 
-Create a peer
-~~~~~~~~~~~~~
-
-Before you can create a peer, you will need to customize the configuration file for the peer. In Fabric, this file is called ``core.yaml``. You can find a sample ``core.yaml`` configuration file `in the sampleconfig directory of Hyperledger Fabric <https://github.com/hyperledger/fabric/blob/master/sampleconfig/core.yaml>`_.
-
-As you can see in the file, there are quite a number of parameters you either have the option to set or will need to set for your node to work properly. In general, if you do not have the need to change a tuning value, leave it alone. You will, however, likely need to adjust the various addresses, specify the database type you want to use, as well as to specify where the MSP for the node is located.
-
-You have two main options for tuning your configuration.
+You have three main options for tuning your configuration.
 
 1. Edit the YAML file bundled with the binaries.
 2. Use environment variable overrides when deploying.
@@ -131,42 +131,55 @@ You have two main options for tuning your configuration.
 
 Option 1 has the advantage of persisting your changes whenever you bring down and bring back up the node. The downside is that you will have to port the options you customized to the new YAML when upgrading to a new binary version (you should use the latest YAML when upgrading to a new version).
 
-Either way, here are some values in ``core.yaml`` you must review.
+.. note:: You can extrapolate environment variables from the parameters in the relevant YAML file by using all capital letters, underscores between the relevant phrases, and a prefix. For example, the peer configuration variable called ``localMSPid`` in ``core.yaml`` would be rendered as an environment variable called ``CORE_PEER_LOCALMSPID``, while the ordering service environment variable ``LocalMSPID`` in the ``orderer.yaml`` configuration file would be rendered as an environment variable called ``ORDERER_GENERAL_LOCALMSPID``.
 
-* ``peer.localMspID``: this is the name of the local MSP of your peer organization. This MSP is where your peer organization admins will be listed as well as the peer organization's root CA and TLS CA certificates.
+          For cases where a parameter is part of a larger configuration section, use an underscore between the section heading and the parameter. For example, in ``orderer.yaml``, the ``TLS`` section has a sub-parameter called ``Enabled``. This parameter would therefore be rendered as an environment variable called ``ORDERER_GENERAL_TLS_ENABLED``.
 
-* ``peer.mspConfigPath``: the place where the local MSP for the peer is located. Note that it is a best practice to mount this volume external to your container. This ensures that even if the container is stopped (for example, during a maintenance cycle) that the MSPs are not lost and have to be recreated.
+.. _dg-create-a-peer:
 
-* ``peer.address``: represents the endpoint to other peers in the same organization, an important consideration when establishing gossip communication within an organization.
+Creating a peer
+~~~~~~~~~~~~~~~
 
-* ``peer.tls``: When you set the ``enabled`` value to ``true`` (as should be done in a production network), you will have to specify the locations of the relevant TLS certificates. Note that all of the nodes in a network (both the peers and the ordering nodes) must either all have TLS enabled or not enabled. For production networks, it is highly recommended to enable TLS. As with your MSP, it is a best practice to mount this volume external to your container.
+If you’ve read through of key concept topic on :doc:`peers/peers`, you should have a good idea of the role peers play in a network and the nature of their interactions with other network components. Put simply, peers are the physical extension of transacting organizations (which are, for this reason, sometimes called "peer organizations"). They connect to the ordering service and to other peers, have smart contracts installed on them, and are where ledgers are stored.
 
-* ``ledger``: users have a number of decisions to make about their ledger, including the state database type (LevelDB or CouchDB, for example), and its location (specified in ``fileSystemPath``). Note that for CouchDB, it is a best practice to operate your state database external to the peer (for example, in a separate container), as you will be better able to allocate specific resources to the database this way. For latency and security reasons, it is a best practice to have the CouchDB container on the same server as the peer. Access to the CouchDB container should be restricted to only the peer container.
+These roles are important to understand before you create a peer, as they will influence your customization and deployment decisions. Once you understand them, you will need to customize the configuration of your peer to suit them, keeping in mind as well the cluster and infrastructure decisions you have made. For a look at the various decisions you will need to make, check out doc:`deploypeer/peerplan`.
 
-* ``gossip``: there are a number of configuration options to think about when setting up :doc:`gossip`, including the ``externalEndpoint`` (which makes peers discoverable to peers owned by other organizations) as well as the ``bootstrap`` address (which identifies a peer in the peer's own organization).
+The configuration file of the peer, which must be customized before the peer can be deployed, is called ``core.yaml``. You can find a sample ``core.yaml`` configuration file `in the sampleconfig directory of Hyperledger Fabric <https://github.com/hyperledger/fabric/blob/master/sampleconfig/core.yaml>`_. Note that while this sample configuration is largely similar to the ``core.yaml`` file that will come bundled with the peer, some additional parameters might be present in the bundled ``core.yaml`` and it is therefore a best practice to use it and not the sample. For information about how to download the production ``core.yaml`` along with the peer image, check out :doc:`deploypeer/peerdeploy`.
 
-* ``chaincode.externalBuilders``: this field is important to set when using :doc:`cc_service`.
+As you can see, there are quite a number of parameters you will need to set or to customize for your node to work properly. In general, if you do not have the need to change a tuning value, leave it alone. You will, however, need to set a number of configuration values.
+
+You can think of ``core.yaml`` as being separated in three main sections:
+
+* **Identifiers**: these include not just the paths to the relevant local MSP and Transport Layer Security (TLS) certificates, but also the name (known as the "peer ID") of the peer and the MSP ID of the organization that owns the peer.
+
+* **Addresses and paths**: because peers are not entities unto themselves but interact with other peers and components, you must specify a series of addresses in the configuration. These include addresses where the peer itself can be found by other components as well as the addresses where, for example, chaincodes can be found (if you are employing external chaincodes). Similarly, you will need to specify the location of your ledger (as well as your state database type) and the path to your external builders (again, if you intend to employ external chaincodes).
+
+  * **Operations and metrics**: these parameters allow you to set up methods for monitoring the health and performance of your peer through the configuration of endpoints.
+
+* **Gossip**: components in Fabric networks communicate with each other using the "gossip" protocol. Through this protocol, they can be discovered by the discovery service and disseminate blocks to each other. Note that gossip communications are secured using TLS.
+
+For more information about ``core.yaml`` and its specific parameters, check out :doc:`deploypeer/peerchecklist`.
 
 When you're comfortable with how your peer has been configured, how your volumes are mounted, and your backend configuration, you can run the command to launch the peer (this command will depend on your backend configuration).
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Deploying a Production Peer
+
+   deploypeer/peerplan
+   deploypeer/peerchecklist
+   deploypeer/peerdeploy
+
 .. _dg-create-an-ordering-node:
 
-Create an ordering node
-~~~~~~~~~~~~~~~~~~~~~~~
+Creating an ordering node
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Unlike the creation of a peer, you will need to create a genesis block (or reference a block that has already been created, if adding an ordering node to an existing ordering service) and specify the path to it before launching the ordering node.
 
 In Fabric, this configuration file for ordering nodes is called ``orderer.yaml``. You can find a sample ``orderer.yaml`` configuration file `in the sampleconfig directory of Hyperledger Fabric <https://github.com/hyperledger/fabric/blob/master/sampleconfig/orderer.yaml>`__. Note that ``orderer.yaml`` is different than the "genesis block" of an ordering service. This block, which includes the initial configuration of the orderer system channel, must be created before an ordering node is created because it is used to bootstrap the node.
 
 As with the peer, you will see that there are quite a number of parameters you either have the option to set or will need to set for your node to work properly. In general, if you do not have the need to change a tuning value, leave it alone.
-
-You have two main options for tuning your configuration.
-
-1. Edit the YAML file bundled with the binaries.
-2. Use environment variable overrides when deploying.
-3. Specify flags on CLI commands.
-
-Option 1 has the advantage of persisting your changes whenever you bring down and bring back up the node. The downside is that you will have to port the options you customized to the new YAML when upgrading to a new binary version (you should use the latest YAML when upgrading to a new version).
 
 Either way, here are some values in ``orderer.yaml`` you must review. You will notice that some of these fields are the same as those in ``core.yaml`` only with different names.
 
@@ -196,14 +209,6 @@ Blockchain networks are all about connection, so once you've deployed nodes, you
 Part of the process of connecting nodes and creating channels will involve modifying policies to fit the use cases of business networks. For more information about policies, check out :doc:`policies/policies`.
 
 One of the common tasks in a Fabric will be the editing of existing channels. For a tutorial about that process, check out :doc:`config_update`. One popular channel update is to add an org to an existing channel. For a tutorial about that specific process, check out :doc:`channel_update_tutorial`. For information about upgrading nodes after they have been deployed, check out :doc:`upgrading_your_components`.
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Deploying a Production CA
-
-   Planning for a CA <https://hyperledger-fabric-ca.readthedocs.io/en/latest/deployguide/ca-deploy-topology.html>
-   Checklist for a production CA server <https://hyperledger-fabric-ca.readthedocs.io/en/latest/deployguide/ca-config.html>
-   CA deployment steps <https://hyperledger-fabric-ca.readthedocs.io/en/latest/deployguide/cadeploy.html>
 
 .. Licensed under Creative Commons Attribution 4.0 International License
    https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/deploypeer/peerchecklist.md
+++ b/docs/source/deploypeer/peerchecklist.md
@@ -1,0 +1,406 @@
+#  Checklist for a production peer
+
+As you prepare to build a production peer, you need to customize the configuration by editing the [core.yaml](https://github.com/hyperledger/fabric/blob/{BRANCH}/sampleconfig/core.yaml) file, also visible inside the peer binary `\config` folder. Ideally, peer configuration happens before the peer is started.
+
+While in a production environment you could override the environment variables in the `core.yaml` file in your Docker container or your Kubernetes job, these instructions show how to edit `core.yaml` instead. It’s important to understand the parameters in the configuration file and their dependancies on other parameter settings in the file. Blindly overriding one setting using an environment variable could affect the functionality of another setting. Therefore, the recommendation is that before starting the peer, you make the modifications to the settings in the configuration file to become familiar with the available settings and how they work. Afterwards, you may choose to override these parameters using environment variables.
+
+This checklist covers key configuration parameters for setting up a production network. Of course, you can always refer to the `core.yaml` file for additional parameters or more information. The list of parameters that you need to understand and that are described in this topic include:
+
+- [id](#id)
+- [networkId](#networkid)
+- [listenAddress](#listenaddress)
+- [chaincodeListenAddress](#chaincodelistenaddress)
+- [chaincodeAddress](#chaincodeaddress)
+- [address](#address)
+- [mspConfigPath](#mspconfigpath)
+- [localMspId](#localmspid)
+- [fileSystemPath](#filesystempath)
+- [gossip](#gossip)
+- [tls](#tls)
+- [bccsp](#bccsp)
+- [externalBuilders](#externalBuilders)
+- [ledger](#ledger)
+- [operations](#operations)
+- [metrics](#metrics)
+
+## id
+
+```
+# The peer id provides a name for this peer instance and is used when
+# naming docker resources.
+id: jdoe
+```
+- **`id`**: (Default value should be overridden.) Start by giving your peer an ID (which is analogous to giving it a name). Often the name indicates the organization that the peer belongs to, for example `peer0.org1.example.com`. The `peer.id` parameter is the name used by service discovery and peer gossip to address the peer. It is used for naming this peer, associated chaincode images, and peer containers.
+
+## networkId
+
+```
+# The networkId allows for logical separation of networks and is used when
+# naming docker resources.
+networkId: dev
+```
+
+- **`networkId`**: (Default value should be overridden.) Specify any name that you want. One recommendation would be to differentiate the network by naming it based on its planned usage (for example, “dev”, “staging”, “test”, ”production”, etc). This value is also used to build the name of the chaincode images and peer containers.
+
+## listenAddress
+
+```
+# The Address at local network interface this Peer will listen on.
+# By default, it will listen on all network interfaces
+listenAddress: 0.0.0.0:7051
+```
+- **`listenAddress`**: (Default value should be overridden.) Specify the address that the peer will listen on, for example, `127.0.0.1:7051`.
+
+## chaincodeListenAddress
+
+```
+# The endpoint this peer uses to listen for inbound chaincode connections.
+# If this is commented-out, the listen address is selected to be
+# the peer's address (see below) with port 7052
+chaincodeListenAddress: 0.0.0.0:7052
+```
+
+- **`chaincodeListenAddress`**: (Default value should be overridden.) Uncomment this parameter and specify the address where this peer listens for chaincode requests. It needs to be different than the `peer.listenAddress`, for example, `127.0.0.1:7052`. This is the network-addressable name that other peers should use.
+
+## chaincodeAddress
+```
+# The endpoint the chaincode for this peer uses to connect to the peer.
+# If this is not specified, the chaincodeListenAddress address is selected.
+# And if chaincodeListenAddress is not specified, address is selected from
+# peer address (see below). If specified peer address is invalid then it
+# will fallback to the auto detected IP (local IP) regardless of the peer
+# addressAutoDetect value.
+chaincodeAddress: 0.0.0.0:7052
+```
+- **`chaincodeAddress`**: (Default value should be overridden.) Uncomment this parameter and specify the address that chaincode containers can use to connect to this peer, for example, `peer0.org1.example.com:7052`.
+
+## address
+```
+# When used as peer config, this represents the endpoint to other peers
+# in the same organization. For peers in other organization, see
+# gossip.externalEndpoint for more info.
+# When used as CLI config, this means the peer's endpoint to interact with
+address: 0.0.0.0:7051
+```
+- **`address`**: (Default value should be overridden.) Specify the address that other peers in the organization use to connect to this peer, for example, `peer0.org1.example.com:7051`.
+
+## mspConfigPath
+```
+mspConfigPath: msp
+```
+- **`mspConfigPath`**: (Default value should be overridden.) This is the path to the peer's local MSP, which must be created before the peer can be deployed. The path can be absolute or relative to `FABRIC_CFG_PATH` (by default, it is `/etc/hyperledger/fabric` in the peer image). Unless an absolute path is specified to a folder named something other than "msp", the peer defaults to looking for a folder called “msp” at the path (in other words, `FABRIC_CFG_PATH/msp`) and when using the peer image: `/etc/hyperledger/fabric/msp`. If you are using the recommended folder structure described in the [Registering and enrolling identities with a CA](https://hyperledger-fabric-ca.readthedocs.io/en/release-1.4/deployguide/use_CA.html) topic, it would be relative to the FABRIC_CFG_PATH as follows:
+`config/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp`
+
+## localMspId
+```
+# Identifier of the local MSP
+# ----!!!!IMPORTANT!!!-!!!IMPORTANT!!!-!!!IMPORTANT!!!!----
+# Deployers need to change the value of the localMspId string.
+# In particular, the name of the local MSP ID of a peer needs
+# to match the name of one of the MSPs in each of the channel
+# that this peer is a member of. Otherwise this peer's messages
+# will not be identified as valid by other nodes.
+localMspId: SampleOrg
+```
+
+- **`localMspId`**: (Default value should be overridden.) This is the value of the MSP ID of the organization the peer belongs to. Because peers can only be joined to a channel if the organization the peer belongs to is a channel member, this MSP ID must match the name of at least one of the MSPs in each of the channels that this peer is a member of.
+
+## fileSystemPath
+```
+# Path on the file system where peer will store data (eg ledger). This
+# location must be access control protected to prevent unintended
+# modification that might corrupt the peer operations.
+fileSystemPath: /var/hyperledger/production
+```
+- **`fileSystemPath`**: (Default value should be overridden.) This is the path to the ledger and installed chaincodes on the local filesystem of the peer. It can be an absolute path or relative to FABRIC_CFG_PATH. It defaults to `/var/hyperledger/production`. The user running the peer needs to own and have write access to this directory.
+
+## gossip
+
+```
+gossip:
+    # Bootstrap set to initialize gossip with.
+    # This is a list of other peers that this peer reaches out to at startup.
+    # Important: The endpoints here have to be endpoints of peers in the same
+    # organization, because the peer would refuse connecting to these endpoints
+    # unless they are in the same organization as the peer.
+    bootstrap: 127.0.0.1:7051
+
+    # Overrides the endpoint that the peer publishes to peers
+    # in its organization. For peers in foreign organizations
+    # see 'externalEndpoint'
+    endpoint:
+
+    # This is an endpoint that is published to peers outside of the organization.
+    # If this isn't set, the peer will not be known to other organizations.
+    externalEndpoint:
+
+    # NOTE: orgLeader and useLeaderElection parameters are mutual exclusive.
+    # Setting both to true would result in the termination of the peer
+    # since this is undefined state. If the peers are configured with
+    # useLeaderElection=false, make sure there is at least 1 peer in the
+    # organization that its orgLeader is set to true.
+
+    # Defines whenever peer will initialize dynamic algorithm for
+    # "leader" selection, where leader is the peer to establish
+    # connection with ordering service and use delivery protocol
+    # to pull ledger blocks from ordering service.
+    useLeaderElection: false
+
+    # Statically defines peer to be an organization "leader",
+    # where this means that current peer will maintain connection
+    # with ordering service and disseminate block across peers in
+    # its own organization. Multiple peers or all peers in an organization
+    # may be configured as org leaders, so that they all pull
+    # blocks directly from ordering service.
+    orgLeader: true
+
+    # Gossip state transfer related configuration
+    state:
+        # indicates whenever state transfer is enabled or not
+        # default value is true, i.e. state transfer is active
+        # and takes care to sync up missing blocks allowing
+        # lagging peer to catch up to speed with rest network
+        enabled: false
+
+    pvtData:
+      implicitCollectionDisseminationPolicy:
+          # requiredPeerCount defines the minimum number of eligible peers to which the peer must successfully
+          # disseminate private data for its own implicit collection during endorsement. Default value is 0.
+          requiredPeerCount: 0
+
+          # maxPeerCount defines the maximum number of eligible peers to which the peer will attempt to
+          # disseminate private data for its own implicit collection during endorsement. Default value is 1.
+          maxPeerCount: 1
+```
+
+Peers leverage the Gossip data dissemination protocol to broadcast ledger and channel data in a scalable fashion. Gossip messaging is continuous, and each peer on a channel is constantly receiving current and consistent ledger data from multiple peers. While there are many Gossip parameters that can be customized, there are three groups of settings you need to pay attention to at a minimum:
+
+* **Endpoints** Gossip is required for block dissemination (not recommended other than for private data transactions) and service discovery (recommended). To use any of these features, you must configure the gossip `bootstrap`, `endpoint`, and `externalEndpoint` parameters in addition to **setting at least one anchor peer** in the peer’s channel configuration.
+
+  - **`bootstrap`**: (Default value should be overridden.) Provide the list of other peer [addresses](#address) in this organization to discover.
+
+  - **`endpoint`**: (Default value should be overridden.) Specify the address that other peers _in this organization_ should use to connect to this peer. For example, `peer0.org1.example.com:7051`.
+
+  - **`externalEndpoint:`** (Default value should be overridden.) Specify the address that peers in _other organizations_ should use to connect to this peer, for example, `peer0.org1.example.com:7051`.
+
+* **Block dissemination** As of Fabric v2.2, in order to reduce network traffic, it is recommended that peers get their blocks from non-private data transactions from the ordering service instead of from other peers in their organization. The combination of the `useLeaderElection:`, `orgLeader:`, and `state.enabled` parameters in this section control this behavior.
+
+  - **`useLeaderElection:`** (Defaults to `false` as of v2.2, which is recommended so that peers get blocks from ordering service.) When `useLeaderElection` is set to false, you must configure at least one peer to be the org leader by setting `peer.gossip.orgLeader` to true. Set `useLeaderElection` to true if you prefer that peers use Gossip for block dissemination among peers in the organization.
+
+  - **`orgLeader:`** (Defaults to `true` as of v2.2, which is recommended so that peers get blocks from ordering service.) Set this value to `false` if you want to use Gossip for block dissemination among peers in the organization.
+
+  - **`state.enabled:`** (Defaults to `false` as of v2.2 which is recommended so that peers get blocks from ordering service.) Set this value to `true` when you want to use Gossip to sync up missing blocks, which allows a lagging peer to catch up with other peers on the network.
+
+* **Implicit data** Fabric v2.0 introduced the concept of private data implicit collections on a peer. If you’d like to utilize per-organization private data patterns, you don’t need to define any collections when deploying chaincode in Fabric v2.x. Implicit organization-specific collections can be used without any upfront definition. When you plan to take advantage of this new feature, you need to configure the values of the `pvtData.implicitCollectionDisseminationPolicy.requiredPeerCount` and `pvtData.implicitCollectionDisseminationPolicy.maxPeerCount`. For more details, review the [Private data tutorial](../private_data_tutorial.html).
+  - **`pvtData.implicitCollectionDisseminationPolicy.requiredPeerCount`:** (Recommended that you override this value when using private data implicit collections.) **New in Fabric 2.0.** It defaults to 0, but you will need to increase it based on the number of peers belonging to your organization. The value represents the maximum number of peers within your own organization that the data must be disseminated to.
+
+  - **`pvtData.implicitCollectionDisseminationPolicy.maxPeerCount`:** (Recommended that you override this value when using private data implicit collections.) **New in Fabric 2.0.** This is an organization-specific collection setting that is used to ensure the private data is disseminated elsewhere in case this peer endorses a request and then goes down for some reason. The default is set to `1` but in a production environment with `n` peers in an organization, the recommended setting is `n-1`.
+
+## tls
+
+```
+tls:
+# Require server-side TLS
+enabled:  false
+# Require client certificates / mutual TLS.
+# Note that clients that are not configured to use a certificate will
+# fail to connect to the peer.
+clientAuthRequired: false
+# X.509 certificate used for TLS server
+cert:
+    file: tls/server.crt
+# Private key used for TLS server (and client if clientAuthEnabled
+# is set to true
+key:
+    file: tls/server.key
+# Trusted root certificate chain for tls.cert
+rootcert:
+    file: tls/ca.crt
+# Set of root certificate authorities used to verify client certificates
+clientRootCAs:
+    files:
+      - tls/ca.crt
+```
+
+Configure this section to enable TLS communications for the peer. After TLS is enabled, all nodes that transact with the peer will also need to enable TLS. Review the topic on [Registering and enrolling identities with a CA](https://hyperledger-fabric-ca.readthedocs.io/en/release-1.4/deployguide/use_CA.html) for instructions on how to generate the peer TLS certificates.
+
+- **`tls.enabled`:** (Default value should be overridden.) To ensure your production environment is secure, TLS should be enabled for all communications between nodes by setting `enabled: true` in the `tls` section of the config file. While this field is disabled by default, which may be acceptable for a test network, it should to be enabled when in production. This setting will configure **server-side TLS**, meaning that TLS will guarantee the identity of the _server_ to the client and provides a two-way encrypted channel between them.
+
+- **`tls.cert.file`:** (Default value should be overridden.) Every peer needs to register and enroll with its TLS CA before it can transact securely with other nodes in the organization. Therefore, before you can deploy a peer, you must first register a user for the peer and enroll the peer identity with the TLS CA to generate the peer's TLS signed certificate. If you are using the recommended folder structure from the [Registering and enrolling identities with a CA](https://hyperledger-fabric-ca.readthedocs.io/en/release-1.4/deployguide/use_CA.html) topic, this file needs to be copied into `config/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls`
+
+- **`tls.key.file`:** (Default value should be overridden.) Similar to the `tls.cert.file`, provide the name and location of the generated TLS private key for this peer, for example, `/msp/keystore/87bf5eff47d33b13d7aee81032b0e8e1e0ffc7a6571400493a7c_sk`. If you are using the recommended folder structure from the [Registering and enrolling identities with a CA](https://hyperledger-fabric-ca.readthedocs.io/en/release-1.4/deployguide/use_CA.html) topic, this file needs to be copied into `config/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls`.  If you are using an [HSM](#bccsp) to store the private key for the peer, this field will be blank.
+
+- **`tls.rootcert.file`:**  (Default value should be overridden.) This value contains the name and location of the peer organization CA root certificate. If you are using the recommended folder structure from the [Registering and enrolling identities with a CA](https://hyperledger-fabric-ca.readthedocs.io/en/release-1.4/deployguide/use_CA.html) topic, this file needs to be copied into `config/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls`.
+
+The next two parameters only need to be provided when mutual TLS is required:
+
+- **`tls.clientAuthRequired`:** Defaults to `false`. Set to `true` for a higher level of security by using **mutual TLS**, which can be configured as an extra verification step of the client-side TLS certificate. Where server-side TLS is considered the minimally necessary level of security, mutual TLS is an additional and optional level of security.
+
+- **`tls.clientRootCAs.files`:** Specify the list of client root CA certificate files that can be used to verify client certificates.
+
+## BCCSP
+
+```
+BCCSP:
+        Default: SW
+        # Settings for the SW crypto provider (i.e. when DEFAULT: SW)
+        SW:
+            # TODO: The default Hash and Security level needs refactoring to be
+            # fully configurable. Changing these defaults requires coordination
+            # SHA2 is hardcoded in several places, not only BCCSP
+            Hash: SHA2
+            Security: 256
+            # Location of Key Store
+            FileKeyStore:
+                # If "", defaults to 'mspConfigPath'/keystore
+                KeyStore:
+        # Settings for the PKCS#11 crypto provider (i.e. when DEFAULT: PKCS11)
+        PKCS11:
+            # Location of the PKCS11 module library
+            Library:
+            # Token Label
+            Label:
+            # User PIN
+            Pin:
+            Hash:
+            Security:
+```
+
+(Optional) This section is used to configure the Blockchain crypto provider.
+
+- **`BCCSP.Default:`** If you plan to use a Hardware Security Module (HSM), then this must be set to `PKCS11`.
+
+- **`BCCSP.PKCS11.*:`** Provide this set of parameters according to your HSM configuration. Refer to this [example]((../hsm.html) of an HSM configuration for more information.
+
+## externalBuilders
+
+```
+# List of directories to treat as external builders and launchers for
+    # chaincode. The external builder detection processing will iterate over the
+    # builders in the order specified below.
+    externalBuilders: []
+        # - path: /path/to/directory
+        #   name: descriptive-builder-name
+        #   propagateEnvironment:
+        #      - ENVVAR_NAME_TO_PROPAGATE_FROM_PEER
+        #      - GOPROXY
+```
+
+(Optional) **New in Fabric 2.0.** This section is used to configure a set of paths where your chaincode builders reside. Each external builder definition must include a name (used for logging) and the path to parent of the `bin` directory containing the builder scripts. Also, you can optionally specify a list of environment variable names to propagate from the peer when it invokes the external builder scripts. For details see [Configuring external builders and launchers](../cc_launcher.html).
+
+- **`externalBuilders.path:`** Specify the path to the builder.
+- **`externalBuilders.name:`** Give this builder a name.
+- **`externalBuilders.propagateEnvironment:`** Specify the list of environment variables that you want to propagate to your peer.
+
+## ledger
+
+```
+ledger:
+
+  state:
+    # stateDatabase - options are "goleveldb", "CouchDB"
+    # goleveldb - default state database stored in goleveldb.
+    # CouchDB - store state database in CouchDB
+    stateDatabase: goleveldb
+
+    couchDBConfig:
+       # It is recommended to run CouchDB on the same server as the peer, and
+       # not map the CouchDB container port to a server port in docker-compose.
+       # Otherwise proper security must be provided on the connection between
+       # CouchDB client (on the peer) and server.
+       couchDBAddress: 127.0.0.1:5984
+
+       # This username must have read and write authority on CouchDB
+       username:
+
+       # The password is recommended to pass as an environment variable
+       # during start up (eg CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD).
+       # If it is stored here, the file must be access control protected
+       # to prevent unintended users from discovering the password.
+       password:
+
+       # CacheSize denotes the maximum mega bytes (MB) to be allocated for the in-memory state
+       # cache. Note that CacheSize needs to be a multiple of 32 MB. If it is not a multiple
+       # of 32 MB, the peer would round the size to the next multiple of 32 MB.
+       # To disable the cache, 0 MB needs to be assigned to the cacheSize.
+       cacheSize: 64
+```
+
+This section is used to select your ledger database type, either `goleveldb` `CouchDB`. To avoid errors all peers should use the same database **type**.  CouchDB is an appropriate choice when ledger states are structured as JSON documents because CouchDB supports rich queries and update of richer data types often found in business transactions. While CouchDB runs in a separate operating system process, there is still a 1:1 relation between a peer node and a CouchDB instance, meaning that each peer will have a single database and that database will only be associated with that peer. The choice of the database is invisible to a smart contract.
+
+- **`ledger.state.stateDatabase:`** (Override this value when you plan to use CouchDB.) Defaults to goleveldb which is appropriate when ledger states are simple key-value pairs. A LevelDB database is co-located with the peer node – it is embedded within the same operating system process.
+
+- **`ledger.state.couchDBConfig.couchDBAddress:`** (Required when using CouchDB.) Specify the address and port where CouchDB is running.
+
+- **`ledger.state.couchDBConfig.username:`** (Required when using CouchDB.) Specify the CouchDB user with read and write authority to the database.
+
+- **`ledger.state.couchDBConfig.password:`** (Required when using CouchDB.) Best practice is to specify an environment variable that represents the password for the CouchDB user with read and write authority to the database.
+
+- **`ledger.state.couchDBConfig.cacheSize:`** (Recommended to override) **New in Fabric 2.0.** When using CouchDB as the state database, read delays during endorsement and validation phases have historically been a performance bottleneck. In Fabric v2.0, a new peer cache replaces many of these expensive lookups with fast local cache reads. The cache size can be configured by using this parameter.
+
+## operations
+```
+operations:
+    # host and port for the operations server
+    listenAddress: 127.0.0.1:9443
+
+    # TLS configuration for the operations endpoint
+    tls:
+        # TLS enabled
+        enabled: false
+
+        # path to PEM encoded server certificate for the operations server
+        cert:
+            file:
+
+        # path to PEM encoded server key for the operations server
+        key:
+            file:
+
+        # most operations service endpoints require client authentication when TLS
+        # is enabled. clientAuthRequired requires client certificate authentication
+        # at the TLS layer to access all resources.
+        clientAuthRequired: false
+
+        # paths to PEM encoded ca certificates to trust for client authentication
+        clientRootCAs:
+            files: []
+```
+
+The operations service is used for monitoring the health of the peer and relies on mutual TLS to secure its communication. Therefore, you need to set `operations.tls.clientAuthRequired` to `true`. When this parameter is set to `true`, clients attempting to ascertain the health of the node are required to provide a valid certificate for authentication. If the client does not provide a certificate or the service cannot verify the client’s certificate, the request is rejected. This means that the clients will need to register with the peer's TLS CA and provide their TLS signing certificate on the requests. See [The Operations Service](../operations_service.html) to learn more.
+
+If you plan to use Prometheus [metrics](#metrics) to monitor your peer, you must configure the operations service here.
+
+In the unlikely case where two peers are running on the same node, you need to modify the `listenAddress`: for the second peer to use a different port. Otherwise, when you start the second peer, it will fail to start, reporting that the bind address is already in use.
+
+- **`operations.listenAddress:`** (Required when using the operations service.) Specify the address and port of the operations server.
+- **`operations.tls.cert.file*:`** (Required when using the operations service). Can be the same file as the `peer.tls.cert.file`.
+- **`operations.tls.key.file*:`** (Required when using the operations service). Can be the same file as the `peer.tls.key.file`.
+- **`operations.tls.clientAuthRequired*:`** (Required when using the operations service). Must be set tp `true` to enable mutual TLS between the client and the server.
+- **`operations.tls.clientRootCAs.files*:`** (Required when using the operations service). Similar to the [peer.tls.clientRootCAs.files](#tls), it contains a list of client root CA certificates that can be used to verify client certificates. If the client enrolled with the peer organization CA, then this value is the peer organization root CA cert.
+
+## metrics
+
+```
+metrics:
+    # metrics provider is one of statsd, prometheus, or disabled
+    provider: disabled
+    # statsd configuration
+    statsd:
+        # network type: tcp or udp
+        network: udp
+
+        # statsd server address
+        address: 127.0.0.1:8125
+```
+By default this is disabled, but if you want to monitor the metrics for the peer, you need to choose either `statsd` or `Prometheus` as your metric provider. `Statsd` uses a "push" model, pushing metrics from the peer to a `statsd` endpoint. Because of this, it does not require configuration of the operations service itself. See the list of [Available metrics for the peer](../metrics_reference.html#peer-metrics).
+
+- **`provider`:** (Required to use `statsd` or `Prometheus` metrics for the peer.) Because Prometheus utilizes a "pull" model there is not any configuration required from the Fabric CA server side. Rather, Prometheus will sends requests to the operations URL to poll for available metrics.
+- **`address:`** (Required when using `statsd`.) When `statsd` is enabled, you will need to configure the hostname and port of the server.
+
+## Next steps
+
+After deciding on your peer configuration, you are ready to deploy your peers. Follow instructions in the [Deploy the peer](./peerdeploy.html) topic for instructions on how to deploy your peer.
+
+<!--- Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/ -->

--- a/docs/source/deploypeer/peerdeploy.md
+++ b/docs/source/deploypeer/peerdeploy.md
@@ -1,0 +1,110 @@
+# Deploy the peer
+
+Before deploying a peer, make sure to digest the material in [Planning for a peer](./peerplan.html) and [Checklist for a production peer](./peerchecklist.html) which discusses all of the relevant decisions you need to make and parameters you need to configure before deploying a peer.
+
+## Download the peer binary and configuration files
+
+The Fabric peer binary and configuration files can be downloaded from [GitHub](https://github.com/hyperledger/fabric/releases) to a folder on your local system for example `fabric/`. Scroll to the Fabric release you want to download, click the **Assets** twistie, and select the binary for your system type. Extract the ZIP file and you will find all of the Fabric binaries in the `/bin` folder and the associated configuration files in the `/config` folder.
+The resulting folder structure is similar to:
+
+```
+├── fabric
+  ├── bin
+  │   ├── configtxgen
+  │   ├── configtxlator
+  │   ├── cryptogen
+  │   ├── discover
+  │   ├── idemixgen
+  │   ├── orderer
+  │   └── peer
+  └── config
+    ├── configtx.yaml
+    ├── core.yaml
+    └── orderer.yaml
+```
+
+Along with the relevant binaries, you will receive both the peer binary executable and the peer configuration file, `core.yaml`, that is required to launch a peer on the network. The other files are not required for the peer deployment but will be useful when you attempt to create or edit channels, among other tasks.
+
+After you have mastered deploying and running a peer by using these two files, it is likely you will want to use the peer image that Fabric publishes instead, for example in a Kubernetes or Docker deployment. For now though, the purpose of this topic is to teach you how to properly use the peer binary.
+
+**Tip:** You may want to add the location of the peer binary to your PATH environment variable so that it can be picked up without fully qualifying the path to the binary executable, for example:
+
+```
+export PATH=<path to download location>/bin:$PATH
+```
+
+## Prerequisites
+
+Before you can launch a peer node in a production network, you need to configure it. Complete the following steps:
+
+1. While **cryptogen** is a convenient utility to generate certificates for a test network, it should never be used on a production network. The core requirement for certificates for Fabric nodes is that they are Elliptic Curve (EC) certificates. You can use any tool you prefer as the certificate authority for issuing these certificates. For example, OpenSSL can be used, but the Fabric CA streamlines the process when it generates the Membership Service Providers (MSPs) for you. Regardless of which certificate provider you choose, you should have already used it to generate the peer enrollment, TLS certificate, private key, and the MSPs that Fabric must consume. Refer to the [CA deployment](https://hyperledger-fabric-ca.readthedocs.io/en/release-1.4/deployguide/cadeploy.html) and [Registering and enrolling identities with a CA](https://hyperledger-fabric-ca.readthedocs.io/en/release-1.4/deployguide/use_CA.html) topics for instructions on how to generate these certificates. You need to generate the following sets of certificates:
+    - **Peer TLS certificates**
+    - **Peer organization admin certificates (organization MSP)**
+    - **Peer enrollment certificates (peer local MSP)**  
+2. Create the recommended folder structure described in the [Registering and enrolling identities with a CA](https://hyperledger-fabric-ca.readthedocs.io/en/release-1.4/deployguide/use_CA.html) topic to store the generated certificates and MSPs:
+    ```
+    ├── organizations
+      └── peerOrganizations
+          └── org1.example.com
+              ├── msp
+              └── peers
+                  └── peer0.org1.example.com
+                      ├── msp
+                      └── tls
+    ```
+3. Copy the generated certificates to their designated folders.
+      - **Peer TLS certificate and private key**:
+        - Copy the TLS CA root `ca-cert.pem` to `organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/tls-ca-cert.pem`. The path and name of the certificate corresponds to `tls.rootcert.file` parameter in `core.yaml`.
+        - After you have generated the peer TLS certificate, rename the generated private key in the `keystore` folder to `peer0-key.pem` so that it can more easily be recognized later on as being a private key.
+        - Copy the peer TLS certificate and private key to `organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls`. The path and name of these certificates correspond to the `tls.cert.file` and `tls.key.file` parameters in the `core.yaml`.
+      - **Peer organization admin MSP**:
+        - After you have registered the peer organization admin user and enrolled the identity, copy the generated MSP folder to `peerOrganizations/org1.example.com/msp`. This is the peer organization MSP definition and is used by every peer node in the organization. This path becomes the value of the `mspConfigPath` parameter in the `core.yaml` file.
+        - Fabric introduced the concept of "Node Organization Unit (OU)" support that allows a role to be conferred onto an identity by setting an OU value inside a certificate. [Node OU](https://hyperledger-fabric-ca.readthedocs.io/en/release-1.4/deployguide/use_CA.html#specifying-nodeous) support is enabled by creating a `config.yaml` file inside the `/msp` folder in the `organizations/peerOrganizations/org1.example.com` path in which a role is tied to the root of trust for the issued certificate. **Important:** After you generate the file, remember to edit it and set the path and file name of the root CA certificate for each role. The name of the root CA certificate file is included in the generated MSP under `/msp/cacerts`).
+      - **Peer enrollment certificate and private key**:
+        - After you have registered the peer user for this node and enrolled its identity with the peer organization CA, copy the generated `msp` folder and replace the **local MSP** with it under `organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp`.
+        - This MSP contains the signed certificate (public key) and the private key for the peer. The private key is used by the node to sign transactions, and is therefore not shared and must be secured. For maximum security, a Hardware Security Module (HSM) can be configured to generate and store this private key.
+4. Provision storage for your ledger. If you are not using an external chaincode builder and launcher, you should factor in storage for that as well. The default location is `/var/hyperledger/production`. Ensure that your peer has write access to the folder. If you choose to use a different location, you need to specify that path in the `fileSystemPath` parameter in the `core.yaml` file.
+5. Now use the [Checklist for a production peer](./peerchecklist.html) to modify the default settings in the `core.yaml` file. In the future, if you decide to deploy the peer through Kubernetes or Docker, you can override the same default settings by using environment variables instead.
+6. Set the value of the FABRIC_CFG_PATH to be the location of the `core.yaml` file. When you run the peer binary from the `fabric/bin` folder, it would point to the  `/config` folder:
+    ```
+    export FABRIC_CFG_PATH=../config
+    ```
+
+## Start the peer
+
+After `core.yaml` has been configured and your deployment backend is ready, you can simply start the peer node with the following command:
+
+```
+cd bin
+./peer node start
+```
+
+When the peer starts successfully, you should see a message similar to:
+
+```
+[nodeCmd] serve -> INFO 017 Started peer with ID=[peer0.org1.example.com], network ID=[prod], address=[peer0.org1.example.com:7060]
+```
+
+## Next steps
+
+In order to be able to transact on a network, the peer must be joined to a channel. The organization the peer belongs to must be a member of a channel before one of its peers can be joined to it. Note that if an organization wants to create a channel, it must be a member of the consortium hosted by the ordering service. Once a peer is joined to a channel, the Fabric chaincode lifecycle process can be used to install chaincode packages on the peer. Only peer admin identities can be used to install a package on a peer.
+
+For high availability, you should consider deploying at least one other peer in the organization so that this peer can safely go offline for maintenance while transaction requests can continue to be addressed by the other peer. This redundant peer should be on a separate system or virtual machine in case the location where both peers are deployed goes down.
+
+## Troubleshooting peer deployment
+
+### Peer fails to start with ERRO 001 Fatal error when initializing core config
+
+**Problem:** When launching the peer, it fails with:
+
+```
+InitCmd -> ERRO 001 Fatal error when initializing core config : Could not find config file. Please make sure that FABRIC_CFG_PATH is set to a path which contains core.yaml
+```
+
+**Solution:**
+
+This error occurs when the `FABRIC_CFG_PATH` is not set or is set incorrectly. Ensure that you have set the `FABRIC_CFG_PATH` environment variable to point to the location of the peer `core.yaml` file. Navigate to the folder where the `peer.exe` binary file resides and run the following command:
+
+```
+export FABRIC_CFG_PATH=../config
+```

--- a/docs/source/deploypeer/peerplan.md
+++ b/docs/source/deploypeer/peerplan.md
@@ -1,0 +1,94 @@
+# Planning for a production peer
+
+Audience: Architects, network operators, users setting up a production Fabric network who are familiar with Transport Layer Security (TLS), Public Key Infrastructure (PKI) and Membership Service Providers (MSPs).
+
+Peer nodes are a fundamental element of a Fabric network because they host ledgers and smart contracts that are used to encapsulate the shared processes and shared information in a blockchain network. These instructions assume you are already familiar with the concept of a [peer](https://hyperledger-fabric.readthedocs.io/en/{BRANCH}/peers/peers.html) and provides guidance for the various decisions you will have to make about a peer you will deploy and join to a production Fabric network channel. If you need to quickly stand up a network for education or testing purposes, check out the [Fabric test network](../test_network.html).
+
+## Generate peer identities and Membership Service Providers (MSPs)
+
+Before proceeding with this topic, you should have reviewed the process for a [Deploying a Certificate Authority (CA)](https://hyperledger-fabric-ca.readthedocs.io/en/release-1.4/deployguide/ca-deploy-topology.html) for your organization in order to generate the identities and MSPs for the admins and peers in your organization. To learn how to use a CA to create these identities, check out [Registering and enrolling identities with a CA](https://hyperledger-fabric-ca.readthedocs.io/en/{BRANCH}/deployguide/use_CA.html)
+
+**Note that the “cryptogen” tool should never be used to generate any identities in a production scenario**.
+
+### Folder management
+
+While it is possible to bootstrap a peer using a number of folder structures for your MSPs and certificates, we do recommend a particular [folder structure](https://hyperledger-fabric-ca.readthedocs.io/en/{BRANCH}/deployguide/use_CA.html#decide-on-the-structure-of-your-folders-and-certificates) for the sake of consistency and repeatability. These instructions will presume that you have used that folder structure.
+
+### Certificates from a non-Fabric CA
+
+While it is possible to use a non-Fabric CA to generate identities, this process requires that you manually construct the MSP folders the peer needs to be deployed. That process will not be covered here and will instead focus on using a Fabric CA to generate the identities and MSP folders for you.
+
+### Transport Layer Security (TLS) enablement
+
+To prevent "man in the middle" attacks and otherwise secure communications, using TLS is a requirement for any production network. Therefore, in addition to registering your peer identities with your organization CA, you will also need to register your peer identities with the TLS CA for the organization. These TLS certificates will be used by the peer when communicating with the network.
+
+## State database
+
+Each peer has maintains a state database that tracks the current value for all of the assets (also known as "keys") listed on the ledger. Two types of state databases are supported: CouchDB (which allows rich queries of the database) or Goleveldb (which does not). The choice of database largely depends on the structure of the data being stored and whether you prefer if the database is embedded with the peer (more practical for the lightweight Goleveldb) or runs a separate process (more advisable for the heavier CouchDB implementation). Because all of the peers on a channel must use the same state database, your choice of database might already be dictated by the channels you wish to join.
+
+The choice of the database is invisible to a smart contract. However, a smart contract can and should be written to support rich data types in channels where CouchDB will be used.
+
+You can review [State Database options](../couchdb_as_state_database.html#state-database-options) for more details.
+
+## Sizing your peer resources
+
+A peer typically has three containers associated with it, though this will depend on your use case.
+
+* **Peer container**: Encapsulates the internal peer processes (such as validating transactions) and the blockchain (in other words, the transaction history) for all of the channels it belongs to. Note that the storage of the peer also includes the smart contracts that are installed on the peer. The size of peer needed will depend on a few factors, including estimates about the transaction throughput that will be expected as well as the number of channels it will be joined to.
+
+* **CouchDB container** (optional): Where the state databases of the peer are stored. Recall that each channel has a distinct state database each peer hosts an instance of. If Goleveldb is selected as the state database for the peer, this container is considered optional as "level" databases do not require as much CPU and memory. However, a separate container should be used in cases where CouchDB is the database.
+
+* **Chaincode launcher container** (optional): Used to launch a separate container for each smart contract, eliminating the need for a Docker-in-Docker container in the peer container. Note that the smart contract launcher container is not where smart contracts actually run, and is therefore given a smaller default resource than the "smart contracts" container that used to be deployed along with a peer. It only exists to help create the containers where a smart contract will run. You must make your own allowances in your cluster for the containers for the chaincodes deployed by the launcher.
+
+Note that the recommended process is to deploy each chaincode into a separate container, even if you have multiple peers on the same channel that have all installed the same chaincode. So if you have three peers on a channel, and install a smart contract on each one, you will have three smart contract containers running. However, if these three peers are on more than one channel using the exact same smart contract, you will still only have three pods running.
+
+## Storage considerations
+
+Identities, MSPs, and the ledger (one for each channel) are physically stored on a peer under the `peer.fileSystemPath` parameter (by default, this location is at `/var/hyperledger/production`). **This file system needs to be protected, secured, and writable by authorized users only** and should also be regularly backed up. Note that the best practice is to use externally mounted volumes for the identities and MSP, as they will therefore be easy to reference when restarting or upgrading the peer.
+
+When you configure your peer, you need to decide if the state database will be stored in CouchDB or LevelDB (default) by configuring the `ledger.state.stateDatabase` parameter.
+
+While this topic is focused on how to use the peer binary images, there are important storage considerations you need to be aware of when you run the Fabric images in Docker containers or use Kubernetes. Docker containers requires a volume bind mount in the docker-compose file that mounts the external folder pathing to your container. This is critical when the container restarts, so that the storage is not lost. Similarly, if you are using Kubernetes, you need to provision storage for the peer and then map it in your Kubernetes pod deployment YAML file.
+
+## High Availability
+
+As part of planning to create a peer, you will need consider your strategy at an organization level in order to ensure zero downtime of your components. This means building redundant components, and specifically redundant peers. To ensure zero downtown, you need at least one redundant peer **in a separate virtual machine** so that peers can go down for maintenance while client applications go on submitting endorsement proposals uninterrupted.
+
+Along similar lines, client applications should be configured to use Service Discovery to ensure that transactions are only submitted to peers that are currently available. As long as at least one peer from each organization is available, and service discovered is being used, any endorsement policy will be able to be satisfied. It is the responsibility of each organization to make sure their high availability strategy is robust enough to ensure that at least one peer owned by their organization is available at all times in every channel they're joined to.
+
+## Monitoring
+
+All blockchain nodes require careful monitoring, but it is critically important to monitor the peer and ordering nodes. By virtue of being immutable, the ledger inevitably grows. As a result, storage must be monitored and extended as needed. If the storage for a peer is exhausted you also have the option to deploy a new peer with a larger storage allocation and let the ledger sync. In a production environment you should also monitor the CPU and memory allocated to a peer using widely available tooling. If you see the peer struggling to keep up with the transaction load or when performing relatively simple tasks (querying the ledger, for example), it is a sign that you might need to increase its resource allocation.
+
+## Chaincode
+
+Note: "chaincode" refers to the packages that are installed on peers, while "smart contracts" refers to the business logic that is agreed to by organizations defines the structure of queries and transactions.
+
+Prior to Hyperledger Fabric 2.0, the process used to build and launch chaincode was part of the peer implementation and could not be easily customized. All chaincode installed on the peer would be “built” using language specific logic hard coded in the peer. This build process would generate a Docker container image that would be launched to execute chaincode that connected as a client to the peer.
+
+This approach limited chaincode implementations to a handful of languages, required Docker to be part of the deployment environment, prevented running chaincode as a long-running server process, and required that the peer have privileged access to the chaincode container.
+
+Starting with Fabric 2.0, External Builders and Launchers enable operators to extend the peer with programs that can build, launch, and discover chaincode. To leverage this capability on peers that already exist you will need to create your own buildpack and then modify `core.yaml` to include a new externalBuilder configuration element which lets the peer know an external builder is available.
+
+## Gossip
+
+Peers leverage the [gossip data dissemination protocol](../gossip.html) to broadcast ledger and channel data in a scalable fashion. Gossip messaging is continuous, and each peer on a channel is constantly receiving data from multiple peers, including peers in other organizations (if cross-organization gossip is enabled).
+
+For peer gossip to work you need to configure four parameters. Three of them --- `peer.gossip.bootstrap`, `peer.gossip.endpoint`, `peer.gossip.externalEndpoint` --- are in the peer’s `core.yaml` file. The fourth enables gossip between organization by specifying an anchor peer in the channel configuration.
+
+To reduce network traffic, Fabric v2.2 includes the recommendation that peers get their blocks from the ordering service instead of through gossip dissemination among peers (with the exception of private data transactions, which are still sent from peer to peer). To get all non-private data blocks from the orderer, you must configure the following three parameters in the `core.yaml` file:
+
+* `useLeaderElection = false`
+* `orgLeader = true` for ( you must designate one peer in the org to be the leader)
+* `peer.gossip.state.enabled = false`
+
+If you have only one peer in your organization configured with `orgLeader=true`, then that peer will get blocks from ordering service and distribute them to all the other peers in the org using gossip. If all peers have `orgLeader=true` (recommended), then each peer will get blocks from the ordering service.
+
+### Service Discovery
+
+In any network it is possible that peer nodes can be down for maintenance, unreachable due to network issues, or the peer ledger has fallen behind while being offline. For this reason, Fabric includes a “discovery service” that enables client applications that use the SDK to locate good candidate peers to target with endorsement requests. If service discovery is not enabled, if a client application targets a peer that is offline, the request fails and will need to be resubmitted to another peer. The discovery service runs on peers and uses the network metadata information maintained by the gossip communication layer to find out which peers are online and can be targeted for requests.
+
+Service discovery (and private data) requires that gossip is enabled, therefore you should configure the `peer.gossip.bootstrap`, `peer.gossip.endpoint` , and `peer.gossip.externalEndpoint` parameters to take advantage of this feature.
+
+<!--- Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/ -->


### PR DESCRIPTION
Doc updates for instructions for deploying a
production peer

Change-Id: I08b5e3ac0394a2fa089a88dd11c28acd6f8b0a57
Signed-off-by: joe-alewine <Joe.Alewine@ibm.com>

#### Type of change

- Documentation update

#### Description

The initial push of this material will include updates to the deployment overview and to add a doc about planning for a peer and a checklist of variables listed in core.yaml. A doc that walks users through the process of deploying the peer itself will be added to this PR when it's ready. 