### PR TITLE
Peer CLI communicate with orderers with expired TLS certs (release-2.2)

### DIFF
--- a/docs/source/commands/peerchaincode.md
+++ b/docs/source/commands/peerchaincode.md
@@ -92,8 +92,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -127,8 +128,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -159,8 +161,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -188,8 +191,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -219,8 +223,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -250,8 +255,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -273,8 +279,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -309,8 +316,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 

--- a/docs/source/commands/peerchannel.md
+++ b/docs/source/commands/peerchannel.md
@@ -40,8 +40,9 @@ Flags:
   -h, --help                                help for channel
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 
 Use "peer channel [command] --help" for more information about a command.
 ```
@@ -68,8 +69,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -92,8 +94,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -115,8 +118,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -138,8 +142,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -160,8 +165,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -183,8 +189,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -207,8 +214,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 ## Example Usage

--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -72,8 +72,9 @@ Flags:
   -h, --help                                help for chaincode
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 
 Use "peer lifecycle chaincode [command] --help" for more information about a command.
 ```
@@ -102,8 +103,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -127,8 +129,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -153,8 +156,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -180,8 +184,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -218,8 +223,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -247,8 +253,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -283,8 +290,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -320,8 +328,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -348,8 +357,9 @@ Global Flags:
       --connTimeout duration                Timeout for client to connect (default 3s)
       --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
   -o, --orderer string                      Ordering service endpoint
-      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
+      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hyperledger/fabric-amcl v0.0.0-20200128223036-d1aa2665426a
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed
-	github.com/hyperledger/fabric-config v0.0.5
+	github.com/hyperledger/fabric-config v0.0.7
 	github.com/hyperledger/fabric-lib-go v1.0.0
 	github.com/hyperledger/fabric-protos-go v0.0.0-20200506201313-25f6564b9ac4
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/hyperledger/fabric-amcl v0.0.0-20200128223036-d1aa2665426a h1:HgdNn3U
 github.com/hyperledger/fabric-amcl v0.0.0-20200128223036-d1aa2665426a/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=
 github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed h1:VNnrD/ilIUO9DDHQP/uioYSy1309rYy0Z1jf3GLNRIc=
 github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed/go.mod h1:N7H3sA7Tx4k/YzFq7U0EPdqJtqvM4Kild0JoCc7C0Dc=
-github.com/hyperledger/fabric-config v0.0.5 h1:khRkm8U9Ghdg8VmZfptgzCFlCzrka8bPfUkM+/j6Zlg=
-github.com/hyperledger/fabric-config v0.0.5/go.mod h1:YpITBI/+ZayA3XWY5lF302K7PAsFYjEEPM/zr3hegA8=
+github.com/hyperledger/fabric-config v0.0.7 h1:sHuUxTTP6l0p8BDWeag5tvGUNCsiOYZ3Mux2CXZVWe8=
+github.com/hyperledger/fabric-config v0.0.7/go.mod h1:aeDZ0moG/qKvwLjddcqYr8+58/oNaJy3HE0tI01546c=
 github.com/hyperledger/fabric-lib-go v1.0.0 h1:UL1w7c9LvHZUSkIvHTDGklxFv2kTeva1QI2emOVc324=
 github.com/hyperledger/fabric-lib-go v1.0.0/go.mod h1:H362nMlunurmHwkYqR5uHL2UDWbQdbfz74n8kbCFsqc=
 github.com/hyperledger/fabric-protos-go v0.0.0-20190919234611-2a87503ac7c9/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=

