### PR TITLE
Fix orderer/common/multichannel flake when removing channel

### DIFF
--- a/orderer/common/multichannel/registrar_test.go
+++ b/orderer/common/multichannel/registrar_test.go
@@ -1376,6 +1376,12 @@ func TestRegistrar_RemoveChannel(t *testing.T) {
 			},
 			General: localconfig.General{
 				BootstrapMethod: "none",
+				Cluster: localconfig.Cluster{
+					ReplicationBufferSize:   1,
+					ReplicationPullTimeout:  time.Microsecond,
+					ReplicationRetryTimeout: time.Microsecond,
+					ReplicationMaxRetries:   2,
+				},
 			},
 			FileLedger: localconfig.FileLedger{
 				Location: tmpdir,


### PR DESCRIPTION
#### Type of change

- Test update

#### Description

Set the cluster config in the RemoveChannel tests to avoid an endless loop due to ReplicationMaxRetries = 0.


#### Related issues

[FAB-18251](https://jira.hyperledger.org/browse/FAB-18251)