### PR TITLE
Enable pvtdata store to receive pvtdata hashes during bootstrap

### DIFF
--- a/core/ledger/kvledger/kv_ledger_provider.go
+++ b/core/ledger/kvledger/kv_ledger_provider.go
@@ -333,13 +333,7 @@ func (p *Provider) open(ledgerID string, bootSnapshotMetadata *snapshotMetadata,
 	if err != nil {
 		return nil, err
 	}
-
-	storeInitializer := &pvtdatastorage.Initializer{}
-	if bootSnapshotMetadata != nil {
-		storeInitializer.CreatedFromSnapshot = true
-		storeInitializer.LastBlockInSnapshot = bootSnapshotMetadata.LastBlockNumber
-	}
-	pvtdataStore, err := p.pvtdataStoreProvider.OpenStore(ledgerID, storeInitializer)
+	pvtdataStore, err := p.pvtdataStoreProvider.OpenStore(ledgerID)
 	if err != nil {
 		return nil, err
 	}

--- a/core/ledger/kvledger/kv_ledger_provider_test.go
+++ b/core/ledger/kvledger/kv_ledger_provider_test.go
@@ -605,6 +605,7 @@ func testutilNewProvider(conf *lgr.Config, t *testing.T, ccInfoProvider *mock.De
 			HashProvider:                    cryptoProvider,
 			HealthCheckRegistry:             &mock.HealthCheckRegistry{},
 			ChaincodeLifecycleEventProvider: &mock.ChaincodeLifecycleEventProvider{},
+			MembershipInfoProvider:          &mock.MembershipInfoProvider{},
 		},
 	)
 	require.NoError(t, err, "Failed to create new Provider")

--- a/core/ledger/kvledger/snapshot_test.go
+++ b/core/ledger/kvledger/snapshot_test.go
@@ -104,6 +104,20 @@ func TestSnapshotGenerationAndNewLedgerCreation(t *testing.T) {
 		},
 	)
 
+	// add dummy entry in collection config history and commit block-3 and generate the snapshot
+	collConfigPkg := &peer.CollectionConfigPackage{
+		Config: []*peer.CollectionConfig{
+			{
+				Payload: &peer.CollectionConfig_StaticCollectionConfig{
+					StaticCollectionConfig: &peer.StaticCollectionConfig{
+						Name: "coll",
+					},
+				},
+			},
+		},
+	}
+	addDummyEntryInCollectionConfigHistory(t, provider, kvlgr.ledgerID, "ns", 1, collConfigPkg)
+
 	// add block-2 only with public and private data and generate the snapshot
 	blockAndPvtdata2 := prepareNextBlockForTest(t, kvlgr, blkGenerator, "SimulateForBlk2",
 		map[string]string{
@@ -132,23 +146,11 @@ func TestSnapshotGenerationAndNewLedgerCreation(t *testing.T) {
 				"txids.data", "txids.metadata",
 				"public_state.data", "public_state.metadata",
 				"private_state_hashes.data", "private_state_hashes.metadata",
+				"confighistory.data", "confighistory.metadata",
 			},
 		},
 	)
 
-	// add dummy entry in collection config history and commit block-3 and generate the snapshot
-	collConfigPkg := &peer.CollectionConfigPackage{
-		Config: []*peer.CollectionConfig{
-			{
-				Payload: &peer.CollectionConfig_StaticCollectionConfig{
-					StaticCollectionConfig: &peer.StaticCollectionConfig{
-						Name: "coll",
-					},
-				},
-			},
-		},
-	}
-	addDummyEntryInCollectionConfigHistory(t, provider, kvlgr.ledgerID, "ns", 2, collConfigPkg)
 	blockAndPvtdata3 := prepareNextBlockForTest(t, kvlgr, blkGenerator, "SimulateForBlk3",
 		map[string]string{
 			"key1": "value1.3",
@@ -196,7 +198,7 @@ func TestSnapshotGenerationAndNewLedgerCreation(t *testing.T) {
 					"key3": "value3.3",
 				},
 				collectionConfig: map[uint64]*peer.CollectionConfigPackage{
-					2: collConfigPkg,
+					1: collConfigPkg,
 				},
 			},
 		)

