### PR TITLE
[FAB-18117] Add policy checking to snapshot grpc service

### DIFF
--- a/core/aclmgmt/aclmgmt.go
+++ b/core/aclmgmt/aclmgmt.go
@@ -17,4 +17,9 @@ type ACLProvider interface {
 	//idinfo. idinfo is an object such as SignedProposal from which an
 	//id can be extracted for testing against a policy
 	CheckACL(resName string, channelID string, idinfo interface{}) error
+
+	// CheckACLNoChannel checks the ACL for the resource for the local MSP
+	// using the idinfo. idinfo is an object such as SignedProposal
+	// from which an id can be extracted for testing against a policy.
+	CheckACLNoChannel(resName string, idinfo interface{}) error
 }

--- a/core/aclmgmt/aclmgmtimpl.go
+++ b/core/aclmgmt/aclmgmtimpl.go
@@ -27,6 +27,14 @@ func (am *aclMgmtImpl) CheckACL(resName string, channelID string, idinfo interfa
 	return am.rescfgProvider.CheckACL(resName, channelID, idinfo)
 }
 
+// CheckACLNoChannel checks the ACL for the resource for the local MSP
+// using the idinfo. idinfo is an object such as SignedProposal
+// from which an id can be extracted for testing against a policy.
+func (am *aclMgmtImpl) CheckACLNoChannel(resName string, idinfo interface{}) error {
+	//use the resource based config provider (which will in turn default to 1.0 provider)
+	return am.rescfgProvider.CheckACLNoChannel(resName, idinfo)
+}
+
 //ACLProvider consists of two providers, supplied one and a default one (1.0 ACL management
 //using ChannelReaders and ChannelWriters). If supplied provider is nil, a resource based
 //ACL provider is created.

--- a/core/aclmgmt/defaultaclprovider.go
+++ b/core/aclmgmt/defaultaclprovider.go
@@ -60,6 +60,11 @@ func newDefaultACLProvider(policyChecker policy.PolicyChecker) defaultACLProvide
 	d.cResourcePolicyMap[resources.Lifecycle_QueryChaincodeDefinitions] = CHANNELWRITERS
 	d.cResourcePolicyMap[resources.Lifecycle_CheckCommitReadiness] = CHANNELWRITERS
 
+	//-------------- snapshot ---------------
+	d.pResourcePolicyMap[resources.Snapshot_submitrequest] = mgmt.Admins
+	d.pResourcePolicyMap[resources.Snapshot_cancelrequest] = mgmt.Admins
+	d.pResourcePolicyMap[resources.Snapshot_listpending] = mgmt.Admins
+
 	//-------------- LSCC --------------
 	//p resources (implemented by the chaincode currently)
 	d.pResourcePolicyMap[resources.Lscc_Install] = mgmt.Admins
@@ -138,4 +143,30 @@ func (d *defaultACLProviderImpl) CheckACL(resName string, channelID string, idin
 		aclLogger.Errorf("Unmapped id on checkACL %s", resName)
 		return fmt.Errorf("Unknown id on checkACL %s", resName)
 	}
+}
+
+// CheckACL provides default behavior by mapping channelless resources to their ACL.
+func (d *defaultACLProviderImpl) CheckACLNoChannel(resName string, idinfo interface{}) error {
+	policy := d.pResourcePolicyMap[resName]
+	if policy == "" {
+		aclLogger.Errorf("Unmapped channelless policy for %s", resName)
+		return fmt.Errorf("Unmapped channelless policy for %s", resName)
+	}
+
+	switch typedData := idinfo.(type) {
+	case *pb.SignedProposal:
+		return d.policyChecker.CheckPolicyNoChannel(policy, typedData)
+	case *common.Envelope:
+		sd, err := protoutil.EnvelopeAsSignedData(typedData)
+		if err != nil {
+			return err
+		}
+		return d.policyChecker.CheckPolicyNoChannelBySignedData(policy, sd)
+	case []*protoutil.SignedData:
+		return d.policyChecker.CheckPolicyNoChannelBySignedData(policy, typedData)
+	default:
+		aclLogger.Errorf("Unmapped id on channelless checkACL %s", resName)
+		return fmt.Errorf("Unknown id on channelless checkACL %s", resName)
+	}
+
 }

