### PR TITLE
Pass unreconciled missingData info to ledger from reconciler

### DIFF
--- a/core/chaincode/mock/peer_ledger.go
+++ b/core/chaincode/mock/peer_ledger.go
@@ -38,10 +38,11 @@ type PeerLedger struct {
 	commitLegacyReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CommitPvtDataOfOldBlocksStub        func([]*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error)
+	CommitPvtDataOfOldBlocksStub        func([]*ledger.ReconciledPvtdata, ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error)
 	commitPvtDataOfOldBlocksMutex       sync.RWMutex
 	commitPvtDataOfOldBlocksArgsForCall []struct {
 		arg1 []*ledger.ReconciledPvtdata
+		arg2 ledger.MissingPvtDataInfo
 	}
 	commitPvtDataOfOldBlocksReturns struct {
 		result1 []*ledger.PvtdataHashMismatch
@@ -437,7 +438,7 @@ func (fake *PeerLedger) CommitLegacyReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *PeerLedger) CommitPvtDataOfOldBlocks(arg1 []*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error) {
+func (fake *PeerLedger) CommitPvtDataOfOldBlocks(arg1 []*ledger.ReconciledPvtdata, arg2 ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error) {
 	var arg1Copy []*ledger.ReconciledPvtdata
 	if arg1 != nil {
 		arg1Copy = make([]*ledger.ReconciledPvtdata, len(arg1))
@@ -447,11 +448,12 @@ func (fake *PeerLedger) CommitPvtDataOfOldBlocks(arg1 []*ledger.ReconciledPvtdat
 	ret, specificReturn := fake.commitPvtDataOfOldBlocksReturnsOnCall[len(fake.commitPvtDataOfOldBlocksArgsForCall)]
 	fake.commitPvtDataOfOldBlocksArgsForCall = append(fake.commitPvtDataOfOldBlocksArgsForCall, struct {
 		arg1 []*ledger.ReconciledPvtdata
-	}{arg1Copy})
-	fake.recordInvocation("CommitPvtDataOfOldBlocks", []interface{}{arg1Copy})
+		arg2 ledger.MissingPvtDataInfo
+	}{arg1Copy, arg2})
+	fake.recordInvocation("CommitPvtDataOfOldBlocks", []interface{}{arg1Copy, arg2})
 	fake.commitPvtDataOfOldBlocksMutex.Unlock()
 	if fake.CommitPvtDataOfOldBlocksStub != nil {
-		return fake.CommitPvtDataOfOldBlocksStub(arg1)
+		return fake.CommitPvtDataOfOldBlocksStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -466,17 +468,17 @@ func (fake *PeerLedger) CommitPvtDataOfOldBlocksCallCount() int {
 	return len(fake.commitPvtDataOfOldBlocksArgsForCall)
 }
 
-func (fake *PeerLedger) CommitPvtDataOfOldBlocksCalls(stub func([]*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error)) {
+func (fake *PeerLedger) CommitPvtDataOfOldBlocksCalls(stub func([]*ledger.ReconciledPvtdata, ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error)) {
 	fake.commitPvtDataOfOldBlocksMutex.Lock()
 	defer fake.commitPvtDataOfOldBlocksMutex.Unlock()
 	fake.CommitPvtDataOfOldBlocksStub = stub
 }
 
-func (fake *PeerLedger) CommitPvtDataOfOldBlocksArgsForCall(i int) []*ledger.ReconciledPvtdata {
+func (fake *PeerLedger) CommitPvtDataOfOldBlocksArgsForCall(i int) ([]*ledger.ReconciledPvtdata, ledger.MissingPvtDataInfo) {
 	fake.commitPvtDataOfOldBlocksMutex.RLock()
 	defer fake.commitPvtDataOfOldBlocksMutex.RUnlock()
 	argsForCall := fake.commitPvtDataOfOldBlocksArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *PeerLedger) CommitPvtDataOfOldBlocksReturns(result1 []*ledger.PvtdataHashMismatch, result2 error) {

--- a/core/committer/committer.go
+++ b/core/committer/committer.go
@@ -59,7 +59,7 @@ type Committer interface {
 	// If hashes for some of the private data supplied in this function does not match
 	// the corresponding hash present in the block, the unmatched private data is not
 	// committed and instead the mismatch inforation is returned back
-	CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error)
+	CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.ReconciledPvtdata, unreconciled ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error)
 
 	// GetMissingPvtDataTracker return the MissingPvtDataTracker
 	GetMissingPvtDataTracker() (ledger.MissingPvtDataTracker, error)

--- a/core/committer/committer_impl.go
+++ b/core/committer/committer_impl.go
@@ -28,7 +28,7 @@ type PeerLedgerSupport interface {
 
 	CommitLegacy(blockAndPvtdata *ledger.BlockAndPvtData, commitOpts *ledger.CommitOptions) error
 
-	CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error)
+	CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.ReconciledPvtdata, unreconciled ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error)
 
 	GetBlockchainInfo() (*common.BlockchainInfo, error)
 

--- a/core/committer/committer_test.go
+++ b/core/committer/committer_test.go
@@ -112,7 +112,7 @@ func (m *mockLedger) CommitLegacy(blockAndPvtdata *ledger2.BlockAndPvtData, comm
 	return args.Error(0)
 }
 
-func (m *mockLedger) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger2.ReconciledPvtdata) ([]*ledger2.PvtdataHashMismatch, error) {
+func (m *mockLedger) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger2.ReconciledPvtdata, unreconciled ledger2.MissingPvtDataInfo) ([]*ledger2.PvtdataHashMismatch, error) {
 	panic("implement me")
 }
 

--- a/core/committer/txvalidator/v14/validator_test.go
+++ b/core/committer/txvalidator/v14/validator_test.go
@@ -1519,7 +1519,7 @@ func (m *mockLedger) GetConfigHistoryRetriever() (ledger.ConfigHistoryRetriever,
 	return args.Get(0).(ledger.ConfigHistoryRetriever), nil
 }
 
-func (m *mockLedger) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error) {
+func (m *mockLedger) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.ReconciledPvtdata, unreconciled ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error) {
 	return nil, nil
 }
 

--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -743,7 +743,7 @@ func (l *kvLedger) GetConfigHistoryRetriever() (ledger.ConfigHistoryRetriever, e
 	return l.configHistoryRetriever, nil
 }
 
-func (l *kvLedger) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error) {
+func (l *kvLedger) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.ReconciledPvtdata, unreconciled ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error) {
 	logger.Debugf("[%s:] Comparing pvtData of [%d] old blocks against the hashes in transaction's rwset to find valid and invalid data",
 		l.ledgerID, len(reconciledPvtdata))
 

--- a/core/ledger/ledger_interface.go
+++ b/core/ledger/ledger_interface.go
@@ -186,7 +186,7 @@ type PeerLedger interface {
 	// If hashes for some of the private data supplied in this function does not match
 	// the corresponding hash present in the block, the unmatched private data is not
 	// committed and instead the mismatch inforation is returned back
-	CommitPvtDataOfOldBlocks(reconciledPvtdata []*ReconciledPvtdata) ([]*PvtdataHashMismatch, error)
+	CommitPvtDataOfOldBlocks(reconciledPvtdata []*ReconciledPvtdata, unreconciled MissingPvtDataInfo) ([]*PvtdataHashMismatch, error)
 	// GetMissingPvtDataTracker return the MissingPvtDataTracker
 	GetMissingPvtDataTracker() (MissingPvtDataTracker, error)
 	// DoesPvtDataInfoExist returns true when

--- a/core/ledger/pvtdatastorage/reconcile_missing_pvtdata.go
+++ b/core/ledger/pvtdatastorage/reconcile_missing_pvtdata.go
@@ -14,13 +14,6 @@ import (
 	"github.com/willf/bitset"
 )
 
-type elgMissingDataGroup int
-
-const (
-	prioritized elgMissingDataGroup = iota
-	deprioritized
-)
-
 // CommitPvtDataOfOldBlocks commits the pvtData (i.e., previously missing data) of old blockp.
 // The parameter `blocksPvtData` refers a list of old block's pvtdata which are missing in the pvtstore.
 // Given a list of old block's pvtData, `CommitPvtDataOfOldBlocks` performs the following three

--- a/core/ledger/pvtdatastorage/store.go
+++ b/core/ledger/pvtdatastorage/store.go
@@ -31,7 +31,7 @@ var (
 	// from other peers. A chance for eligible deprioritized missing data
 	// would be given after giving deprioritizedMissingDataPeriodicity number
 	// of chances to the eligible prioritized missing data
-	deprioritizedMissingDataPeriodicity = 1000
+	deprioritizedMissingDataPeriodicity = 100
 )
 
 // Provider provides handle to specific 'Store' that in turn manages
@@ -438,10 +438,12 @@ func (s *Store) GetMissingPvtDataInfoForMostRecentBlocks(maxBlock int) (ledger.M
 
 	if s.iterSinceDeprioMissingDataAccess == deprioritizedMissingDataPeriodicity {
 		s.iterSinceDeprioMissingDataAccess = 0
+		logger.Debug("fetching missing pvtdata entries from the deprioritized list")
 		return s.getMissingData(elgDeprioritizedMissingDataGroup, maxBlock)
 	}
 
 	s.iterSinceDeprioMissingDataAccess++
+	logger.Debug("fetching missing pvtdata entries from the prioritized list")
 	return s.getMissingData(elgPrioritizedMissingDataGroup, maxBlock)
 }
 

--- a/core/peer/mock/peer_ledger.go
+++ b/core/peer/mock/peer_ledger.go
@@ -38,10 +38,11 @@ type PeerLedger struct {
 	commitLegacyReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CommitPvtDataOfOldBlocksStub        func([]*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error)
+	CommitPvtDataOfOldBlocksStub        func([]*ledger.ReconciledPvtdata, ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error)
 	commitPvtDataOfOldBlocksMutex       sync.RWMutex
 	commitPvtDataOfOldBlocksArgsForCall []struct {
 		arg1 []*ledger.ReconciledPvtdata
+		arg2 ledger.MissingPvtDataInfo
 	}
 	commitPvtDataOfOldBlocksReturns struct {
 		result1 []*ledger.PvtdataHashMismatch
@@ -437,7 +438,7 @@ func (fake *PeerLedger) CommitLegacyReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *PeerLedger) CommitPvtDataOfOldBlocks(arg1 []*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error) {
+func (fake *PeerLedger) CommitPvtDataOfOldBlocks(arg1 []*ledger.ReconciledPvtdata, arg2 ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error) {
 	var arg1Copy []*ledger.ReconciledPvtdata
 	if arg1 != nil {
 		arg1Copy = make([]*ledger.ReconciledPvtdata, len(arg1))
@@ -447,11 +448,12 @@ func (fake *PeerLedger) CommitPvtDataOfOldBlocks(arg1 []*ledger.ReconciledPvtdat
 	ret, specificReturn := fake.commitPvtDataOfOldBlocksReturnsOnCall[len(fake.commitPvtDataOfOldBlocksArgsForCall)]
 	fake.commitPvtDataOfOldBlocksArgsForCall = append(fake.commitPvtDataOfOldBlocksArgsForCall, struct {
 		arg1 []*ledger.ReconciledPvtdata
-	}{arg1Copy})
-	fake.recordInvocation("CommitPvtDataOfOldBlocks", []interface{}{arg1Copy})
+		arg2 ledger.MissingPvtDataInfo
+	}{arg1Copy, arg2})
+	fake.recordInvocation("CommitPvtDataOfOldBlocks", []interface{}{arg1Copy, arg2})
 	fake.commitPvtDataOfOldBlocksMutex.Unlock()
 	if fake.CommitPvtDataOfOldBlocksStub != nil {
-		return fake.CommitPvtDataOfOldBlocksStub(arg1)
+		return fake.CommitPvtDataOfOldBlocksStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -466,17 +468,17 @@ func (fake *PeerLedger) CommitPvtDataOfOldBlocksCallCount() int {
 	return len(fake.commitPvtDataOfOldBlocksArgsForCall)
 }
 
-func (fake *PeerLedger) CommitPvtDataOfOldBlocksCalls(stub func([]*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error)) {
+func (fake *PeerLedger) CommitPvtDataOfOldBlocksCalls(stub func([]*ledger.ReconciledPvtdata, ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error)) {
 	fake.commitPvtDataOfOldBlocksMutex.Lock()
 	defer fake.commitPvtDataOfOldBlocksMutex.Unlock()
 	fake.CommitPvtDataOfOldBlocksStub = stub
 }
 
-func (fake *PeerLedger) CommitPvtDataOfOldBlocksArgsForCall(i int) []*ledger.ReconciledPvtdata {
+func (fake *PeerLedger) CommitPvtDataOfOldBlocksArgsForCall(i int) ([]*ledger.ReconciledPvtdata, ledger.MissingPvtDataInfo) {
 	fake.commitPvtDataOfOldBlocksMutex.RLock()
 	defer fake.commitPvtDataOfOldBlocksMutex.RUnlock()
 	argsForCall := fake.commitPvtDataOfOldBlocksArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *PeerLedger) CommitPvtDataOfOldBlocksReturns(result1 []*ledger.PvtdataHashMismatch, result2 error) {

--- a/gossip/privdata/mocks/committer.go
+++ b/gossip/privdata/mocks/committer.go
@@ -30,13 +30,13 @@ func (_m *Committer) CommitLegacy(blockAndPvtData *ledger.BlockAndPvtData, commi
 	return r0
 }
 
-// CommitPvtDataOfOldBlocks provides a mock function with given fields: reconciledPvtdata
-func (_m *Committer) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error) {
-	ret := _m.Called(reconciledPvtdata)
+// CommitPvtDataOfOldBlocks provides a mock function with given fields: reconciledPvtdata, unreconciled
+func (_m *Committer) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.ReconciledPvtdata, unreconciled ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error) {
+	ret := _m.Called(reconciledPvtdata, unreconciled)
 
 	var r0 []*ledger.PvtdataHashMismatch
-	if rf, ok := ret.Get(0).(func([]*ledger.ReconciledPvtdata) []*ledger.PvtdataHashMismatch); ok {
-		r0 = rf(reconciledPvtdata)
+	if rf, ok := ret.Get(0).(func([]*ledger.ReconciledPvtdata, ledger.MissingPvtDataInfo) []*ledger.PvtdataHashMismatch); ok {
+		r0 = rf(reconciledPvtdata, unreconciled)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*ledger.PvtdataHashMismatch)
@@ -44,8 +44,8 @@ func (_m *Committer) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.Reconc
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func([]*ledger.ReconciledPvtdata) error); ok {
-		r1 = rf(reconciledPvtdata)
+	if rf, ok := ret.Get(1).(func([]*ledger.ReconciledPvtdata, ledger.MissingPvtDataInfo) error); ok {
+		r1 = rf(reconciledPvtdata, unreconciled)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/gossip/privdata/mocks/config_history_retriever.go
+++ b/gossip/privdata/mocks/config_history_retriever.go
@@ -10,29 +10,6 @@ type ConfigHistoryRetriever struct {
 	mock.Mock
 }
 
-// CollectionConfigAt provides a mock function with given fields: blockNum, chaincodeName
-func (_m *ConfigHistoryRetriever) CollectionConfigAt(blockNum uint64, chaincodeName string) (*ledger.CollectionConfigInfo, error) {
-	ret := _m.Called(blockNum, chaincodeName)
-
-	var r0 *ledger.CollectionConfigInfo
-	if rf, ok := ret.Get(0).(func(uint64, string) *ledger.CollectionConfigInfo); ok {
-		r0 = rf(blockNum, chaincodeName)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*ledger.CollectionConfigInfo)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(uint64, string) error); ok {
-		r1 = rf(blockNum, chaincodeName)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // MostRecentCollectionConfigBelow provides a mock function with given fields: blockNum, chaincodeName
 func (_m *ConfigHistoryRetriever) MostRecentCollectionConfigBelow(blockNum uint64, chaincodeName string) (*ledger.CollectionConfigInfo, error) {
 	ret := _m.Called(blockNum, chaincodeName)

--- a/gossip/privdata/reconcile.go
+++ b/gossip/privdata/reconcile.go
@@ -161,14 +161,10 @@ func (r *Reconciler) reconcile() error {
 			logger.Error("reconciliation error when trying to fetch missing items from different peers:", err)
 			return err
 		}
-		if len(fetchedData.AvailableElements) == 0 {
-			logger.Warning("missing private data is not available on other peers")
-			return nil
-		}
 
 		pvtDataToCommit := r.preparePvtDataToCommit(fetchedData.AvailableElements)
-		// commit missing private data that was reconciled and log mismatched
-		pvtdataHashMismatch, err := r.CommitPvtDataOfOldBlocks(pvtDataToCommit)
+		unreconciled := constructUnreconciledMissingData(dig2collectionCfg, fetchedData.AvailableElements)
+		pvtdataHashMismatch, err := r.CommitPvtDataOfOldBlocks(pvtDataToCommit, unreconciled)
 		if err != nil {
 			return errors.Wrap(err, "failed to commit private data")
 		}

--- a/gossip/privdata/reconcile_test.go
+++ b/gossip/privdata/reconcile_test.go
@@ -105,6 +105,10 @@ func TestReconciliationHappyPathWithoutScheduler(t *testing.T) {
 		3: map[uint64][]*ledger.MissingCollectionPvtDataInfo{
 			1: {{Collection: "col1", Namespace: "ns1"}},
 		},
+		4: map[uint64][]*ledger.MissingCollectionPvtDataInfo{
+			4: {{Collection: "col1", Namespace: "ns1"}},
+			5: {{Collection: "col1", Namespace: "ns1"}},
+		},
 	}
 
 	collectionConfigInfo := ledger.CollectionConfigInfo{
@@ -131,8 +135,13 @@ func TestReconciliationHappyPathWithoutScheduler(t *testing.T) {
 	result := &privdatacommon.FetchedPvtDataContainer{}
 	fetcher.On("FetchReconciledItems", mock.Anything).Run(func(args mock.Arguments) {
 		var dig2CollectionConfig = args.Get(0).(privdatacommon.Dig2CollectionConfig)
-		require.Equal(t, 1, len(dig2CollectionConfig))
+		require.Equal(t, 3, len(dig2CollectionConfig))
 		for digest := range dig2CollectionConfig {
+			if digest.BlockSeq != 3 {
+				// fetch private data only for block 3. Assume that the other
+				// block's private data could not be fetched
+				continue
+			}
 			hash := util2.ComputeSHA256([]byte("rws-pre-image"))
 			element := &gossip2.PvtDataElement{
 				Digest: &gossip2.PvtDataDigest{
@@ -148,11 +157,19 @@ func TestReconciliationHappyPathWithoutScheduler(t *testing.T) {
 		}
 	}).Return(result, nil)
 
+	expectedUnreconciledMissingData := ledger.MissingPvtDataInfo{
+		4: map[uint64][]*ledger.MissingCollectionPvtDataInfo{
+			4: {{Collection: "col1", Namespace: "ns1"}},
+			5: {{Collection: "col1", Namespace: "ns1"}},
+		},
+	}
+
 	var commitPvtDataOfOldBlocksHappened bool
 	var blockNum, seqInBlock uint64
 	blockNum = 3
 	seqInBlock = 1
-	committer.On("CommitPvtDataOfOldBlocks", mock.Anything).Run(func(args mock.Arguments) {
+	committer.On("CommitPvtDataOfOldBlocks", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		require.Len(t, args, 2)
 		var reconciledPvtdata = args.Get(0).([]*ledger.ReconciledPvtdata)
 		require.Equal(t, 1, len(reconciledPvtdata))
 		require.Equal(t, blockNum, reconciledPvtdata[0].BlockNum)
@@ -160,6 +177,9 @@ func TestReconciliationHappyPathWithoutScheduler(t *testing.T) {
 		require.Equal(t, "ns1", reconciledPvtdata[0].WriteSets[1].WriteSet.NsPvtRwset[0].Namespace)
 		require.Equal(t, "col1", reconciledPvtdata[0].WriteSets[1].WriteSet.NsPvtRwset[0].CollectionPvtRwset[0].CollectionName)
 		commitPvtDataOfOldBlocksHappened = true
+
+		var unreconciledPvtdata = args.Get(1).(ledger.MissingPvtDataInfo)
+		require.Equal(t, expectedUnreconciledMissingData, unreconciledPvtdata)
 	}).Return([]*ledger.PvtdataHashMismatch{}, nil)
 
 	testMetricProvider := gmetricsmocks.TestUtilConstructMetricProvider()
@@ -244,7 +264,7 @@ func TestReconciliationHappyPathWithScheduler(t *testing.T) {
 	var blockNum, seqInBlock uint64
 	blockNum = 3
 	seqInBlock = 1
-	committer.On("CommitPvtDataOfOldBlocks", mock.Anything).Run(func(args mock.Arguments) {
+	committer.On("CommitPvtDataOfOldBlocks", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		var reconciledPvtdata = args.Get(0).([]*ledger.ReconciledPvtdata)
 		require.Equal(t, 1, len(reconciledPvtdata))
 		require.Equal(t, blockNum, reconciledPvtdata[0].BlockNum)
@@ -252,6 +272,8 @@ func TestReconciliationHappyPathWithScheduler(t *testing.T) {
 		require.Equal(t, "ns1", reconciledPvtdata[0].WriteSets[1].WriteSet.NsPvtRwset[0].Namespace)
 		require.Equal(t, "col1", reconciledPvtdata[0].WriteSets[1].WriteSet.NsPvtRwset[0].CollectionPvtRwset[0].CollectionName)
 		commitPvtDataOfOldBlocksHappened = true
+
+		require.Nil(t, args.Get(1))
 		wg.Done()
 	}).Return([]*ledger.PvtdataHashMismatch{}, nil)
 
@@ -365,11 +387,13 @@ func TestReconciliationPullingMissingPrivateDataAtOnePass(t *testing.T) {
 
 	var commitPvtDataOfOldBlocksHappened bool
 	pvtDataStore := make([][]*ledger.ReconciledPvtdata, 0)
-	committer.On("CommitPvtDataOfOldBlocks", mock.Anything).Run(func(args mock.Arguments) {
+	committer.On("CommitPvtDataOfOldBlocks", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		var reconciledPvtdata = args.Get(0).([]*ledger.ReconciledPvtdata)
 		require.Equal(t, 1, len(reconciledPvtdata))
 		pvtDataStore = append(pvtDataStore, reconciledPvtdata)
 		commitPvtDataOfOldBlocksHappened = true
+
+		require.Nil(t, args.Get(1))
 		wg.Done()
 	}).Return([]*ledger.PvtdataHashMismatch{}, nil)
 
@@ -458,7 +482,7 @@ func TestReconciliationFailedToCommit(t *testing.T) {
 		}
 	}).Return(result, nil)
 
-	committer.On("CommitPvtDataOfOldBlocks", mock.Anything).Return(nil, errors.New("failed to commit"))
+	committer.On("CommitPvtDataOfOldBlocks", mock.Anything, mock.Anything).Return(nil, errors.New("failed to commit"))
 
 	r := &Reconciler{
 		channel:                "",
@@ -514,37 +538,35 @@ func TestFailuresWhileReconcilingMissingPvtData(t *testing.T) {
 }
 
 func TestConstructUnreconciledMissingData(t *testing.T) {
-	requestedMissingData := func() privdatacommon.Dig2CollectionConfig {
-		return privdatacommon.Dig2CollectionConfig{
-			privdatacommon.DigKey{
-				TxId:       "tx1",
-				Namespace:  "ns1",
-				Collection: "coll1",
-				BlockSeq:   1,
-				SeqInBlock: 1,
-			}: nil,
-			privdatacommon.DigKey{
-				TxId:       "tx1",
-				Namespace:  "ns2",
-				Collection: "coll2",
-				BlockSeq:   1,
-				SeqInBlock: 1,
-			}: nil,
-			privdatacommon.DigKey{
-				TxId:       "tx1",
-				Namespace:  "ns3",
-				Collection: "coll3",
-				BlockSeq:   1,
-				SeqInBlock: 3,
-			}: nil,
-			privdatacommon.DigKey{
-				TxId:       "tx2",
-				Namespace:  "ns4",
-				Collection: "coll4",
-				BlockSeq:   4,
-				SeqInBlock: 4,
-			}: nil,
-		}
+	requestedMissingData := privdatacommon.Dig2CollectionConfig{
+		privdatacommon.DigKey{
+			TxId:       "tx1",
+			Namespace:  "ns1",
+			Collection: "coll1",
+			BlockSeq:   1,
+			SeqInBlock: 1,
+		}: nil,
+		privdatacommon.DigKey{
+			TxId:       "tx1",
+			Namespace:  "ns2",
+			Collection: "coll2",
+			BlockSeq:   1,
+			SeqInBlock: 1,
+		}: nil,
+		privdatacommon.DigKey{
+			TxId:       "tx1",
+			Namespace:  "ns3",
+			Collection: "coll3",
+			BlockSeq:   1,
+			SeqInBlock: 3,
+		}: nil,
+		privdatacommon.DigKey{
+			TxId:       "tx2",
+			Namespace:  "ns4",
+			Collection: "coll4",
+			BlockSeq:   4,
+			SeqInBlock: 4,
+		}: nil,
 	}
 
 	testCases := []struct {
@@ -672,8 +694,13 @@ func TestConstructUnreconciledMissingData(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			unreconciledData := constructUnreconciledMissingData(requestedMissingData(), testCase.fetchedData)
-			require.Equal(t, testCase.expectedUnreconciledMissingData, unreconciledData)
+			unreconciledData := constructUnreconciledMissingData(requestedMissingData, testCase.fetchedData)
+			require.Equal(t, len(testCase.expectedUnreconciledMissingData), len(unreconciledData))
+			for blkNum, txsMissingData := range testCase.expectedUnreconciledMissingData {
+				for txNum, expectedUnreconciledData := range txsMissingData {
+					require.ElementsMatch(t, expectedUnreconciledData, unreconciledData[blkNum][txNum])
+				}
+			}
 		})
 	}
 }

--- a/gossip/service/gossip_service_test.go
+++ b/gossip/service/gossip_service_test.go
@@ -419,7 +419,7 @@ func (li *mockLedgerInfo) CommitLegacy(blockAndPvtData *ledger.BlockAndPvtData, 
 	panic("implement me")
 }
 
-func (li *mockLedgerInfo) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error) {
+func (li *mockLedgerInfo) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.ReconciledPvtdata, unreconciled ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error) {
 	panic("implement me")
 }
 

--- a/gossip/state/state_test.go
+++ b/gossip/state/state_test.go
@@ -253,7 +253,10 @@ func (*mockCommitter) GetMissingPvtDataTracker() (ledger.MissingPvtDataTracker, 
 	panic("implement me")
 }
 
-func (*mockCommitter) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error) {
+func (*mockCommitter) CommitPvtDataOfOldBlocks(
+	reconciledPvtdata []*ledger.ReconciledPvtdata,
+	unreconciled ledger.MissingPvtDataInfo,
+) ([]*ledger.PvtdataHashMismatch, error) {
 	panic("implement me")
 }
 
@@ -269,7 +272,10 @@ func (mock *ramLedger) GetMissingPvtDataTracker() (ledger.MissingPvtDataTracker,
 	panic("implement me")
 }
 
-func (mock *ramLedger) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error) {
+func (mock *ramLedger) CommitPvtDataOfOldBlocks(
+	reconciledPvtdata []*ledger.ReconciledPvtdata,
+	unreconciled ledger.MissingPvtDataInfo,
+) ([]*ledger.PvtdataHashMismatch, error) {
 	panic("implement me")
 }
 

--- a/internal/peer/node/mock/peer_ledger.go
+++ b/internal/peer/node/mock/peer_ledger.go
@@ -38,10 +38,11 @@ type PeerLedger struct {
 	commitLegacyReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CommitPvtDataOfOldBlocksStub        func([]*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error)
+	CommitPvtDataOfOldBlocksStub        func([]*ledger.ReconciledPvtdata, ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error)
 	commitPvtDataOfOldBlocksMutex       sync.RWMutex
 	commitPvtDataOfOldBlocksArgsForCall []struct {
 		arg1 []*ledger.ReconciledPvtdata
+		arg2 ledger.MissingPvtDataInfo
 	}
 	commitPvtDataOfOldBlocksReturns struct {
 		result1 []*ledger.PvtdataHashMismatch
@@ -437,7 +438,7 @@ func (fake *PeerLedger) CommitLegacyReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *PeerLedger) CommitPvtDataOfOldBlocks(arg1 []*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error) {
+func (fake *PeerLedger) CommitPvtDataOfOldBlocks(arg1 []*ledger.ReconciledPvtdata, arg2 ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error) {
 	var arg1Copy []*ledger.ReconciledPvtdata
 	if arg1 != nil {
 		arg1Copy = make([]*ledger.ReconciledPvtdata, len(arg1))
@@ -447,11 +448,12 @@ func (fake *PeerLedger) CommitPvtDataOfOldBlocks(arg1 []*ledger.ReconciledPvtdat
 	ret, specificReturn := fake.commitPvtDataOfOldBlocksReturnsOnCall[len(fake.commitPvtDataOfOldBlocksArgsForCall)]
 	fake.commitPvtDataOfOldBlocksArgsForCall = append(fake.commitPvtDataOfOldBlocksArgsForCall, struct {
 		arg1 []*ledger.ReconciledPvtdata
-	}{arg1Copy})
-	fake.recordInvocation("CommitPvtDataOfOldBlocks", []interface{}{arg1Copy})
+		arg2 ledger.MissingPvtDataInfo
+	}{arg1Copy, arg2})
+	fake.recordInvocation("CommitPvtDataOfOldBlocks", []interface{}{arg1Copy, arg2})
 	fake.commitPvtDataOfOldBlocksMutex.Unlock()
 	if fake.CommitPvtDataOfOldBlocksStub != nil {
-		return fake.CommitPvtDataOfOldBlocksStub(arg1)
+		return fake.CommitPvtDataOfOldBlocksStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -466,17 +468,17 @@ func (fake *PeerLedger) CommitPvtDataOfOldBlocksCallCount() int {
 	return len(fake.commitPvtDataOfOldBlocksArgsForCall)
 }
 
-func (fake *PeerLedger) CommitPvtDataOfOldBlocksCalls(stub func([]*ledger.ReconciledPvtdata) ([]*ledger.PvtdataHashMismatch, error)) {
+func (fake *PeerLedger) CommitPvtDataOfOldBlocksCalls(stub func([]*ledger.ReconciledPvtdata, ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error)) {
 	fake.commitPvtDataOfOldBlocksMutex.Lock()
 	defer fake.commitPvtDataOfOldBlocksMutex.Unlock()
 	fake.CommitPvtDataOfOldBlocksStub = stub
 }
 
-func (fake *PeerLedger) CommitPvtDataOfOldBlocksArgsForCall(i int) []*ledger.ReconciledPvtdata {
+func (fake *PeerLedger) CommitPvtDataOfOldBlocksArgsForCall(i int) ([]*ledger.ReconciledPvtdata, ledger.MissingPvtDataInfo) {
 	fake.commitPvtDataOfOldBlocksMutex.RLock()
 	defer fake.commitPvtDataOfOldBlocksMutex.RUnlock()
 	argsForCall := fake.commitPvtDataOfOldBlocksArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *PeerLedger) CommitPvtDataOfOldBlocksReturns(result1 []*ledger.PvtdataHashMismatch, result2 error) {


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Reconciler needs to pass the unreconciled missing data info to the ledger so that the ledger can deprioritize these unreconcilable data. 
