### PR TITLE
[FAB-18242] Remove GetSessionInfo Call

### DIFF
--- a/bccsp/pkcs11/pkcs11.go
+++ b/bccsp/pkcs11/pkcs11.go
@@ -67,14 +67,7 @@ func (csp *impl) getSession() (session pkcs11.SessionHandle, err error) {
 	for {
 		select {
 		case session = <-csp.sessPool:
-			if _, err = csp.ctx.GetSessionInfo(session); err == nil {
-				logger.Debugf("Reusing existing pkcs11 session %d on slot %d\n", session, csp.slot)
-				return session, nil
-			}
-
-			logger.Warningf("Get session info failed [%s], closing existing session and getting a new session\n", err)
-			csp.closeSession(session)
-
+			return
 		default:
 			// cache is empty (or completely in use), create a new session
 			return csp.createSession()


### PR DESCRIPTION
The GetSessionInfo call was added to the getSession
function which retrieves a session from the pool.
The call was used to validate the state of the session
before using it to ensure it was still healthy.
Unfortunately the call is exceedingly expensive with
preliminary tests showing nearly a second to perform the
single operation. With a transaction require requiring
several signings it is possible for it to take several
seconds for a transaction just to retrieve all of it signatures.

This change reverts the call and in future implementations
we can look into other ways of verifying if a session has
become stale, perhaps by analyzing failed transaction error
messages and ejecting the session on transaction failures.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
