### PR TITLE
[FAB-18171] Update Raft administration guide

### DIFF
--- a/docs/source/raft_configuration.md
+++ b/docs/source/raft_configuration.md
@@ -258,6 +258,9 @@ little as a few months, so check with your issuer. Before the expiration date,
 you will need to rotate these certificates on the node itself and every channel
 the node is joined to, including the system channel.
 
+**Note:** In case the public key of the TLS certificate remains the same, 
+there is no need to issue channel configuration updates.
+
 For each channel the node participates in:
 
   1. Update the channel configuration with the new certificates.


### PR DESCRIPTION
Mention there is no need to do channel config updates
in case the public key of the TLS certificate of the orderer remains the same.

Change-Id: I8f77fc0a7b4eae98a15f6abdb29164012057b6ff
Signed-off-by: yacovm <yacovm@il.ibm.com>