--- a/core/aclmgmt/mocks/defaultaclprovider.go
+++ b/core/aclmgmt/mocks/defaultaclprovider.go
@@ -19,6 +19,18 @@ type DefaultACLProvider struct {
 	checkACLReturnsOnCall map[int]struct {
 		result1 error
 	}
+	CheckACLNoChannelStub        func(string, interface{}) error
+	checkACLNoChannelMutex       sync.RWMutex
+	checkACLNoChannelArgsForCall []struct {
+		arg1 string
+		arg2 interface{}
+	}
+	checkACLNoChannelReturns struct {
+		result1 error
+	}
+	checkACLNoChannelReturnsOnCall map[int]struct {
+		result1 error
+	}
 	IsPtypePolicyStub        func(string) bool
 	isPtypePolicyMutex       sync.RWMutex
 	isPtypePolicyArgsForCall []struct {
@@ -96,6 +108,67 @@ func (fake *DefaultACLProvider) CheckACLReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *DefaultACLProvider) CheckACLNoChannel(arg1 string, arg2 interface{}) error {
+	fake.checkACLNoChannelMutex.Lock()
+	ret, specificReturn := fake.checkACLNoChannelReturnsOnCall[len(fake.checkACLNoChannelArgsForCall)]
+	fake.checkACLNoChannelArgsForCall = append(fake.checkACLNoChannelArgsForCall, struct {
+		arg1 string
+		arg2 interface{}
+	}{arg1, arg2})
+	fake.recordInvocation("CheckACLNoChannel", []interface{}{arg1, arg2})
+	fake.checkACLNoChannelMutex.Unlock()
+	if fake.CheckACLNoChannelStub != nil {
+		return fake.CheckACLNoChannelStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.checkACLNoChannelReturns
+	return fakeReturns.result1
+}
+
+func (fake *DefaultACLProvider) CheckACLNoChannelCallCount() int {
+	fake.checkACLNoChannelMutex.RLock()
+	defer fake.checkACLNoChannelMutex.RUnlock()
+	return len(fake.checkACLNoChannelArgsForCall)
+}
+
+func (fake *DefaultACLProvider) CheckACLNoChannelCalls(stub func(string, interface{}) error) {
+	fake.checkACLNoChannelMutex.Lock()
+	defer fake.checkACLNoChannelMutex.Unlock()
+	fake.CheckACLNoChannelStub = stub
+}
+
+func (fake *DefaultACLProvider) CheckACLNoChannelArgsForCall(i int) (string, interface{}) {
+	fake.checkACLNoChannelMutex.RLock()
+	defer fake.checkACLNoChannelMutex.RUnlock()
+	argsForCall := fake.checkACLNoChannelArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *DefaultACLProvider) CheckACLNoChannelReturns(result1 error) {
+	fake.checkACLNoChannelMutex.Lock()
+	defer fake.checkACLNoChannelMutex.Unlock()
+	fake.CheckACLNoChannelStub = nil
+	fake.checkACLNoChannelReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *DefaultACLProvider) CheckACLNoChannelReturnsOnCall(i int, result1 error) {
+	fake.checkACLNoChannelMutex.Lock()
+	defer fake.checkACLNoChannelMutex.Unlock()
+	fake.CheckACLNoChannelStub = nil
+	if fake.checkACLNoChannelReturnsOnCall == nil {
+		fake.checkACLNoChannelReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.checkACLNoChannelReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *DefaultACLProvider) IsPtypePolicy(arg1 string) bool {
 	fake.isPtypePolicyMutex.Lock()
 	ret, specificReturn := fake.isPtypePolicyReturnsOnCall[len(fake.isPtypePolicyArgsForCall)]
@@ -161,6 +234,8 @@ func (fake *DefaultACLProvider) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.checkACLMutex.RLock()
 	defer fake.checkACLMutex.RUnlock()
+	fake.checkACLNoChannelMutex.RLock()
+	defer fake.checkACLNoChannelMutex.RUnlock()
 	fake.isPtypePolicyMutex.RLock()
 	defer fake.isPtypePolicyMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/core/aclmgmt/mocks/mocks.go
+++ b/core/aclmgmt/mocks/mocks.go
@@ -30,6 +30,11 @@ func (m *MockACLProvider) CheckACL(resName string, channelID string, idinfo inte
 	return args.Error(0)
 }
 
+func (m *MockACLProvider) CheckACLNoChannel(resName string, idinfo interface{}) error {
+	args := m.mock.Called(resName, idinfo)
+	return args.Error(0)
+}
+
 func (m *MockACLProvider) GenerateSimulationResults(txEnvelop *common.Envelope, simulator ledger.TxSimulator, initializingLedger bool) error {
 	return nil
 }

--- a/core/aclmgmt/resourceprovider.go
+++ b/core/aclmgmt/resourceprovider.go
@@ -181,3 +181,12 @@ func (rp *resourceProvider) CheckACL(resName string, channelID string, idinfo in
 
 	return rp.defaultProvider.CheckACL(resName, channelID, idinfo)
 }
+
+// CheckACLNoChannel implements the ACLProvider interface function
+func (rp *resourceProvider) CheckACLNoChannel(resName string, idinfo interface{}) error {
+	if !rp.enforceDefaultBehavior(resName, "", idinfo) {
+		return fmt.Errorf("cannot override peer type policy for channeless ACL check")
+	}
+
+	return rp.defaultProvider.CheckACLNoChannel(resName, idinfo)
+}

--- a/core/aclmgmt/resources/resources.go
+++ b/core/aclmgmt/resources/resources.go
@@ -23,6 +23,11 @@ const (
 	Lifecycle_QueryChaincodeDefinitions          = "_lifecycle/QueryChaincodeDefinitions"
 	Lifecycle_CheckCommitReadiness               = "_lifecycle/CheckCommitReadiness"
 
+	// snapshot resources
+	Snapshot_submitrequest = "snapshot/submitrequest"
+	Snapshot_cancelrequest = "snapshot/cancelrequest"
+	Snapshot_listpending   = "snapshot/listpending"
+
 	//Lscc resources
 	Lscc_Install                   = "lscc/Install"
 	Lscc_Deploy                    = "lscc/Deploy"

--- a/core/chaincode/chaincode_support_test.go
+++ b/core/chaincode/chaincode_support_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/hyperledger/fabric/common/metrics/disabled"
 	"github.com/hyperledger/fabric/common/policies"
 	"github.com/hyperledger/fabric/common/util"
+	aclmocks "github.com/hyperledger/fabric/core/aclmgmt/mocks"
 	"github.com/hyperledger/fabric/core/aclmgmt/resources"
 	"github.com/hyperledger/fabric/core/chaincode/accesscontrol"
 	"github.com/hyperledger/fabric/core/chaincode/lifecycle"
@@ -218,7 +219,7 @@ func initMockPeer(channelIDs ...string) (*peer.Peer, *ChaincodeSupport, func(), 
 			GetMSPIDs: peerInstance.GetMSPIDs,
 		},
 		SCCProvider:      &lscc.PeerShim{Peer: peerInstance},
-		ACLProvider:      mockAclProvider,
+		ACLProvider:      &aclmocks.DefaultACLProvider{},
 		GetMSPIDs:        peerInstance.GetMSPIDs,
 		PolicyChecker:    newPolicyChecker(peerInstance),
 		BCCSP:            cryptoProvider,

--- a/core/ledger/snapshotgrpc/mock/acl_provider.go
+++ b/core/ledger/snapshotgrpc/mock/acl_provider.go
@@ -6,19 +6,6 @@ import (
 )
 
 type ACLProvider struct {
-	CheckACLStub        func(string, string, interface{}) error
-	checkACLMutex       sync.RWMutex
-	checkACLArgsForCall []struct {
-		arg1 string
-		arg2 string
-		arg3 interface{}
-	}
-	checkACLReturns struct {
-		result1 error
-	}
-	checkACLReturnsOnCall map[int]struct {
-		result1 error
-	}
 	CheckACLNoChannelStub        func(string, interface{}) error
 	checkACLNoChannelMutex       sync.RWMutex
 	checkACLNoChannelArgsForCall []struct {
@@ -33,68 +20,6 @@ type ACLProvider struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *ACLProvider) CheckACL(arg1 string, arg2 string, arg3 interface{}) error {
-	fake.checkACLMutex.Lock()
-	ret, specificReturn := fake.checkACLReturnsOnCall[len(fake.checkACLArgsForCall)]
-	fake.checkACLArgsForCall = append(fake.checkACLArgsForCall, struct {
-		arg1 string
-		arg2 string
-		arg3 interface{}
-	}{arg1, arg2, arg3})
-	fake.recordInvocation("CheckACL", []interface{}{arg1, arg2, arg3})
-	fake.checkACLMutex.Unlock()
-	if fake.CheckACLStub != nil {
-		return fake.CheckACLStub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.checkACLReturns
-	return fakeReturns.result1
-}
-
-func (fake *ACLProvider) CheckACLCallCount() int {
-	fake.checkACLMutex.RLock()
-	defer fake.checkACLMutex.RUnlock()
-	return len(fake.checkACLArgsForCall)
-}
-
-func (fake *ACLProvider) CheckACLCalls(stub func(string, string, interface{}) error) {
-	fake.checkACLMutex.Lock()
-	defer fake.checkACLMutex.Unlock()
-	fake.CheckACLStub = stub
-}
-
-func (fake *ACLProvider) CheckACLArgsForCall(i int) (string, string, interface{}) {
-	fake.checkACLMutex.RLock()
-	defer fake.checkACLMutex.RUnlock()
-	argsForCall := fake.checkACLArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
-}
-
-func (fake *ACLProvider) CheckACLReturns(result1 error) {
-	fake.checkACLMutex.Lock()
-	defer fake.checkACLMutex.Unlock()
-	fake.CheckACLStub = nil
-	fake.checkACLReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *ACLProvider) CheckACLReturnsOnCall(i int, result1 error) {
-	fake.checkACLMutex.Lock()
-	defer fake.checkACLMutex.Unlock()
-	fake.CheckACLStub = nil
-	if fake.checkACLReturnsOnCall == nil {
-		fake.checkACLReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.checkACLReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *ACLProvider) CheckACLNoChannel(arg1 string, arg2 interface{}) error {
@@ -161,8 +86,6 @@ func (fake *ACLProvider) CheckACLNoChannelReturnsOnCall(i int, result1 error) {
 func (fake *ACLProvider) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.checkACLMutex.RLock()
-	defer fake.checkACLMutex.RUnlock()
 	fake.checkACLNoChannelMutex.RLock()
 	defer fake.checkACLNoChannelMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/core/ledger/snapshotgrpc/snapshot_service.go
+++ b/core/ledger/snapshotgrpc/snapshot_service.go
@@ -8,17 +8,23 @@ package snapshotgrpc
 
 import (
 	"context"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/empty"
+	cb "github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/common/crypto"
+	"github.com/hyperledger/fabric/core/aclmgmt/resources"
 	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 )
 
 // Snapshot Service implements SnapshotServer grpc interface
 type SnapshotService struct {
 	LedgerGetter LedgerGetter
+	ACLProvider  ACLProvider
 }
 
 // LedgerGetter gets the PeerLedger associated with a channel.
@@ -26,11 +32,20 @@ type LedgerGetter interface {
 	GetLedger(cid string) ledger.PeerLedger
 }
 
+// ACLProvider checks ACL for a channelless resource
+type ACLProvider interface {
+	CheckACLNoChannel(resName string, idinfo interface{}) error
+}
+
 // Generate generates a snapshot request.
 func (s *SnapshotService) Generate(ctx context.Context, signedRequest *pb.SignedSnapshotRequest) (*empty.Empty, error) {
 	request := &pb.SnapshotRequest{}
 	if err := proto.Unmarshal(signedRequest.Request, request); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal snapshot request")
+	}
+
+	if err := s.checkACL(resources.Snapshot_submitrequest, request.SignatureHeader, signedRequest); err != nil {
+		return nil, err
 	}
 
 	lgr, err := s.getLedger(request.ChannelId)
@@ -52,6 +67,10 @@ func (s *SnapshotService) Cancel(ctx context.Context, signedRequest *pb.SignedSn
 		return nil, errors.Wrap(err, "failed to unmarshal snapshot request")
 	}
 
+	if err := s.checkACL(resources.Snapshot_cancelrequest, request.SignatureHeader, signedRequest); err != nil {
+		return nil, err
+	}
+
 	lgr, err := s.getLedger(request.ChannelId)
 	if err != nil {
 		return nil, err
@@ -71,6 +90,10 @@ func (s *SnapshotService) QueryPendings(ctx context.Context, signedRequest *pb.S
 		return nil, errors.Wrap(err, "failed to unmarshal snapshot request")
 	}
 
+	if err := s.checkACL(resources.Snapshot_listpending, query.SignatureHeader, signedRequest); err != nil {
+		return nil, err
+	}
+
 	lgr, err := s.getLedger(query.ChannelId)
 	if err != nil {
 		return nil, err
@@ -82,6 +105,30 @@ func (s *SnapshotService) QueryPendings(ctx context.Context, signedRequest *pb.S
 	}
 
 	return &pb.QueryPendingSnapshotsResponse{BlockNumbers: result}, nil
+}
+
+func (s *SnapshotService) checkACL(resName string, signatureHdr *cb.SignatureHeader, signedRequest *pb.SignedSnapshotRequest) error {
+	if signatureHdr == nil {
+		return errors.New("missing signature header")
+	}
+
+	expirationTime := crypto.ExpiresAt(signatureHdr.Creator)
+	if !expirationTime.IsZero() && time.Now().After(expirationTime) {
+		return errors.New("client identity expired")
+	}
+
+	if err := s.ACLProvider.CheckACLNoChannel(
+		resName,
+		[]*protoutil.SignedData{{
+			Identity:  signatureHdr.Creator,
+			Data:      signedRequest.Request,
+			Signature: signedRequest.Signature,
+		}},
+	); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *SnapshotService) getLedger(channelID string) (ledger.PeerLedger, error) {

--- a/core/ledger/snapshotgrpc/snapshot_service_test.go
+++ b/core/ledger/snapshotgrpc/snapshot_service_test.go
@@ -8,9 +8,11 @@ package snapshotgrpc
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"testing"
 
+	"github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/common/configtx/test"
 	"github.com/hyperledger/fabric/core/ledger/ledgermgmt"
@@ -21,16 +23,19 @@ import (
 )
 
 //go:generate counterfeiter -o mock/ledger_getter.go -fake-name LedgerGetter . ledgerGetter
+//go:generate counterfeiter -o mock/acl_provider.go -fake-name ACLProvider . aclProvider
 
 type ledgerGetter interface {
 	LedgerGetter
 }
 
+type aclProvider interface {
+	ACLProvider
+}
+
 func TestSnapshot(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "snapshotgrpc")
-	if err != nil {
-		t.Fatalf("Failed to create ledger directory: %s", err)
-	}
+	require.NoError(t, err)
 
 	ledgerID := "testsnapshot"
 	ledgermgmtInitializer := ledgermgmttest.NewInitializer(testDir)
@@ -43,7 +48,9 @@ func TestSnapshot(t *testing.T) {
 
 	fakeLedgerGetter := &mock.LedgerGetter{}
 	fakeLedgerGetter.GetLedgerReturns(lgr)
-	snapshotSvc := &SnapshotService{fakeLedgerGetter}
+	fakeACLProvider := &mock.ACLProvider{}
+	fakeACLProvider.CheckACLNoChannelReturns(nil)
+	snapshotSvc := &SnapshotService{LedgerGetter: fakeLedgerGetter, ACLProvider: fakeACLProvider}
 
 	// test generate, cancel and query bindings
 	var signedRequest *pb.SignedSnapshotRequest
@@ -87,37 +94,51 @@ func TestSnapshot(t *testing.T) {
 			errMsg:        "failed to unmarshal snapshot request: proto: can't skip unknown wire type 4",
 		},
 		{
-			name:      "missing channel ID",
-			channelID: "",
-			errMsg:    "missing channel ID",
+			name:          "missing channel ID",
+			channelID:     "",
+			signedRequest: createSignedQuery(""),
+			errMsg:        "missing channel ID",
 		},
 		{
-			name:      "cannot find ledger",
-			channelID: ledgerID,
-			errMsg:    "cannot find ledger for channel " + ledgerID,
+			name:          "missing signature header",
+			channelID:     "",
+			signedRequest: &pb.SignedSnapshotRequest{Request: protoutil.MarshalOrPanic(&pb.SnapshotQuery{})},
+			errMsg:        "missing signature header",
+		},
+		{
+			name:          "cannot find ledger",
+			channelID:     ledgerID,
+			signedRequest: createSignedQuery(ledgerID),
+			errMsg:        "cannot find ledger for channel " + ledgerID,
 		},
 	}
 
 	fakeLedgerGetter.GetLedgerReturns(nil)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			signedRequest = test.signedRequest
-			if signedRequest == nil {
-				// create a SignedQuery for all requests because blockNumber does not matter in these error tests
-				signedRequest = createSignedQuery(test.channelID)
-			}
-			_, err := snapshotSvc.Generate(context.Background(), signedRequest)
+			_, err := snapshotSvc.Generate(context.Background(), test.signedRequest)
 			require.EqualError(t, err, test.errMsg)
-			_, err = snapshotSvc.Cancel(context.Background(), signedRequest)
+			_, err = snapshotSvc.Cancel(context.Background(), test.signedRequest)
 			require.EqualError(t, err, test.errMsg)
-			_, err = snapshotSvc.QueryPendings(context.Background(), signedRequest)
+			_, err = snapshotSvc.QueryPendings(context.Background(), test.signedRequest)
 			require.EqualError(t, err, test.errMsg)
 		})
 	}
 
+	// test error propagation of CheckACLNoChannel
+	fakeACLProvider.CheckACLNoChannelReturns(fmt.Errorf("fake-check-acl-error"))
+	signedRequest = createSignedQuery(ledgerID)
+	_, err = snapshotSvc.Generate(context.Background(), signedRequest)
+	require.EqualError(t, err, "fake-check-acl-error")
+	_, err = snapshotSvc.Cancel(context.Background(), signedRequest)
+	require.EqualError(t, err, "fake-check-acl-error")
+	_, err = snapshotSvc.QueryPendings(context.Background(), signedRequest)
+	require.EqualError(t, err, "fake-check-acl-error")
+
 	// verify panic from generate/cancel after ledger is closed
 	lgr.Close()
 	fakeLedgerGetter.GetLedgerReturns(lgr)
+	fakeACLProvider.CheckACLNoChannelReturns(nil)
 
 	require.PanicsWithError(
 		t,
@@ -132,20 +153,32 @@ func TestSnapshot(t *testing.T) {
 }
 
 func createSignedRequest(channelID string, blockNumber uint64) *pb.SignedSnapshotRequest {
+	sigHeader := &common.SignatureHeader{
+		Creator: []byte("creator"),
+		Nonce:   []byte("nonce-ignored"),
+	}
 	request := &pb.SnapshotRequest{
-		ChannelId:   channelID,
-		BlockNumber: blockNumber,
+		SignatureHeader: sigHeader,
+		ChannelId:       channelID,
+		BlockNumber:     blockNumber,
 	}
 	return &pb.SignedSnapshotRequest{
-		Request: protoutil.MarshalOrPanic(request),
+		Request:   protoutil.MarshalOrPanic(request),
+		Signature: []byte("dummy-signatures"),
 	}
 }
 
 func createSignedQuery(channelID string) *pb.SignedSnapshotRequest {
+	sigHeader := &common.SignatureHeader{
+		Creator: []byte("creator"),
+		Nonce:   []byte("nonce-ignored"),
+	}
 	query := &pb.SnapshotQuery{
-		ChannelId: channelID,
+		SignatureHeader: sigHeader,
+		ChannelId:       channelID,
 	}
 	return &pb.SignedSnapshotRequest{
-		Request: protoutil.MarshalOrPanic(query),
+		Request:   protoutil.MarshalOrPanic(query),
+		Signature: []byte("dummy-signatures"),
 	}
 }

--- a/core/scc/cscc/mocks/acl_provider.go
+++ b/core/scc/cscc/mocks/acl_provider.go
@@ -19,6 +19,18 @@ type ACLProvider struct {
 	checkACLReturnsOnCall map[int]struct {
 		result1 error
 	}
+	CheckACLNoChannelStub        func(string, interface{}) error
+	checkACLNoChannelMutex       sync.RWMutex
+	checkACLNoChannelArgsForCall []struct {
+		arg1 string
+		arg2 interface{}
+	}
+	checkACLNoChannelReturns struct {
+		result1 error
+	}
+	checkACLNoChannelReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -85,11 +97,74 @@ func (fake *ACLProvider) CheckACLReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *ACLProvider) CheckACLNoChannel(arg1 string, arg2 interface{}) error {
+	fake.checkACLNoChannelMutex.Lock()
+	ret, specificReturn := fake.checkACLNoChannelReturnsOnCall[len(fake.checkACLNoChannelArgsForCall)]
+	fake.checkACLNoChannelArgsForCall = append(fake.checkACLNoChannelArgsForCall, struct {
+		arg1 string
+		arg2 interface{}
+	}{arg1, arg2})
+	fake.recordInvocation("CheckACLNoChannel", []interface{}{arg1, arg2})
+	fake.checkACLNoChannelMutex.Unlock()
+	if fake.CheckACLNoChannelStub != nil {
+		return fake.CheckACLNoChannelStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.checkACLNoChannelReturns
+	return fakeReturns.result1
+}
+
+func (fake *ACLProvider) CheckACLNoChannelCallCount() int {
+	fake.checkACLNoChannelMutex.RLock()
+	defer fake.checkACLNoChannelMutex.RUnlock()
+	return len(fake.checkACLNoChannelArgsForCall)
+}
+
+func (fake *ACLProvider) CheckACLNoChannelCalls(stub func(string, interface{}) error) {
+	fake.checkACLNoChannelMutex.Lock()
+	defer fake.checkACLNoChannelMutex.Unlock()
+	fake.CheckACLNoChannelStub = stub
+}
+
+func (fake *ACLProvider) CheckACLNoChannelArgsForCall(i int) (string, interface{}) {
+	fake.checkACLNoChannelMutex.RLock()
+	defer fake.checkACLNoChannelMutex.RUnlock()
+	argsForCall := fake.checkACLNoChannelArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *ACLProvider) CheckACLNoChannelReturns(result1 error) {
+	fake.checkACLNoChannelMutex.Lock()
+	defer fake.checkACLNoChannelMutex.Unlock()
+	fake.CheckACLNoChannelStub = nil
+	fake.checkACLNoChannelReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ACLProvider) CheckACLNoChannelReturnsOnCall(i int, result1 error) {
+	fake.checkACLNoChannelMutex.Lock()
+	defer fake.checkACLNoChannelMutex.Unlock()
+	fake.CheckACLNoChannelStub = nil
+	if fake.checkACLNoChannelReturnsOnCall == nil {
+		fake.checkACLNoChannelReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.checkACLNoChannelReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *ACLProvider) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.checkACLMutex.RLock()
 	defer fake.checkACLMutex.RUnlock()
+	fake.checkACLNoChannelMutex.RLock()
+	defer fake.checkACLNoChannelMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/core/scc/cscc/mocks/policy_checker.go
+++ b/core/scc/cscc/mocks/policy_checker.go
@@ -47,6 +47,18 @@ type PolicyChecker struct {
 	checkPolicyNoChannelReturnsOnCall map[int]struct {
 		result1 error
 	}
+	CheckPolicyNoChannelBySignedDataStub        func(string, []*protoutil.SignedData) error
+	checkPolicyNoChannelBySignedDataMutex       sync.RWMutex
+	checkPolicyNoChannelBySignedDataArgsForCall []struct {
+		arg1 string
+		arg2 []*protoutil.SignedData
+	}
+	checkPolicyNoChannelBySignedDataReturns struct {
+		result1 error
+	}
+	checkPolicyNoChannelBySignedDataReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -241,6 +253,72 @@ func (fake *PolicyChecker) CheckPolicyNoChannelReturnsOnCall(i int, result1 erro
 	}{result1}
 }
 
+func (fake *PolicyChecker) CheckPolicyNoChannelBySignedData(arg1 string, arg2 []*protoutil.SignedData) error {
+	var arg2Copy []*protoutil.SignedData
+	if arg2 != nil {
+		arg2Copy = make([]*protoutil.SignedData, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.checkPolicyNoChannelBySignedDataMutex.Lock()
+	ret, specificReturn := fake.checkPolicyNoChannelBySignedDataReturnsOnCall[len(fake.checkPolicyNoChannelBySignedDataArgsForCall)]
+	fake.checkPolicyNoChannelBySignedDataArgsForCall = append(fake.checkPolicyNoChannelBySignedDataArgsForCall, struct {
+		arg1 string
+		arg2 []*protoutil.SignedData
+	}{arg1, arg2Copy})
+	fake.recordInvocation("CheckPolicyNoChannelBySignedData", []interface{}{arg1, arg2Copy})
+	fake.checkPolicyNoChannelBySignedDataMutex.Unlock()
+	if fake.CheckPolicyNoChannelBySignedDataStub != nil {
+		return fake.CheckPolicyNoChannelBySignedDataStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.checkPolicyNoChannelBySignedDataReturns
+	return fakeReturns.result1
+}
+
+func (fake *PolicyChecker) CheckPolicyNoChannelBySignedDataCallCount() int {
+	fake.checkPolicyNoChannelBySignedDataMutex.RLock()
+	defer fake.checkPolicyNoChannelBySignedDataMutex.RUnlock()
+	return len(fake.checkPolicyNoChannelBySignedDataArgsForCall)
+}
+
+func (fake *PolicyChecker) CheckPolicyNoChannelBySignedDataCalls(stub func(string, []*protoutil.SignedData) error) {
+	fake.checkPolicyNoChannelBySignedDataMutex.Lock()
+	defer fake.checkPolicyNoChannelBySignedDataMutex.Unlock()
+	fake.CheckPolicyNoChannelBySignedDataStub = stub
+}
+
+func (fake *PolicyChecker) CheckPolicyNoChannelBySignedDataArgsForCall(i int) (string, []*protoutil.SignedData) {
+	fake.checkPolicyNoChannelBySignedDataMutex.RLock()
+	defer fake.checkPolicyNoChannelBySignedDataMutex.RUnlock()
+	argsForCall := fake.checkPolicyNoChannelBySignedDataArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *PolicyChecker) CheckPolicyNoChannelBySignedDataReturns(result1 error) {
+	fake.checkPolicyNoChannelBySignedDataMutex.Lock()
+	defer fake.checkPolicyNoChannelBySignedDataMutex.Unlock()
+	fake.CheckPolicyNoChannelBySignedDataStub = nil
+	fake.checkPolicyNoChannelBySignedDataReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *PolicyChecker) CheckPolicyNoChannelBySignedDataReturnsOnCall(i int, result1 error) {
+	fake.checkPolicyNoChannelBySignedDataMutex.Lock()
+	defer fake.checkPolicyNoChannelBySignedDataMutex.Unlock()
+	fake.CheckPolicyNoChannelBySignedDataStub = nil
+	if fake.checkPolicyNoChannelBySignedDataReturnsOnCall == nil {
+		fake.checkPolicyNoChannelBySignedDataReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.checkPolicyNoChannelBySignedDataReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *PolicyChecker) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -250,6 +328,8 @@ func (fake *PolicyChecker) Invocations() map[string][][]interface{} {
 	defer fake.checkPolicyBySignedDataMutex.RUnlock()
 	fake.checkPolicyNoChannelMutex.RLock()
 	defer fake.checkPolicyNoChannelMutex.RUnlock()
+	fake.checkPolicyNoChannelBySignedDataMutex.RLock()
+	defer fake.checkPolicyNoChannelBySignedDataMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -874,7 +874,7 @@ func serve(args []string) error {
 	pb.RegisterEndorserServer(peerServer.Server(), auth)
 
 	// register the snapshot server
-	snapshotSvc := &snapshotgrpc.SnapshotService{LedgerGetter: peerInstance}
+	snapshotSvc := &snapshotgrpc.SnapshotService{LedgerGetter: peerInstance, ACLProvider: aclProvider}
 	pb.RegisterSnapshotServer(peerServer.Server(), snapshotSvc)
 
 	go func() {


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao wenjianq@gmail.com

#### Type of change
- New feature

#### Description
- Add ACLProvider to snapshot service to check ACL
- Add resources for snapshot submitrequest, cancelrequest and listpending
- Add CheckPolicyNoChannel to ACLProvider interface and implement CheckPolicyNoChannelBySignedData func in policy.go

#### Additional details
This PR is stacked on top of https://github.com/hyperledger/fabric/pull/1790

#### Related issues
https://jira.hyperledger.org/browse/FAB-18117


