### PR TITLE
Update write_first_app.rst to use correct package name

### DIFF
--- a/docs/source/write_first_app.rst
+++ b/docs/source/write_first_app.rst
@@ -88,7 +88,7 @@ In addition to the standard :doc:`prereqs` for Fabric, this tutorial leverages t
 
   .. code:: bash
 
-    sudo apt install build-essentials
+    sudo apt install build-essential
 
 Set up the blockchain network
 -----------------------------


### PR DESCRIPTION
Fix typo for installation of `build-essential` package

#### Type of change

- Documentation update

#### Description
Fix typo for installation of `build-essential` package

#### Additional details
N/A

#### Related issues
N/A

