### PR TITLE
Update Release Notes With New Updates

### DIFF
--- a/release_notes/v2.2.1.md
+++ b/release_notes/v2.2.1.md
@@ -43,13 +43,6 @@ with a new certificate that has the same public key, without requiring channel c
 
 The enrollment, TLS server, and TLS client certificate expiration dates are now logged upon peer and orderer startup.
 
-**peer and orderer PKCS#11 - Drain session pool before creating new sessions**
-
-If an invalid PKCS#11 session was acquired from the session pool,
-a new session would be immediately created instead of attempting to acquire another
-session from the pool.
-This change attempts to uses pooled sessions before creating new ones.
-
 **peer and orderer PKCS#11 - Add object handle cache**
 
 With this change, object handles are cached in the PKCS#11 implementation.

--- a/release_notes/v2.2.1.md
+++ b/release_notes/v2.2.1.md
@@ -116,6 +116,15 @@ However, chaincode still attempted to retrieve from the cache,
 and therefore an incorrect value may be retrieved.
 The fix ensures that for values larger than 64kb, the data will be retrieved from CouchDB.
 
+**FAB-18250: Introduce error checking for evicting invalid PKCS11 sessions**
+
+FAB-17722 introduced a call to the pkcs11 GetSessionInfo function for retrieving the current state of
+the PKCS11 session. The result of this function was used to determine whether a session was still
+valid to perform HSM operations or if it should be evicted from the session pool. Performance tests
+showed that the call to GetSessionInfo was computationally prohibitively expensive. FAB-18242 reverted 
+this change and FAB-18250 introduced a new method for determining if the PKCS11 session is invalid.
+Now when an HSM operation fails, we check the resultant error against the known session error codes and 
+evict the session from the pool if the error was the result of an invalid session. 
 
 Deprecations (existing)
 -----------------------


### PR DESCRIPTION
Add release note for HSM session eviction and remove no longer relevant HSM session pool draining.