### PR TITLE
Add RemoveStorage to config struct

### DIFF
--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -201,7 +201,9 @@ type Statsd struct {
 // ChannelParticipation provides the channel participation API configuration for the orderer.
 // Channel participation uses the same ListenAddress and TLS settings of the Operations service.
 type ChannelParticipation struct {
-	Enabled            bool
+	Enabled bool
+	// Deprecated: RemoveStorage should be removed in 3.0, currently a no-op
+	RemoveStorage      bool
 	MaxRequestBodySize uint32
 }
 


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

https://github.com/hyperledger/fabric/commit/2ec048503027adf71ece21ebaaf8f626f4723f80#diff-d9c9ae912bb17d731001a3f2afd99346 results in a breaking change between minor fabric versions for the orderer. To avoid this RemoveStorage is left on the Config struct and properly commented. 


