### PR TITLE
Documentation - Fixes softhsm default config path

### DIFF
--- a/docs/source/dev-setup/devenv.rst
+++ b/docs/source/dev-setup/devenv.rst
@@ -109,7 +109,7 @@ SoftHSM generally requires additional configuration before it can be used. For
 example, the default configuration will attempt to store token data in a system
 directory that unprivileged users are unable to write to.
 
-SoftHSM configuration typically involves copying ``/etc/softhsm2.conf`` to
+SoftHSM configuration typically involves copying ``/etc/softhsm/softhsm2.conf`` to
 ``$HOME/.config/softhsm2/softhsm2.conf`` and changing ``directories.tokendir``
 to an appropriate location. Please see the man page for ``softhsm2.conf`` for
 details.


### PR DESCRIPTION
Fixes the default softhsm configuration path on setting environment manual.

#### Type of change

- Documentation update

#### Description

In the documentation the softhsm default config path was wrong "/etc/softhsm2.conf" the correct is "/etc/softhsm/softhsm2.conf"
