### PR TITLE
Validate pvt-data during reconciliation for bootstrapped ledger

### DIFF
--- a/core/ledger/confighistory/confighistorytest/confighistory.go
+++ b/core/ledger/confighistory/confighistorytest/confighistory.go
@@ -15,7 +15,7 @@ import (
 
 type Mgr struct {
 	*confighistory.Mgr
-	mockCCInfoProvider *mock.DeployedChaincodeInfoProvider
+	MockCCInfoProvider *mock.DeployedChaincodeInfoProvider
 }
 
 func NewMgr(dbPath string) (*Mgr, error) {
@@ -26,13 +26,13 @@ func NewMgr(dbPath string) (*Mgr, error) {
 	}
 	return &Mgr{
 		Mgr:                configHistory,
-		mockCCInfoProvider: mockCCInfoProvider,
+		MockCCInfoProvider: mockCCInfoProvider,
 	}, nil
 }
 
 func (m *Mgr) Setup(ledgerID, namespace string, configHistory map[uint64][]*peer.StaticCollectionConfig) error {
 	for committingBlk, config := range configHistory {
-		m.mockCCInfoProvider.UpdatedChaincodesReturns(
+		m.MockCCInfoProvider.UpdatedChaincodesReturns(
 			[]*ledger.ChaincodeLifecycleInfo{
 				{
 					Name: namespace,
@@ -40,7 +40,7 @@ func (m *Mgr) Setup(ledgerID, namespace string, configHistory map[uint64][]*peer
 			}, nil,
 		)
 
-		m.mockCCInfoProvider.ChaincodeInfoReturns(
+		m.MockCCInfoProvider.ChaincodeInfoReturns(
 			&ledger.DeployedChaincodeInfo{
 				Name:                        namespace,
 				ExplicitCollectionConfigPkg: BuildCollConfigPkg(config),

--- a/core/ledger/kvledger/hashcheck_pvtdata_test.go
+++ b/core/ledger/kvledger/hashcheck_pvtdata_test.go
@@ -8,21 +8,21 @@ package kvledger
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset"
+	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/common/ledger/testutil"
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
-	"github.com/hyperledger/fabric/protoutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConstructValidInvalidBlocksPvtData(t *testing.T) {
 	conf, cleanup := testConfig(t)
 	defer cleanup()
+
 	nsCollBtlConfs := []*nsCollBtlConfig{
 		{
 			namespace: "ns-1",
@@ -37,18 +37,6 @@ func TestConstructValidInvalidBlocksPvtData(t *testing.T) {
 				"coll-2": 0,
 			},
 		},
-		{
-			namespace: "ns-4",
-			btlConfig: map[string]uint64{
-				"coll-2": 0,
-			},
-		},
-		{
-			namespace: "ns-6",
-			btlConfig: map[string]uint64{
-				"coll-2": 0,
-			},
-		},
 	}
 	provider := testutilNewProviderWithCollectionConfig(
 		t,
@@ -57,135 +45,420 @@ func TestConstructValidInvalidBlocksPvtData(t *testing.T) {
 	)
 	defer provider.Close()
 
-	_, gb := testutil.NewBlockGenerator(t, "testLedger", false)
-	gbHash := protoutil.BlockHeaderHash(gb.Header)
+	blocksGenerator, gb := testutil.NewBlockGenerator(t, "testLedger", false)
 	lg, _ := provider.CreateFromGenesisBlock(gb)
-	defer lg.Close()
+	kvledger := lg.(*kvLedger)
+	defer kvledger.Close()
 
-	// construct pvtData and pubRwSet (i.e., hashed rw set)
-	v0 := []byte{0}
-	pvtDataBlk1Tx0, pubSimResBytesBlk1Tx0 := produceSamplePvtdata(t, 0, []string{"ns-1:coll-1", "ns-1:coll-2"}, [][]byte{v0, v0})
-	v1 := []byte{1}
-	pvtDataBlk1Tx1, pubSimResBytesBlk1Tx1 := produceSamplePvtdata(t, 1, []string{"ns-1:coll-1", "ns-1:coll-2"}, [][]byte{v1, v1})
-	v2 := []byte{2}
-	pvtDataBlk1Tx2, pubSimResBytesBlk1Tx2 := produceSamplePvtdata(t, 2, []string{"ns-1:coll-1", "ns-2:coll-2"}, [][]byte{v2, v2})
-	v3 := []byte{3}
-	pvtDataBlk1Tx3, pubSimResBytesBlk1Tx3 := produceSamplePvtdata(t, 3, []string{"ns-1:coll-1", "ns-1:coll-2"}, [][]byte{v3, v3})
-	v4 := []byte{4}
-	pvtDataBlk1Tx4, pubSimResBytesBlk1Tx4 := produceSamplePvtdata(t, 4, []string{"ns-1:coll-1", "ns-4:coll-2"}, [][]byte{v4, v4})
-	v5 := []byte{5}
-	pvtDataBlk1Tx5, pubSimResBytesBlk1Tx5 := produceSamplePvtdata(t, 5, []string{"ns-1:coll-1", "ns-1:coll-2"}, [][]byte{v5, v5})
-	v6 := []byte{6}
-	pvtDataBlk1Tx6, pubSimResBytesBlk1Tx6 := produceSamplePvtdata(t, 6, []string{"ns-6:coll-2"}, [][]byte{v6})
-	v7 := []byte{7}
-	_, pubSimResBytesBlk1Tx7 := produceSamplePvtdata(t, 7, []string{"ns-1:coll-2"}, [][]byte{v7})
-	wrongPvtDataBlk1Tx7, _ := produceSamplePvtdata(t, 7, []string{"ns-6:coll-2"}, [][]byte{v6})
+	// block-1
+	commitCollectionConfigsHistoryAndDummyBlock(t, provider, kvledger, nsCollBtlConfs, blocksGenerator)
 
-	pubSimulationResults := &rwset.TxReadWriteSet{}
-	err := proto.Unmarshal(pubSimResBytesBlk1Tx7, pubSimulationResults)
-	require.NoError(t, err)
-	tx7PvtdataHash := pubSimulationResults.NsRwset[0].CollectionHashedRwset[0].PvtRwsetHash
+	pvtDataTx0, pubSimResTx0 := produceSamplePvtdata(t, 0,
+		[][4]string{
+			{"ns-1", "coll-1", "tx0-key-1", "tx0-val-1"},
+			{"ns-1", "coll-2", "tx0-key-2", "tx0-val-2"},
+		},
+	)
 
-	// construct block1
-	simulationResultsBlk1 := [][]byte{pubSimResBytesBlk1Tx0, pubSimResBytesBlk1Tx1, pubSimResBytesBlk1Tx2,
-		pubSimResBytesBlk1Tx3, pubSimResBytesBlk1Tx4, pubSimResBytesBlk1Tx5,
-		pubSimResBytesBlk1Tx6, pubSimResBytesBlk1Tx7}
-	blk1 := testutil.ConstructBlock(t, 1, gbHash, simulationResultsBlk1, false)
+	pvtDataTx1, pubSimResTx1 := produceSamplePvtdata(t, 1,
+		[][4]string{
+			{"ns-1", "coll-1", "tx1-key-1", "tx1-val-1"},
+			{"ns-2", "coll-2", "tx1-key-2", "tx1-val-2"},
+			{"ns-2", "coll-2", "tx1-key-3", "tx1-val-3"},
+			{"ns-2", "coll-2", "tx1-key-4", "tx1-val-4"},
+			{"ns-2", "coll-2", "tx1-key-5", "tx1-val-5"},
+		},
+	)
 
-	// construct a pvtData list for block1
-	pvtDataBlk1 := map[uint64]*ledger.TxPvtData{
-		0: pvtDataBlk1Tx0,
-		1: pvtDataBlk1Tx1,
-		2: pvtDataBlk1Tx2,
-		4: pvtDataBlk1Tx4,
-		5: pvtDataBlk1Tx5,
+	pvtData := map[uint64]*ledger.TxPvtData{
+		0: pvtDataTx0,
+		1: pvtDataTx1,
 	}
-
-	// construct a missingData list for block1
+	simulationResults := [][]byte{pubSimResTx0, pubSimResTx1}
 	missingData := make(ledger.TxMissingPvtData)
-	missingData.Add(3, "ns-1", "coll-1", true)
-	missingData.Add(3, "ns-1", "coll-2", true)
-	missingData.Add(6, "ns-6", "coll-2", true)
-	missingData.Add(7, "ns-1", "coll-2", true)
+	missingData.Add(0, "ns-1", "coll-1", true)
+	missingData.Add(0, "ns-1", "coll-2", true)
+	missingData.Add(1, "ns-1", "coll-1", true)
+	missingData.Add(1, "ns-2", "coll-2", true)
 
-	// commit block1
+	// commit block-2
+	blk2 := blocksGenerator.NextBlock([][]byte{pubSimResTx0, pubSimResTx1})
 	blockAndPvtData1 := &ledger.BlockAndPvtData{
-		Block:          blk1,
-		PvtData:        pvtDataBlk1,
+		Block:          blk2,
+		PvtData:        pvtData,
 		MissingPvtData: missingData}
-	require.NoError(t, lg.(*kvLedger).commitToPvtAndBlockStore(blockAndPvtData1))
+	require.NoError(t, kvledger.commit(blockAndPvtData1, &ledger.CommitOptions{}))
 
-	// construct pvtData from missing data in tx3, tx6, and tx7
-	pvtdata := []*ledger.ReconciledPvtdata{
-		{
-			BlockNum: 1,
-			WriteSets: map[uint64]*ledger.TxPvtData{
-				3: pvtDataBlk1Tx3,
-				6: pvtDataBlk1Tx6,
-				7: wrongPvtDataBlk1Tx7,
-				// ns-6:coll-2 does not present in tx7
-			},
-		},
-	}
+	// generate snapshot at block-2
+	require.NoError(t, kvledger.generateSnapshot())
+	freshConf, cleanup := testConfig(t)
+	defer cleanup()
 
-	expectedValidBlocksPvtData := map[uint64][]*ledger.TxPvtData{
-		1: {
-			pvtDataBlk1Tx3,
-			pvtDataBlk1Tx6,
-		},
-	}
+	freshProvider := testutilNewProviderWithCollectionConfig(
+		t,
+		nsCollBtlConfs,
+		freshConf,
+	)
+	defer freshProvider.Close()
 
-	blocksValidPvtData, hashMismatched, err := constructValidAndInvalidPvtData(pvtdata, lg.(*kvLedger).blockStore)
+	lgr, _, err := freshProvider.CreateFromSnapshot(SnapshotDirForLedgerBlockNum(conf.SnapshotsConfig.RootDir, "testLedger", 2))
+	fmt.Printf("%+v", err)
 	require.NoError(t, err)
-	require.Equal(t, len(expectedValidBlocksPvtData), len(blocksValidPvtData))
-	require.ElementsMatch(t, expectedValidBlocksPvtData[1], blocksValidPvtData[1])
-	// should not include the pvtData passed for the tx7 even in hashmismatched as ns-6:coll-2 does not exist in tx7
-	require.Len(t, hashMismatched, 0)
+	bootstrappedLedger := lgr.(*kvLedger)
+	defer bootstrappedLedger.Close()
 
-	// construct pvtData from missing data in tx7 with wrong pvtData
-	wrongPvtDataBlk1Tx7, _ = produceSamplePvtdata(t, 7, []string{"ns-1:coll-2"}, [][]byte{v6})
-	pvtdata = []*ledger.ReconciledPvtdata{
-		{
-			BlockNum: 1,
-			WriteSets: map[uint64]*ledger.TxPvtData{
-				7: wrongPvtDataBlk1Tx7,
-				// ns-1:coll-1 exists in tx7 but the passed pvtData is incorrect
+	// commit block-3
+	blk3 := blocksGenerator.NextBlock(simulationResults)
+	require.NoError(t, bootstrappedLedger.commit(
+		&ledger.BlockAndPvtData{
+			Block:   blk3,
+			PvtData: pvtData,
+		},
+		&ledger.CommitOptions{},
+	))
+
+	pvtdataCopy := func() map[uint64]*ledger.TxPvtData {
+		m := make(map[uint64]*ledger.TxPvtData, len(pvtData))
+		for k, v := range pvtData {
+			wsCopy := (proto.Clone(v.WriteSet)).(*rwset.TxPvtReadWriteSet)
+			m[k] = &ledger.TxPvtData{
+				SeqInBlock: v.SeqInBlock,
+				WriteSet:   wsCopy,
+			}
+		}
+		return m
+	}
+
+	t.Run("for-data-after-snapshot:extra-collection-is-ignored", func(t *testing.T) {
+		lgr := bootstrappedLedger
+		pvtdata := pvtdataCopy()
+		pvtdata[1], _ = produceSamplePvtdata(t, 1,
+			[][4]string{
+				{"ns-1", "non-existing-collection", "randomValue", "randomValue"},
 			},
-		},
-	}
+		)
 
-	expectedHashMismatches := []*ledger.PvtdataHashMismatch{
-		{
-			BlockNum:     1,
-			TxNum:        7,
-			Namespace:    "ns-1",
-			Collection:   "coll-2",
-			ExpectedHash: tx7PvtdataHash,
-		},
-	}
+		blocksValidPvtData, hashMismatched, err := constructValidAndInvalidPvtData(
+			[]*ledger.ReconciledPvtdata{
+				{
+					BlockNum:  3,
+					WriteSets: pvtdata,
+				},
+			},
+			lgr.blockStore,
+			lgr.pvtdataStore,
+			2,
+		)
+		require.NoError(t, err)
+		verifyBlocksPvtdata(t,
+			map[uint64][]*ledger.TxPvtData{
+				3: {
+					pvtdata[0],
+				},
+			},
+			blocksValidPvtData,
+		)
+		// should not include the pvtData passed for the tx1 even in hashmismatched as the collection does not exist in tx1
+		require.Len(t, hashMismatched, 0)
+	})
 
-	blocksValidPvtData, hashMismatches, err := constructValidAndInvalidPvtData(pvtdata, lg.(*kvLedger).blockStore)
-	require.NoError(t, err)
-	require.Len(t, blocksValidPvtData, 0)
+	t.Run("for-data-after-snapshot:hash-mismatch-is-reported", func(t *testing.T) {
+		lgr := bootstrappedLedger
+		pvtdata := pvtdataCopy()
 
-	require.ElementsMatch(t, expectedHashMismatches, hashMismatches)
+		pvtdata[1], _ = produceSamplePvtdata(t, 1,
+			[][4]string{
+				{"ns-2", "coll-2", "key-2", "randomValue"},
+			},
+		)
+
+		blocksValidPvtData, hashMismatches, err := constructValidAndInvalidPvtData(
+			[]*ledger.ReconciledPvtdata{
+				{
+					BlockNum:  3,
+					WriteSets: pvtdata,
+				},
+			},
+			lgr.blockStore,
+			lgr.pvtdataStore,
+			2,
+		)
+		require.NoError(t, err)
+		verifyBlocksPvtdata(t,
+			map[uint64][]*ledger.TxPvtData{
+				3: {
+					pvtdata[0],
+				},
+			},
+			blocksValidPvtData,
+		)
+		require.Equal(
+			t,
+			[]*ledger.PvtdataHashMismatch{
+				{
+					BlockNum:   3,
+					TxNum:      1,
+					Namespace:  "ns-2",
+					Collection: "coll-2",
+				},
+			},
+			hashMismatches,
+		)
+	})
+
+	t.Run("works-for-mixed-data-before-and-after-snapshot", func(t *testing.T) {
+		lgr := bootstrappedLedger
+		pvtdata := pvtdataCopy()
+
+		blocksValidPvtData, hashMismatches, err := constructValidAndInvalidPvtData(
+			[]*ledger.ReconciledPvtdata{
+				{
+					BlockNum:  2,
+					WriteSets: pvtdata,
+				},
+				{
+					BlockNum:  3,
+					WriteSets: pvtdata,
+				},
+			},
+			lgr.blockStore,
+			lgr.pvtdataStore,
+			2,
+		)
+		require.NoError(t, err)
+		verifyBlocksPvtdata(t,
+			map[uint64][]*ledger.TxPvtData{
+				2: {
+					pvtdata[0],
+					pvtdata[1],
+				},
+				3: {
+					pvtdata[0],
+					pvtdata[1],
+				},
+			},
+			blocksValidPvtData,
+		)
+		require.Len(t, hashMismatches, 0)
+	})
+
+	t.Run("for-data-before-snapshot:trims-the-extra-keys", func(t *testing.T) {
+		lgr := bootstrappedLedger
+		pvtdata := pvtdataCopy()
+		pvtdataWithExtraKey := pvtdataCopy()
+		pvtdataWithExtraKey[0], _ = produceSamplePvtdata(t, 0,
+			[][4]string{
+				{"ns-1", "coll-1", "tx0-key-1", "tx0-val-1"},
+				{"ns-1", "coll-2", "tx0-key-2", "tx0-val-2"},
+				{"ns-1", "coll-2", "extra-key", "extra-val"},
+			},
+		)
+		pvtdataWithExtraKey[2], _ = produceSamplePvtdata(t, 2,
+			[][4]string{
+				{"ns-1", "coll-1", "tx2-key-1", "tx2-val-1"},
+			},
+		)
+
+		blocksValidPvtData, hashMismatches, err := constructValidAndInvalidPvtData(
+			[]*ledger.ReconciledPvtdata{
+				{
+					BlockNum:  2,
+					WriteSets: pvtdataWithExtraKey,
+				},
+			},
+			lgr.blockStore,
+			lgr.pvtdataStore,
+			2,
+		)
+		require.NoError(t, err)
+
+		verifyBlocksPvtdata(t,
+			map[uint64][]*ledger.TxPvtData{
+				2: {
+					pvtdata[0],
+					pvtdata[1],
+				},
+			},
+			blocksValidPvtData,
+		)
+		require.Len(t, hashMismatches, 0)
+	})
+
+	t.Run("for-data-before-snapshot:reports-hash-mismatch-and-partial-data-supplied", func(t *testing.T) {
+		lgr := bootstrappedLedger
+		temptered := pvtdataCopy()
+		temptered[0], _ = produceSamplePvtdata(t, 0,
+			[][4]string{
+				{"ns-1", "coll-1", "tx0-key-1", "tx0-val-1-tempered"},
+			},
+		)
+		temptered[1], _ = produceSamplePvtdata(t, 1,
+			[][4]string{
+				{"ns-2", "coll-2", "tx1-key-2", "tx1-val-2-tempered"},
+				{"ns-2", "coll-2", "tx1-key-3", "tx1-val-3-tempered"},
+			},
+		)
+
+		blocksValidPvtData, hashMismatches, err := constructValidAndInvalidPvtData(
+			[]*ledger.ReconciledPvtdata{
+				{
+					BlockNum:  2,
+					WriteSets: temptered,
+				},
+			},
+			lgr.blockStore,
+			lgr.pvtdataStore,
+			2,
+		)
+		require.NoError(t, err)
+		require.Len(t, blocksValidPvtData, 0)
+		require.ElementsMatch(t,
+			[]*ledger.PvtdataHashMismatch{
+				{
+					BlockNum:   2,
+					TxNum:      0,
+					Namespace:  "ns-1",
+					Collection: "coll-1",
+				},
+				{
+					BlockNum:   2,
+					TxNum:      1,
+					Namespace:  "ns-2",
+					Collection: "coll-2",
+				},
+			},
+			hashMismatches,
+		)
+	})
+
+	t.Run("for-data-before-snapshot:ignores-bad-data-corrupted-writeset", func(t *testing.T) {
+		lgr := bootstrappedLedger
+		pvtdata := pvtdataCopy()
+		pvtdataWithBadData := pvtdataCopy()
+		pvtdataWithBadData[0].WriteSet.NsPvtRwset[0].CollectionPvtRwset[0].Rwset = []byte("bad-data")
+
+		blocksValidPvtData, hashMismatches, err := constructValidAndInvalidPvtData(
+			[]*ledger.ReconciledPvtdata{
+				{
+					BlockNum:  2,
+					WriteSets: pvtdataWithBadData,
+				},
+			},
+			lgr.blockStore,
+			lgr.pvtdataStore,
+			2,
+		)
+		require.NoError(t, err)
+
+		verifyBlocksPvtdata(t,
+			map[uint64][]*ledger.TxPvtData{
+				2: {
+					pvtdata[1],
+				},
+			},
+			blocksValidPvtData,
+		)
+		require.Len(t, hashMismatches, 0)
+	})
+
+	t.Run("for-data-before-snapshot:ignores-bad-data-empty-collections", func(t *testing.T) {
+		lgr := bootstrappedLedger
+		pvtdata := pvtdataCopy()
+		pvtdataWithEmptyCollections := pvtdataCopy()
+		pvtdataWithEmptyCollections[0].WriteSet.NsPvtRwset[0].CollectionPvtRwset[0].Rwset = nil
+
+		expectedValidDataForTx0, _ := produceSamplePvtdata(t, 0,
+			[][4]string{
+				{"ns-1", "coll-2", "tx0-key-2", "tx0-val-2"},
+			},
+		)
+
+		blocksValidPvtData, hashMismatches, err := constructValidAndInvalidPvtData(
+			[]*ledger.ReconciledPvtdata{
+				{
+					BlockNum:  2,
+					WriteSets: pvtdataWithEmptyCollections,
+				},
+			},
+			lgr.blockStore,
+			lgr.pvtdataStore,
+			2,
+		)
+		require.NoError(t, err)
+
+		verifyBlocksPvtdata(t,
+			map[uint64][]*ledger.TxPvtData{
+				2: {
+					expectedValidDataForTx0,
+					pvtdata[1],
+				},
+			},
+			blocksValidPvtData,
+		)
+		require.Len(t, hashMismatches, 0)
+	})
 }
 
-func produceSamplePvtdata(t *testing.T, txNum uint64, nsColls []string, values [][]byte) (*ledger.TxPvtData, []byte) {
+func verifyBlocksPvtdata(t *testing.T, expected, actual map[uint64][]*ledger.TxPvtData) {
+	require.Len(t, actual, len(expected))
+	for blkNum, expectedTx := range expected {
+		actualTx := actual[blkNum]
+		require.Len(t, actualTx, len(expectedTx))
+		m := map[uint64]*rwset.TxPvtReadWriteSet{}
+		for _, a := range actualTx {
+			m[a.SeqInBlock] = a.WriteSet
+		}
+
+		for _, e := range expectedTx {
+			require.NotNil(t, m[e.SeqInBlock])
+			require.True(t, proto.Equal(e.WriteSet, m[e.SeqInBlock]))
+		}
+	}
+}
+
+func produceSamplePvtdata(t *testing.T, txNum uint64, data [][4]string) (*ledger.TxPvtData, []byte) {
 	builder := rwsetutil.NewRWSetBuilder()
-	for index, nsColl := range nsColls {
-		nsCollSplit := strings.Split(nsColl, ":")
-		ns := nsCollSplit[0]
-		coll := nsCollSplit[1]
-		key := fmt.Sprintf("key-%s-%s", ns, coll)
-		value := values[index]
-		builder.AddToPvtAndHashedWriteSet(ns, coll, key, value)
+	for _, d := range data {
+		builder.AddToPvtAndHashedWriteSet(d[0], d[1], d[2], []byte(d[3]))
 	}
 	simRes, err := builder.GetTxSimulationResults()
 	require.NoError(t, err)
 	pubSimulationResultsBytes, err := proto.Marshal(simRes.PubSimulationResults)
 	require.NoError(t, err)
 	return &ledger.TxPvtData{SeqInBlock: txNum, WriteSet: simRes.PvtSimulationResults}, pubSimulationResultsBytes
+}
+
+func commitCollectionConfigsHistoryAndDummyBlock(t *testing.T, provider *Provider, kvledger *kvLedger,
+	nsCollBtlConfs []*nsCollBtlConfig, blocksGenerator *testutil.BlockGenerator,
+) {
+	blockAndPvtdata := prepareNextBlockForTest(t, kvledger, blocksGenerator, "SimulateForBlk1",
+		map[string]string{
+			"dummyKeyForCollectionConfig": "dummyValForCollectionConfig",
+		},
+		nil,
+	)
+	require.NoError(t, kvledger.commit(blockAndPvtdata, &ledger.CommitOptions{}))
+
+	for _, nsBTLConf := range nsCollBtlConfs {
+		namespace := nsBTLConf.namespace
+		collConfig := []*peer.StaticCollectionConfig{}
+		for coll, btl := range nsBTLConf.btlConfig {
+			collConfig = append(collConfig,
+				&peer.StaticCollectionConfig{
+					Name:        coll,
+					BlockToLive: btl,
+				},
+			)
+		}
+		addDummyEntryInCollectionConfigHistory(
+			t,
+			provider,
+			kvledger.ledgerID,
+			namespace,
+			blockAndPvtdata.Block.Header.Number,
+			collConfig,
+		)
+	}
 }
 
 func TestRemoveCollFromTxPvtReadWriteSet(t *testing.T) {

--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -752,7 +752,14 @@ func (l *kvLedger) CommitPvtDataOfOldBlocks(reconciledPvtdata []*ledger.Reconcil
 	logger.Debugf("[%s:] Comparing pvtData of [%d] old blocks against the hashes in transaction's rwset to find valid and invalid data",
 		l.ledgerID, len(reconciledPvtdata))
 
-	hashVerifiedPvtData, hashMismatches, err := constructValidAndInvalidPvtData(reconciledPvtdata, l.blockStore)
+	lastBlockInBootstrapSnapshot := uint64(0)
+	if l.bootSnapshotMetadata != nil {
+		lastBlockInBootstrapSnapshot = l.bootSnapshotMetadata.LastBlockNumber
+	}
+
+	hashVerifiedPvtData, hashMismatches, err := constructValidAndInvalidPvtData(
+		reconciledPvtdata, l.blockStore, l.pvtdataStore, lastBlockInBootstrapSnapshot,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/core/ledger/kvledger/txmgmt/rwsetutil/rwset_builder.go
+++ b/core/ledger/kvledger/txmgmt/rwsetutil/rwset_builder.go
@@ -138,7 +138,7 @@ func (b *RWSetBuilder) GetTxSimulationResults() (*ledger.TxSimulationResults, er
 
 	// Populate the collection-level hashes into pub rwset and compute the proto bytes for pvt rwset
 	if pvtData != nil {
-		if pvtDataProto, err = pvtData.toProtoMsg(); err != nil {
+		if pvtDataProto, err = pvtData.ToProtoMsg(); err != nil {
 			return nil, err
 		}
 		for _, ns := range pvtDataProto.NsPvtRwset {

--- a/core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util.go
+++ b/core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util.go
@@ -128,7 +128,7 @@ func (txRwSet *TxRwSet) FromProtoBytes(protoBytes []byte) error {
 func (txPvtRwSet *TxPvtRwSet) ToProtoBytes() ([]byte, error) {
 	var protoMsg *rwset.TxPvtReadWriteSet
 	var err error
-	if protoMsg, err = txPvtRwSet.toProtoMsg(); err != nil {
+	if protoMsg, err = txPvtRwSet.ToProtoMsg(); err != nil {
 		return nil, err
 	}
 	return proto.Marshal(protoMsg)
@@ -251,7 +251,8 @@ func (txRwSet *TxRwSet) NumCollections() int {
 // functions for private read-write set
 ///////////////////////////////////////////////////////////////////////////////
 
-func (txPvtRwSet *TxPvtRwSet) toProtoMsg() (*rwset.TxPvtReadWriteSet, error) {
+// ToToProtoMsg transforms the struct into equivalent proto message
+func (txPvtRwSet *TxPvtRwSet) ToProtoMsg() (*rwset.TxPvtReadWriteSet, error) {
 	protoMsg := &rwset.TxPvtReadWriteSet{DataModel: rwset.TxReadWriteSet_KV}
 	var nsProtoMsg *rwset.NsPvtReadWriteSet
 	var err error

--- a/core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util_test.go
+++ b/core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util_test.go
@@ -193,7 +193,7 @@ func sampleCollHashedRwSet(collectionName string) *CollHashedRwSet {
 
 func TestTxPvtRwSetConversion(t *testing.T) {
 	txPvtRwSet := sampleTxPvtRwSet()
-	protoMsg, err := txPvtRwSet.toProtoMsg()
+	protoMsg, err := txPvtRwSet.ToProtoMsg()
 	require.NoError(t, err)
 	txPvtRwSet1, err := TxPvtRwSetFromProtoMsg(protoMsg)
 	require.NoError(t, err)

--- a/core/ledger/ledger_interface.go
+++ b/core/ledger/ledger_interface.go
@@ -623,11 +623,11 @@ func (e *InvalidCollNameError) Error() string {
 
 // PvtdataHashMismatch is used when the hash of private write-set
 // does not match the corresponding hash present in the block
-// See function `PeerLedger.CommitPvtData` for the usages
+// or there is a mismatch with the boot-KV-hashes present in the
+// private block store if the legder is created from a snapshot
 type PvtdataHashMismatch struct {
 	BlockNum, TxNum       uint64
 	Namespace, Collection string
-	ExpectedHash          []byte
 }
 
 // DeployedChaincodeInfoProvider is a dependency that is used by ledger to build collection config history

--- a/gossip/privdata/reconcile.go
+++ b/gossip/privdata/reconcile.go
@@ -282,7 +282,7 @@ func (r *Reconciler) preparePvtDataToCommit(elements []*protosgossip.PvtDataElem
 func (r *Reconciler) logMismatched(pvtdataMismatched []*ledger.PvtdataHashMismatch) {
 	if len(pvtdataMismatched) > 0 {
 		for _, hashMismatch := range pvtdataMismatched {
-			logger.Warningf("failed to reconcile pvtdata chaincode %s, collection %s, block num %d, tx num %d due to hash mismatch",
+			logger.Warningf("failed to reconcile pvtdata chaincode %s, collection %s, block num %d, tx num %d due to hash mismatch or partially available bootKVs",
 				hashMismatch.Namespace, hashMismatch.Collection, hashMismatch.BlockNum, hashMismatch.TxNum)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Description
This PR enhances the function for validating the pvtdata supplied by the reconciler. For the pvtdata that belongs to the blocks prior to the snapshot, boot kv hashes in the private data store are used for validating the data.