### PR TITLE
Peer CLI communicate with orderers with expired TLS certs

### DIFF
--- a/integration/nwo/commands/peer.go
+++ b/integration/nwo/commands/peer.go
@@ -8,6 +8,7 @@ package commands
 
 import (
 	"strconv"
+	"time"
 )
 
 type NodeStart struct {
@@ -135,11 +136,12 @@ func (c ChannelJoin) Args() []string {
 }
 
 type ChannelFetch struct {
-	ChannelID  string
-	Block      string
-	Orderer    string
-	OutputFile string
-	ClientAuth bool
+	ChannelID             string
+	Block                 string
+	Orderer               string
+	OutputFile            string
+	ClientAuth            bool
+	TLSHandshakeTimeShift time.Duration
 }
 
 func (c ChannelFetch) SessionName() string {
@@ -149,15 +151,10 @@ func (c ChannelFetch) SessionName() string {
 func (c ChannelFetch) Args() []string {
 	args := []string{
 		"channel", "fetch", c.Block,
-	}
-	if c.ChannelID != "" {
-		args = append(args, "--channelID", c.ChannelID)
-	}
-	if c.Orderer != "" {
-		args = append(args, "--orderer", c.Orderer)
-	}
-	if c.OutputFile != "" {
-		args = append(args, c.OutputFile)
+		"--channelID", c.ChannelID,
+		"--orderer", c.Orderer,
+		"--tlsHandshakeTimeShift", c.TLSHandshakeTimeShift.String(),
+		c.OutputFile,
 	}
 	if c.ClientAuth {
 		args = append(args, "--clientauth")
@@ -747,10 +744,11 @@ func (s SignConfigTx) Args() []string {
 }
 
 type ChannelUpdate struct {
-	ChannelID  string
-	Orderer    string
-	File       string
-	ClientAuth bool
+	ChannelID             string
+	Orderer               string
+	File                  string
+	ClientAuth            bool
+	TLSHandshakeTimeShift time.Duration
 }
 
 func (c ChannelUpdate) SessionName() string {
@@ -763,6 +761,7 @@ func (c ChannelUpdate) Args() []string {
 		"--channelID", c.ChannelID,
 		"--orderer", c.Orderer,
 		"--file", c.File,
+		"--tlsHandshakeTimeShift", c.TLSHandshakeTimeShift.String(),
 	}
 	if c.ClientAuth {
 		args = append(args, "--clientauth")

--- a/integration/raft/cft_test.go
+++ b/integration/raft/cft_test.go
@@ -17,12 +17,14 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/protobuf/proto"
+	conftx "github.com/hyperledger/fabric-config/configtx"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric/cmd/common/signer"
@@ -427,7 +429,8 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			o3Runner = network.OrdererRunner(o3)
 
 			By("Launching orderers with a clustered timeshift")
-			for _, orderer := range []*nwo.Orderer{o1, o2, o3} {
+			orderers := []*nwo.Orderer{o1, o2, o3}
+			for _, orderer := range orderers {
 				ordererConfig := network.ReadOrdererConfig(orderer)
 				ordererConfig.General.Cluster.TLSHandshakeTimeShift = 5 * time.Minute
 				network.WriteOrdererConfig(orderer, ordererConfig)
@@ -457,7 +460,7 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			o3Runner = network.OrdererRunner(o3)
 
 			By("Launching orderers again without a general timeshift re-using the cluster port")
-			for _, orderer := range []*nwo.Orderer{o1, o2, o3} {
+			for _, orderer := range orderers {
 				ordererConfig := network.ReadOrdererConfig(orderer)
 				ordererConfig.General.ListenPort = ordererConfig.General.Cluster.ListenPort
 				ordererConfig.General.TLS.Certificate = ordererConfig.General.Cluster.ServerCertificate
@@ -496,10 +499,58 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			o3Runner = network.OrdererRunner(o3)
 
 			By("Launching orderers again with a general timeshift re-using the cluster port")
-			for _, orderer := range []*nwo.Orderer{o1, o2, o3} {
+			for _, orderer := range orderers {
 				ordererConfig := network.ReadOrdererConfig(orderer)
 				ordererConfig.General.TLS.TLSHandshakeTimeShift = 5 * time.Minute
 				network.WriteOrdererConfig(orderer, ordererConfig)
+			}
+
+			o1Proc = ifrit.Invoke(o1Runner)
+			o2Proc = ifrit.Invoke(o2Runner)
+			o3Proc = ifrit.Invoke(o3Runner)
+
+			Eventually(o1Proc.Ready(), network.EventuallyTimeout).Should(BeClosed())
+			Eventually(o2Proc.Ready(), network.EventuallyTimeout).Should(BeClosed())
+			Eventually(o3Proc.Ready(), network.EventuallyTimeout).Should(BeClosed())
+
+			By("Waiting for a leader to be elected")
+			findLeader([]*ginkgomon.Runner{o1Runner, o2Runner, o3Runner})
+
+			By("submitting config updates to orderers with expired TLS certs to replace the expired certs")
+			for _, o := range orderers {
+				timeShift := 5 * time.Minute
+				configBlock := fetchConfigBlock(network, peer, o, nwo.ClusterPort, network.SystemChannel.Name, timeShift)
+				channelConfig := configFromBlock(configBlock)
+				c := conftx.New(channelConfig)
+				err = c.Orderer().RemoveConsenter(consenterChannelConfig(network, o))
+				Expect(err).NotTo(HaveOccurred())
+
+				By("renewing the orderer TLS certificates for " + o.Name)
+				renewOrdererCertificates(network, o)
+				err = c.Orderer().AddConsenter(consenterChannelConfig(network, o))
+				Expect(err).NotTo(HaveOccurred())
+
+				By("updating the config for " + o.Name)
+				updateOrdererConfig(network, o, nwo.ClusterPort, network.SystemChannel.Name, timeShift, c.OriginalConfig(), c.UpdatedConfig(), peer)
+			}
+
+			By("Killing orderers")
+			o1Proc.Signal(syscall.SIGTERM)
+			o2Proc.Signal(syscall.SIGTERM)
+			o3Proc.Signal(syscall.SIGTERM)
+			Eventually(o1Proc.Wait(), network.EventuallyTimeout).Should(Receive())
+			Eventually(o2Proc.Wait(), network.EventuallyTimeout).Should(Receive())
+			Eventually(o3Proc.Wait(), network.EventuallyTimeout).Should(Receive())
+
+			o1Runner = network.OrdererRunner(o1)
+			o2Runner = network.OrdererRunner(o2)
+			o3Runner = network.OrdererRunner(o3)
+
+			By("Launching orderers again without a general timeshift")
+			for _, o := range orderers {
+				ordererConfig := network.ReadOrdererConfig(o)
+				ordererConfig.General.TLS.TLSHandshakeTimeShift = 0
+				network.WriteOrdererConfig(o, ordererConfig)
 			}
 
 			o1Proc = ifrit.Invoke(o1Runner)
@@ -764,8 +815,11 @@ func findLeader(ordererRunners []*ginkgomon.Runner) int {
 	return firstLeader
 }
 
-func renewOrdererCertificates(network *nwo.Network, o1, o2, o3 *nwo.Orderer) {
-	ordererDomain := network.Organization(o1.Organization).Domain
+func renewOrdererCertificates(network *nwo.Network, orderers ...*nwo.Orderer) {
+	if len(orderers) == 0 {
+		return
+	}
+	ordererDomain := network.Organization(orderers[0].Organization).Domain
 	ordererTLSCAKeyPath := filepath.Join(network.RootDir, "crypto", "ordererOrganizations",
 		ordererDomain, "tlsca", "priv_sk")
 
@@ -777,8 +831,8 @@ func renewOrdererCertificates(network *nwo.Network, o1, o2, o3 *nwo.Orderer) {
 	ordererTLSCACert, err := ioutil.ReadFile(ordererTLSCACertPath)
 	Expect(err).NotTo(HaveOccurred())
 
-	serverTLSCerts := make(map[string][]byte)
-	for _, orderer := range []*nwo.Orderer{o1, o2, o3} {
+	serverTLSCerts := map[string][]byte{}
+	for _, orderer := range orderers {
 		tlsCertPath := filepath.Join(network.OrdererLocalTLSDir(orderer), "server.crt")
 		serverTLSCerts[tlsCertPath], err = ioutil.ReadFile(tlsCertPath)
 		Expect(err).NotTo(HaveOccurred())
@@ -895,7 +949,10 @@ func configFromBootstrapBlock(bootstrapBlock []byte) *common.Config {
 	block := &common.Block{}
 	err := proto.Unmarshal(bootstrapBlock, block)
 	Expect(err).NotTo(HaveOccurred())
+	return configFromBlock(block)
+}
 
+func configFromBlock(block *common.Block) *common.Config {
 	envelope, err := protoutil.GetEnvelopeFromBlock(block.Data.Data[0])
 	Expect(err).NotTo(HaveOccurred())
 
@@ -907,5 +964,64 @@ func configFromBootstrapBlock(bootstrapBlock []byte) *common.Config {
 	Expect(err).NotTo(HaveOccurred())
 
 	return configEnv.Config
+}
 
+func fetchConfigBlock(n *nwo.Network, peer *nwo.Peer, orderer *nwo.Orderer, port nwo.PortName, channel string, tlsHandshakeTimeShift time.Duration) *common.Block {
+	tempDir, err := ioutil.TempDir(n.RootDir, "fetchConfigBlock")
+	Expect(err).NotTo(HaveOccurred())
+	defer os.RemoveAll(tempDir)
+
+	output := filepath.Join(tempDir, "config_block.pb")
+	sess, err := n.OrdererAdminSession(orderer, peer, commands.ChannelFetch{
+		ChannelID:             channel,
+		Block:                 "config",
+		Orderer:               n.OrdererAddress(orderer, port),
+		OutputFile:            output,
+		ClientAuth:            n.ClientAuthRequired,
+		TLSHandshakeTimeShift: tlsHandshakeTimeShift,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
+	Expect(sess.Err).To(gbytes.Say("Received block: "))
+
+	configBlock := nwo.UnmarshalBlockFromFile(output)
+	return configBlock
+}
+
+func currentConfigBlockNumber(n *nwo.Network, peer *nwo.Peer, orderer *nwo.Orderer, port nwo.PortName, channel string, tlsHandshakeTimeShift time.Duration) uint64 {
+	configBlock := fetchConfigBlock(n, peer, orderer, port, channel, tlsHandshakeTimeShift)
+	return configBlock.Header.Number
+}
+
+func updateOrdererConfig(n *nwo.Network, orderer *nwo.Orderer, port nwo.PortName, channel string, tlsHandshakeTimeShift time.Duration, current, updated *common.Config, submitter *nwo.Peer, additionalSigners ...*nwo.Orderer) {
+	tempDir, err := ioutil.TempDir(n.RootDir, "updateConfig")
+	Expect(err).NotTo(HaveOccurred())
+	updateFile := filepath.Join(tempDir, "update.pb")
+	defer os.RemoveAll(tempDir)
+
+	currentBlockNumber := currentConfigBlockNumber(n, submitter, orderer, port, channel, tlsHandshakeTimeShift)
+	nwo.ComputeUpdateOrdererConfig(updateFile, n, channel, current, updated, submitter, additionalSigners...)
+
+	Eventually(func() bool {
+		sess, err := n.OrdererAdminSession(orderer, submitter, commands.ChannelUpdate{
+			ChannelID:             channel,
+			Orderer:               n.OrdererAddress(orderer, port),
+			File:                  updateFile,
+			ClientAuth:            n.ClientAuthRequired,
+			TLSHandshakeTimeShift: tlsHandshakeTimeShift,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		sess.Wait(n.EventuallyTimeout)
+		if sess.ExitCode() != 0 {
+			return false
+		}
+
+		return strings.Contains(string(sess.Err.Contents()), "Successfully submitted channel update")
+	}, n.EventuallyTimeout).Should(BeTrue())
+
+	ccb := func() uint64 {
+		return currentConfigBlockNumber(n, submitter, orderer, port, channel, tlsHandshakeTimeShift)
+	}
+	Eventually(ccb, n.EventuallyTimeout).Should(BeNumerically(">", currentBlockNumber))
 }

--- a/internal/peer/chaincode/common.go
+++ b/internal/peer/chaincode/common.go
@@ -500,7 +500,6 @@ func InitCmdFactory(cmdName string, isEndorserRequired, isOrdererRequired bool, 
 		}
 
 		broadcastClient, err = common.GetBroadcastClientFnc()
-
 		if err != nil {
 			return nil, errors.WithMessage(err, "error getting broadcast client")
 		}

--- a/internal/peer/common/common.go
+++ b/internal/peer/common/common.go
@@ -245,7 +245,9 @@ func configFromEnv(prefix string) (address, override string, clientConfig comm.C
 	clientConfig.Timeout = connTimeout
 	secOpts := comm.SecureOptions{
 		UseTLS:            viper.GetBool(prefix + ".tls.enabled"),
-		RequireClientCert: viper.GetBool(prefix + ".tls.clientAuthRequired")}
+		RequireClientCert: viper.GetBool(prefix + ".tls.clientAuthRequired"),
+		TimeShift:         viper.GetDuration(prefix + ".tls.handshakeTimeShift"),
+	}
 	if secOpts.UseTLS {
 		caPEM, res := ioutil.ReadFile(config.GetPath(prefix + ".tls.rootcert.file"))
 		if res != nil {

--- a/internal/peer/common/deliverclient.go
+++ b/internal/peer/common/deliverclient.go
@@ -163,7 +163,6 @@ type ordererDeliverService struct {
 
 // NewDeliverClientForOrderer creates a new DeliverClient from an OrdererClient
 func NewDeliverClientForOrderer(channelID string, signer identity.SignerSerializer, bestEffort bool) (*DeliverClient, error) {
-	var tlsCertHash []byte
 	oc, err := NewOrdererClientFromEnv()
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create deliver client for orderer")
@@ -174,6 +173,7 @@ func NewDeliverClientForOrderer(channelID string, signer identity.SignerSerializ
 		return nil, errors.WithMessage(err, "failed to create deliver client for orderer")
 	}
 	// check for client certificate and create hash if present
+	var tlsCertHash []byte
 	if len(oc.Certificate().Certificate) > 0 {
 		tlsCertHash = util.ComputeSHA256(oc.Certificate().Certificate[0])
 	}

--- a/internal/peer/common/ordererclient.go
+++ b/internal/peer/common/ordererclient.go
@@ -35,7 +35,9 @@ func NewOrdererClientFromEnv() (*OrdererClient, error) {
 		CommonClient: CommonClient{
 			GRPCClient: gClient,
 			Address:    address,
-			sn:         override}}
+			sn:         override,
+		},
+	}
 	return oClient, nil
 }
 

--- a/internal/peer/common/ordererenv.go
+++ b/internal/peer/common/ordererenv.go
@@ -21,6 +21,7 @@ var (
 	certFile                   string
 	ordererTLSHostnameOverride string
 	connTimeout                time.Duration
+	tlsHandshakeTimeShift      time.Duration
 )
 
 // SetOrdererEnv adds orderer-specific settings to the global Viper environment
@@ -45,26 +46,29 @@ func SetOrdererEnv(cmd *cobra.Command, args []string) {
 	viper.Set("orderer.tls.enabled", tlsEnabled)
 	viper.Set("orderer.tls.clientAuthRequired", clientAuth)
 	viper.Set("orderer.client.connTimeout", connTimeout)
+	viper.Set("orderer.tls.handshakeTimeShift", tlsHandshakeTimeShift)
 }
 
 // AddOrdererFlags adds flags for orderer-related commands
 func AddOrdererFlags(cmd *cobra.Command) {
 	flags := cmd.PersistentFlags()
 
-	flags.StringVarP(&OrderingEndpoint, "orderer", "o", "", "Ordering service endpoint")
-	flags.BoolVarP(&tlsEnabled, "tls", "", false, "Use TLS when communicating with the orderer endpoint")
+	flags.StringVarP(&OrderingEndpoint, "orderer", "o", "",
+		"Ordering service endpoint")
+	flags.BoolVarP(&tlsEnabled, "tls", "", false,
+		"Use TLS when communicating with the orderer endpoint")
 	flags.BoolVarP(&clientAuth, "clientauth", "", false,
 		"Use mutual TLS when communicating with the orderer endpoint")
 	flags.StringVarP(&caFile, "cafile", "", "",
 		"Path to file containing PEM-encoded trusted certificate(s) for the ordering endpoint")
 	flags.StringVarP(&keyFile, "keyfile", "", "",
-		"Path to file containing PEM-encoded private key to use for mutual TLS "+
-			"communication with the orderer endpoint")
+		"Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint")
 	flags.StringVarP(&certFile, "certfile", "", "",
-		"Path to file containing PEM-encoded X509 public key to use for "+
-			"mutual TLS communication with the orderer endpoint")
-	flags.StringVarP(&ordererTLSHostnameOverride, "ordererTLSHostnameOverride",
-		"", "", "The hostname override to use when validating the TLS connection to the orderer.")
-	flags.DurationVarP(&connTimeout, "connTimeout",
-		"", 3*time.Second, "Timeout for client to connect")
+		"Path to file containing PEM-encoded X509 public key to use for mutual TLS communication with the orderer endpoint")
+	flags.StringVarP(&ordererTLSHostnameOverride, "ordererTLSHostnameOverride", "", "",
+		"The hostname override to use when validating the TLS connection to the orderer")
+	flags.DurationVarP(&connTimeout, "connTimeout", "", 3*time.Second,
+		"Timeout for client to connect")
+	flags.DurationVarP(&tlsHandshakeTimeShift, "tlsHandshakeTimeShift", "", 0,
+		"The amount of time to shift backwards for certificate expiration checks during TLS handshakes")
 }

--- a/internal/pkg/comm/client.go
+++ b/internal/pkg/comm/client.go
@@ -79,8 +79,7 @@ func (client *GRPCClient) parseSecureOptions(opts SecureOptions) error {
 			err := AddPemToCertPool(certBytes, client.tlsConfig.RootCAs)
 			if err != nil {
 				commLogger.Debugf("error adding root certificate: %v", err)
-				return errors.WithMessage(err,
-					"error adding root certificate")
+				return errors.WithMessage(err, "error adding root certificate")
 			}
 		}
 	}
@@ -91,14 +90,12 @@ func (client *GRPCClient) parseSecureOptions(opts SecureOptions) error {
 			cert, err := tls.X509KeyPair(opts.Certificate,
 				opts.Key)
 			if err != nil {
-				return errors.WithMessage(err, "failed to "+
-					"load client certificate")
+				return errors.WithMessage(err, "failed to load client certificate")
 			}
 			client.tlsConfig.Certificates = append(
 				client.tlsConfig.Certificates, cert)
 		} else {
-			return errors.New("both Key and Certificate " +
-				"are required when using mutual TLS")
+			return errors.New("both Key and Certificate are required when using mutual TLS")
 		}
 	}
 


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Implement a TLS handshake timeshift for the "peer channel fetch" and "peer channel update" comands to allow fetching config blocks and updating the config for orderers with expired TLS certificates.

#### Related issues

[FAB-18205](https://jira.hyperledger.org/browse/FAB-18205)