### PR TITLE
[FAB-18164] Change CreateLedgerFromSnapshot to async

### DIFF
--- a/core/ledger/ledgermgmt/ledger_mgmt_test.go
+++ b/core/ledger/ledgermgmt/ledger_mgmt_test.go
@@ -28,19 +28,8 @@ import (
 )
 
 func TestLedgerMgmt(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "ledgermgmt")
-	if err != nil {
-		t.Fatalf("Failed to create ledger directory: %s", err)
-	}
-	initializer, err := constructDefaultInitializer(testDir)
-	if err != nil {
-		t.Fatalf("Failed to create default initializer: %s", err)
-	}
-
-	ledgerMgr := NewLedgerMgr(initializer)
-	defer func() {
-		os.RemoveAll(testDir)
-	}()
+	initializer, ledgerMgr, cleanup := setup(t, "ledgermgmt")
+	defer cleanup()
 
 	numLedgers := 10
 	ledgers := make([]ledger.PeerLedger, numLedgers)
@@ -60,7 +49,7 @@ func TestLedgerMgmt(t *testing.T) {
 
 	ledgerID := constructTestLedgerID(2)
 	t.Logf("Ledger selected for test = %s", ledgerID)
-	_, err = ledgerMgr.OpenLedger(ledgerID)
+	_, err := ledgerMgr.OpenLedger(ledgerID)
 	require.Equal(t, ErrLedgerAlreadyOpened, err)
 
 	l := ledgers[2]
@@ -86,76 +75,191 @@ func TestLedgerMgmt(t *testing.T) {
 // TestCreateLedgerFromSnapshot first creates a ledger using a genesis block and generates a snapshot.
 // After it, it tests creating ledger from the snapshot.
 func TestCreateLedgerFromSnapshot(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "createledgerfromsnapshot")
-	require.NoError(t, err)
-	initializer, err := constructDefaultInitializer(testDir)
-	require.NoError(t, err)
-	ledgerMgr := NewLedgerMgr(initializer)
-	defer func() {
-		os.RemoveAll(testDir)
-	}()
+	initializer, lgrMgr, cleanup := setup(t, "createledgerfromsnapshot")
+	defer cleanup()
 
 	channelID := "testcreatefromsnapshot"
-	_, gb := testutil.NewBlockGenerator(t, channelID, false)
-	l, err := ledgerMgr.CreateLedger(channelID, gb)
-	require.NoError(t, err)
+	snapshotDir, gb := generateSnapshot(t, lgrMgr, initializer, channelID)
 
-	// submit a snapshot request, wait until it is generated (request removed from pending requests)
-	require.NoError(t, l.SubmitSnapshotRequest(0))
-	snapshotDir := kvledger.SnapshotDirForLedgerBlockNum(initializer.Config.SnapshotsConfig.RootDir, channelID, 0)
-	snapshotGenerated := func() bool {
-		pendingRequests, err := l.PendingSnapshotRequests()
+	t.Run("create_ledger_from_snapshot_internal", func(t *testing.T) {
+		_, ledgerMgr, cleanup := setup(t, "createledgerfromsnapshot_internal")
+		defer cleanup()
+
+		l, _, err := ledgerMgr.createFromSnapshot(snapshotDir)
 		require.NoError(t, err)
-		return len(pendingRequests) == 0
+		bcInfo, _ := l.GetBlockchainInfo()
+		require.Equal(t, &common.BlockchainInfo{
+			Height: 1, CurrentBlockHash: protoutil.BlockHeaderHash(gb.Header), PreviousBlockHash: nil,
+		}, bcInfo)
+	})
+
+	t.Run("create_ledger_from_snapshot_async", func(t *testing.T) {
+		_, ledgerMgr, cleanup := setup(t, "createledgerfromsnapshot_async")
+		defer cleanup()
+
+		callbackCounter := 0
+		callback := func(l ledger.PeerLedger, cid string) { callbackCounter++ }
+
+		require.NoError(t, ledgerMgr.CreateLedgerFromSnapshot(snapshotDir, callback))
+
+		ledgerCreated := func() bool {
+			return ledgerMgr.GetCreateFromSnapshotInfo() == ""
+		}
+
+		require.Eventually(t, ledgerCreated, time.Minute, time.Second)
+		require.Equal(t, 1, callbackCounter)
+
+		ledgerids, err := ledgerMgr.GetLedgerIDs()
+		require.NoError(t, err)
+		require.Equal(t, ledgerids, []string{channelID})
+	})
+
+	t.Run("create_existing_ledger_returns_error", func(t *testing.T) {
+		// create the ledger from snapshot under the same rootdir should return error because the ledger already exists
+		_, _, err := lgrMgr.createFromSnapshot(snapshotDir)
+		require.EqualError(t, err, "error while creating ledger id: ledger [testcreatefromsnapshot] already exists with state [ACTIVE]")
+	})
+
+	t.Run("create_ledger_from_nonexist_or_empty_dir_returns_error", func(t *testing.T) {
+		testDir, err := ioutil.TempDir("", "invalidsnapshotdir")
+		require.NoError(t, err)
+		defer os.RemoveAll(testDir)
+
+		nonExistDir := filepath.Join(testDir, "nonexistdir")
+		require.EqualError(t, lgrMgr.CreateLedgerFromSnapshot(nonExistDir, nil),
+			fmt.Sprintf("error opening dir [%s]: open %s: no such file or directory", nonExistDir, nonExistDir))
+
+		require.EqualError(t, lgrMgr.CreateLedgerFromSnapshot(testDir, nil),
+			fmt.Sprintf("snapshot dir %s is empty", testDir))
+	})
+
+	t.Run("callback_func_is_not_called_if_create_ledger_from_snapshot_failed", func(t *testing.T) {
+		initializer, ledgerMgr, cleanup := setup(t, "callbackfuncisnotcalled")
+		defer cleanup()
+
+		// copy snapshotDir to a new dir and remove a metadata file so that kvledger.CreateFromSnapshot will fail
+		require.NoError(t, os.MkdirAll(initializer.Config.SnapshotsConfig.RootDir, 0755))
+		require.NoError(t, testutil.CopyDir(snapshotDir, initializer.Config.SnapshotsConfig.RootDir, false))
+		newSnapshotDir := filepath.Join(initializer.Config.SnapshotsConfig.RootDir, "0")
+		require.NoError(t, os.Remove(filepath.Join(newSnapshotDir, "_snapshot_signable_metadata.json")))
+
+		callbackCounter := 0
+		callback := func(l ledger.PeerLedger, cid string) { callbackCounter++ }
+
+		require.NoError(t, ledgerMgr.CreateLedgerFromSnapshot(newSnapshotDir, callback))
+
+		// wait until CreateFromSnapshot is done
+		createLedgerIsDone := func() bool {
+			return ledgerMgr.GetCreateFromSnapshotInfo() == ""
+		}
+		require.Eventually(t, createLedgerIsDone, time.Minute, time.Second)
+
+		// callback should not be called and ledger should not be generated
+		require.Equal(t, 0, callbackCounter)
+
+		ids, err := ledgerMgr.GetLedgerIDs()
+		require.NoError(t, err)
+		require.Equal(t, 0, len(ids))
+	})
+}
+
+func TestConcurrentCreateLedgerFromGB(t *testing.T) {
+	_, ledgerMgr, cleanup := setup(t, "concurrentcreateledgerfromgb")
+	defer cleanup()
+
+	var err error
+	gbs := make([]*common.Block, 0, 5)
+	for i := 0; i < len(gbs); i++ {
+		gbs[i], err = test.MakeGenesisBlock(fmt.Sprintf("l%d", i))
+		require.NoError(t, err)
 	}
-	require.Eventually(t, snapshotGenerated, 30*time.Second, 100*time.Millisecond)
+
+	// verify CreateLedger (from genesisblock) can be called concurrently
+	for i := 0; i < len(gbs); i++ {
+		gb := gbs[i]
+		ledgerID := fmt.Sprintf("l%d", i)
+		go func() {
+			_, err := ledgerMgr.CreateLedger(ledgerID, gb)
+			require.NoError(t, err)
+		}()
+	}
+
+	ledgersGenerated := func() bool {
+		ledgerIds, err := ledgerMgr.GetLedgerIDs()
+		require.NoError(t, err)
+		return len(ledgerIds) == len(gbs)
+	}
+	require.Eventually(t, ledgersGenerated, time.Minute, time.Second)
+}
+
+func TestConcurrentCreateLedgerFromSnapshot(t *testing.T) {
+	initializer, ledgerMgr, cleanup := setup(t, "concurrentcreateledgerfromsnapshot")
+	defer cleanup()
+
+	// generate 2 snapshots for 2 channels
+	channelID1 := "testcreatefromsnapshot1"
+	snapshotDir1, _ := generateSnapshot(t, ledgerMgr, initializer, channelID1)
+	channelID2 := "testcreatefromsnapshot2"
+	snapshotDir2, _ := generateSnapshot(t, ledgerMgr, initializer, channelID2)
 
 	ledgerMgr.Close()
 
-	// re-create the ledger from snapshot under the same rootdir should return error because the ledger already exists
-	ledgerMgr = NewLedgerMgr(initializer)
-	_, _, err = ledgerMgr.CreateLedgerFromSnapshot(snapshotDir)
-	require.EqualError(t, err, "error while creating ledger id: ledger [testcreatefromsnapshot] already exists with state [ACTIVE]")
+	// create a new ledger mgr to import snapshot
+	_, ledgerMgr2, cleanup2 := setup(t, "concurrentcreateledgerfromsnapshot2")
+	defer cleanup2()
 
-	// re-create the ledger from snapshot under a different root dir should work because the idStore is empty
-	testDir2, err := ioutil.TempDir("", "createledgerfromsnapshot2")
-	require.NoError(t, err)
-	initializer2, err := constructDefaultInitializer(testDir2)
-	require.NoError(t, err)
+	// use a channel to keep the callback func waiting so that we can test concurrent CreateLedger/CreateLedgerBySnapshot calls
+	waitCh := make(chan struct{})
+	callback := func(l ledger.PeerLedger, cid string) {
+		<-waitCh
+	}
+	require.NoError(t, ledgerMgr2.CreateLedgerFromSnapshot(snapshotDir1, callback))
 
-	ledgerMgr2 := NewLedgerMgr(initializer2)
-	defer func() {
-		ledgerMgr2.Close()
-		os.RemoveAll(testDir2)
-	}()
-
-	l2, cid, err := ledgerMgr2.CreateLedgerFromSnapshot(snapshotDir)
+	// concurrent CreateLedger call should fail
+	channelID3 := "ledgerfromgb"
+	gb, err := test.MakeGenesisBlock(channelID3)
 	require.NoError(t, err)
-	require.Equal(t, channelID, cid)
-	bcInfo, _ := l2.GetBlockchainInfo()
-	require.Equal(t, &common.BlockchainInfo{
-		Height: 1, CurrentBlockHash: protoutil.BlockHeaderHash(gb.Header), PreviousBlockHash: nil,
-	}, bcInfo)
+	_, err = ledgerMgr2.CreateLedger(channelID3, gb)
+	require.EqualError(t, err, fmt.Sprintf("a ledger is being created from a snapshot at %s. Call ledger creation again after it is done.", snapshotDir1))
+
+	// concurrent CreateLedgerBySnapshot call should fail
+	err = ledgerMgr2.CreateLedgerFromSnapshot(snapshotDir2, callback)
+	require.EqualError(t, err, fmt.Sprintf("a ledger is being created from a snapshot at %s. Call ledger creation again after it is done.", snapshotDir1))
+
+	waitCh <- struct{}{}
+	ledgerCreated := func() bool {
+		return ledgerMgr2.GetCreateFromSnapshotInfo() == ""
+	}
+	require.Eventually(t, ledgerCreated, time.Minute, time.Second)
+
+	ledgerIDs, err := ledgerMgr2.GetLedgerIDs()
+	require.NoError(t, err)
+	require.Equal(t, ledgerIDs, []string{channelID1})
+
+	// CreateLedger should work after the previous CreateLedgerFromSnapshot is done
+	_, err = ledgerMgr2.CreateLedger(channelID3, gb)
+
+	// CreateLedgerFromSnapshot should work after the previous CreateLedgerFromSnapshot is done
+	callback = func(l ledger.PeerLedger, cid string) {}
+	require.NoError(t, ledgerMgr2.CreateLedgerFromSnapshot(snapshotDir2, callback))
+
+	// wait until ledger is created from snapshotDir2
+	ledgerCreated = func() bool {
+		return ledgerMgr2.GetCreateFromSnapshotInfo() == ""
+	}
+	require.Eventually(t, ledgerCreated, time.Minute, time.Second)
+
+	ledgerIDs, err = ledgerMgr2.GetLedgerIDs()
+	require.NoError(t, err)
+	require.ElementsMatch(t, ledgerIDs, []string{channelID1, channelID2, channelID3})
 }
 
 func TestChaincodeInfoProvider(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "ledgermgmt")
-	if err != nil {
-		t.Fatalf("Failed to create ledger directory: %s", err)
-	}
-	initializer, err := constructDefaultInitializer(testDir)
-	if err != nil {
-		t.Fatalf("Failed to create default initializer: %s", err)
-	}
-
-	ledgerMgr := NewLedgerMgr(initializer)
-	defer func() {
-		ledgerMgr.Close()
-		os.RemoveAll(testDir)
-	}()
+	_, ledgerMgr, cleanup := setup(t, "chaincodeinfoprovider")
+	defer cleanup()
 
 	gb, _ := test.MakeGenesisBlock("ledger1")
-	_, err = ledgerMgr.CreateLedger("ledger1", gb)
+	_, err := ledgerMgr.CreateLedger("ledger1", gb)
 	require.NoError(t, err)
 
 	mockDeployedCCInfoProvider := &mock.DeployedChaincodeInfoProvider{}
@@ -182,6 +286,19 @@ func TestChaincodeInfoProvider(t *testing.T) {
 	ccInfo, err = ccInfoProvider.GetDeployedChaincodeInfo("ledger1", constructTestCCDef("cc1", "cc1", "cc1"))
 	require.NoError(t, err)
 	require.Equal(t, constructTestCCInfo("cc1", "cc1", "cc1"), ccInfo)
+}
+
+func setup(t *testing.T, basename string) (*Initializer, *LedgerMgr, func()) {
+	testDir, err := ioutil.TempDir("", basename)
+	require.NoError(t, err)
+	initializer, err := constructDefaultInitializer(testDir)
+	require.NoError(t, err)
+	ledgerMgr := NewLedgerMgr(initializer)
+	cleanup := func() {
+		ledgerMgr.Close()
+		os.Remove(testDir)
+	}
+	return initializer, ledgerMgr, cleanup
 }
 
 func constructDefaultInitializer(testDir string) (*Initializer, error) {
@@ -230,4 +347,23 @@ func constructTestCCDef(ccName, version, hash string) *cceventmgmt.ChaincodeDefi
 		Hash:    []byte(hash),
 		Version: version,
 	}
+}
+
+// generateSnapshot creates a ledger with genesis block and generates a snapshot when the ledger only has genesisblock
+func generateSnapshot(t *testing.T, ledgerMgr *LedgerMgr, initializer *Initializer, channelID string) (string, *common.Block) {
+	_, gb := testutil.NewBlockGenerator(t, channelID, false)
+	l, err := ledgerMgr.CreateLedger(channelID, gb)
+	require.NoError(t, err)
+
+	require.NoError(t, l.SubmitSnapshotRequest(0))
+
+	snapshotDir := kvledger.SnapshotDirForLedgerBlockNum(initializer.Config.SnapshotsConfig.RootDir, channelID, 0)
+	snapshotGenerated := func() bool {
+		pendingRequests, err := l.PendingSnapshotRequests()
+		require.NoError(t, err)
+		return len(pendingRequests) == 0
+	}
+	require.Eventually(t, snapshotGenerated, 30*time.Second, 100*time.Millisecond)
+
+	return snapshotDir, gb
 }

--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -224,23 +224,26 @@ func (p *Peer) CreateChannel(
 	return nil
 }
 
-// CreateChannelFromSnapshot create a channel from the specified snapshot.
-func (p *Peer) CreateChannelFromSnaphotshot(
+// CreateChannelFromSnapshot creates a channel from the specified snapshot.
+func (p *Peer) CreateChannelFromSnapshot(
 	snapshotDir string,
 	deployedCCInfoProvider ledger.DeployedChaincodeInfoProvider,
 	legacyLifecycleValidation plugindispatcher.LifecycleResources,
 	newLifecycleValidation plugindispatcher.CollectionAndLifecycleResources,
 ) error {
-	l, cid, err := p.LedgerMgr.CreateLedgerFromSnapshot(snapshotDir)
+	channelCallback := func(l ledger.PeerLedger, cid string) {
+		if err := p.createChannel(cid, l, deployedCCInfoProvider, legacyLifecycleValidation, newLifecycleValidation); err != nil {
+			logger.Errorf("error creating channel for %s", cid)
+			return
+		}
+		p.initChannel(cid)
+	}
+
+	err := p.LedgerMgr.CreateLedgerFromSnapshot(snapshotDir, channelCallback)
 	if err != nil {
 		return errors.WithMessagef(err, "cannot create ledger from snapshot %s", snapshotDir)
 	}
 
-	if err := p.createChannel(cid, l, deployedCCInfoProvider, legacyLifecycleValidation, newLifecycleValidation); err != nil {
-		return err
-	}
-
-	p.initChannel(cid)
 	return nil
 }
 

--- a/core/scc/cscc/configure.go
+++ b/core/scc/cscc/configure.go
@@ -267,7 +267,7 @@ func (e *PeerConfiger) JoinChainBySnapshot(
 	lr plugindispatcher.LifecycleResources,
 	nr plugindispatcher.CollectionAndLifecycleResources,
 ) pb.Response {
-	if err := e.peer.CreateChannelFromSnaphotshot(snapshotDir, deployedCCInfoProvider, lr, nr); err != nil {
+	if err := e.peer.CreateChannelFromSnapshot(snapshotDir, deployedCCInfoProvider, lr, nr); err != nil {
 		return shim.Error(err.Error())
 	}
 


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- New feature

#### Description
- Change CreateLedgerFromSnapshot to async
- Track the ledger when it is under creation from a snapshot
- Do not allow to create another ledger if a ledger
  is under creation from a snapshot
<!--- Describe your changes in detail, including motivation. -->

#### Additional details

#### Related issues
https://jira.hyperledger.org/browse/FAB-18164
