### PR TITLE
Document the doc-merge label

### DIFF
--- a/docs/source/docs_guide.md
+++ b/docs/source/docs_guide.md
@@ -292,7 +292,10 @@ can find the maintainers listed in the following `CODEOWNERS` files:
 
 Both language repositories have a GitHub webhook defined so that, once approved,
 your newly merged content in the `docs/` folder will trigger an automatic build
-and publication of the updated documentation.
+and publication of the updated documentation.  
+
+**Note:** Documentation maintainers are not able to to merge documentation PRs by clicking the `Merge pull request` button. Instead, if you are a documentation maintainer and have approved the PR, simply add the label `doc-merge` to the PR and a `Mergify` bot that runs every minute will merge the PR.
+
 
 ## Commands Reference updates
 


### PR DESCRIPTION
Signed-off-by: pama-ibm <pama@ibm.com>

#### Type of change

- Documentation update

#### Description

Documentation Translation maintainers did not realize that they can merge their PRs by adding the `doc-merge` label to the PR after they approve it. I've added these instructions to the documentation section of the contributing guide for their awareness. 
