### PR TITLE
FAB-17915 Ch.Part.API: switch member to follower

### DIFF
--- a/orderer/consensus/etcdraft/chain.go
+++ b/orderer/consensus/etcdraft/chain.go
@@ -431,7 +431,7 @@ func (c *Chain) Halt() {
 }
 
 // halt stops the chain and calls the haltCallback function, which allows the
-// chain to transfer responsbility to a follower or inactive chain when a chain
+// chain to transfer responsibility to a follower or inactive chain when a chain
 // discovers it is no longer a member of a channel
 func (c *Chain) halt() {
 	c.Halt()

--- a/orderer/consensus/etcdraft/consenter_test.go
+++ b/orderer/consensus/etcdraft/consenter_test.go
@@ -256,10 +256,14 @@ var _ = Describe("Consenter", func() {
 		consenter.EtcdRaftConfig.SnapDir = snapDir
 		// consenter.EtcdRaftConfig.EvictionSuspicion is missing
 		var defaultSuspicionFallback bool
+		var trackChainCallback bool
 		consenter.Metrics = newFakeMetrics(newFakeMetricsFields())
 		consenter.Logger = consenter.Logger.WithOptions(zap.Hooks(func(entry zapcore.Entry) error {
 			if strings.Contains(entry.Message, "EvictionSuspicion not set, defaulting to 10m0s") {
 				defaultSuspicionFallback = true
+			}
+			if strings.Contains(entry.Message, "With system channel: after eviction InactiveChainRegistry.TrackChain will be called") {
+				trackChainCallback = true
 			}
 			return nil
 		}))
@@ -270,6 +274,7 @@ var _ = Describe("Consenter", func() {
 
 		Expect(chain.Start).NotTo(Panic())
 		Expect(defaultSuspicionFallback).To(BeTrue())
+		Expect(trackChainCallback).To(BeTrue())
 	})
 
 	It("successfully constructs a Chain without a system channel", func() {
@@ -306,10 +311,14 @@ var _ = Describe("Consenter", func() {
 
 		// consenter.EtcdRaftConfig.EvictionSuspicion is missing
 		var defaultSuspicionFallback bool
+		var switchToFollowerCallback bool
 		consenter.Metrics = newFakeMetrics(newFakeMetricsFields())
 		consenter.Logger = consenter.Logger.WithOptions(zap.Hooks(func(entry zapcore.Entry) error {
 			if strings.Contains(entry.Message, "EvictionSuspicion not set, defaulting to 10m0s") {
 				defaultSuspicionFallback = true
+			}
+			if strings.Contains(entry.Message, "Without system channel: after eviction Registrar.SwitchToFollower will be called") {
+				switchToFollowerCallback = true
 			}
 			return nil
 		}))
@@ -320,6 +329,7 @@ var _ = Describe("Consenter", func() {
 
 		Expect(chain.Start).NotTo(Panic())
 		Expect(defaultSuspicionFallback).To(BeTrue())
+		Expect(switchToFollowerCallback).To(BeTrue())
 		Expect(chain.Halt).NotTo(Panic())
 	})
 


### PR DESCRIPTION
An orderer that is a cluster member of a channel, detects that it is no longer a member by observing the incoming channel config. When that happens, the etcdraft.Chain shuts down and switches to follower.Chain.

This only works when there is no system-channel.

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: I39f901b8960ea0b96af059e985b3dad1bdb94b62


#### Type of change
- New feature

#### Related issues

Task: FAB-17915
Story: FAB-15711
Epic: FAB-17715
