### PR TITLE
Fix empty address in peer CLI ClientWait log (release-2.2)

### DIFF
--- a/integration/nwo/deploy.go
+++ b/integration/nwo/deploy.go
@@ -246,7 +246,7 @@ func ApproveChaincodeForMyOrg(n *Network, channel string, orderer *Orderer, chai
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
 			approvedOrgs[p.Organization] = true
-			Eventually(sess.Err, n.EventuallyTimeout).Should(gbytes.Say(`\Qcommitted with status (VALID)\E`))
+			Eventually(sess.Err, n.EventuallyTimeout).Should(gbytes.Say(fmt.Sprintf(`\Qcommitted with status (VALID) at %s\E`, n.PeerAddress(p, ListenPort))))
 		}
 	}
 }

--- a/internal/peer/chaincode/common.go
+++ b/internal/peer/chaincode/common.go
@@ -693,9 +693,13 @@ func NewDeliverGroup(
 ) *DeliverGroup {
 	clients := make([]*DeliverClient, len(deliverClients))
 	for i, client := range deliverClients {
+		address := peerAddresses[i]
+		if address == "" {
+			address = viper.GetString("peer.address")
+		}
 		dc := &DeliverClient{
 			Client:  client,
-			Address: peerAddresses[i],
+			Address: address,
 		}
 		clients[i] = dc
 	}


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Log the CORE_PEER_ADDRESS when --peerAddresses flag is not used.

#### Related issues

[FAB-18249](https://jira.hyperledger.org/browse/FAB-18249)