### PR TITLE
Remove escc and vscc from list of system chaincodes

### DIFF
--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -588,8 +588,6 @@ chaincode:
         _lifecycle: enable
         cscc: enable
         lscc: enable
-        escc: enable
-        vscc: enable
         qscc: enable
 
     # Logging section for the chaincode container


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement to core.yaml config

#### Description

escc and vscc shifted from system chaincodes to plugins
in v1.2, but the entries were never cleaned up from core.yaml.
This change removes them from core.yaml

Signed-off-by: David Enyeart <enyeart@us.ibm.com>