--- a/core/ledger/pvtdatastorage/kv_encoding.go
+++ b/core/ledger/pvtdatastorage/kv_encoding.go
@@ -29,6 +29,7 @@ var (
 	lastUpdatedOldBlocksKey          = []byte{7}
 	elgDeprioritizedMissingDataGroup = []byte{8}
 	bootKVHashesKeyPrefix            = []byte{9}
+	lastBlockInBootSnapshotKey       = []byte{'a'}
 
 	nilByte    = byte(0)
 	emptyValue = []byte{}
@@ -212,6 +213,18 @@ func decodeBootKVHashesVal(b []byte) (*BootKVHashes, error) {
 		return nil, errors.Wrap(err, "error while unmarshalling bytes for BootKVHashes")
 	}
 	return val, nil
+}
+
+func encodeLastBlockInBootSnapshotVal(blockNum uint64) []byte {
+	return proto.EncodeVarint(blockNum)
+}
+
+func decodeLastBlockInBootSnapshotVal(blockNumBytes []byte) (uint64, error) {
+	s, n := proto.DecodeVarint(blockNumBytes)
+	if n == 0 {
+		return 0, errors.New("unexpected bytes for interpreting as varint")
+	}
+	return s, nil
 }
 
 func createRangeScanKeysForElgMissingData(blkNum uint64, group []byte) ([]byte, []byte) {

--- a/core/ledger/pvtdatastorage/kv_encoding_test.go
+++ b/core/ledger/pvtdatastorage/kv_encoding_test.go
@@ -165,3 +165,19 @@ func TestDecodingAppendedValues(t *testing.T) {
 		}
 	}
 }
+
+func TestEncodingDecodingLastBlockInSnapshotVal(t *testing.T) {
+	t.Run("basic-coding-encoding", func(t *testing.T) {
+		for i := uint64(0); i < 100; i++ {
+			encoded := encodeLastBlockInBootSnapshotVal(i)
+			decoded, err := decodeLastBlockInBootSnapshotVal(encoded)
+			require.NoError(t, err)
+			require.Equal(t, i, decoded)
+		}
+	})
+
+	t.Run("error-case", func(t *testing.T) {
+		_, err := decodeLastBlockInBootSnapshotVal([]byte{0xff})
+		require.EqualError(t, err, "unexpected bytes for interpreting as varint")
+	})
+}

--- a/core/ledger/pvtdatastorage/persistent_msgs_helper.go
+++ b/core/ledger/pvtdatastorage/persistent_msgs_helper.go
@@ -63,6 +63,14 @@ func (e *ExpiryData) addBootKVHash(ns, coll string, txNum uint64) {
 	txNums.List = append(txNums.List, txNum)
 }
 
