### PR TITLE
[FAB-18235] Properly handle Newest when a peer is bootstrapped from a snapshot

### DIFF
--- a/common/ledger/blkstorage/blkstoragetest/blkstoragetest.go
+++ b/common/ledger/blkstorage/blkstoragetest/blkstoragetest.go
@@ -1,0 +1,82 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blkstoragetest
+
+import (
+	"crypto/sha256"
+	"hash"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric/common/ledger/blkstorage"
+	"github.com/hyperledger/fabric/common/metrics/disabled"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testNewHashFunc = func() (hash.Hash, error) {
+		return sha256.New(), nil
+	}
+
+	attrsToIndex = []blkstorage.IndexableAttr{
+		blkstorage.IndexableAttrBlockHash,
+		blkstorage.IndexableAttrBlockNum,
+		blkstorage.IndexableAttrTxID,
+		blkstorage.IndexableAttrBlockNumTranNum,
+	}
+)
+
+// BootstrapBlockstoreFromSnapshot does the following:
+// - create a block store using the provided blocks
+// - generate a snapshot from the block store
+// - bootstrap another block store from the snapshot
+func BootstrapBlockstoreFromSnapshot(t *testing.T, ledgerName string, blocks []*common.Block) (*blkstorage.BlockStore, func()) {
+	require.NotEqual(t, 0, len(blocks))
+
+	testDir, err := ioutil.TempDir("", ledgerName)
+	require.NoError(t, err)
+	snapshotDir := filepath.Join(testDir, "snapshot")
+	require.NoError(t, os.Mkdir(snapshotDir, 0755))
+
+	conf := blkstorage.NewConf(testDir, 0)
+	indexConfig := &blkstorage.IndexConfig{AttrsToIndex: attrsToIndex}
+	provider, err := blkstorage.NewProvider(conf, indexConfig, &disabled.Provider{})
+	require.NoError(t, err)
+
+	// create an original store from the provided blocks so that we can create a snapshot
+	originalBlkStore, err := provider.Open(ledgerName + "original")
+	require.NoError(t, err)
+
+	for _, block := range blocks {
+		require.NoError(t, originalBlkStore.AddBlock(block))
+	}
+
+	_, err = originalBlkStore.ExportTxIds(snapshotDir, testNewHashFunc)
+	require.NoError(t, err)
+
+	lastBlockInSnapshot := blocks[len(blocks)-1]
+	snapshotInfo := &blkstorage.SnapshotInfo{
+		LastBlockHash:     protoutil.BlockHeaderHash(lastBlockInSnapshot.Header),
+		LastBlockNum:      lastBlockInSnapshot.Header.Number,
+		PreviousBlockHash: lastBlockInSnapshot.Header.PreviousHash,
+	}
+
+	err = provider.ImportFromSnapshot(ledgerName, snapshotDir, snapshotInfo)
+	require.NoError(t, err)
+	blockStore, err := provider.Open(ledgerName)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		provider.Close()
+		os.RemoveAll(testDir)
+	}
+	return blockStore, cleanup
+}

--- a/common/ledger/blkstorage/snapshot_test.go
+++ b/common/ledger/blkstorage/snapshot_test.go
@@ -152,7 +152,7 @@ func TestImportFromSnapshot(t *testing.T) {
 				CurrentBlockHash:  snapshotInfo.LastBlockHash,
 				PreviousBlockHash: snapshotInfo.PreviousBlockHash,
 				BootstrappingSnapshotInfo: &common.BootstrappingSnapshotInfo{
-					LastBlockInSnapshot: uint64(snapshotInfo.LastBlockNum),
+					LastBlockInSnapshot: snapshotInfo.LastBlockNum,
 				},
 			},
 			blocksDetailsBeforeSnapshot,
@@ -178,7 +178,7 @@ func TestImportFromSnapshot(t *testing.T) {
 			CurrentBlockHash:  protoutil.BlockHeaderHash(finalBlock.Header),
 			PreviousBlockHash: finalBlock.Header.PreviousHash,
 			BootstrappingSnapshotInfo: &common.BootstrappingSnapshotInfo{
-				LastBlockInSnapshot: uint64(snapshotInfo.LastBlockNum),
+				LastBlockInSnapshot: snapshotInfo.LastBlockNum,
 			},
 		}
 		verifyQueriesOnBlocksPriorToSnapshot(t,
@@ -208,7 +208,7 @@ func TestImportFromSnapshot(t *testing.T) {
 				CurrentBlockHash:  snapshotInfo.LastBlockHash,
 				PreviousBlockHash: snapshotInfo.PreviousBlockHash,
 				BootstrappingSnapshotInfo: &common.BootstrappingSnapshotInfo{
-					LastBlockInSnapshot: uint64(snapshotInfo.LastBlockNum),
+					LastBlockInSnapshot: snapshotInfo.LastBlockNum,
 				},
 			},
 			blocksDetailsBeforeSnapshot,
@@ -226,7 +226,7 @@ func TestImportFromSnapshot(t *testing.T) {
 			CurrentBlockHash:  protoutil.BlockHeaderHash(finalBlock.Header),
 			PreviousBlockHash: finalBlock.Header.PreviousHash,
 			BootstrappingSnapshotInfo: &common.BootstrappingSnapshotInfo{
-				LastBlockInSnapshot: uint64(snapshotInfo.LastBlockNum),
+				LastBlockInSnapshot: snapshotInfo.LastBlockNum,
 			},
 		}
 		verifyQueriesOnBlocksAddedAfterBootstrapping(t,
@@ -300,7 +300,7 @@ func TestImportFromSnapshot(t *testing.T) {
 					CurrentBlockHash:  protoutil.BlockHeaderHash(finalBlock.Header),
 					PreviousBlockHash: finalBlock.Header.PreviousHash,
 					BootstrappingSnapshotInfo: &common.BootstrappingSnapshotInfo{
-						LastBlockInSnapshot: uint64(snapshotInfo.LastBlockNum),
+						LastBlockInSnapshot: snapshotInfo.LastBlockNum,
 					},
 				},
 				blockDetails,

--- a/common/ledger/blockledger/fileledger/impl.go
+++ b/common/ledger/blockledger/fileledger/impl.go
@@ -74,6 +74,9 @@ func (fl *FileLedger) Iterator(startPosition *ab.SeekPosition) (blockledger.Iter
 			logger.Panic(err)
 		}
 		newestBlockNumber := info.Height - 1
+		if info.BootstrappingSnapshotInfo != nil && newestBlockNumber == info.BootstrappingSnapshotInfo.LastBlockInSnapshot {
+			newestBlockNumber = info.Height
+		}
 		startingBlockNumber = newestBlockNumber
 	case *ab.SeekPosition_Specified:
 		startingBlockNumber = start.Specified.Number
@@ -81,6 +84,8 @@ func (fl *FileLedger) Iterator(startPosition *ab.SeekPosition) (blockledger.Iter
 		if startingBlockNumber > height {
 			return &blockledger.NotFoundErrorIterator{}, 0
 		}
+	case *ab.SeekPosition_NextCommit:
+		startingBlockNumber = fl.Height()
 	default:
 		return &blockledger.NotFoundErrorIterator{}, 0
 	}


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- New feature

#### Description
- Update block iterator generation code to properly handle Newest for snapshot

#### Related issues
https://jira.hyperledger.org/browse/FAB-18235
