### PR TITLE
[FAB-18250] Cherry-Pick -- Check Error Before Returning Session to Pool

### DIFF
--- a/bccsp/pkcs11/pkcs11_test.go
+++ b/bccsp/pkcs11/pkcs11_test.go
@@ -409,3 +409,31 @@ func TestPKCS11ECKeySignVerify(t *testing.T) {
 	}
 
 }
+
+func TestHandleSessionReturn(t *testing.T) {
+	opts := PKCS11Opts{
+		HashFamily: "SHA2",
+		SecLevel:   256,
+		SoftVerify: false,
+	}
+	opts.Library, opts.Pin, opts.Label = FindPKCS11Lib()
+
+	provider, err := New(opts, currentKS)
+	require.NoError(t, err)
+	pi := provider.(*impl)
+	defer pi.ctx.Destroy()
+
+	// Retrieve and destroy default session created during initialization
+	session, err := pi.getSession()
+	require.NoError(t, err)
+	pi.closeSession(session)
+
+	// Verify session pool is empty and place invalid session in pool
+	require.Empty(t, pi.sessPool, "sessionPool should be empty")
+	pi.returnSession(pkcs11.SessionHandle(^uint(0)))
+
+	// Attempt to generate key with invalid session
+	_, err = pi.KeyGen(&bccsp.ECDSAP256KeyGenOpts{Temporary: false})
+	require.EqualError(t, err, "Failed generating ECDSA P256 key: P11: keypair generate failed [pkcs11: 0xB3: CKR_SESSION_HANDLE_INVALID]")
+	require.Empty(t, pi.sessPool, "sessionPool should be empty")
+}


### PR DESCRIPTION
FAB-17722 introduced logic for evicting invalid sessions from
the pkcs11 session pool. The GetSessionInfo call was expensive,
taking nearly a full second per call. The change was reverted
in FAB-18242.

This change introduces a new method for evicting sessions by
checking the error message returned when pkcs11 call fail
and closing sessions that resulted in SESSION errors.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
