### PR TITLE
Create statedb indexes when creating ledger from snapshot

### DIFF
--- a/core/chaincode/lifecycle/cache_test.go
+++ b/core/chaincode/lifecycle/cache_test.go
@@ -768,6 +768,189 @@ var _ = Describe("Cache", func() {
 		})
 	})
 
+	Describe("RegisterListener", func() {
+		var fakeListener *ledgermock.ChaincodeLifecycleEventListener
+		BeforeEach(func() {
+			fakeListener = &ledgermock.ChaincodeLifecycleEventListener{}
+			channelCache = &lifecycle.ChannelCache{
+				Chaincodes: map[string]*lifecycle.CachedChaincodeDefinition{
+					"definedInstalledAndApprovedCC": {
+						Definition: &lifecycle.ChaincodeDefinition{
+							Sequence: 3,
+							EndorsementInfo: &lb.ChaincodeEndorsementInfo{
+								Version: "chaincode-version",
+							},
+							ValidationInfo: &lb.ChaincodeValidationInfo{
+								ValidationParameter: []byte("validation-parameter"),
+							},
+							Collections: &pb.CollectionConfigPackage{},
+						},
+						Approved: true,
+					},
+					"anotherDefinedInstalledAndApprovedCC": {
+						Definition: &lifecycle.ChaincodeDefinition{
+							Sequence: 3,
+							EndorsementInfo: &lb.ChaincodeEndorsementInfo{
+								Version: "chaincode-version",
+							},
+							ValidationInfo: &lb.ChaincodeValidationInfo{
+								ValidationParameter: []byte("validation-parameter"),
+							},
+							Collections: &pb.CollectionConfigPackage{},
+						},
+						Approved: true,
+					},
+					"idontapprove": {
+						Definition: &lifecycle.ChaincodeDefinition{
+							Sequence: 3,
+							EndorsementInfo: &lb.ChaincodeEndorsementInfo{
+								Version: "chaincode-version",
+							},
+							ValidationInfo: &lb.ChaincodeValidationInfo{
+								ValidationParameter: []byte("validation-parameter"),
+							},
+							Collections: &pb.CollectionConfigPackage{},
+						},
+						Approved: false,
+					},
+					"ididntinstall": {
+						Definition: &lifecycle.ChaincodeDefinition{
+							Sequence: 3,
+							EndorsementInfo: &lb.ChaincodeEndorsementInfo{
+								Version: "chaincode-version",
+							},
+							ValidationInfo: &lb.ChaincodeValidationInfo{
+								ValidationParameter: []byte("validation-parameter"),
+							},
+							Collections: &pb.CollectionConfigPackage{},
+						},
+						Approved: true,
+					},
+				},
+			}
+
+			localChaincodes = map[string]*lifecycle.LocalChaincode{
+				string(util.ComputeSHA256(protoutil.MarshalOrPanic(&lb.StateData{
+					Type: &lb.StateData_String_{String_: "packageID"},
+				}))): {
+					References: map[string]map[string]*lifecycle.CachedChaincodeDefinition{
+						"channel-id": {
+							"definedInstalledAndApprovedCC": channelCache.Chaincodes["definedInstalledAndApprovedCC"],
+							"idontapprove":                  channelCache.Chaincodes["idontapprove"],
+						},
+					},
+				},
+
+				string(util.ComputeSHA256(protoutil.MarshalOrPanic(&lb.StateData{
+					Type: &lb.StateData_String_{String_: "anotherPackageID"},
+				}))): {
+					References: map[string]map[string]*lifecycle.CachedChaincodeDefinition{
+						"channel-id": {
+							"anotherDefinedInstalledAndApprovedCC": channelCache.Chaincodes["anotherDefinedInstalledAndApprovedCC"],
+						},
+					},
+				},
+			}
+
+			fakeCCStore.ListInstalledChaincodesReturns([]chaincode.InstalledChaincode{
+				{
+					Hash:      []byte("hash"),
+					PackageID: "packageID",
+				},
+				{
+					Hash:      []byte("hash"),
+					PackageID: "anotherPackageID",
+				},
+			}, nil)
+
+			lifecycle.SetChaincodeMap(c, "channel-id", channelCache)
+			lifecycle.SetLocalChaincodesMap(c, localChaincodes)
+			err := c.InitializeLocalChaincodes()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when channel does not exist", func() {
+			It("returns error", func() {
+				err := c.RegisterListener("non-existing-channel", fakeListener, true)
+				Expect(err).To(MatchError("unknown channel 'non-existing-channel'"))
+			})
+		})
+
+		Context("when listener wants existing chaincode info", func() {
+			It("calls back the listener with only invocable chaincodes", func() {
+				err := c.RegisterListener("channel-id", fakeListener, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeListener.HandleChaincodeDeployCallCount()).To(Equal(2))
+				Expect(fakeListener.ChaincodeDeployDoneCallCount()).To(Equal(2))
+				ccdef0, dbArtifacts0 := fakeListener.HandleChaincodeDeployArgsForCall(0)
+				ccdef1, dbArtifacts1 := fakeListener.HandleChaincodeDeployArgsForCall(1)
+				Expect(
+					[]*ledger.ChaincodeDefinition{
+						ccdef0,
+						ccdef1,
+					},
+				).To(ConsistOf(
+					[]*ledger.ChaincodeDefinition{
+						{
+							Name:              "definedInstalledAndApprovedCC",
+							Version:           "chaincode-version",
+							Hash:              []byte("packageID"),
+							CollectionConfigs: &pb.CollectionConfigPackage{},
+						},
+						{
+							Name:              "anotherDefinedInstalledAndApprovedCC",
+							Version:           "chaincode-version",
+							Hash:              []byte("anotherPackageID"),
+							CollectionConfigs: &pb.CollectionConfigPackage{},
+						},
+					},
+				))
+				Expect([][]byte{dbArtifacts0, dbArtifacts1}).To(Equal([][]byte{[]byte("db-artifacts"), []byte("db-artifacts")}))
+			})
+
+			Context("when chaincode store returns error for one of the chaincodes", func() {
+				BeforeEach(func() {
+					fakeCCStore.LoadStub = func(packageID string) ([]byte, error) {
+						if packageID == "packageID" {
+							return nil, fmt.Errorf("loading-error")
+						}
+						return []byte("package-bytes"), nil
+					}
+				})
+				It("supresses the error", func() {
+					err := c.RegisterListener("channel-id", fakeListener, true)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeListener.HandleChaincodeDeployCallCount()).To(Equal(1))
+					Expect(fakeListener.ChaincodeDeployDoneCallCount()).To(Equal(1))
+				})
+			})
+
+			Context("when chaincode package parser returns error for both the chaincodes", func() {
+				BeforeEach(func() {
+					fakeParser.ParseReturns(nil, fmt.Errorf("parsing-error"))
+				})
+				It("supresses the error", func() {
+					err := c.RegisterListener("channel-id", fakeListener, true)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeListener.HandleChaincodeDeployCallCount()).To(Equal(0))
+					Expect(fakeListener.ChaincodeDeployDoneCallCount()).To(Equal(0))
+				})
+			})
+
+			Context("when listener returns error", func() {
+				BeforeEach(func() {
+					fakeListener.HandleChaincodeDeployReturns(fmt.Errorf("listener-error"))
+				})
+				It("supresses the error", func() {
+					err := c.RegisterListener("channel-id", fakeListener, true)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeListener.HandleChaincodeDeployCallCount()).To(Equal(2))
+					Expect(fakeListener.HandleChaincodeDeployCallCount()).To(Equal(2))
+				})
+			})
+		})
+	})
+
 	Describe("StateListener", func() {
 		Describe("InterestedInNamespaces", func() {
 			It("returns _lifecycle", func() {
@@ -906,7 +1089,7 @@ var _ = Describe("Cache", func() {
 
 		BeforeEach(func() {
 			fakeListener = &ledgermock.ChaincodeLifecycleEventListener{}
-			c.RegisterListener("channel-id", fakeListener)
+			c.RegisterListener("channel-id", fakeListener, false)
 
 		})
 

--- a/core/chaincode/lifecycle/event_broker.go
+++ b/core/chaincode/lifecycle/event_broker.go
@@ -35,7 +35,45 @@ func NewEventBroker(chaincodeStore ChaincodeStore, pkgParser PackageParser, ebMe
 	}
 }
 
-func (b *EventBroker) RegisterListener(channelID string, listener ledger.ChaincodeLifecycleEventListener) {
+func (b *EventBroker) RegisterListener(
+	channelID string,
+	listener ledger.ChaincodeLifecycleEventListener,
+	existingCachedChaincodes map[string]*CachedChaincodeDefinition) {
+	// when invoking chaincode event listener with existing invocable chaincodes, we logs
+	// errors instead of returning the error from this function to keep the consustent behavior
+	// similar to the code path when we invoke the listener later on as a response to the chaincode
+	// lifecycle events. See other functions below for details on this behavior.
+	for chaincodeName, cachedChaincode := range existingCachedChaincodes {
+		if !isChaincodeInvocable(cachedChaincode) {
+			continue
+		}
+
+		dbArtifacts, err := b.loadDBArtifacts(cachedChaincode.InstallInfo.PackageID)
+		if err != nil {
+			logger.Errorw(
+				"error while loading db artifacts for chaincode package. Continuing...",
+				"packageID", cachedChaincode.InstallInfo.PackageID,
+				"error", err,
+			)
+			continue
+		}
+		legacyDefinition := &ledger.ChaincodeDefinition{
+			Name:              chaincodeName,
+			Version:           cachedChaincode.Definition.EndorsementInfo.Version,
+			Hash:              []byte(cachedChaincode.InstallInfo.PackageID),
+			CollectionConfigs: cachedChaincode.Definition.Collections,
+		}
+
+		if err := listener.HandleChaincodeDeploy(legacyDefinition, dbArtifacts); err != nil {
+			logger.Errorw(
+				"error while invoking chaincode lifecycle events listener. Continuing...",
+				"packageID", cachedChaincode.InstallInfo.PackageID,
+				"error", err,
+			)
+		}
+		listener.ChaincodeDeployDone(true)
+	}
+
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 	b.listeners[channelID] = append(b.listeners[channelID], listener)
@@ -53,7 +91,7 @@ func (b *EventBroker) ProcessInstallEvent(localChaincode *LocalChaincode) {
 	for channelID, channelCache := range localChaincode.References {
 		listenersInvokedOnChannel := false
 		for chaincodeName, cachedChaincode := range channelCache {
-			if !isChaincodeInvokable(cachedChaincode) {
+			if !isChaincodeInvocable(cachedChaincode) {
 				continue
 			}
 			ccdef := &ledger.ChaincodeDefinition{
@@ -86,7 +124,7 @@ func (b *EventBroker) ProcessInstallEvent(localChaincode *LocalChaincode) {
 // invokes this function when approve and define both become true.
 func (b *EventBroker) ProcessApproveOrDefineEvent(channelID string, chaincodeName string, cachedChaincode *CachedChaincodeDefinition) {
 	logger.Debugw("processApproveOrDefineEvent()", "channelID", channelID, "chaincodeName", chaincodeName, "cachedChaincode", cachedChaincode)
-	if !isChaincodeInvokable(cachedChaincode) {
+	if !isChaincodeInvocable(cachedChaincode) {
 		return
 	}
 	dbArtifacts, err := b.loadDBArtifacts(cachedChaincode.InstallInfo.PackageID)
@@ -176,7 +214,7 @@ func (b *EventBroker) loadDBArtifacts(packageID string) ([]byte, error) {
 	return pkg.DBArtifacts, nil
 }
 
-// isChaincodeInvokable returns true iff a chaincode is approved and installed and defined
-func isChaincodeInvokable(ccInfo *CachedChaincodeDefinition) bool {
+// isChaincodeInvocable returns true iff a chaincode is approved and installed and defined
+func isChaincodeInvocable(ccInfo *CachedChaincodeDefinition) bool {
 	return ccInfo.Approved && ccInfo.InstallInfo != nil && ccInfo.Definition != nil
 }

--- a/core/chaincode/lifecycle/event_broker_test.go
+++ b/core/chaincode/lifecycle/event_broker_test.go
@@ -49,7 +49,7 @@ var _ = Describe("EventBroker", func() {
 			},
 			References: make(map[string]map[string]*lifecycle.CachedChaincodeDefinition),
 		}
-		eventBroker.RegisterListener("channel-1", fakeListener)
+		eventBroker.RegisterListener("channel-1", fakeListener, nil)
 		pkgParser.ParseReturns(&persistence.ChaincodePackage{
 			DBArtifacts: []byte("db-artifacts"),
 		}, nil)

--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -68,6 +68,7 @@ type kvLedger struct {
 
 type lgrInitializer struct {
 	ledgerID                 string
+	initializingFromSnapshot bool
 	bootSnapshotMetadata     *snapshotMetadata
 	blockStore               *blkstorage.BlockStore
 	pvtdataStore             *pvtdatastorage.Store
@@ -148,7 +149,11 @@ func newKVLedger(initializer *lgrInitializer) (*kvLedger, error) {
 	logger.Debugf("Register state db for chaincode lifecycle events: %t", ccEventListener != nil)
 	if ccEventListener != nil {
 		cceventmgmt.GetMgr().Register(ledgerID, ccEventListener)
-		initializer.ccLifecycleEventProvider.RegisterListener(ledgerID, &ccEventListenerAdaptor{ccEventListener})
+		initializer.ccLifecycleEventProvider.RegisterListener(
+			ledgerID,
+			&ccEventListenerAdaptor{ccEventListener},
+			initializer.initializingFromSnapshot,
+		)
 	}
 
 	//Recover both state DB and history DB if they are out of sync with block storage

--- a/core/ledger/kvledger/kv_ledger_provider.go
+++ b/core/ledger/kvledger/kv_ledger_provider.go
@@ -276,7 +276,7 @@ func (p *Provider) CreateFromGenesisBlock(genesisBlock *common.Block) (ledger.Pe
 		return nil, err
 	}
 
-	lgr, err := p.open(ledgerID, nil)
+	lgr, err := p.open(ledgerID, nil, false)
 	if err != nil {
 		return nil, p.deleteUnderConstructionLedger(lgr, ledgerID, err)
 	}
@@ -324,10 +324,10 @@ func (p *Provider) Open(ledgerID string) (ledger.PeerLedger, error) {
 	if err != nil {
 		return nil, err
 	}
-	return p.open(ledgerID, bootSnapshotMetadata)
+	return p.open(ledgerID, bootSnapshotMetadata, false)
 }
 
-func (p *Provider) open(ledgerID string, bootSnapshotMetadata *snapshotMetadata) (ledger.PeerLedger, error) {
+func (p *Provider) open(ledgerID string, bootSnapshotMetadata *snapshotMetadata, initializingFromSnapshot bool) (ledger.PeerLedger, error) {
 	// Get the block store for a chain/ledger
 	blockStore, err := p.blkStoreProvider.Open(ledgerID)
 	if err != nil {
@@ -375,6 +375,7 @@ func (p *Provider) open(ledgerID string, bootSnapshotMetadata *snapshotMetadata)
 		hashProvider:             p.initializer.HashProvider,
 		config:                   p.initializer.Config,
 		bootSnapshotMetadata:     bootSnapshotMetadata,
+		initializingFromSnapshot: initializingFromSnapshot,
 	}
 
 	l, err := newKVLedger(initializer)

--- a/core/ledger/kvledger/kv_ledger_test.go
+++ b/core/ledger/kvledger/kv_ledger_test.go
@@ -30,9 +30,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var couchDBAddress string
+var stopCouchDBFunc func()
+
 func TestMain(m *testing.M) {
 	flogging.ActivateSpec("lockbasedtxmgr,statevalidator,valimpl,confighistory,pvtstatepurgemgmt=debug")
-	os.Exit(m.Run())
+	exitCode := m.Run()
+	if couchDBAddress != "" {
+		couchDBAddress = ""
+		stopCouchDBFunc()
+	}
+	os.Exit(exitCode)
 }
 
 func TestKVLedgerNilHistoryDBProvider(t *testing.T) {

--- a/core/ledger/kvledger/snapshot.go
+++ b/core/ledger/kvledger/snapshot.go
@@ -299,7 +299,7 @@ func (p *Provider) CreateFromSnapshot(snapshotDir string) (ledger.PeerLedger, st
 		}
 	}
 
-	lgr, err := p.open(ledgerID, metadata)
+	lgr, err := p.open(ledgerID, metadata, true)
 	if err != nil {
 		return nil, "", p.deleteUnderConstructionLedger(
 			lgr,

--- a/core/ledger/ledger_interface.go
+++ b/core/ledger/ledger_interface.go
@@ -708,8 +708,13 @@ func (cdef *ChaincodeDefinition) String() string {
 	return fmt.Sprintf("Name=%s, Version=%s, Hash=%#v", cdef.Name, cdef.Version, cdef.Hash)
 }
 
+// ChaincodeLifecycleEventProvider enables ledger to create indexes in the statedb
 type ChaincodeLifecycleEventProvider interface {
-	RegisterListener(channelID string, listener ChaincodeLifecycleEventListener)
+	// RegisterListener is used by ledger to receive a callback alongwith dbArtifacts when a chaincode becomes invocable on the peer
+	// In addition, if needsExistingChaincodesDefinitions is true, the provider calls back the listener with existing invocable chaincodes
+	// This parameter is used when we create a ledger from a snapshot so that we can create indexes for the existing invocable chaincodes
+	// already defined in the imported ledger data
+	RegisterListener(channelID string, listener ChaincodeLifecycleEventListener, needsExistingChaincodesDefinitions bool) error
 }
 
 // CustomTxProcessor allows to generate simulation results during commit time for custom transactions.

--- a/core/ledger/mock/cc_event_provider.go
+++ b/core/ledger/mock/cc_event_provider.go
@@ -8,27 +8,41 @@ import (
 )
 
 type ChaincodeLifecycleEventProvider struct {
-	RegisterListenerStub        func(string, ledger.ChaincodeLifecycleEventListener)
+	RegisterListenerStub        func(string, ledger.ChaincodeLifecycleEventListener, bool) error
 	registerListenerMutex       sync.RWMutex
 	registerListenerArgsForCall []struct {
 		arg1 string
 		arg2 ledger.ChaincodeLifecycleEventListener
+		arg3 bool
+	}
+	registerListenerReturns struct {
+		result1 error
+	}
+	registerListenerReturnsOnCall map[int]struct {
+		result1 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ChaincodeLifecycleEventProvider) RegisterListener(arg1 string, arg2 ledger.ChaincodeLifecycleEventListener) {
+func (fake *ChaincodeLifecycleEventProvider) RegisterListener(arg1 string, arg2 ledger.ChaincodeLifecycleEventListener, arg3 bool) error {
 	fake.registerListenerMutex.Lock()
+	ret, specificReturn := fake.registerListenerReturnsOnCall[len(fake.registerListenerArgsForCall)]
 	fake.registerListenerArgsForCall = append(fake.registerListenerArgsForCall, struct {
 		arg1 string
 		arg2 ledger.ChaincodeLifecycleEventListener
-	}{arg1, arg2})
-	fake.recordInvocation("RegisterListener", []interface{}{arg1, arg2})
+		arg3 bool
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("RegisterListener", []interface{}{arg1, arg2, arg3})
 	fake.registerListenerMutex.Unlock()
 	if fake.RegisterListenerStub != nil {
-		fake.RegisterListenerStub(arg1, arg2)
+		return fake.RegisterListenerStub(arg1, arg2, arg3)
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.registerListenerReturns
+	return fakeReturns.result1
 }
 
 func (fake *ChaincodeLifecycleEventProvider) RegisterListenerCallCount() int {
@@ -37,17 +51,40 @@ func (fake *ChaincodeLifecycleEventProvider) RegisterListenerCallCount() int {
 	return len(fake.registerListenerArgsForCall)
 }
 
-func (fake *ChaincodeLifecycleEventProvider) RegisterListenerCalls(stub func(string, ledger.ChaincodeLifecycleEventListener)) {
+func (fake *ChaincodeLifecycleEventProvider) RegisterListenerCalls(stub func(string, ledger.ChaincodeLifecycleEventListener, bool) error) {
 	fake.registerListenerMutex.Lock()
 	defer fake.registerListenerMutex.Unlock()
 	fake.RegisterListenerStub = stub
 }
 
-func (fake *ChaincodeLifecycleEventProvider) RegisterListenerArgsForCall(i int) (string, ledger.ChaincodeLifecycleEventListener) {
+func (fake *ChaincodeLifecycleEventProvider) RegisterListenerArgsForCall(i int) (string, ledger.ChaincodeLifecycleEventListener, bool) {
 	fake.registerListenerMutex.RLock()
 	defer fake.registerListenerMutex.RUnlock()
 	argsForCall := fake.registerListenerArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *ChaincodeLifecycleEventProvider) RegisterListenerReturns(result1 error) {
+	fake.registerListenerMutex.Lock()
+	defer fake.registerListenerMutex.Unlock()
+	fake.RegisterListenerStub = nil
+	fake.registerListenerReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ChaincodeLifecycleEventProvider) RegisterListenerReturnsOnCall(i int, result1 error) {
+	fake.registerListenerMutex.Lock()
+	defer fake.registerListenerMutex.Unlock()
+	fake.RegisterListenerStub = nil
+	if fake.registerListenerReturnsOnCall == nil {
+		fake.registerListenerReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.registerListenerReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *ChaincodeLifecycleEventProvider) Invocations() map[string][][]interface{} {


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Description
When we create a new ledger from a snapshot, we need to create indexes in the statedb (couchdb) for the chaincodes that are already defined (and approved by the org) in the imported state from the snapshot, and are already installed on the bootstrapping peer. This PR adds the code for dealing with the chaincodes that are defined and installed via the new lifecycle (namely the `_lifecycle`).

#### Additional details
There will be a separate PR for handling the index creation for the chaincodes that are defined and installed via the legacy method (namely, the `lscc`). Note that, in the regular path of indexes creation, the legacy chaincodes are dealt with separately and hence it will be good to use the same mechanism in this scenario. As a side note, eventually this legacy path is expected to be removed when we remove the support of legacy chaincodes in a future release

#### Related issues
FAB-18158
