### PR TITLE
[FAB-18194] Fix service discovery for legacy installed chaincodes

### DIFF
--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -366,6 +366,10 @@ func serve(args []string) error {
 		LegacyDeployedCCInfoProvider: &lscc.DeployedCCInfoProvider{},
 	}
 
+	// Configure CC package storage before ccInfoFSImpl.ListInstalledChaincodes() gets called
+	lsccInstallPath := filepath.Join(coreconfig.GetPath("peer.fileSystemPath"), "chaincodes")
+	ccprovider.SetChaincodesPath(lsccInstallPath)
+
 	ccInfoFSImpl := &ccprovider.CCInfoFSImpl{GetHasher: factory.GetDefault()}
 
 	// legacyMetadataManager collects metadata information from the legacy
@@ -457,10 +461,6 @@ func serve(args []string) error {
 	defer gossipService.Stop()
 
 	peerInstance.GossipService = gossipService
-
-	// Configure CC package storage
-	lsccInstallPath := filepath.Join(coreconfig.GetPath("peer.fileSystemPath"), "chaincodes")
-	ccprovider.SetChaincodesPath(lsccInstallPath)
 
 	if err := lifecycleCache.InitializeLocalChaincodes(); err != nil {
 		return errors.WithMessage(err, "could not initialize local chaincodes")


### PR DESCRIPTION
Service discovery endorsers query fails with errors:
"failed constructing descriptor for chaincodes"
"required chaincodes are not installed on sufficient peers"

The chaincodes installed with legacy chaincode lifecycle were not getting recognized
after peer restart since the path to installed chaincodes was set after
the legacy chaincode cache initialized.
Setting the installed chaincode path earlier in peer start sequence resolves the issue.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