--- a/integration/configtx/configtx_test.go
+++ b/integration/configtx/configtx_test.go
@@ -11,9 +11,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"io/ioutil"
-	"net"
 	"os"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -155,7 +153,7 @@ var _ = Describe("ConfigTx", func() {
 		oConfig.BatchTimeout = 2 * time.Second
 		err = o.SetConfiguration(oConfig)
 		Expect(err).NotTo(HaveOccurred())
-		host, port := ordererHostPort(network, orderer)
+		host, port := OrdererHostPort(network, orderer)
 		err = o.Organization(orderer.Organization).SetEndpoint(configtx.Address{Host: host, Port: port + 1})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -257,7 +255,7 @@ var _ = Describe("ConfigTx", func() {
 			peerOrg := c.Application().Organization(peer.Organization)
 
 			By("adding the anchor peer for " + peer.Organization)
-			host, port := peerHostPort(network, peer)
+			host, port := PeerHostPort(network, peer)
 			err = peerOrg.AddAnchorPeer(configtx.Address{Host: host, Port: port})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -329,20 +327,4 @@ func parsePrivateKey(filename string) crypto.PrivateKey {
 	privateKey, err := x509.ParsePKCS8PrivateKey(pemBlock.Bytes)
 	Expect(err).NotTo(HaveOccurred())
 	return privateKey
-}
-
-func peerHostPort(n *nwo.Network, p *nwo.Peer) (string, int) {
-	return splitHostPort(n.PeerAddress(p, nwo.ListenPort))
-}
-
-func ordererHostPort(n *nwo.Network, o *nwo.Orderer) (string, int) {
-	return splitHostPort(n.OrdererAddress(o, nwo.ListenPort))
-}
-
-func splitHostPort(address string) (string, int) {
-	host, port, err := net.SplitHostPort(address)
-	Expect(err).NotTo(HaveOccurred())
-	portInt, err := strconv.Atoi(port)
-	Expect(err).NotTo(HaveOccurred())
-	return host, portInt
 }

--- a/integration/configtx/host_port.go
+++ b/integration/configtx/host_port.go
@@ -1,0 +1,40 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package configtx
+
+import (
+	"net"
+	"strconv"
+
+	"github.com/hyperledger/fabric/integration/nwo"
+	. "github.com/onsi/gomega"
+)
+
+// PeerHostPort returns the host name and port number for the specified peer.
+func PeerHostPort(n *nwo.Network, p *nwo.Peer) (string, int) {
+	return splitHostPort(n.PeerAddress(p, nwo.ListenPort))
+}
+
+// OrdererHostPort returns the host name and port number for the specified
+// orderer.
+func OrdererHostPort(n *nwo.Network, o *nwo.Orderer) (string, int) {
+	return splitHostPort(n.OrdererAddress(o, nwo.ListenPort))
+}
+
+// OrdererClusterHostPort returns the host name and cluster port number for the
+// specified orderer.
+func OrdererClusterHostPort(n *nwo.Network, o *nwo.Orderer) (string, int) {
+	return splitHostPort(n.OrdererAddress(o, nwo.ClusterPort))
+}
+
+func splitHostPort(address string) (string, int) {
+	host, port, err := net.SplitHostPort(address)
+	Expect(err).NotTo(HaveOccurred())
+	portInt, err := strconv.Atoi(port)
+	Expect(err).NotTo(HaveOccurred())
+	return host, portInt
+}

--- a/integration/nwo/commands/peer.go
+++ b/integration/nwo/commands/peer.go
@@ -8,6 +8,7 @@ package commands
 
 import (
 	"strconv"
+	"time"
 )
 
 type NodeStart struct {
@@ -135,11 +136,12 @@ func (c ChannelJoin) Args() []string {
 }
 
 type ChannelFetch struct {
-	ChannelID  string
-	Block      string
-	Orderer    string
-	OutputFile string
-	ClientAuth bool
+	ChannelID             string
+	Block                 string
+	Orderer               string
+	OutputFile            string
+	ClientAuth            bool
+	TLSHandshakeTimeShift time.Duration
 }
 
 func (c ChannelFetch) SessionName() string {
@@ -149,15 +151,10 @@ func (c ChannelFetch) SessionName() string {
 func (c ChannelFetch) Args() []string {
 	args := []string{
 		"channel", "fetch", c.Block,
-	}
-	if c.ChannelID != "" {
-		args = append(args, "--channelID", c.ChannelID)
-	}
-	if c.Orderer != "" {
-		args = append(args, "--orderer", c.Orderer)
-	}
-	if c.OutputFile != "" {
-		args = append(args, c.OutputFile)
+		"--channelID", c.ChannelID,
+		"--orderer", c.Orderer,
+		"--tlsHandshakeTimeShift", c.TLSHandshakeTimeShift.String(),
+		c.OutputFile,
 	}
 	if c.ClientAuth {
 		args = append(args, "--clientauth")
@@ -747,10 +744,11 @@ func (s SignConfigTx) Args() []string {
 }
 
 type ChannelUpdate struct {
-	ChannelID  string
-	Orderer    string
-	File       string
-	ClientAuth bool
+	ChannelID             string
+	Orderer               string
+	File                  string
+	ClientAuth            bool
+	TLSHandshakeTimeShift time.Duration
 }
 
 func (c ChannelUpdate) SessionName() string {
@@ -763,6 +761,7 @@ func (c ChannelUpdate) Args() []string {
 		"--channelID", c.ChannelID,
 		"--orderer", c.Orderer,
 		"--file", c.File,
+		"--tlsHandshakeTimeShift", c.TLSHandshakeTimeShift.String(),
 	}
 	if c.ClientAuth {
 		args = append(args, "--clientauth")

--- a/internal/peer/chaincode/common.go
+++ b/internal/peer/chaincode/common.go
@@ -500,7 +500,6 @@ func InitCmdFactory(cmdName string, isEndorserRequired, isOrdererRequired bool, 
 		}
 
 		broadcastClient, err = common.GetBroadcastClientFnc()
-
 		if err != nil {
 			return nil, errors.WithMessage(err, "error getting broadcast client")
 		}

--- a/internal/peer/common/common.go
+++ b/internal/peer/common/common.go
@@ -248,7 +248,9 @@ func configFromEnv(prefix string) (address, override string, clientConfig comm.C
 	clientConfig.Timeout = connTimeout
 	secOpts := comm.SecureOptions{
 		UseTLS:            viper.GetBool(prefix + ".tls.enabled"),
-		RequireClientCert: viper.GetBool(prefix + ".tls.clientAuthRequired")}
+		RequireClientCert: viper.GetBool(prefix + ".tls.clientAuthRequired"),
+		TimeShift:         viper.GetDuration(prefix + ".tls.handshakeTimeShift"),
+	}
 	if secOpts.UseTLS {
 		caPEM, res := ioutil.ReadFile(config.GetPath(prefix + ".tls.rootcert.file"))
 		if res != nil {

--- a/internal/peer/common/deliverclient.go
+++ b/internal/peer/common/deliverclient.go
@@ -163,7 +163,6 @@ type ordererDeliverService struct {
 
 // NewDeliverClientForOrderer creates a new DeliverClient from an OrdererClient
 func NewDeliverClientForOrderer(channelID string, signer identity.SignerSerializer, bestEffort bool) (*DeliverClient, error) {
-	var tlsCertHash []byte
 	oc, err := NewOrdererClientFromEnv()
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create deliver client for orderer")
@@ -174,6 +173,7 @@ func NewDeliverClientForOrderer(channelID string, signer identity.SignerSerializ
 		return nil, errors.WithMessage(err, "failed to create deliver client for orderer")
 	}
 	// check for client certificate and create hash if present
+	var tlsCertHash []byte
 	if len(oc.Certificate().Certificate) > 0 {
 		tlsCertHash = util.ComputeSHA256(oc.Certificate().Certificate[0])
 	}

--- a/internal/peer/common/ordererclient.go
+++ b/internal/peer/common/ordererclient.go
@@ -35,7 +35,9 @@ func NewOrdererClientFromEnv() (*OrdererClient, error) {
 		CommonClient: CommonClient{
 			GRPCClient: gClient,
 			Address:    address,
-			sn:         override}}
+			sn:         override,
+		},
+	}
 	return oClient, nil
 }
 

--- a/internal/peer/common/ordererenv.go
+++ b/internal/peer/common/ordererenv.go
@@ -21,6 +21,7 @@ var (
 	certFile                   string
 	ordererTLSHostnameOverride string
 	connTimeout                time.Duration
+	tlsHandshakeTimeShift      time.Duration
 )
 
 // SetOrdererEnv adds orderer-specific settings to the global Viper environment
@@ -45,26 +46,29 @@ func SetOrdererEnv(cmd *cobra.Command, args []string) {
 	viper.Set("orderer.tls.enabled", tlsEnabled)
 	viper.Set("orderer.tls.clientAuthRequired", clientAuth)
 	viper.Set("orderer.client.connTimeout", connTimeout)
+	viper.Set("orderer.tls.handshakeTimeShift", tlsHandshakeTimeShift)
 }
 
 // AddOrdererFlags adds flags for orderer-related commands
 func AddOrdererFlags(cmd *cobra.Command) {
 	flags := cmd.PersistentFlags()
 
-	flags.StringVarP(&OrderingEndpoint, "orderer", "o", "", "Ordering service endpoint")
-	flags.BoolVarP(&tlsEnabled, "tls", "", false, "Use TLS when communicating with the orderer endpoint")
+	flags.StringVarP(&OrderingEndpoint, "orderer", "o", "",
+		"Ordering service endpoint")
+	flags.BoolVarP(&tlsEnabled, "tls", "", false,
+		"Use TLS when communicating with the orderer endpoint")
 	flags.BoolVarP(&clientAuth, "clientauth", "", false,
 		"Use mutual TLS when communicating with the orderer endpoint")
 	flags.StringVarP(&caFile, "cafile", "", "",
 		"Path to file containing PEM-encoded trusted certificate(s) for the ordering endpoint")
 	flags.StringVarP(&keyFile, "keyfile", "", "",
-		"Path to file containing PEM-encoded private key to use for mutual TLS "+
-			"communication with the orderer endpoint")
+		"Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint")
 	flags.StringVarP(&certFile, "certfile", "", "",
-		"Path to file containing PEM-encoded X509 public key to use for "+
-			"mutual TLS communication with the orderer endpoint")
-	flags.StringVarP(&ordererTLSHostnameOverride, "ordererTLSHostnameOverride",
-		"", "", "The hostname override to use when validating the TLS connection to the orderer.")
-	flags.DurationVarP(&connTimeout, "connTimeout",
-		"", 3*time.Second, "Timeout for client to connect")
+		"Path to file containing PEM-encoded X509 public key to use for mutual TLS communication with the orderer endpoint")
+	flags.StringVarP(&ordererTLSHostnameOverride, "ordererTLSHostnameOverride", "", "",
+		"The hostname override to use when validating the TLS connection to the orderer")
+	flags.DurationVarP(&connTimeout, "connTimeout", "", 3*time.Second,
+		"Timeout for client to connect")
+	flags.DurationVarP(&tlsHandshakeTimeShift, "tlsHandshakeTimeShift", "", 0,
+		"The amount of time to shift backwards for certificate expiration checks during TLS handshakes")
 }

--- a/internal/pkg/comm/client.go
+++ b/internal/pkg/comm/client.go
@@ -79,8 +79,7 @@ func (client *GRPCClient) parseSecureOptions(opts SecureOptions) error {
 			err := AddPemToCertPool(certBytes, client.tlsConfig.RootCAs)
 			if err != nil {
 				commLogger.Debugf("error adding root certificate: %v", err)
-				return errors.WithMessage(err,
-					"error adding root certificate")
+				return errors.WithMessage(err, "error adding root certificate")
 			}
 		}
 	}
@@ -91,14 +90,12 @@ func (client *GRPCClient) parseSecureOptions(opts SecureOptions) error {
 			cert, err := tls.X509KeyPair(opts.Certificate,
 				opts.Key)
 			if err != nil {
-				return errors.WithMessage(err, "failed to "+
-					"load client certificate")
+				return errors.WithMessage(err, "failed to load client certificate")
 			}
 			client.tlsConfig.Certificates = append(
 				client.tlsConfig.Certificates, cert)
 		} else {
-			return errors.New("both Key and Certificate " +
-				"are required when using mutual TLS")
+			return errors.New("both Key and Certificate are required when using mutual TLS")
 		}
 	}
 

--- a/vendor/github.com/hyperledger/fabric-config/configtx/application.go
+++ b/vendor/github.com/hyperledger/fabric-config/configtx/application.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package configtx
 
 import (
-	"crypto/x509"
-	"crypto/x509/pkix"
 	"errors"
 	"fmt"
 
@@ -37,6 +35,13 @@ type ApplicationGroup struct {
 type ApplicationOrg struct {
 	orgGroup *cb.ConfigGroup
 	name     string
+}
+
+// MSP returns an OrganizationMSP object that can be used to configure the organization's MSP.
+func (a *ApplicationOrg) MSP() *OrganizationMSP {
+	return &OrganizationMSP{
+		configGroup: a.orgGroup,
+	}
 }
 
 // Application returns the application group the updated config.
@@ -378,16 +383,10 @@ func (a *ApplicationGroup) RemoveACLs(acls []string) error {
 	return nil
 }
 
-// MSP returns the MSP configuration for an existing application
-// org in the updated config of a config transaction.
-func (a *ApplicationOrg) MSP() (MSP, error) {
-	return getMSPConfig(a.orgGroup)
-}
-
 // SetMSP updates the MSP config for the specified application
 // org group.
 func (a *ApplicationOrg) SetMSP(updatedMSP MSP) error {
-	currentMSP, err := a.MSP()
+	currentMSP, err := a.MSP().Configuration()
 	if err != nil {
 		return fmt.Errorf("retrieving msp: %v", err)
 	}
@@ -421,17 +420,6 @@ func (a *ApplicationOrg) setMSPConfig(updatedMSP MSP) error {
 	}
 
 	return nil
-}
-
-// CreateMSPCRL creates a CRL that revokes the provided certificates
-// for the specified application org signed by the provided SigningIdentity.
-func (a *ApplicationOrg) CreateMSPCRL(signingIdentity *SigningIdentity, certs ...*x509.Certificate) (*pkix.CertificateList, error) {
-	msp, err := a.MSP()
-	if err != nil {
-		return nil, fmt.Errorf("retrieving application org msp: %s", err)
-	}
-
-	return msp.newMSPCRL(signingIdentity, certs...)
 }
 
 // newApplicationGroupTemplate returns the application component of the channel

--- a/vendor/github.com/hyperledger/fabric-config/configtx/orderer.go
+++ b/vendor/github.com/hyperledger/fabric-config/configtx/orderer.go
@@ -8,11 +8,11 @@ package configtx
 
 import (
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -59,6 +59,23 @@ type OrdererGroup struct {
 type OrdererOrg struct {
 	orgGroup *cb.ConfigGroup
 	name     string
+}
+
+// MSP returns an OrganizationMSP object that can be used to configure the organization's MSP.
+func (o *OrdererOrg) MSP() *OrganizationMSP {
+	return &OrganizationMSP{
+		configGroup: o.orgGroup,
+	}
+}
+
+// EtcdRaftOptionsValue encapsulates the configuration functions used to modify an etcdraft configuration's options.
+type EtcdRaftOptionsValue struct {
+	value *cb.ConfigValue
+}
+
+// BatchSizeValue encapsulates the configuration functions used to modify an orderer configuration's batch size values.
+type BatchSizeValue struct {
+	value *cb.ConfigValue
 }
 
 // Orderer returns the orderer group from the updated config.
@@ -184,6 +201,174 @@ func (o *OrdererGroup) Configuration() (Orderer, error) {
 	}, nil
 }
 
+// BatchSize returns a BatchSizeValue that can be used to configure an orderer configuration's batch size parameters.
+func (o *OrdererGroup) BatchSize() *BatchSizeValue {
+	return &BatchSizeValue{
+		value: o.ordererGroup.Values[orderer.BatchSizeKey],
+	}
+}
+
+// SetMaxMessageCount sets an orderer configuration's batch size max message count.
+func (b *BatchSizeValue) SetMaxMessageCount(maxMessageCount uint32) error {
+	batchSize := &ob.BatchSize{}
+	err := proto.Unmarshal(b.value.Value, batchSize)
+	if err != nil {
+		return err
+	}
+
+	batchSize.MaxMessageCount = maxMessageCount
+	b.value.Value, err = proto.Marshal(batchSize)
+
+	return err
+}
+
+// SetAbsoluteMaxBytes sets an orderer configuration's batch size max block size.
+func (b *BatchSizeValue) SetAbsoluteMaxBytes(maxBytes uint32) error {
+	batchSize := &ob.BatchSize{}
+	err := proto.Unmarshal(b.value.Value, batchSize)
+	if err != nil {
+		return err
+	}
+
+	batchSize.AbsoluteMaxBytes = maxBytes
+	b.value.Value, err = proto.Marshal(batchSize)
+
+	return err
+}
+
+// SetPreferredMaxBytes sets an orderer configuration's batch size preferred size of blocks.
+func (b *BatchSizeValue) SetPreferredMaxBytes(maxBytes uint32) error {
+	batchSize := &ob.BatchSize{}
+	err := proto.Unmarshal(b.value.Value, batchSize)
+	if err != nil {
+		return err
+	}
+
+	batchSize.PreferredMaxBytes = maxBytes
+	b.value.Value, err = proto.Marshal(batchSize)
+
+	return err
+}
+
+// SetBatchTimeout sets the wait time between transactions.
+func (o *OrdererGroup) SetBatchTimeout(timeout time.Duration) error {
+	return setValue(o.ordererGroup, batchTimeoutValue(timeout.String()), AdminsPolicyKey)
+}
+
+// SetMaxChannels sets the maximum count of channels an orderer supports.
+func (o *OrdererGroup) SetMaxChannels(max int) error {
+	return setValue(o.ordererGroup, channelRestrictionsValue(uint64(max)), AdminsPolicyKey)
+}
+
+// SetEtcdRaftConsensusType sets the orderer consensus type to etcdraft, sets etcdraft metadata, and consensus state.
+func (o *OrdererGroup) SetEtcdRaftConsensusType(consensusMetadata orderer.EtcdRaft, consensusState orderer.ConsensusState) error {
+	consensusMetadataBytes, err := marshalEtcdRaftMetadata(consensusMetadata)
+	if err != nil {
+		return fmt.Errorf("marshaling etcdraft metadata: %v", err)
+	}
+
+	return setValue(o.ordererGroup, consensusTypeValue(orderer.ConsensusTypeEtcdRaft, consensusMetadataBytes, ob.ConsensusType_State_value[string(consensusState)]), AdminsPolicyKey)
+}
+
+// SetConsensusState sets the consensus state.
+func (o *OrdererGroup) SetConsensusState(consensusState orderer.ConsensusState) error {
+	consensusTypeProto := &ob.ConsensusType{}
+	err := unmarshalConfigValueAtKey(o.ordererGroup, orderer.ConsensusTypeKey, consensusTypeProto)
+	if err != nil {
+		return err
+	}
+
+	return setValue(o.ordererGroup, consensusTypeValue(consensusTypeProto.Type, consensusTypeProto.Metadata, ob.ConsensusType_State_value[string(consensusState)]), AdminsPolicyKey)
+}
+
+// EtcdRaftOptions returns an EtcdRaftOptionsValue that can be used to configure an etcdraft configuration's options.
+func (o *OrdererGroup) EtcdRaftOptions() *EtcdRaftOptionsValue {
+	return &EtcdRaftOptionsValue{
+		value: o.ordererGroup.Values[orderer.ConsensusTypeKey],
+	}
+}
+
+func (e *EtcdRaftOptionsValue) etcdRaftConfig(consensusTypeProto *ob.ConsensusType) (orderer.EtcdRaft, error) {
+	err := proto.Unmarshal(e.value.Value, consensusTypeProto)
+	if err != nil {
+		return orderer.EtcdRaft{}, err
+	}
+
+	return unmarshalEtcdRaftMetadata(consensusTypeProto.Metadata)
+}
+
+func (e *EtcdRaftOptionsValue) setEtcdRaftConfig(consensusTypeProto *ob.ConsensusType, etcdRaft orderer.EtcdRaft) error {
+	consensusMetadata, err := marshalEtcdRaftMetadata(etcdRaft)
+	if err != nil {
+		return fmt.Errorf("marshaling etcdraft metadata: %v", err)
+	}
+
+	consensusTypeProto.Metadata = consensusMetadata
+
+	e.value.Value, err = proto.Marshal(consensusTypeProto)
+	return err
+}
+
+// SetTickInterval sets the Etcdraft's tick interval.
+func (e *EtcdRaftOptionsValue) SetTickInterval(interval string) error {
+	consensusTypeProto := &ob.ConsensusType{}
+	etcdRaft, err := e.etcdRaftConfig(consensusTypeProto)
+	if err != nil {
+		return nil
+	}
+
+	etcdRaft.Options.TickInterval = interval
+	return e.setEtcdRaftConfig(consensusTypeProto, etcdRaft)
+}
+
+// SetElectionInterval sets the Etcdraft's election interval.
+func (e *EtcdRaftOptionsValue) SetElectionInterval(interval uint32) error {
+	consensusTypeProto := &ob.ConsensusType{}
+	etcdRaft, err := e.etcdRaftConfig(consensusTypeProto)
+	if err != nil {
+		return nil
+	}
+
+	etcdRaft.Options.ElectionTick = interval
+	return e.setEtcdRaftConfig(consensusTypeProto, etcdRaft)
+}
+
+// SetHeartbeatTick sets the Etcdraft's heartbeat tick interval.
+func (e *EtcdRaftOptionsValue) SetHeartbeatTick(tick uint32) error {
+	consensusTypeProto := &ob.ConsensusType{}
+	etcdRaft, err := e.etcdRaftConfig(consensusTypeProto)
+	if err != nil {
+		return nil
+	}
+
+	etcdRaft.Options.HeartbeatTick = tick
+	return e.setEtcdRaftConfig(consensusTypeProto, etcdRaft)
+}
+
+// SetMaxInflightBlocks sets the Etcdraft's max inflight blocks.
+func (e *EtcdRaftOptionsValue) SetMaxInflightBlocks(maxBlks uint32) error {
+	consensusTypeProto := &ob.ConsensusType{}
+	etcdRaft, err := e.etcdRaftConfig(consensusTypeProto)
+	if err != nil {
+		return nil
+	}
+
+	etcdRaft.Options.MaxInflightBlocks = maxBlks
+	return e.setEtcdRaftConfig(consensusTypeProto, etcdRaft)
+}
+
+// SetSnapshotIntervalSize sets the Etcdraft's snapshot interval size.
+func (e *EtcdRaftOptionsValue) SetSnapshotIntervalSize(intervalSize uint32) error {
+	consensusTypeProto := &ob.ConsensusType{}
+	etcdRaft, err := e.etcdRaftConfig(consensusTypeProto)
+	if err != nil {
+		return nil
+	}
+
+	etcdRaft.Options.SnapshotIntervalSize = intervalSize
+	return e.setEtcdRaftConfig(consensusTypeProto, etcdRaft)
+}
+
 // Configuration retrieves an existing org's configuration from an
 // orderer organization config group in the updated config.
 func (o *OrdererOrg) Configuration() (Organization, error) {
@@ -239,6 +424,82 @@ func (o *OrdererGroup) RemoveOrganization(name string) {
 func (o *OrdererGroup) SetConfiguration(ord Orderer) error {
 	// update orderer values
 	err := addOrdererValues(o.ordererGroup, ord)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AddConsenter adds a consenter to an etcdraft configuration.
+func (o *OrdererGroup) AddConsenter(consenter orderer.Consenter) error {
+	cfg, err := o.Configuration()
+	if err != nil {
+		return err
+	}
+
+	if cfg.OrdererType != orderer.ConsensusTypeEtcdRaft {
+		return fmt.Errorf("consensus type %s is not etcdraft", cfg.OrdererType)
+	}
+
+	for _, c := range cfg.EtcdRaft.Consenters {
+		if reflect.DeepEqual(c, consenter) {
+			return nil
+		}
+	}
+
+	cfg.EtcdRaft.Consenters = append(cfg.EtcdRaft.Consenters, consenter)
+
+	consensusMetadata, err := marshalEtcdRaftMetadata(cfg.EtcdRaft)
+	if err != nil {
+		return fmt.Errorf("marshaling etcdraft metadata: %v", err)
+	}
+
+	consensusState, ok := ob.ConsensusType_State_value[string(cfg.State)]
+	if !ok {
+		return fmt.Errorf("unknown consensus state '%s'", cfg.State)
+	}
+
+	err = setValue(o.ordererGroup, consensusTypeValue(cfg.OrdererType, consensusMetadata, consensusState), AdminsPolicyKey)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RemoveConsenter removes a consenter from an etcdraft configuration.
+func (o *OrdererGroup) RemoveConsenter(consenter orderer.Consenter) error {
+	cfg, err := o.Configuration()
+	if err != nil {
+		return err
+	}
+
+	if cfg.OrdererType != orderer.ConsensusTypeEtcdRaft {
+		return fmt.Errorf("consensus type %s is not etcdraft", cfg.OrdererType)
+	}
+
+	consenters := cfg.EtcdRaft.Consenters[:]
+	for i, c := range cfg.EtcdRaft.Consenters {
+		if reflect.DeepEqual(c, consenter) {
+			consenters = append(consenters[:i], consenters[i+1:]...)
+			break
+		}
+	}
+
+	cfg.EtcdRaft.Consenters = consenters
+
+	consensusMetadata, err := marshalEtcdRaftMetadata(cfg.EtcdRaft)
+	if err != nil {
+		return fmt.Errorf("marshaling etcdraft metadata: %v", err)
+	}
+
+	consensusState, ok := ob.ConsensusType_State_value[string(cfg.State)]
+	if !ok {
+		return fmt.Errorf("unknown consensus state '%s'", cfg.State)
+	}
+
+	err = setValue(o.ordererGroup, consensusTypeValue(cfg.OrdererType, consensusMetadata, consensusState), AdminsPolicyKey)
 	if err != nil {
 		return err
 	}
@@ -383,16 +644,10 @@ func (o *OrdererGroup) Policies() (map[string]Policy, error) {
 	return getPolicies(o.ordererGroup.Policies)
 }
 
-// MSP returns the MSP value for an orderer organization in the
-// updated config.
-func (o *OrdererOrg) MSP() (MSP, error) {
-	return getMSPConfig(o.orgGroup)
-}
-
 // SetMSP updates the MSP config for the specified orderer org
 // in the updated config.
 func (o *OrdererOrg) SetMSP(updatedMSP MSP) error {
-	currentMSP, err := o.MSP()
+	currentMSP, err := o.MSP().Configuration()
 	if err != nil {
 		return fmt.Errorf("retrieving msp: %v", err)
 	}
@@ -406,37 +661,12 @@ func (o *OrdererOrg) SetMSP(updatedMSP MSP) error {
 		return err
 	}
 
-	err = o.setMSPConfig(updatedMSP)
+	err = updatedMSP.setConfig(o.orgGroup)
 	if err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func (o *OrdererOrg) setMSPConfig(updatedMSP MSP) error {
-	mspConfig, err := newMSPConfig(updatedMSP)
-	if err != nil {
-		return fmt.Errorf("new msp config: %v", err)
-	}
-
-	err = setValue(o.orgGroup, mspValue(mspConfig), AdminsPolicyKey)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// CreateMSPCRL creates a CRL that revokes the provided certificates
-// for the specified orderer org signed by the provided SigningIdentity.
-func (o *OrdererOrg) CreateMSPCRL(signingIdentity *SigningIdentity, certs ...*x509.Certificate) (*pkix.CertificateList, error) {
-	msp, err := o.MSP()
-	if err != nil {
-		return nil, fmt.Errorf("retrieving orderer msp: %s", err)
-	}
-
-	return msp.newMSPCRL(signingIdentity, certs...)
 }
 
 // SetPolicy sets the specified policy in the orderer org group's config policy map.
@@ -460,6 +690,12 @@ func (o *OrdererOrg) RemovePolicy(policyName string) error {
 // in the updated config.
 func (o *OrdererOrg) Policies() (map[string]Policy, error) {
 	return getPolicies(o.orgGroup.Policies)
+}
+
+// RemoveLegacyKafkaBrokers removes the legacy kafka brokers config key and value from config.
+// In fabric 2.0, kafka was deprecated as a consensus type.
+func (o *OrdererGroup) RemoveLegacyKafkaBrokers() {
+	delete(o.ordererGroup.Values, orderer.KafkaBrokersKey)
 }
 
 // newOrdererGroup returns the orderer component of the channel configuration.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -154,7 +154,7 @@ github.com/hyperledger/fabric-chaincode-go/pkg/statebased
 github.com/hyperledger/fabric-chaincode-go/shim
 github.com/hyperledger/fabric-chaincode-go/shim/internal
 github.com/hyperledger/fabric-chaincode-go/shimtest
-# github.com/hyperledger/fabric-config v0.0.5
+# github.com/hyperledger/fabric-config v0.0.7
 ## explicit
 github.com/hyperledger/fabric-config/configtx
 github.com/hyperledger/fabric-config/configtx/internal/policydsl


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Implement a TLS handshake timeshift for the "peer channel fetch" and "peer channel update" comands to allow fetching config blocks and updating the config for orderers with expired TLS certificates.

#### Related issues

[FAB-18205](https://jira.hyperledger.org/browse/FAB-18205)