### PR TITLE
[FAB-18188] Log orderer and peer cert expiration date upon startup

### DIFF
--- a/common/crypto/expiration.go
+++ b/common/crypto/expiration.go
@@ -39,35 +39,35 @@ func certExpirationTime(pemBytes []byte) time.Time {
 	return cert.NotAfter
 }
 
-// WarnFunc notifies a warning happened with the given format, and can be replaced with Warnf of a logger.
-type WarnFunc func(format string, args ...interface{})
+// MessageFunc notifies a message happened with the given format, and can be replaced with Warnf or Infof of a logger.
+type MessageFunc func(format string, args ...interface{})
 
 // Scheduler invokes f after d time, and can be replaced with time.AfterFunc.
 type Scheduler func(d time.Duration, f func()) *time.Timer
 
 // TrackExpiration warns a week before one of the certificates expires
-func TrackExpiration(tls bool, serverCert []byte, clientCertChain [][]byte, sIDBytes []byte, warn WarnFunc, now time.Time, s Scheduler) {
+func TrackExpiration(tls bool, serverCert []byte, clientCertChain [][]byte, sIDBytes []byte, info MessageFunc, warn MessageFunc, now time.Time, s Scheduler) {
 	sID := &msp.SerializedIdentity{}
 	if err := proto.Unmarshal(sIDBytes, sID); err != nil {
 		return
 	}
 
-	trackCertExpiration(sID.IdBytes, "enrollment", warn, now, s)
+	trackCertExpiration(sID.IdBytes, "enrollment", info, warn, now, s)
 
 	if !tls {
 		return
 	}
 
-	trackCertExpiration(serverCert, "server TLS", warn, now, s)
+	trackCertExpiration(serverCert, "server TLS", info, warn, now, s)
 
 	if len(clientCertChain) == 0 || len(clientCertChain[0]) == 0 {
 		return
 	}
 
-	trackCertExpiration(clientCertChain[0], "client TLS", warn, now, s)
+	trackCertExpiration(clientCertChain[0], "client TLS", info, warn, now, s)
 }
 
-func trackCertExpiration(rawCert []byte, certRole string, warn WarnFunc, now time.Time, sched Scheduler) {
+func trackCertExpiration(rawCert []byte, certRole string, info MessageFunc, warn MessageFunc, now time.Time, sched Scheduler) {
 	expirationTime := certExpirationTime(rawCert)
 	if expirationTime.IsZero() {
 		// If the certificate expiration time cannot be classified, return.
@@ -82,6 +82,8 @@ func trackCertExpiration(rawCert []byte, certRole string, warn WarnFunc, now tim
 		return
 	}
 
+	info("The %s certificate will expire on %s", certRole, expirationTime)
+
 	if timeLeftUntilExpiration < oneWeek {
 		days := timeLeftUntilExpiration / (time.Hour * 24)
 		hours := (timeLeftUntilExpiration - (days * time.Hour * 24)) / time.Hour
@@ -94,4 +96,5 @@ func trackCertExpiration(rawCert []byte, certRole string, warn WarnFunc, now tim
 	sched(timeLeftUntilOneWeekBeforeExpiration, func() {
 		warn("The %s certificate will expire within one week", certRole)
 	})
+
 }

--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -182,6 +182,7 @@ func Start(cmd string, conf *localconfig.TopLevel) {
 		serverConfig.SecOpts.Certificate,
 		[][]byte{clusterClientConfig.SecOpts.Certificate},
 		sigHdr.Creator,
+		expirationLogger.Infof,
 		expirationLogger.Warnf, // This can be used to piggyback a metric event in the future
 		time.Now(),
 		time.AfterFunc)

--- a/peer/node/start.go
+++ b/peer/node/start.go
@@ -323,6 +323,7 @@ func serve(args []string) error {
 		serverConfig.SecOpts.Certificate,
 		comm.GetCredentialSupport().GetClientCertificate().Certificate,
 		serializedIdentity,
+		expirationLogger.Infof,
 		expirationLogger.Warnf, // This can be used to piggyback a metric event in the future
 		time.Now(),
 		time.AfterFunc)


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to logging)

#### Description

FAB-17000 added a warning if expiration is within a week.

This change additionally info logs the future enrollment, tls server, and tls client
cert expiration dates upon startup, regardless of whether they will expire within a week or not.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>