### PR TITLE
[FAB-18117] Add SignatureHeader to request msg when calling snapshot service

### DIFF
--- a/internal/peer/snapshot/cancelrequest.go
+++ b/internal/peer/snapshot/cancelrequest.go
@@ -55,9 +55,15 @@ func cancelRequest(cmd *cobra.Command, cl *client, cryptoProvider bccsp.BCCSP) e
 		}
 	}
 
+	signatureHdr, err := createSignatureHeader(cl.signer)
+	if err != nil {
+		return err
+	}
+
 	request := &pb.SnapshotRequest{
-		ChannelId:   channelID,
-		BlockNumber: blockNumber,
+		SignatureHeader: signatureHdr,
+		ChannelId:       channelID,
+		BlockNumber:     blockNumber,
 	}
 	signedRequest, err := signSnapshotRequest(cl.signer, request)
 	if err != nil {

--- a/internal/peer/snapshot/cancelrequest_test.go
+++ b/internal/peer/snapshot/cancelrequest_test.go
@@ -38,6 +38,9 @@ func TestCancelRequestCmd(t *testing.T) {
 	mockSigner.SignReturns(nil, fmt.Errorf("fake-sign-error"))
 	require.EqualError(t, cmd.Execute(), "fake-sign-error")
 
+	mockSigner.SerializeReturns(nil, fmt.Errorf("fake-serialize-error"))
+	require.EqualError(t, cmd.Execute(), "fake-serialize-error")
+
 	resetFlags()
 	cmd.SetArgs([]string{"-b", "100"})
 	require.EqualError(t, cmd.Execute(), "the required parameter 'channelID' is empty. Rerun the command with -C flag")

--- a/internal/peer/snapshot/listpending.go
+++ b/internal/peer/snapshot/listpending.go
@@ -53,8 +53,14 @@ func listPending(cmd *cobra.Command, cl *client, cryptoProvider bccsp.BCCSP) err
 		}
 	}
 
+	signatureHdr, err := createSignatureHeader(cl.signer)
+	if err != nil {
+		return err
+	}
+
 	query := &pb.SnapshotQuery{
-		ChannelId: channelID,
+		SignatureHeader: signatureHdr,
+		ChannelId:       channelID,
 	}
 	signedRequest, err := signSnapshotRequest(cl.signer, query)
 	if err != nil {

--- a/internal/peer/snapshot/listpending_test.go
+++ b/internal/peer/snapshot/listpending_test.go
@@ -38,6 +38,9 @@ func TestListPendingCmd(t *testing.T) {
 	mockSigner.SignReturns(nil, fmt.Errorf("fake-sign-error"))
 	require.EqualError(t, cmd.Execute(), "fake-sign-error")
 
+	mockSigner.SerializeReturns(nil, fmt.Errorf("fake-serialize-error"))
+	require.EqualError(t, cmd.Execute(), "fake-serialize-error")
+
 	resetFlags()
 	cmd.SetArgs([]string{})
 	require.EqualError(t, cmd.Execute(), "the required parameter 'channelID' is empty. Rerun the command with -C flag")

--- a/internal/peer/snapshot/snapshot.go
+++ b/internal/peer/snapshot/snapshot.go
@@ -8,6 +8,7 @@ package snapshot
 
 import (
 	"github.com/golang/protobuf/proto"
+	cb "github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/bccsp"
 	"github.com/hyperledger/fabric/common/flogging"
@@ -82,5 +83,22 @@ func signSnapshotRequest(signer common.Signer, request proto.Message) (*pb.Signe
 	return &pb.SignedSnapshotRequest{
 		Request:   requestBytes,
 		Signature: signature,
+	}, nil
+}
+
+func createSignatureHeader(signer common.Signer) (*cb.SignatureHeader, error) {
+	creator, err := signer.Serialize()
+	if err != nil {
+		return nil, err
+	}
+
+	nonce, err := protoutil.CreateNonce()
+	if err != nil {
+		return nil, err
+	}
+
+	return &cb.SignatureHeader{
+		Creator: creator,
+		Nonce:   nonce,
 	}, nil
 }

--- a/internal/peer/snapshot/submitrequest.go
+++ b/internal/peer/snapshot/submitrequest.go
@@ -55,9 +55,15 @@ func submitRequest(cmd *cobra.Command, cl *client, cryptoProvider bccsp.BCCSP) e
 		}
 	}
 
+	signatureHdr, err := createSignatureHeader(cl.signer)
+	if err != nil {
+		return err
+	}
+
 	request := &pb.SnapshotRequest{
-		ChannelId:   channelID,
-		BlockNumber: blockNumber,
+		SignatureHeader: signatureHdr,
+		ChannelId:       channelID,
+		BlockNumber:     blockNumber,
 	}
 	signedRequest, err := signSnapshotRequest(cl.signer, request)
 	if err != nil {

--- a/internal/peer/snapshot/submitrequest_test.go
+++ b/internal/peer/snapshot/submitrequest_test.go
@@ -46,6 +46,9 @@ func TestSubmitRequestCmd(t *testing.T) {
 	mockSigner.SignReturns(nil, fmt.Errorf("fake-sign-error"))
 	require.EqualError(t, cmd.Execute(), "fake-sign-error")
 
+	mockSigner.SerializeReturns(nil, fmt.Errorf("fake-serialize-error"))
+	require.EqualError(t, cmd.Execute(), "fake-serialize-error")
+
 	resetFlags()
 	cmd.SetArgs([]string{})
 	require.EqualError(t, cmd.Execute(), "the required parameter 'channelID' is empty. Rerun the command with -C flag")


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- New feature

#### Description
To enable policy checking for snapshot grpc service, update snapshot CLI commands
to pass SignatureHeader when invoking the service.

#### Additional details
A separate PR will cover policy checking for snapshot service. 

#### Related issues
https://jira.hyperledger.org/browse/FAB-18117