### PR TITLE
[FAB-18237] always update stateInfo message upon chaincode update

### DIFF
--- a/gossip/gossip/channel/channel_test.go
+++ b/gossip/gossip/channel/channel_test.go
@@ -1132,6 +1132,14 @@ func TestNoGossipOrSigningWhenEmptyMembership(t *testing.T) {
 	time.Sleep(conf.PublishStateInfoInterval * 3)
 	// We haven't signed anything
 	assert.Equal(t, uint32(2), atomic.LoadUint32(&adapter.signCallCount))
+
+	assert.Empty(t, gc.Self().GetStateInfo().Properties.Chaincodes)
+	gossipedWG.Add(1)
+	// Now, update chaincodes and check our chaincode information was indeed updated
+	gc.UpdateChaincodes([]*proto.Chaincode{{Name: "mycc"}})
+	// We should have signed regardless!
+	assert.Equal(t, uint32(3), atomic.LoadUint32(&adapter.signCallCount))
+	assert.Equal(t, "mycc", gc.Self().GetStateInfo().Properties.Chaincodes[0].Name)
 }
 
 func TestChannelPulledBadBlocks(t *testing.T) {


### PR DESCRIPTION
With the change of FAB-18208, gossip saves CPU cycles by only updating
metadata information if peer membership is not empty.

However, this makes discovery incapable of operating in case
anchor/bootstrap peers are not defined, or, in case
the peer is the only peer in the network.

This change makes gossip always update its information, including
signing the stateInfo message, whenever it receives a chaincode update.

Change-Id: Iaf04441944a3fe5d889233d35bdcb1173c31e2bc
Signed-off-by: yacovm <yacovm@il.ibm.com>
