### PR TITLE
Populate metadata-hint db from snapshot files

### DIFF
--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/optimization.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/optimization.go
@@ -45,6 +45,14 @@ func (h *metadataHint) setMetadataUsedFlag(updates *UpdateBatch) error {
 	return h.bookkeeper.WriteBatch(batch, true)
 }
 
+func (h *metadataHint) importNamespacesThatUseMetadata(namespaces map[string]struct{}) error {
+	batch := h.bookkeeper.NewUpdateBatch()
+	for ns := range namespaces {
+		batch.Put([]byte(ns), []byte{})
+	}
+	return h.bookkeeper.WriteBatch(batch, true)
+}
+
 func filterNamespacesThatHasMetadata(updates *UpdateBatch) map[string]bool {
 	namespaces := map[string]bool{}
 	pubUpdates, hashUpdates := updates.PubUpdates, updates.HashUpdates


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Description
This commits loads the data into metadata-hint db while importing the world state from snapshot files.