### PR TITLE
FAB-18233 Ch.Part.API: BlockPuller verify skip-genesis

### DIFF
--- a/orderer/common/follower/block_puller.go
+++ b/orderer/common/follower/block_puller.go
@@ -150,11 +150,15 @@ func (creator *BlockPullerCreator) VerifyBlockSequence(blocks []*common.Block, _
 			return errors.Wrap(err, "failed to construct a block signature verifier from genesis block")
 		}
 		blocksAfterGenesis := blocks[1:]
+		if len(blocksAfterGenesis) == 0 {
+			return nil
+		}
 		return creator.ClusterVerifyBlocks(blocksAfterGenesis, creator.blockSigVerifier)
 	}
 
 	if creator.blockSigVerifier == nil {
 		return errors.New("nil block signature verifier")
 	}
+
 	return creator.ClusterVerifyBlocks(blocks, creator.blockSigVerifier)
 }


### PR DESCRIPTION
The verify returns an error if the block slice contains only
one block (number 0), since it tries to further verify an
empty slice.

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: I38589499c06acbf81b7b171031efd0fd47093132

#### Type of change

- Bug fix

#### Related issues

Issue: FAB-18233
