### PR TITLE
[FAB-18242] Remove GetSessionInfo Call

### DIFF
--- a/bccsp/pkcs11/pkcs11.go
+++ b/bccsp/pkcs11/pkcs11.go
@@ -302,14 +302,7 @@ func (csp *impl) getSession() (session pkcs11.SessionHandle, err error) {
 	for {
 		select {
 		case session = <-csp.sessPool:
-			if _, err = csp.ctx.GetSessionInfo(session); err == nil {
-				logger.Debugf("Reusing existing pkcs11 session %d on slot %d\n", session, csp.slot)
-				return session, nil
-			}
-
-			logger.Warningf("Get session info failed [%s], closing existing session and getting a new session\n", err)
-			csp.closeSession(session)
-
+			return
 		default:
 			// cache is empty (or completely in use), create a new session
 			return csp.createSession()

--- a/bccsp/pkcs11/pkcs11_test.go
+++ b/bccsp/pkcs11/pkcs11_test.go
@@ -1313,39 +1313,14 @@ func TestPKCS11GetSession(t *testing.T) {
 	for _, session := range sessions {
 		currentBCCSP.(*impl).returnSession(session)
 	}
-	sessions = nil
-
-	// Lets break OpenSession, so non-cached session cannot be opened
-	oldSlot := currentBCCSP.(*impl).slot
-	currentBCCSP.(*impl).slot = ^uint(0)
 
 	// Should be able to get sessionCacheSize cached sessions
+	sessions = nil
 	for i := 0; i < sessionCacheSize; i++ {
 		session, err := currentBCCSP.(*impl).getSession()
 		assert.NoError(t, err)
 		sessions = append(sessions, session)
 	}
-
-	_, err := currentBCCSP.(*impl).getSession()
-	assert.EqualError(t, err, "OpenSession failed: pkcs11: 0x3: CKR_SLOT_ID_INVALID")
-
-	// Load cache with bad sessions
-	for i := 0; i < sessionCacheSize; i++ {
-		currentBCCSP.(*impl).returnSession(pkcs11.SessionHandle(^uint(0)))
-	}
-
-	// Fix OpenSession so non-cached sessions can be opened
-	currentBCCSP.(*impl).slot = oldSlot
-
-	// Request a session, return, and re-acquire. The pool should be emptied
-	// before creating a new session so when returned, it should be the only
-	// session in the cache.
-	sess, err := currentBCCSP.(*impl).getSession()
-	require.NoError(t, err)
-	currentBCCSP.(*impl).returnSession(sess)
-	sess2, err := currentBCCSP.(*impl).getSession()
-	require.NoError(t, err)
-	require.Equal(t, sess, sess2, "expected to get back the same session")
 
 	// Cleanup
 	for _, session := range sessions {
@@ -1410,11 +1385,6 @@ func TestSessionHandleCaching(t *testing.T) {
 		pi.returnSession(sess2)
 		require.Empty(t, pi.sessions, "expected sessions to be empty")
 		require.Empty(t, pi.handleCache, "expected handles to be cleared")
-
-		pi.slot = ^uint(0) // break OpenSession
-		_, err = pi.getSession()
-		require.EqualError(t, err, "OpenSession failed: pkcs11: 0x3: CKR_SLOT_ID_INVALID")
-		require.Empty(t, pi.sessions, "expected sessions to be empty")
 	})
 
 	t.Run("SessionCacheEnabled", func(t *testing.T) {
@@ -1463,31 +1433,6 @@ func TestSessionHandleCaching(t *testing.T) {
 		require.Len(t, pi.sessions, 1, "expected one open session (sess1)")
 		require.Len(t, pi.sessPool, 0, "sessionPool should be empty")
 		require.Len(t, pi.handleCache, 2, "expected two handles in handle cache")
-
-		pi.slot = ^uint(0) // break OpenSession
-		_, err = pi.getSession()
-		require.EqualError(t, err, "OpenSession failed: pkcs11: 0x3: CKR_SLOT_ID_INVALID")
-		require.Len(t, pi.sessions, 1, "expected one active session (sess1)")
-		require.Len(t, pi.sessPool, 0, "sessionPool should be empty")
-		require.Len(t, pi.handleCache, 2, "expected two handles in handle cache")
-
-		// Return a busted session that should be cached
-		pi.returnSession(pkcs11.SessionHandle(^uint(0)))
-		require.Len(t, pi.sessions, 1, "expected one active session (sess1)")
-		require.Len(t, pi.sessPool, 1, "sessionPool should contain busted session")
-		require.Len(t, pi.handleCache, 2, "expected two handles in handle cache")
-
-		// Return sess1 that should be discarded
-		pi.returnSession(sess1)
-		require.Len(t, pi.sessions, 0, "expected sess1 to be removed")
-		require.Len(t, pi.sessPool, 1, "sessionPool should contain busted session")
-		require.Empty(t, pi.handleCache, "expected handles to be purged on removal of last tracked session")
-
-		// Try to get broken session from cache
-		_, err = pi.getSession()
-		require.EqualError(t, err, "OpenSession failed: pkcs11: 0x3: CKR_SLOT_ID_INVALID")
-		require.Empty(t, pi.sessions, "expected sessions to be empty")
-		require.Len(t, pi.sessPool, 0, "sessionPool should be empty")
 	})
 }
 


### PR DESCRIPTION
The GetSessionInfo call was added to the getSession function which retrieves a session from the pool. The call was used to validate the state of the session before using it to ensure it was still healthy. Unfortunately the call is exceedingly expensive with prelimary tests showing nearly a second to perform the single operation. With a transaction require requiring several signings it is possible for it to take several seconds for a transaction just to retrieve all of it signatures.

This change reverts the call and in future implementations we can look into other ways of verifying if a session has become stale such as analyzing transaction failures to identify sessions that should be ejected.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
