### PR TITLE
Use blocknumber instead of height for snapshot related code

### DIFF
--- a/core/ledger/kvledger/kv_ledger_provider.go
+++ b/core/ledger/kvledger/kv_ledger_provider.go
@@ -337,7 +337,7 @@ func (p *Provider) open(ledgerID string, bootSnapshotMetadata *snapshotMetadata)
 	storeInitializer := &pvtdatastorage.Initializer{}
 	if bootSnapshotMetadata != nil {
 		storeInitializer.CreatedFromSnapshot = true
-		storeInitializer.LastBlockInSnapshot = bootSnapshotMetadata.ChannelHeight - 1
+		storeInitializer.LastBlockInSnapshot = bootSnapshotMetadata.LastBlockNumber
 	}
 	pvtdataStore, err := p.pvtdataStoreProvider.OpenStore(ledgerID, storeInitializer)
 	if err != nil {

--- a/core/ledger/kvledger/ledger_filepath.go
+++ b/core/ledger/kvledger/ledger_filepath.go
@@ -65,7 +65,7 @@ func SnapshotsDirForLedger(snapshotRootDir, ledgerID string) string {
 	return filepath.Join(CompletedSnapshotsPath(snapshotRootDir), ledgerID)
 }
 
-// SnapshotDirForLedgerHeight returns the absolute path for a particular snapshot for a ledger
-func SnapshotDirForLedgerHeight(snapshotRootDir, ledgerID string, snapshotHeight uint64) string {
-	return filepath.Join(SnapshotsDirForLedger(snapshotRootDir, ledgerID), strconv.FormatUint(snapshotHeight, 10))
+// SnapshotDirForLedgerBlockNum returns the absolute path for a particular snapshot for a ledger
+func SnapshotDirForLedgerBlockNum(snapshotRootDir, ledgerID string, blockNumber uint64) string {
+	return filepath.Join(SnapshotsDirForLedger(snapshotRootDir, ledgerID), strconv.FormatUint(blockNumber, 10))
 }

--- a/core/ledger/ledgermgmt/ledger_mgmt_test.go
+++ b/core/ledger/ledgermgmt/ledger_mgmt_test.go
@@ -102,7 +102,7 @@ func TestCreateLedgerFromSnapshot(t *testing.T) {
 
 	// submit a snapshot request, wait until it is generated (request removed from pending requests)
 	require.NoError(t, l.SubmitSnapshotRequest(0))
-	snapshotDir := kvledger.SnapshotDirForLedgerHeight(initializer.Config.SnapshotsConfig.RootDir, channelID, 1)
+	snapshotDir := kvledger.SnapshotDirForLedgerBlockNum(initializer.Config.SnapshotsConfig.RootDir, channelID, 0)
 	snapshotGenerated := func() bool {
 		pendingRequests, err := l.PendingSnapshotRequests()
 		require.NoError(t, err)
@@ -155,7 +155,8 @@ func TestChaincodeInfoProvider(t *testing.T) {
 	}()
 
 	gb, _ := test.MakeGenesisBlock("ledger1")
-	ledgerMgr.CreateLedger("ledger1", gb)
+	_, err = ledgerMgr.CreateLedger("ledger1", gb)
+	require.NoError(t, err)
 
 	mockDeployedCCInfoProvider := &mock.DeployedChaincodeInfoProvider{}
 	mockDeployedCCInfoProvider.ChaincodeInfoStub = func(channelName, ccName string, qe ledger.SimpleQueryExecutor) (*ledger.DeployedChaincodeInfo, error) {

--- a/core/ledger/ledgermgmt/ledgermgmttest/ledgermgmttest.go
+++ b/core/ledger/ledgermgmt/ledgermgmttest/ledgermgmttest.go
@@ -79,8 +79,8 @@ func CreateSnapshotWithGenesisBlock(t *testing.T, testDir string, ledgerID strin
 	l, err := ledgerMgr.CreateLedger(ledgerID, gb)
 	require.NoError(t, err)
 
-	require.NoError(t, l.SubmitSnapshotRequest(1))
-	snapshotDir := kvledger.SnapshotDirForLedgerHeight(initializer.Config.SnapshotsConfig.RootDir, ledgerID, 1)
+	require.NoError(t, l.SubmitSnapshotRequest(0))
+	snapshotDir := kvledger.SnapshotDirForLedgerBlockNum(initializer.Config.SnapshotsConfig.RootDir, ledgerID, 0)
 	snapshotGenerated := func() bool {
 		pendingRequests, err := l.PendingSnapshotRequests()
 		require.NoError(t, err)

--- a/core/ledger/snapshotgrpc/snapshot_service_test.go
+++ b/core/ledger/snapshotgrpc/snapshot_service_test.go
@@ -67,12 +67,12 @@ func TestSnapshot(t *testing.T) {
 	// test error propagation from ledger, generate blockNumber=50 should return an error
 	signedRequest = createSignedRequest(ledgerID, 50)
 	_, err = snapshotSvc.Generate(context.Background(), signedRequest)
-	require.EqualError(t, err, "duplicate snapshot request for height 50")
+	require.EqualError(t, err, "duplicate snapshot request for block number 50")
 
 	// test error propagation from ledger, cancel blockNumber=100 again should return an error
 	signedRequest = createSignedRequest(ledgerID, 100)
 	_, err = snapshotSvc.Cancel(context.Background(), signedRequest)
-	require.EqualError(t, err, "no snapshot request exists for height 100")
+	require.EqualError(t, err, "no snapshot request exists for block number 100")
 
 	// common error tests for all requests
 	var tests = []struct {


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Additional details
We had planned for using the height as a number to use for the snapshots. But during the discussions for the end user commands (CLI), we decided to expose the block number instead of height. It's easy to maintain the code and correlate the logs by the end users if we use the block number all the way through the code.