### PR TITLE
[FAB-18183] Bump sphinx in requirements.txt to v1.8.5

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,6 +11,6 @@ Pygments==2.1.3
 pytz==2016.4
 six==1.10.0
 snowballstemmer==1.2.1
-Sphinx==1.7.2
+Sphinx==1.8.5
 sphinx-rtd-theme==0.2.5b2
 recommonmark==0.4.0


### PR DESCRIPTION
This patch bumps sphinx to v1.8.5 to use the same version as Pipfile.

#### Type of change

- Improvement (improvement to code, performance, etc)
- Documentation update

#### Description

Currently, the sphinx version are not consistent between `docs/requirements.txt` and `docs/Pipfile`

- requirements.txt
  - sphinx version: v1.7.2
  - This file is supposed to be used to build the docs on ReadTheDocs
- Pipfile
  - sphinx version: v1.8.5
  - This file is referred to by `docs/source/docs_guide.md` to build the docs locally.
 
I think the versions for local and ReadTheDocs build should be unified to avoid problems due to version differences.
So, this patch bumps sphinx to v1.8.5 to use the same version as Pipfile.

I have tested the committed file in my local env with `tox -edocs` which is the same way as the old CI.

#### Related issues

- https://jira.hyperledger.org/browse/FAB-18183

