### PR TITLE
Add extra queryexecutor nil checks

### DIFF
--- a/core/scc/lscc/lscc.go
+++ b/core/scc/lscc/lscc.go
@@ -163,6 +163,10 @@ func (lscc *LifeCycleSysCC) InvokableCC2CC() bool      { return true }
 func (lscc *LifeCycleSysCC) Enabled() bool             { return true }
 
 func (lscc *LifeCycleSysCC) ChaincodeContainerInfo(chaincodeName string, qe ledger.QueryExecutor) (*ccprovider.ChaincodeContainerInfo, error) {
+	if qe == nil {
+		return nil, errors.Errorf("could not get container info for chaincode %s without a ledger context\n", chaincodeName)
+	}
+
 	chaincodeDataBytes, err := qe.GetState("lscc", chaincodeName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not retrieve state for chaincode %s", chaincodeName)
@@ -184,6 +188,10 @@ func (lscc *LifeCycleSysCC) ChaincodeContainerInfo(chaincodeName string, qe ledg
 }
 
 func (lscc *LifeCycleSysCC) ChaincodeDefinition(chaincodeName string, qe ledger.QueryExecutor) (ccprovider.ChaincodeDefinition, error) {
+	if qe == nil {
+		return nil, errors.Errorf("could not get definition for chaincode %s without a ledger context\n", chaincodeName)
+	}
+
 	chaincodeDataBytes, err := qe.GetState("lscc", chaincodeName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not retrieve state for chaincode %s", chaincodeName)

--- a/core/scc/lscc/lscc_noncc_test.go
+++ b/core/scc/lscc/lscc_noncc_test.go
@@ -113,6 +113,13 @@ var _ = Describe("LSCC", func() {
 				Expect(err).To(MatchError("chaincode chaincode-data-name not found"))
 			})
 		})
+
+		When("the queryexecutor is nil", func() {
+			It("returns an error", func() {
+				_, err := l.ChaincodeContainerInfo("chaincode-data-name", nil)
+				Expect(err).To(MatchError("could not get container info for chaincode chaincode-data-name without a ledger context\n"))
+			})
+		})
 	})
 
 	Describe("ChaincodeDefinition", func() {
@@ -162,6 +169,13 @@ var _ = Describe("LSCC", func() {
 			It("wraps and returns the error", func() {
 				_, err := l.ChaincodeDefinition("cc-name", fakeQueryExecutor)
 				Expect(err).To(MatchError(MatchRegexp("chaincode cc-name has bad definition: proto:.*")))
+			})
+		})
+
+		When("the queryexecutor is nil", func() {
+			It("returns an error", func() {
+				_, err := l.ChaincodeDefinition("cc-name", nil)
+				Expect(err).To(MatchError("could not get definition for chaincode cc-name without a ledger context\n"))
 			})
 		})
 	})


### PR DESCRIPTION
Because system chaincode sometimes executes in a channel-less context,
there is a broken path throughout the chaincode package where despite
being passed as a parameter, the query executor is nil.

This path has been significantly cleaned up in the v2.0 code, though, so
long as system chaincode exists which attempts to execute without a
channel context, we will have this problem.

This small PR simply adds extra nil checks to prevent a crash in the
cases where a nil query executor makes it to this point in the code
path.