### PR TITLE
Fix broken pkcs11 tests

### DIFF
--- a/bccsp/pkcs11/pkcs11.go
+++ b/bccsp/pkcs11/pkcs11.go
@@ -105,7 +105,7 @@ func createSession(ctx *pkcs11.Ctx, slot uint, pin string) pkcs11.SessionHandle 
 		time.Sleep(100 * time.Millisecond)
 	}
 	if err != nil {
-		logger.Fatalf("OpenSession failed [%s]", err)
+		logger.Panicf("OpenSession failed [%s]", err)
 	}
 	logger.Debugf("Created new pkcs11 session %+v on slot %d\n", s, slot)
 	session := s
@@ -233,15 +233,11 @@ func (csp *impl) generateECKey(curve asn1.ObjectIdentifier, ephemeral bool) (ski
 		// Generate using the SKI process and then make keypair immutable according to csp.immutable
 		keylabel = fmt.Sprintf("BCP%s", nextIDCtr().Text(16))
 		updateSKI = true
-	} else if csp.altId != "" && csp.immutable {
+	} else if csp.altId != "" {
 		// Generate the key pair using AltID process.
 		// No need to worry about immutable since AltID is used with Write-Once HSMs
 		keylabel = csp.altId
 		updateSKI = false
-	} else if csp.altId != "" && !csp.immutable {
-		// Raise an error since AltID is used with Write-Once HSMs
-		// So cannot make support AltID with immutable = false.
-		return nil, nil, fmt.Errorf("Cannot generate a mutable key using AltID.")
 	}
 
 	marshaledOID, err := asn1.Marshal(curve)

--- a/bccsp/pkcs11/pkcs11_test.go
+++ b/bccsp/pkcs11/pkcs11_test.go
@@ -91,10 +91,6 @@ func TestOIDFromNamedCurve(t *testing.T) {
 }
 
 func TestAlternateLabelGeneration(t *testing.T) {
-	if currentTestConfig.altId == "" {
-		t.Skip("Skipping TestAlternateLabelGeneration since AltId is not set for this test run.")
-	}
-
 	// We generate a unique Alt ID for the test
 	uniqueAltId := strconv.FormatInt(time.Now().UnixNano()/1e6, 10)
 	fakeSKI := []byte("FakeSKI")
@@ -218,8 +214,8 @@ func TestPKCS11ECKeySignVerify(t *testing.T) {
 	}
 
 	msg1 := []byte("This is my very authentic message")
-	msg2 := []byte("This is my very unauthentic message")
 	hash1, _ := currentBCCSP.Hash(msg1, &bccsp.SHAOpts{})
+	msg2 := []byte("This is my very unauthentic message")
 	hash2, _ := currentBCCSP.Hash(msg2, &bccsp.SHAOpts{})
 
 	var oid asn1.ObjectIdentifier
@@ -270,4 +266,5 @@ func TestPKCS11ECKeySignVerify(t *testing.T) {
 	if pass != false {
 		t.Fatal("Signature should not match with software verification!")
 	}
+
 }


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Running go test -tags pkcs11 was failing for
bccsp.  This was probably not caught in CI because
CI runs with the short flag and the failing tests
are omitted.