### PR TITLE
Adding notes for the usage of script during samples install

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -64,6 +64,10 @@ the binaries and images.
 	  the un-shortened URL:
 	  https://raw.githubusercontent.com/hyperledger/fabric/{BRANCH}/scripts/bootstrap.sh
 
+.. note:: For additional use pattern you can use the -h flag to view the help and available commands for the 
+          Fabric-Samples bootstrap script. For example:
+          ``curl -sSL https://bit.ly/2ysbOFE | bash -s -- -h``
+
 The command above downloads and executes a bash script
 that will download and extract all of the platform-specific binaries you
 will need to set up your network and place them into the cloned repo you


### PR DESCRIPTION
Signed-off-by: Rijul Aggarwal <rijul.aggarwal@ibm.com>

#### Type of change

- Documentation update

#### Description

The main motivation behind this is that it's hard to know the details about the script that we use for installing and setting up fabric samples. It becomes easier to handle erroneous situations if we know what the script is capable of, and what it's trying to do.

The script to be used provides some options that a user can provide to entertain different behaviour from the script/install step.

#### Additional details

You can visit https://bit.ly/2ysbOFE to see the contents of the script used for install
