### PR TITLE
Add two and three digit publishing

### DIFF
--- a/ci/scripts/publish_docker.sh
+++ b/ci/scripts/publish_docker.sh
@@ -10,6 +10,8 @@ docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_PASSWORD}"
 for image in baseos peer orderer ccenv tools; do
   for release in ${RELEASE} ${TWO_DIGIT_RELEASE}; do
     docker tag "hyperledger/fabric-${image}" "hyperledger/fabric-${image}:amd64-${release}"
+    docker tag "hyperledger/fabric-${image}" "hyperledger/fabric-${image}:${release}"
     docker push "hyperledger/fabric-${image}:amd64-${release}"
+    docker push "hyperledger/fabric-${image}:${release}"
   done
 done


### PR DESCRIPTION
The two and three digit images were accidentally
removed from publishing in a prior commit

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
