### PR TITLE
Revert "[FAB-18183] Bump sphinx in requirements.txt to v1.8.5"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,6 +11,6 @@ Pygments==2.1.3
 pytz==2016.4
 six==1.10.0
 snowballstemmer==1.2.1
-Sphinx==1.8.5
+Sphinx==1.7.2
 sphinx-rtd-theme==0.2.5b2
 recommonmark==0.4.0


### PR DESCRIPTION
This commit created a formatting issue in the doc.

This reverts commit 445b997f66bcbda77a5e2ebe18919cb1d09c7a26.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
