### PR TITLE
Peer CLI communicate with orderers with expired TLS certs (release-1.4)

### DIFF
--- a/docs/source/commands/peerchaincode.md
+++ b/docs/source/commands/peerchaincode.md
@@ -94,6 +94,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -129,6 +130,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -160,6 +162,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -189,6 +192,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -220,6 +224,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -251,6 +256,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -274,6 +280,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -310,6 +317,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
       --transient string                    Transient map of arguments in JSON encoding
 ```
 
@@ -476,7 +484,7 @@ upgrades the chaincode named `mycc` at version `1.0` on channel
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    peer chaincode upgrade -o orderer.example.com:7050 --tls --cafile $ORDERER_CA -C mychannel -n mycc -v 1.2 -c '{"Args":["init","a","100","b","200"]}' -P "AND ('Org1MSP.peer','Org2MSP.peer')"
+    peer chaincode upgrade -o orderer.example.com:7050 --tls --cafile $ORDERER_CA -C mychannel -n mycc -v 1.2 -c '{"Args":["init","a","100","b","200","c","300"]}' -P "AND ('Org1MSP.peer','Org2MSP.peer')"
     .
     .
     .
@@ -500,7 +508,7 @@ upgrades the chaincode named `mycc` at version `1.0` on channel
     network with TLS disabled:
 
     ```
-    peer chaincode upgrade -o orderer.example.com:7050 -C mychannel -n mycc -v 1.2 -c '{"Args":["init","a","100","b","200"]}' -P "AND ('Org1MSP.peer','Org2MSP.peer')"
+    peer chaincode upgrade -o orderer.example.com:7050 -C mychannel -n mycc -v 1.2 -c '{"Args":["init","a","100","b","200","c","300"]}' -P "AND ('Org1MSP.peer','Org2MSP.peer')"
     .
     .
     .

--- a/docs/source/commands/peerchannel.md
+++ b/docs/source/commands/peerchannel.md
@@ -42,6 +42,7 @@ Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 
 Use "peer channel [command] --help" for more information about a command.
 ```
@@ -70,6 +71,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -94,6 +96,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -117,6 +120,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -140,6 +144,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -162,6 +167,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -185,6 +191,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 
@@ -209,6 +216,7 @@ Global Flags:
   -o, --orderer string                      Ordering service endpoint
       --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer.
       --tls                                 Use TLS when communicating with the orderer endpoint
+      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes
 ```
 
 ## Example Usage

