### PR TITLE
[FAB-18171] Disregard certificate validity period in intra-orderer communication

### DIFF
--- a/common/crypto/expiration_test.go
+++ b/common/crypto/expiration_test.go
@@ -7,8 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package crypto_test
 
 import (
+	"bytes"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -21,6 +23,7 @@ import (
 	"github.com/hyperledger/fabric/protos/msp"
 	"github.com/hyperledger/fabric/protos/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestX509CertExpiresAt(t *testing.T) {
@@ -185,4 +188,119 @@ func TestTrackExpiration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLogNonPubKeyMismatchErr(t *testing.T) {
+	ca, err := tlsgen.NewCA()
+	require.NoError(t, err)
+
+	aliceKeyPair, err := ca.NewClientCertKeyPair()
+	require.NoError(t, err)
+
+	bobKeyPair, err := ca.NewClientCertKeyPair()
+	require.NoError(t, err)
+
+	expected := &bytes.Buffer{}
+	expected.WriteString(fmt.Sprintf("Failed determining if public key of %s matches public key of %s: foo",
+		string(aliceKeyPair.Cert),
+		string(bobKeyPair.Cert)))
+
+	b := &bytes.Buffer{}
+	f := func(template string, args ...interface{}) {
+		fmt.Fprintf(b, template, args...)
+	}
+
+	crypto.LogNonPubKeyMismatchErr(f, errors.New("foo"), aliceKeyPair.TLSCert.Raw, bobKeyPair.TLSCert.Raw)
+
+	require.Equal(t, expected.String(), b.String())
+}
+
+func TestCertificatesWithSamePublicKey(t *testing.T) {
+	ca, err := tlsgen.NewCA()
+	require.NoError(t, err)
+
+	bobKeyPair, err := ca.NewClientCertKeyPair()
+	require.NoError(t, err)
+
+	bobCert := bobKeyPair.Cert
+	bob := pem2der(bobCert)
+
+	aliceCert := `-----BEGIN CERTIFICATE-----
+MIIBNjCB3KADAgECAgELMAoGCCqGSM49BAMCMBAxDjAMBgNVBAUTBUFsaWNlMB4X
+DTIwMDgxODIxMzU1NFoXDTIwMDgyMDIxMzU1NFowEDEOMAwGA1UEBRMFQWxpY2Uw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQjZP5VD/RaczoPFbA4gkt1qb54R6SP
+J/V5oxkhDboG9xWi0wpyghaMGwwxC7Q9wegEnyOVp9nXoLrQ8LUJ5BfZoycwJTAO
+BgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAwwCgYIKwYBBQUHAwIwCgYIKoZIzj0EAwID
+SQAwRgIhAK4le5XgH5edyhaQ9Sz7sFz3Zc4bbhPAzt9zQUYnoqK+AiEA5zcyLB/4
+Oqe93lroE6GF9W7UoCZFzD7lXsWku/dgFOU=
+-----END CERTIFICATE-----`
+
+	reIssuedAliceCert := `-----BEGIN CERTIFICATE-----
+MIIBNDCB3KADAgECAgELMAoGCCqGSM49BAMCMBAxDjAMBgNVBAUTBUFsaWNlMB4X
+DTIwMDgxODIxMzY1NFoXDTIwMDgyMDIxMzY1NFowEDEOMAwGA1UEBRMFQWxpY2Uw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQjZP5VD/RaczoPFbA4gkt1qb54R6SP
+J/V5oxkhDboG9xWi0wpyghaMGwwxC7Q9wegEnyOVp9nXoLrQ8LUJ5BfZoycwJTAO
+BgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAwwCgYIKwYBBQUHAwIwCgYIKoZIzj0EAwID
+RwAwRAIgDc8WyXFvsxCk97KS7D/LdYJxMpDKdHNFqpzJT9LddlsCIEr8KcMd/t5p
+cRv6rqxvy5M+t0DhRtiwCen70YCUsksb
+-----END CERTIFICATE-----`
+
+	alice := pem2der([]byte(aliceCert))
+	aliceMakesComeback := pem2der([]byte(reIssuedAliceCert))
+
+	for _, test := range []struct {
+		description string
+		errContains string
+		first       []byte
+		second      []byte
+	}{
+		{
+			description: "Bad first certificate",
+			errContains: "asn1:",
+			first:       []byte{1, 2, 3},
+			second:      bob,
+		},
+
+		{
+			description: "Bad second certificate",
+			errContains: "asn1:",
+			first:       alice,
+			second:      []byte{1, 2, 3},
+		},
+
+		{
+			description: "Different certificate",
+			errContains: crypto.ErrPubKeyMismatch.Error(),
+			first:       alice,
+			second:      bob,
+		},
+
+		{
+			description: "Same certificate",
+			first:       alice,
+			second:      alice,
+		},
+
+		{
+			description: "Same certificate but different validity period",
+			first:       alice,
+			second:      aliceMakesComeback,
+		},
+	} {
+		t.Run(test.description, func(t *testing.T) {
+			err := crypto.CertificatesWithSamePublicKey(test.first, test.second)
+			if test.errContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func pem2der(p []byte) []byte {
+	b, _ := pem.Decode(p)
+	return b.Bytes
 }

--- a/orderer/common/cluster/comm_test.go
+++ b/orderer/common/cluster/comm_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/common/crypto"
 	"github.com/hyperledger/fabric/common/crypto/tlsgen"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/common/metrics"
@@ -266,6 +267,10 @@ func newTestNodeWithMetrics(t *testing.T, metrics cluster.MetricsProvider, tlsCo
 
 	tstSrv.freezeCond.L = &tstSrv.lock
 
+	compareCert := cluster.CachePublicKeyComparisons(func(a, b []byte) bool {
+		return crypto.CertificatesWithSamePublicKey(a, b) == nil
+	})
+
 	tstSrv.c = &cluster.Comm{
 		CertExpWarningThreshold: time.Hour,
 		SendBufferSize:          1,
@@ -275,6 +280,7 @@ func newTestNodeWithMetrics(t *testing.T, metrics cluster.MetricsProvider, tlsCo
 		ChanExt:                 channelExtractor,
 		Connections:             cluster.NewConnectionStore(dialer, tlsConnGauge),
 		Metrics:                 cluster.NewMetrics(metrics),
+		CompareCertificate:      compareCert,
 	}
 
 	orderer.RegisterClusterServer(gRPCServer.Server(), tstSrv)

--- a/orderer/common/cluster/connections.go
+++ b/orderer/common/cluster/connections.go
@@ -7,11 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package cluster
 
 import (
-	"bytes"
 	"crypto/x509"
 	"sync"
 	"sync/atomic"
 
+	"github.com/hyperledger/fabric/common/crypto"
 	"github.com/hyperledger/fabric/common/metrics"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -59,10 +59,12 @@ func NewConnectionStore(dialer SecureDialer, tlsConnectionCount metrics.Gauge) *
 // itself with the given TLS certificate
 func (c *ConnectionStore) verifyHandshake(endpoint string, certificate []byte) RemoteVerifier {
 	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-		if bytes.Equal(certificate, rawCerts[0]) {
+		err := crypto.CertificatesWithSamePublicKey(certificate, rawCerts[0])
+		if err == nil {
 			return nil
 		}
-		return errors.Errorf("certificate presented by %s doesn't match any authorized certificate", endpoint)
+		return errors.Errorf("public key of server certificate presented by %s doesn't match the expected public key",
+			endpoint)
 	}
 }
 

--- a/orderer/common/server/onboarding.go
+++ b/orderer/common/server/onboarding.go
@@ -49,7 +49,10 @@ func (ri *replicationInitiator) replicateIfNeeded(bootstrapBlock *common.Block) 
 }
 
 func (ri *replicationInitiator) createReplicator(bootstrapBlock *common.Block, filter func(string) bool) *cluster.Replicator {
-	consenterCert := etcdraft.ConsenterCertificate(ri.secOpts.Certificate)
+	consenterCert := &etcdraft.ConsenterCertificate{
+		Logger:               ri.logger,
+		ConsenterCertificate: ri.secOpts.Certificate,
+	}
 	systemChannelName, err := utils.GetChainIDFromBlock(bootstrapBlock)
 	if err != nil {
 		ri.logger.Panicf("Failed extracting system channel name from bootstrap block: %v", err)

--- a/orderer/consensus/etcdraft/chain.go
+++ b/orderer/consensus/etcdraft/chain.go
@@ -1328,8 +1328,13 @@ func (c *Chain) suspectEviction() bool {
 }
 
 func (c *Chain) newEvictionSuspector() *evictionSuspector {
+	consenterCertificate := &ConsenterCertificate{
+		Logger:               c.logger,
+		ConsenterCertificate: c.opts.Cert,
+	}
+
 	return &evictionSuspector{
-		amIInChannel:               ConsenterCertificate(c.opts.Cert).IsConsenterOfChannel,
+		amIInChannel:               consenterCertificate.IsConsenterOfChannel,
 		evictionSuspicionThreshold: c.opts.EvictionSuspicion,
 		writeBlock:                 c.support.Append,
 		createPuller:               c.createPuller,

--- a/orderer/consensus/etcdraft/consenter_test.go
+++ b/orderer/consensus/etcdraft/consenter_test.go
@@ -35,19 +35,27 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+var (
+	certAsPEM []byte
+)
+
 var _ = Describe("Consenter", func() {
 	var (
-		certAsPEM   []byte
 		chainGetter *mocks.ChainGetter
 		support     *consensusmocks.FakeConsenterSupport
 		dataDir     string
 		snapDir     string
 		walDir      string
-		err         error
 	)
 
 	BeforeEach(func() {
-		certAsPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("cert bytes")})
+		ca, err := tlsgen.NewCA()
+		Expect(err).NotTo(HaveOccurred())
+		kp, err := ca.NewClientCertKeyPair()
+		Expect(err).NotTo(HaveOccurred())
+		if certAsPEM == nil {
+			certAsPEM = kp.Cert
+		}
 		chainGetter = &mocks.ChainGetter{}
 		support = &consensusmocks.FakeConsenterSupport{}
 		dataDir, err = ioutil.TempDir("", "snap-")
@@ -144,8 +152,7 @@ var _ = Describe("Consenter", func() {
 	})
 
 	It("successfully constructs a Chain", func() {
-		// We append a line feed to our cert, just to ensure that we can still consume it and ignore.
-		certAsPEMWithLineFeed := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("cert bytes")})
+		certAsPEMWithLineFeed := certAsPEM
 		certAsPEMWithLineFeed = append(certAsPEMWithLineFeed, []byte("\n")...)
 		m := &etcdraftproto.ConfigMetadata{
 			Consenters: []*etcdraftproto.Consenter{
@@ -272,7 +279,7 @@ func newConsenter(chainGetter *mocks.ChainGetter) *consenter {
 	communicator.On("Configure", mock.Anything, mock.Anything)
 	icr := &mocks.InactiveChainRegistry{}
 	icr.On("TrackChain", "foo", mock.Anything, mock.Anything)
-	certAsPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("cert bytes")})
+
 	c := &etcdraft.Consenter{
 		InactiveChainRegistry: icr,
 		Communication:         communicator,

--- a/orderer/consensus/etcdraft/util.go
+++ b/orderer/consensus/etcdraft/util.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package etcdraft
 
 import (
-	"bytes"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -18,6 +17,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/common/channelconfig"
 	"github.com/hyperledger/fabric/common/configtx"
+	"github.com/hyperledger/fabric/common/crypto"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/orderer/common/cluster"
 	"github.com/hyperledger/fabric/orderer/common/localconfig"
@@ -444,14 +444,19 @@ func validateCert(pemData []byte, certRole string) error {
 }
 
 // ConsenterCertificate denotes a TLS certificate of a consenter
-type ConsenterCertificate []byte
+type ConsenterCertificate struct {
+	ConsenterCertificate []byte
+	Logger               *flogging.FabricLogger
+}
+
+// type ConsenterCertificate []byte
 
 // IsConsenterOfChannel returns whether the caller is a consenter of a channel
 // by inspecting the given configuration block.
 // It returns nil if true, else returns an error.
 func (conCert ConsenterCertificate) IsConsenterOfChannel(configBlock *common.Block) error {
-	if configBlock == nil {
-		return errors.New("nil block")
+	if configBlock == nil || configBlock.Header == nil {
+		return errors.New("nil block or nil header")
 	}
 	envelopeConfig, err := utils.ExtractEnvelope(configBlock, 0)
 	if err != nil {
@@ -470,11 +475,38 @@ func (conCert ConsenterCertificate) IsConsenterOfChannel(configBlock *common.Blo
 		return err
 	}
 
+	bl, _ := pem.Decode(conCert.ConsenterCertificate)
+	if bl == nil {
+		return errors.Errorf("my consenter certificate %s is not a valid PEM", string(conCert.ConsenterCertificate))
+	}
+
+	myCertDER := bl.Bytes
+
+	var failedMatches []string
 	for _, consenter := range m.Consenters {
-		if bytes.Equal(conCert, consenter.ServerTlsCert) || bytes.Equal(conCert, consenter.ClientTlsCert) {
+		candidateBlock, _ := pem.Decode(consenter.ServerTlsCert)
+		if candidateBlock == nil {
+			return errors.Errorf("candidate server certificate %s is not a valid PEM", string(consenter.ServerTlsCert))
+		}
+		sameServerCertErr := crypto.CertificatesWithSamePublicKey(myCertDER, candidateBlock.Bytes)
+
+		candidateBlock, _ = pem.Decode(consenter.ClientTlsCert)
+		if candidateBlock == nil {
+			return errors.Errorf("candidate client certificate %s is not a valid PEM", string(consenter.ClientTlsCert))
+		}
+		sameClientCertErr := crypto.CertificatesWithSamePublicKey(myCertDER, candidateBlock.Bytes)
+
+		if sameServerCertErr == nil || sameClientCertErr == nil {
 			return nil
 		}
+		conCert.Logger.Debugf("I am not %s:%d because %s, %s", consenter.Host, consenter.Port, sameServerCertErr, sameClientCertErr)
+		failedMatches = append(failedMatches, string(consenter.ClientTlsCert))
 	}
+	conCert.Logger.Debugf("Failed matching our certificate %s against certificates encoded in config block %d: %v",
+		string(conCert.ConsenterCertificate),
+		configBlock.Header.Number,
+		failedMatches)
+
 	return cluster.ErrNotInChannel
 }
 


### PR DESCRIPTION
This change set makes the orderer cluster authentication infrastructure
disregard validity periods when comparing certificates, and only regard public keys.

With this change, one can replace the TLS certificate of Raft,
by a certificate that has the same public key without issuing channel config updates.

This is to ensure that if a certificate of a consenter expired,
one can quickly renew it and start the orderer without performing
a config update per channel.

Change-Id: Id1b29e220d37aa33617b2143b702075bf5b01f6f
Signed-off-by: yacovm <yacovm@il.ibm.com>
