### PR TITLE
Revert "[FAB-18183] Bump sphinx in requirements.txt to v1.8.5"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,6 +11,6 @@ Pygments==2.1.3
 pytz==2016.4
 six==1.10.0
 snowballstemmer==1.2.1
-Sphinx==1.8.5
+Sphinx==1.7.2
 sphinx-rtd-theme==0.2.5b2
 recommonmark==0.4.0


### PR DESCRIPTION
This reverts commit 57f2834d1425f2b918f62ed77a0adc40d2d4d91e.

This commit created a formatting issue in the doc.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