--- a/integration/e2e/cft_test.go
+++ b/integration/e2e/cft_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package e2e
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -20,6 +21,7 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -33,6 +35,8 @@ import (
 	"github.com/hyperledger/fabric/integration/nwo/commands"
 	"github.com/hyperledger/fabric/protos/common"
 	"github.com/hyperledger/fabric/protos/msp"
+	protosorderer "github.com/hyperledger/fabric/protos/orderer"
+	"github.com/hyperledger/fabric/protos/orderer/etcdraft"
 	"github.com/hyperledger/fabric/protos/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -444,7 +448,8 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			o3Runner = network.OrdererRunner(o3)
 
 			By("Launching orderers with a clustered timeshift")
-			for _, orderer := range []*nwo.Orderer{o1, o2, o3} {
+			orderers := []*nwo.Orderer{o1, o2, o3}
+			for _, orderer := range orderers {
 				ordererConfig := network.ReadOrdererConfig(orderer)
 				ordererConfig.General.Cluster.TLSHandshakeTimeShift = 5 * time.Minute
 				network.WriteOrdererConfig(orderer, ordererConfig)
@@ -474,7 +479,7 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			o3Runner = network.OrdererRunner(o3)
 
 			By("Launching orderers again without a general timeshift re-using the cluster port")
-			for _, orderer := range []*nwo.Orderer{o1, o2, o3} {
+			for _, orderer := range orderers {
 				ordererConfig := network.ReadOrdererConfig(orderer)
 				ordererConfig.General.ListenPort = ordererConfig.General.Cluster.ListenPort
 				ordererConfig.General.TLS.Certificate = ordererConfig.General.Cluster.ServerCertificate
@@ -513,10 +518,53 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			o3Runner = network.OrdererRunner(o3)
 
 			By("Launching orderers again with a general timeshift re-using the cluster port")
-			for _, orderer := range []*nwo.Orderer{o1, o2, o3} {
+			for _, orderer := range orderers {
 				ordererConfig := network.ReadOrdererConfig(orderer)
 				ordererConfig.General.TLS.TLSHandshakeTimeShift = 5 * time.Minute
 				network.WriteOrdererConfig(orderer, ordererConfig)
+			}
+
+			o1Proc = ifrit.Invoke(o1Runner)
+			o2Proc = ifrit.Invoke(o2Runner)
+			o3Proc = ifrit.Invoke(o3Runner)
+
+			Eventually(o1Proc.Ready(), network.EventuallyTimeout).Should(BeClosed())
+			Eventually(o2Proc.Ready(), network.EventuallyTimeout).Should(BeClosed())
+			Eventually(o3Proc.Ready(), network.EventuallyTimeout).Should(BeClosed())
+
+			By("Waiting for a leader to be elected")
+			findLeader([]*ginkgomon.Runner{o1Runner, o2Runner, o3Runner})
+
+			By("submitting config updates to orderers with expired TLS certs to replace the expired certs")
+			timeShift := 5 * time.Minute
+			for _, o := range orderers {
+				expiredTlsCert, err := ioutil.ReadFile(filepath.Join(network.OrdererLocalTLSDir(o), "server.crt"))
+				Expect(err).NotTo(HaveOccurred())
+				By("renewing the orderer TLS certificates for " + o.Name)
+				renewOrdererCertificates(network, o)
+				renewedTlsCert, err := ioutil.ReadFile(filepath.Join(network.OrdererLocalTLSDir(o), "server.crt"))
+				Expect(err).NotTo(HaveOccurred())
+				By("updating the config for " + o.Name)
+				renewConsenterCertWithTimeShift(network, peer, o, nwo.ClusterPort, network.SystemChannel.Name, expiredTlsCert, renewedTlsCert, timeShift)
+			}
+
+			By("Killing orderers")
+			o1Proc.Signal(syscall.SIGTERM)
+			o2Proc.Signal(syscall.SIGTERM)
+			o3Proc.Signal(syscall.SIGTERM)
+			Eventually(o1Proc.Wait(), network.EventuallyTimeout).Should(Receive())
+			Eventually(o2Proc.Wait(), network.EventuallyTimeout).Should(Receive())
+			Eventually(o3Proc.Wait(), network.EventuallyTimeout).Should(Receive())
+
+			o1Runner = network.OrdererRunner(o1)
+			o2Runner = network.OrdererRunner(o2)
+			o3Runner = network.OrdererRunner(o3)
+
+			By("Launching orderers again without a general timeshift")
+			for _, o := range orderers {
+				ordererConfig := network.ReadOrdererConfig(o)
+				ordererConfig.General.TLS.TLSHandshakeTimeShift = 0
+				network.WriteOrdererConfig(o, ordererConfig)
 			}
 
 			o1Proc = ifrit.Invoke(o1Runner)
@@ -817,8 +865,11 @@ func findLeader(ordererRunners []*ginkgomon.Runner) int {
 	return firstLeader
 }
 
-func renewOrdererCertificates(network *nwo.Network, o1, o2, o3 *nwo.Orderer) {
-	ordererDomain := network.Organization(o1.Organization).Domain
+func renewOrdererCertificates(network *nwo.Network, orderers ...*nwo.Orderer) {
+	if len(orderers) == 0 {
+		return
+	}
+	ordererDomain := network.Organization(orderers[0].Organization).Domain
 	ordererTLSCACertPath := filepath.Join(network.RootDir, "crypto", "ordererOrganizations",
 		ordererDomain, "tlsca", fmt.Sprintf("tlsca.%s-cert.pem", ordererDomain))
 	ordererTLSCACert, err := ioutil.ReadFile(ordererTLSCACertPath)
@@ -831,7 +882,7 @@ func renewOrdererCertificates(network *nwo.Network, o1, o2, o3 *nwo.Orderer) {
 	Expect(err).NotTo(HaveOccurred())
 
 	serverTLSCerts := make(map[string][]byte)
-	for _, orderer := range []*nwo.Orderer{o1, o2, o3} {
+	for _, orderer := range orderers {
 		tlsCertPath := filepath.Join(network.OrdererLocalTLSDir(orderer), "server.crt")
 		serverTLSCerts[tlsCertPath], err = ioutil.ReadFile(tlsCertPath)
 		Expect(err).NotTo(HaveOccurred())
@@ -961,7 +1012,10 @@ func configFromBootstrapBlock(bootstrapBlock []byte) *common.Config {
 	block := &common.Block{}
 	err := proto.Unmarshal(bootstrapBlock, block)
 	Expect(err).NotTo(HaveOccurred())
+	return configFromBlock(block)
+}
 
+func configFromBlock(block *common.Block) *common.Config {
 	envelope, err := utils.GetEnvelopeFromBlock(block.Data.Data[0])
 	Expect(err).NotTo(HaveOccurred())
 
@@ -973,5 +1027,119 @@ func configFromBootstrapBlock(bootstrapBlock []byte) *common.Config {
 	Expect(err).NotTo(HaveOccurred())
 
 	return configEnv.Config
+}
 
+// renewConsenterCert renews a consenter cert with the given certificate
+// in PEM format for the given channel.
+func renewConsenterCertWithTimeShift(n *nwo.Network, peer *nwo.Peer, orderer *nwo.Orderer, port nwo.PortName, channel string, oldCertificate, newCertificate []byte, timeShift time.Duration) {
+	updateEtcdRaftMetadataWithTimeShift(n, peer, orderer, port, channel, timeShift, func(metadata *etcdraft.ConfigMetadata) {
+		var newConsenters []*etcdraft.Consenter
+		for _, consenter := range metadata.Consenters {
+			if bytes.Equal(consenter.ClientTlsCert, oldCertificate) {
+				consenter.ClientTlsCert = newCertificate
+			}
+			if bytes.Equal(consenter.ServerTlsCert, oldCertificate) {
+				consenter.ServerTlsCert = newCertificate
+			}
+			newConsenters = append(newConsenters, consenter)
+		}
+
+		metadata.Consenters = newConsenters
+	})
+}
+
+// updateEtcdRaftMetadataWithTimeShift executes a config update that updates the etcdraft
+// metadata according to the given function f.
+func updateEtcdRaftMetadataWithTimeShift(network *nwo.Network, peer *nwo.Peer, orderer *nwo.Orderer, port nwo.PortName, channel string, timeShift time.Duration, f func(md *etcdraft.ConfigMetadata)) {
+	updateConsensusMetadataWithTimeShift(network, peer, orderer, port, channel, timeShift, func(originalMetadata []byte) []byte {
+		metadata := &etcdraft.ConfigMetadata{}
+		err := proto.Unmarshal(originalMetadata, metadata)
+		Expect(err).NotTo(HaveOccurred())
+
+		f(metadata)
+
+		newMetadata, err := proto.Marshal(metadata)
+		Expect(err).NotTo(HaveOccurred())
+		return newMetadata
+	})
+}
+
+// UpdateConsensusMetadata executes a config update that updates the consensus
+// metadata according to the given ConsensusMetadataMutator.
+func updateConsensusMetadataWithTimeShift(network *nwo.Network, peer *nwo.Peer, orderer *nwo.Orderer, port nwo.PortName, channel string, timeShift time.Duration, mutateMetadata nwo.ConsensusMetadataMutator) {
+	configBlock := fetchConfigBlock(network, peer, orderer, port, network.SystemChannel.Name, timeShift)
+	config := configFromBlock(configBlock)
+	updatedConfig := proto.Clone(config).(*common.Config)
+
+	consensusTypeConfigValue := updatedConfig.ChannelGroup.Groups["Orderer"].Values["ConsensusType"]
+	consensusTypeValue := &protosorderer.ConsensusType{}
+	err := proto.Unmarshal(consensusTypeConfigValue.Value, consensusTypeValue)
+	Expect(err).NotTo(HaveOccurred())
+
+	consensusTypeValue.Metadata = mutateMetadata(consensusTypeValue.Metadata)
+
+	updatedConfig.ChannelGroup.Groups["Orderer"].Values["ConsensusType"] = &common.ConfigValue{
+		ModPolicy: "Admins",
+		Value:     utils.MarshalOrPanic(consensusTypeValue),
+	}
+
+	updateOrdererConfig(network, orderer, port, channel, timeShift, config, updatedConfig, peer)
+}
+
+func fetchConfigBlock(n *nwo.Network, peer *nwo.Peer, orderer *nwo.Orderer, port nwo.PortName, channel string, tlsHandshakeTimeShift time.Duration) *common.Block {
+	tempDir, err := ioutil.TempDir(n.RootDir, "fetchConfigBlock")
+	Expect(err).NotTo(HaveOccurred())
+	defer os.RemoveAll(tempDir)
+
+	output := filepath.Join(tempDir, "config_block.pb")
+	sess, err := n.OrdererAdminSession(orderer, peer, commands.ChannelFetch{
+		ChannelID:             channel,
+		Block:                 "config",
+		Orderer:               n.OrdererAddress(orderer, port),
+		OutputFile:            output,
+		TLSHandshakeTimeShift: tlsHandshakeTimeShift,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
+	Expect(sess.Err).To(gbytes.Say("Received block: "))
+
+	configBlock := nwo.UnmarshalBlockFromFile(output)
+	return configBlock
+}
+
+func currentConfigBlockNumber(n *nwo.Network, peer *nwo.Peer, orderer *nwo.Orderer, port nwo.PortName, channel string, tlsHandshakeTimeShift time.Duration) uint64 {
+	configBlock := fetchConfigBlock(n, peer, orderer, port, channel, tlsHandshakeTimeShift)
+	return configBlock.Header.Number
+}
+
+func updateOrdererConfig(n *nwo.Network, orderer *nwo.Orderer, port nwo.PortName, channel string, tlsHandshakeTimeShift time.Duration, current, updated *common.Config, submitter *nwo.Peer, checkOrderers ...*nwo.Orderer) {
+	tempDir, err := ioutil.TempDir(n.RootDir, "updateConfig")
+	Expect(err).NotTo(HaveOccurred())
+	updateFile := filepath.Join(tempDir, "update.pb")
+	defer os.RemoveAll(tempDir)
+
+	currentBlockNumber := currentConfigBlockNumber(n, submitter, orderer, port, channel, tlsHandshakeTimeShift)
+	nwo.ComputeUpdateOrdererConfig(updateFile, n, channel, current, updated, submitter)
+
+	Eventually(func() bool {
+		sess, err := n.OrdererAdminSession(orderer, submitter, commands.ChannelUpdate{
+			ChannelID:             channel,
+			Orderer:               n.OrdererAddress(orderer, port),
+			File:                  updateFile,
+			TLSHandshakeTimeShift: tlsHandshakeTimeShift,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		sess.Wait(n.EventuallyTimeout)
+		if sess.ExitCode() != 0 {
+			return false
+		}
+
+		return strings.Contains(string(sess.Err.Contents()), "Successfully submitted channel update")
+	}, n.EventuallyTimeout).Should(BeTrue())
+
+	ccb := func() uint64 {
+		return currentConfigBlockNumber(n, submitter, orderer, port, channel, tlsHandshakeTimeShift)
+	}
+	Eventually(ccb, n.EventuallyTimeout).Should(BeNumerically(">", currentBlockNumber))
 }

--- a/integration/nwo/commands/peer.go
+++ b/integration/nwo/commands/peer.go
@@ -8,6 +8,7 @@ package commands
 
 import (
 	"strconv"
+	"time"
 )
 
 type NodeStart struct {
@@ -95,10 +96,11 @@ func (c ChannelJoin) Args() []string {
 }
 
 type ChannelFetch struct {
-	ChannelID  string
-	Block      string
-	Orderer    string
-	OutputFile string
+	ChannelID             string
+	Block                 string
+	Orderer               string
+	OutputFile            string
+	TLSHandshakeTimeShift time.Duration
 }
 
 func (c ChannelFetch) SessionName() string {
@@ -108,15 +110,10 @@ func (c ChannelFetch) SessionName() string {
 func (c ChannelFetch) Args() []string {
 	args := []string{
 		"channel", "fetch", c.Block,
-	}
-	if c.ChannelID != "" {
-		args = append(args, "--channelID", c.ChannelID)
-	}
-	if c.Orderer != "" {
-		args = append(args, "--orderer", c.Orderer)
-	}
-	if c.OutputFile != "" {
-		args = append(args, c.OutputFile)
+		"--channelID", c.ChannelID,
+		"--orderer", c.Orderer,
+		"--tlsHandshakeTimeShift", c.TLSHandshakeTimeShift.String(),
+		c.OutputFile,
 	}
 	return args
 }
@@ -347,9 +344,10 @@ func (s SignConfigTx) Args() []string {
 }
 
 type ChannelUpdate struct {
-	ChannelID string
-	Orderer   string
-	File      string
+	ChannelID             string
+	Orderer               string
+	File                  string
+	TLSHandshakeTimeShift time.Duration
 }
 
 func (c ChannelUpdate) SessionName() string {
@@ -362,6 +360,7 @@ func (c ChannelUpdate) Args() []string {
 		"--channelID", c.ChannelID,
 		"--orderer", c.Orderer,
 		"--file", c.File,
+		"--tlsHandshakeTimeShift", c.TLSHandshakeTimeShift.String(),
 	}
 }
 

--- a/peer/common/common.go
+++ b/peer/common/common.go
@@ -241,7 +241,9 @@ func configFromEnv(prefix string) (address, override string, clientConfig comm.C
 	clientConfig.Timeout = connTimeout
 	secOpts := &comm.SecureOptions{
 		UseTLS:            viper.GetBool(prefix + ".tls.enabled"),
-		RequireClientCert: viper.GetBool(prefix + ".tls.clientAuthRequired")}
+		RequireClientCert: viper.GetBool(prefix + ".tls.clientAuthRequired"),
+		TimeShift:         viper.GetDuration(prefix + ".tls.handshakeTimeShift"),
+	}
 	if secOpts.UseTLS {
 		caPEM, res := ioutil.ReadFile(config.GetPath(prefix + ".tls.rootcert.file"))
 		if res != nil {

--- a/peer/common/ordererenv.go
+++ b/peer/common/ordererenv.go
@@ -23,6 +23,7 @@ var (
 	certFile                   string
 	ordererTLSHostnameOverride string
 	connTimeout                time.Duration
+	tlsHandshakeTimeShift      time.Duration
 )
 
 // SetOrdererEnv adds orderer-specific settings to the global Viper environment
@@ -51,6 +52,7 @@ func SetOrdererEnv(cmd *cobra.Command, args []string) {
 	viper.Set("orderer.tls.enabled", tlsEnabled)
 	viper.Set("orderer.tls.clientAuthRequired", clientAuth)
 	viper.Set("orderer.client.connTimeout", connTimeout)
+	viper.Set("orderer.tls.handshakeTimeShift", tlsHandshakeTimeShift)
 }
 
 // AddOrdererFlags adds flags for orderer-related commands
@@ -73,4 +75,6 @@ func AddOrdererFlags(cmd *cobra.Command) {
 		"", "", "The hostname override to use when validating the TLS connection to the orderer.")
 	flags.DurationVarP(&connTimeout, "connTimeout",
 		"", 3*time.Second, "Timeout for client to connect")
+	flags.DurationVarP(&tlsHandshakeTimeShift, "tlsHandshakeTimeShift", "", 0,
+		"The amount of time to shift backwards for certificate expiration checks during TLS handshakes")
 }


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Implement a TLS handshake timeshift for the "peer channel fetch" and "peer channel update" comands to allow fetching config blocks and updating the config for orderers with expired TLS certificates.

#### Related issues

[FAB-18205](https://jira.hyperledger.org/browse/FAB-18205)