### PR TITLE
Enable Custom System Chaincode via go build constraints

### DIFF
--- a/core/scc/opt_scc/mock.go
+++ b/core/scc/opt_scc/mock.go
@@ -1,0 +1,28 @@
+//+build mock_scc
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+Copyright 2020 Intel Corporation
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package opt_scc
+
+import (
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/aclmgmt"
+	"github.com/hyperledger/fabric/core/peer"
+	"github.com/hyperledger/fabric/core/scc"
+	"github.com/hyperledger/fabric/core/scc/opt_scc/mock"
+)
+
+var mscclogger = flogging.MustGetLogger("mscc")
+
+func init() {
+	mscclogger.Debug("Registring mock as system chaincode")
+	AddFactoryFunc(func(aclProvider aclmgmt.ACLProvider, p *peer.Peer) scc.SelfDescribingSysCC {
+		mscclogger.Debug("Enabling mock as system chaincode")
+		return mock.New(aclProvider, p)
+	})
+}

--- a/core/scc/opt_scc/mock/echo.go
+++ b/core/scc/opt_scc/mock/echo.go
@@ -1,0 +1,46 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mock
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/fabric-chaincode-go/shim"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/aclmgmt"
+	"github.com/hyperledger/fabric/core/peer"
+)
+
+func New(aclProvider aclmgmt.ACLProvider, p *peer.Peer) *EchoSCC {
+	return &EchoSCC{}
+}
+
+// EchoSCC echos any (string) request back as response
+type EchoSCC struct {
+}
+
+func (e *EchoSCC) Name() string              { return "mscc" }
+func (e *EchoSCC) Chaincode() shim.Chaincode { return e }
+
+var mscclogger = flogging.MustGetLogger("mscc")
+
+func (e *EchoSCC) Init(stub shim.ChaincodeStubInterface) pb.Response {
+	mscclogger.Info("Init MSCC")
+
+	return shim.Success(nil)
+}
+
+// Invoke is called with args[0] contains the query function name, args[1]
+func (e *EchoSCC) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
+	args := stub.GetStringArgs()
+
+	mscclogger.Infof("Invoke MSCC(%v)", args)
+
+	bytes := []byte(fmt.Sprintf("%v", args))
+	return shim.Success(bytes)
+}

--- a/core/scc/opt_scc/registry.go
+++ b/core/scc/opt_scc/registry.go
@@ -1,0 +1,34 @@
+/*
+ Copyright 2020 Intel Corporation
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package opt_scc
+
+import (
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/aclmgmt"
+	"github.com/hyperledger/fabric/core/peer"
+	"github.com/hyperledger/fabric/core/scc"
+)
+
+var logger = flogging.MustGetLogger("opt_scc")
+var factories = make([]FactoryFunc, 0)
+
+// FactoryFunc defines the type for factory function registring an optional system chaincode
+type FactoryFunc func(aclProvider aclmgmt.ACLProvider, p *peer.Peer) scc.SelfDescribingSysCC
+
+// AddFactoryFunc allows to register a factory function for an optional system chaincode
+func AddFactoryFunc(ff FactoryFunc) {
+	if ff == nil {
+		logger.Panic("Illegal factory function")
+	}
+	factories = append(factories, ff)
+}
+
+//ListFactoryFuncs lists all registered factory functions
+func ListFactoryFuncs() []FactoryFunc {
+	logger.Debugf("ListFactoryFuncs: %v", factories)
+	return factories
+}

--- a/core/scc/opt_scc/registry_test.go
+++ b/core/scc/opt_scc/registry_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 Intel Corporation
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package opt_scc_test
+
+import (
+	"sort"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/hyperledger/fabric-chaincode-go/shim"
+	"github.com/hyperledger/fabric/core/aclmgmt"
+	"github.com/hyperledger/fabric/core/peer"
+	"github.com/hyperledger/fabric/core/scc"
+	"github.com/hyperledger/fabric/core/scc/opt_scc"
+)
+
+type mock_scc struct {
+	name string
+}
+
+func (s *mock_scc) Name() string {
+	return s.name
+}
+func (s *mock_scc) Chaincode() shim.Chaincode {
+	return nil
+}
+
+func TestRegistry(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// 1. initially we should get an empty list
+	ffs := opt_scc.ListFactoryFuncs()
+	g.Expect(ffs).NotTo(BeNil(), "factory function list should not be nil")
+	g.Expect(len(ffs)).To(Equal(0), "factory function list should have zero elements")
+
+	// 2. after adding several handlers, make sure it returns exactly and only these handlers
+	names := []string{"ff1", "ff2", "ff3"}
+	for _, n := range names {
+		nLocal := n // to get separate version for below closure ...
+		opt_scc.AddFactoryFunc(
+			func(aclProvider aclmgmt.ACLProvider, p *peer.Peer) scc.SelfDescribingSysCC {
+				return &mock_scc{nLocal}
+			})
+	}
+	ffs = opt_scc.ListFactoryFuncs()
+	g.Expect(ffs).NotTo(BeNil(), "factory function list should not be nil")
+	g.Expect(len(ffs)).To(Equal(len(names)), "factory function list should have %v elements", len(names))
+	got_names := []string{}
+	for i, ff := range ffs {
+		s := ff(nil, nil)
+		g.Expect(s).NotTo(BeNil(), "received unexpected factory function (element %v in list) returns nil", i)
+		got_names = append(got_names, s.Name())
+	}
+	// Note: we do not force any order, so compare sorted lists
+	sort.Strings(names)
+	sort.Strings(got_names)
+	g.Expect(got_names).To(Equal(names), "Unexpected factory function in list")
+
+	// 3. Test that error on nil factory functions
+	g.Expect(func() {
+		opt_scc.AddFactoryFunc(nil)
+	}).To(Panic(), "Adding a nil factory function should panic")
+
+}


### PR DESCRIPTION
#### Type of change

- New (build) feature

#### Description

As part of part of the effort to remove go plugins ( [FAB-15338](https://jira.hyperledger.org/browse/FAB-15338)), the support for custom system chaincodes to be loaded via go plugins was remvoed in [FAB-17564](https://jira.hyperledger.org/browse/FAB-17564) . The implication of this change is that currently any project which require custom system chaincode, e.g., [Fabric Private Chaincode](https://github.com/hyperledger-labs/fabric-private-chaincode/), has to patch existing fabric files.

This PR provides a a small extension, dubbed `opt_scc`, which allows to add such custom system chaincode by just adding new files, without touching existing ones, and then allows the selective enablement of said custom chaincodes in builds via build constraints/build tags.


#### Additional details

There are two commits in the PR:
- The core framework and unit tests
- A mock custom SCC to illustrate use of the opt_scc extension point

From a design perspective, the parameters currently passed to the factory functions are the common parameters across the current SCCs started in `internal/peer/node/start.go` and what we needed for FPC.
There seemed to be much less commonality among the remaining parameters, so i left it at the current two (but additional parameters could obviously be easily added.)

BTW: the framework would also easily allow using `opt_scc`  to launch `qscc`.  This is probably not desired but just in case i'm wrong, i would have the corresponding (small) patch at hand ...