### PR TITLE
Update release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,24 @@ open source architecture; Hyperledger Fabric is your starting point.
 
 ## Releases
 
+Fabric provides a release approximately once every four months with new features
+and improvements. Additionally, certain releases are designated as long-term
+support (LTS) releases. Important fixes will be backported to the most recent
+LTS release, and to the prior LTS release during periods of LTS release overlap.
+For more details see the [LTS strategy](https://github.com/hyperledger/fabric-rfcs/blob/master/text/0005-lts-release-strategy.md).
+
+LTS releases:
+- [v2.2.x](https://hyperledger-fabric.readthedocs.io/en/release-2.2/whatsnew.html) (current LTS release)
+- [v1.4.x](https://hyperledger-fabric.readthedocs.io/en/release-1.4/whatsnew.html) (prior LTS release, maintained through April 2021)
+
+Unless specified otherwise, all releases will be upgradable from the prior minor release.
+Additionally, each LTS release is upgradable to the next LTS release.
+
 Fabric releases and release notes can be found on the [GitHub releases page](https://github.com/hyperledger/fabric/releases).
 
 Please visit the [Hyperledger Fabric Jira dashboard](https://jira.hyperledger.org/secure/Dashboard.jspa?selectPageId=10104) for our release roadmap.
-We plan on a quarterly release cadence, delivering on a scoped set of themes and select features.
-Unless specified otherwise, all releases will be upgradable from the prior minor release.
+
+Follow the release discussion on the [#fabric-release](https://chat.hyperledger.org/channel/fabric-release) channel in RocketChat.
 
 ## Documentation, Getting Started and Developer Guides
 

--- a/docs/source/CONTRIBUTING.rst
+++ b/docs/source/CONTRIBUTING.rst
@@ -148,14 +148,17 @@ also requires a majority approval. A maintainer removed for
 inactivity should be restored following a sustained resumption of contributions
 and reviews (a month or more) demonstrating a renewed commitment to the project.
 
-Release cadence
-~~~~~~~~~~~~~~~
+Releases
+~~~~~~~~
 
-The Fabric maintainers have settled on a quarterly (approximately) release
-cadence (see `releases <https://github.com/hyperledger/fabric#releases>`__).
-At any given time, there will be a stable LTS (long term support) release branch,
-as well as the master branch for upcoming new features.
-Follow the discussion on the #fabric-release channel in RocketChat.
+Fabric provides a release approximately once every four months with new features and improvements.
+New feature work is merged to the Fabric master branch on `Github <https://github.com/hyperledger/fabric>`__.
+Releases branches are created prior to each release so that the code can stabilize while
+new features continue to get merged to the master branch.
+Important fixes will also be backported to the most recent LTS (long-term support) release branch,
+and to the prior LTS release branch during periods of LTS release overlap.
+
+See `releases <https://github.com/hyperledger/fabric#releases>`__ for more details.
 
 Making Feature/Enhancement Proposals
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,7 +1,7 @@
 Releases
 ========
 
-Hyperledger Fabric releases are documented on the `Fabric github page <https://github.com/hyperledger/fabric#releases>`__.
+Hyperledger Fabric releases are documented on the `Fabric Github page <https://github.com/hyperledger/fabric#releases>`__.
 
 .. Licensed under Creative Commons Attribution 4.0 International License
    https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Update the Fabric README and doc references for releases.
Keep main release information in the main Fabric README,
and link the documentation to the README release information.

This change adds clarity to the LTS releases.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