+func (h *BootKVHashes) toMap() map[string][]byte {
+	m := make(map[string][]byte, len(h.List))
+	for _, kv := range h.List {
+		m[string(kv.KeyHash)] = kv.ValueHash
+	}
+	return m
+}
+
 func newCollElgInfo(nsCollMap map[string][]string) *CollElgInfo {
 	m := &CollElgInfo{NsCollMap: map[string]*CollNames{}}
 	for ns, colls := range nsCollMap {

--- a/core/ledger/pvtdatastorage/store_created_from_snapshot_test.go
+++ b/core/ledger/pvtdatastorage/store_created_from_snapshot_test.go
@@ -1,0 +1,327 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pvtdatastorage
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/ledger/confighistory/confighistorytest"
+	"github.com/hyperledger/fabric/core/ledger/internal/version"
+	btltestutil "github.com/hyperledger/fabric/core/ledger/pvtdatapolicy/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPvtdataStoreCreatedFromSnapshot(t *testing.T) {
+	type snapshotData struct {
+		collection         string
+		keyHash, valueHash []byte
+		version            *version.Height
+	}
+
+	setup := func(snapshotData []*snapshotData) *Store {
+		testDir := testDir(t)
+		conf := pvtDataConf()
+		conf.StorePath = testDir
+		t.Cleanup(func() { os.RemoveAll(testDir) })
+
+		p, err := NewProvider(conf)
+		require.NoError(t, err)
+		t.Cleanup(func() { p.Close() })
+
+		configHistoryMgr, err := confighistorytest.NewMgr(path.Join(testDir, "config-history"))
+		require.NoError(t, err)
+
+		require.NoError(t,
+			configHistoryMgr.Setup(
+				"test-ledger", "ns",
+				map[uint64][]*peer.StaticCollectionConfig{
+					1: {
+						{
+							Name:             "eligible-coll",
+							MemberOrgsPolicy: iamIn.toMemberOrgPolicy(),
+							BlockToLive:      40,
+						},
+
+						{
+							Name:             "ineligible-coll",
+							MemberOrgsPolicy: iamOut.toMemberOrgPolicy(),
+							BlockToLive:      50,
+						},
+					},
+				},
+			),
+		)
+
+		snapshotDataImporter, err := p.SnapshotDataImporterFor("test-ledger", 25,
+			newMockMembershipProvider("myOrg"), configHistoryMgr.GetRetriever("test-ledger"),
+		)
+		require.NoError(t, err)
+
+		for _, d := range snapshotData {
+			require.NoError(t,
+				snapshotDataImporter.ConsumeSnapshotData("ns", d.collection, d.keyHash, d.valueHash, d.version),
+			)
+		}
+
+		store, err := p.OpenStore("test-ledger")
+		require.NoError(t, err)
+		store.Init(
+			btltestutil.SampleBTLPolicy(
+				map[[2]string]uint64{
+					{"ns", "eligible-coll"}:   40,
+					{"ns", "ineligible-coll"}: 50,
+				},
+			),
+		)
+		return store
+	}
+
+	t.Run("basic-functions-on-store", func(t *testing.T) {
+		store := setup(
+			[]*snapshotData{
+				{
+					collection: "eligible-coll",
+					keyHash:    []byte("eligible-coll-key-hash"),
+					valueHash:  []byte("eligible-coll-value-hash"),
+					version:    version.NewHeight(20, 200),
+				},
+			},
+		)
+
+		require.False(t, store.isEmpty)
+		require.Equal(t, &bootsnapshotInfo{createdFromSnapshot: true, lastBlockInSnapshot: 25}, store.bootsnapshotInfo)
+
+		isEmpty, lastBlkNum, err := store.getLastCommittedBlockNum()
+		require.NoError(t, err)
+		require.False(t, isEmpty)
+		require.Equal(t, uint64(25), lastBlkNum)
+
+		err = store.Commit(25, nil, nil)
+		require.EqualError(t, err, "Expected block number=26, received block number=25")
+		require.NoError(t, store.Commit(26, nil, nil))
+	})
+
+	t.Run("fetch-bootkv-hashes", func(t *testing.T) {
+		store := setup(
+			[]*snapshotData{
+				{
+					collection: "eligible-coll",
+					keyHash:    []byte("eligible-coll-key-hash-1"),
+					valueHash:  []byte("eligible-coll-value-hash-1"),
+					version:    version.NewHeight(20, 200),
+				},
+				{
+					collection: "eligible-coll",
+					keyHash:    []byte("eligible-coll-key-hash-2"),
+					valueHash:  []byte("eligible-coll-value-hash-2"),
+					version:    version.NewHeight(20, 200),
+				},
+			},
+		)
+
+		m, err := store.FetchBootKVHashes(20, 200, "ns", "eligible-coll")
+		require.NoError(t, err)
+		require.Equal(t,
+			map[string][]byte{
+				"eligible-coll-key-hash-1": []byte("eligible-coll-value-hash-1"),
+				"eligible-coll-key-hash-2": []byte("eligible-coll-value-hash-2"),
+			},
+			m,
+		)
+
+		m, err = store.FetchBootKVHashes(25, 200, "ns", "eligible-coll")
+		require.NoError(t, err)
+		require.Len(t, m, 0)
+
+		_, err = store.FetchBootKVHashes(26, 200, "ns", "eligible-coll")
+		require.EqualError(t, err, "unexpected call. Boot KV Hashes are persisted only for the data imported from snapshot")
+	})
+
+	t.Run("committing-old-blocks-pvtdata-deletes-bootKV-hashes", func(t *testing.T) {
+		store := setup(
+			[]*snapshotData{
+				{
+					collection: "eligible-coll",
+					keyHash:    []byte("eligible-coll-key-hash"),
+					valueHash:  []byte("eligible-coll-value-hash"),
+					version:    version.NewHeight(20, 200),
+				},
+				{
+					collection: "ineligible-coll",
+					keyHash:    []byte("ineligible-coll-key-hash"),
+					valueHash:  []byte("ineligible-coll-value-hash"),
+					version:    version.NewHeight(21, 210),
+				},
+				{
+					collection: "eligible-coll",
+					keyHash:    []byte("key-hash-at-last-block-in-snapshot"),
+					valueHash:  []byte("value-hash-at-last-block-in-snapshot"),
+					version:    version.NewHeight(25, 250),
+				},
+			},
+		)
+
+		m, err := store.FetchBootKVHashes(20, 200, "ns", "eligible-coll")
+		require.NoError(t, err)
+		require.Equal(t,
+			map[string][]byte{
+				"eligible-coll-key-hash": []byte("eligible-coll-value-hash"),
+			},
+			m,
+		)
+
+		m, err = store.FetchBootKVHashes(25, 250, "ns", "eligible-coll")
+		require.NoError(t, err)
+		require.Equal(t,
+			map[string][]byte{
+				"key-hash-at-last-block-in-snapshot": []byte("value-hash-at-last-block-in-snapshot"),
+			},
+			m,
+		)
+
+		m, err = store.FetchBootKVHashes(21, 210, "ns", "ineligible-coll")
+		require.NoError(t, err)
+		require.Equal(t,
+			map[string][]byte{
+				"ineligible-coll-key-hash": []byte("ineligible-coll-value-hash"),
+			},
+			m,
+		)
+
+		missingDataInfo, err := store.GetMissingPvtDataInfoForMostRecentBlocks(4)
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			ledger.MissingPvtDataInfo{
+				20: ledger.MissingBlockPvtdataInfo{
+					200: []*ledger.MissingCollectionPvtDataInfo{
+						{
+							Namespace:  "ns",
+							Collection: "eligible-coll",
+						},
+					},
+				},
+				25: ledger.MissingBlockPvtdataInfo{
+					250: []*ledger.MissingCollectionPvtDataInfo{
+						{
+							Namespace:  "ns",
+							Collection: "eligible-coll",
+						},
+					},
+				},
+			},
+			missingDataInfo,
+		)
+
+		err = store.CommitPvtDataOfOldBlocks(
+			map[uint64][]*ledger.TxPvtData{
+				20: {
+					produceSamplePvtdata(t, 200, []string{"ns:eligible-coll"}),
+				},
+				25: {
+					produceSamplePvtdata(t, 250, []string{"ns:eligible-coll"}),
+				},
+			},
+			nil,
+		)
+		require.NoError(t, err)
+
+		missingDataInfo, err = store.GetMissingPvtDataInfoForMostRecentBlocks(4)
+		require.NoError(t, err)
+		require.Len(t, missingDataInfo, 0)
+
+		m, err = store.FetchBootKVHashes(20, 200, "ns", "eligible-coll")
+		require.NoError(t, err)
+		require.Len(t, m, 0)
+
+		m, err = store.FetchBootKVHashes(25, 250, "ns", "eligible-coll")
+		require.NoError(t, err)
+		require.Len(t, m, 0)
+
+		m, err = store.FetchBootKVHashes(21, 210, "ns", "ineligible-coll")
+		require.NoError(t, err)
+		require.Equal(t,
+			map[string][]byte{
+				"ineligible-coll-key-hash": []byte("ineligible-coll-value-hash"),
+			},
+			m,
+		)
+	})
+
+	t.Run("purger-deletes-expired-bootKV-hashes", func(t *testing.T) {
+		store := setup(
+			[]*snapshotData{
+				{
+					collection: "eligible-coll",
+					keyHash:    []byte("eligible-coll-key-hash"),
+					valueHash:  []byte("eligible-coll-value-hash"),
+					version:    version.NewHeight(20, 200),
+				},
+				{
+					collection: "ineligible-coll",
+					keyHash:    []byte("ineligible-coll-key-hash"),
+					valueHash:  []byte("ineligible-coll-value-hash"),
+					version:    version.NewHeight(21, 210),
+				},
+			},
+		)
+
+		m, err := store.FetchBootKVHashes(20, 200, "ns", "eligible-coll")
+		require.NoError(t, err)
+		require.Equal(t,
+			map[string][]byte{
+				"eligible-coll-key-hash": []byte("eligible-coll-value-hash"),
+			},
+			m,
+		)
+
+		m, err = store.FetchBootKVHashes(21, 210, "ns", "ineligible-coll")
+		require.NoError(t, err)
+		require.Equal(t,
+			map[string][]byte{
+				"ineligible-coll-key-hash": []byte("ineligible-coll-value-hash"),
+			},
+			m,
+		)
+
+		// commit 100 blocks and the bootkvhashes should expire
+		store.purgeInterval = 10
+		for i := 0; i < 100; i++ {
+			require.NoError(t, store.Commit(uint64(26+i), nil, nil))
+		}
+
+		m, err = store.FetchBootKVHashes(20, 200, "ns", "eligible-coll")
+		require.NoError(t, err)
+		require.Len(t, m, 0)
+
+		m, err = store.FetchBootKVHashes(21, 210, "ns", "ineligible-coll")
+		require.NoError(t, err)
+		require.Len(t, m, 0)
+	})
+}
+
+func TestStoreCreationErrorPath(t *testing.T) {
+	testDir := testDir(t)
+	conf := pvtDataConf()
+	conf.StorePath = testDir
+	defer os.RemoveAll(testDir)
+
+	p, err := NewProvider(conf)
+	require.NoError(t, err)
+	defer p.Close()
+
+	configHistoryMgr, err := confighistorytest.NewMgr(path.Join(testDir, "config-history"))
+	require.NoError(t, err)
+
+	p.Close()
+	_, err = p.SnapshotDataImporterFor("test-ledger", 25, newMockMembershipProvider("myOrg"), configHistoryMgr.GetRetriever("test-ledger"))
+	require.Contains(t, err.Error(), "error while writing snapshot info to db")
+}

--- a/core/ledger/pvtdatastorage/test_exports.go
+++ b/core/ledger/pvtdatastorage/test_exports.go
@@ -52,7 +52,7 @@ func NewTestStoreEnv(
 	conf.StorePath = storeDir
 	testStoreProvider, err := NewProvider(conf)
 	require.NoError(t, err)
-	testStore, err := testStoreProvider.OpenStore(ledgerid, &Initializer{})
+	testStore, err := testStoreProvider.OpenStore(ledgerid)
 	testStore.Init(btlPolicy)
 	require.NoError(t, err)
 	return &StoreEnv{t, testStoreProvider, testStore, ledgerid, btlPolicy, conf}
@@ -64,7 +64,7 @@ func (env *StoreEnv) CloseAndReopen() {
 	env.TestStoreProvider.Close()
 	env.TestStoreProvider, err = NewProvider(env.conf)
 	require.NoError(env.t, err)
-	env.TestStore, err = env.TestStoreProvider.OpenStore(env.ledgerid, &Initializer{})
+	env.TestStore, err = env.TestStoreProvider.OpenStore(env.ledgerid)
 	env.TestStore.Init(env.btlPolicy)
 	require.NoError(env.t, err)
 }

--- a/core/ledger/pvtdatastorage/v11_V12_test.go
+++ b/core/ledger/pvtdatastorage/v11_V12_test.go
@@ -51,7 +51,7 @@ func TestV11v12(t *testing.T) {
 	p, err := NewProvider(conf)
 	require.NoError(t, err)
 	defer p.Close()
-	s, err := p.OpenStore(ledgerid, &Initializer{})
+	s, err := p.OpenStore(ledgerid)
 	require.NoError(t, err)
 	s.Init(btlPolicy)
 


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Description
As a follow up PR to #1908, this PR 
- Registers the snapshot data importer from pvtdatastore for receiving the pvtdata hashes while loading the hashes from snapshot files into the statedb
- Persists basic information about the booting snapshot in the pvtdata store
- Adds UTs relating to query and deletion of the boot KV hashes upon commit of missing data or expiry of the data

#### Additional details
In a follow up PR, the changes in the reconciliation will be made to pull the bootKV hashes from the pvtdata store instead of from the blockstore for the data below snapshot height


#### Related issues
FAB-18033
