### PR TITLE
Allow BCCSP config to be set using environment variables (release-1.4)

### DIFF
--- a/bccsp/factory/nopkcs11.go
+++ b/bccsp/factory/nopkcs11.go
@@ -15,13 +15,6 @@ import (
 
 const pkcs11Enabled = false
 
-// FactoryOpts holds configuration information used to initialize factory implementations
-type FactoryOpts struct {
-	ProviderName string      `mapstructure:"default" json:"default" yaml:"Default"`
-	SwOpts       *SwOpts     `mapstructure:"SW,omitempty" json:"SW,omitempty" yaml:"SwOpts"`
-	PluginOpts   *PluginOpts `mapstructure:"PLUGIN,omitempty" json:"PLUGIN,omitempty" yaml:"PluginOpts"`
-}
-
 // InitFactories must be called before using factory interfaces
 // It is acceptable to call with config = nil, in which case
 // some defaults will get used

--- a/bccsp/factory/opts.go
+++ b/bccsp/factory/opts.go
@@ -1,19 +1,19 @@
 /*
-Copyright IBM Corp. 2016 All Rights Reserved.
+Copyright IBM Corp. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-		 http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
 */
 package factory
+
+import "github.com/hyperledger/fabric/bccsp/pkcs11"
+
+// FactoryOpts holds configuration information used to initialize factory implementations
+type FactoryOpts struct {
+	ProviderName string             `mapstructure:"default" json:"default" yaml:"Default"`
+	SwOpts       *SwOpts            `mapstructure:"SW,omitempty" json:"SW,omitempty" yaml:"SW,omitempty"`
+	PluginOpts   *PluginOpts        `mapstructure:"PLUGIN,omitempty" json:"PLUGIN,omitempty" yaml:"PluginOpts"`
+	Pkcs11Opts   *pkcs11.PKCS11Opts `mapstructure:"PKCS11,omitempty" json:"PKCS11,omitempty" yaml:"PKCS11"`
+}
 
 // GetDefaultOpts offers a default implementation for Opts
 // returns a new instance every time
@@ -25,6 +25,10 @@ func GetDefaultOpts() *FactoryOpts {
 			SecLevel:   256,
 
 			Ephemeral: true,
+		},
+		Pkcs11Opts: &pkcs11.PKCS11Opts{
+			HashFamily: "SHA2",
+			SecLevel:   256,
 		},
 	}
 }

--- a/bccsp/factory/pkcs11.go
+++ b/bccsp/factory/pkcs11.go
@@ -10,19 +10,10 @@ package factory
 
 import (
 	"github.com/hyperledger/fabric/bccsp"
-	"github.com/hyperledger/fabric/bccsp/pkcs11"
 	"github.com/pkg/errors"
 )
 
 const pkcs11Enabled = true
-
-// FactoryOpts holds configuration information used to initialize factory implementations
-type FactoryOpts struct {
-	ProviderName string             `mapstructure:"default" json:"default" yaml:"Default"`
-	SwOpts       *SwOpts            `mapstructure:"SW,omitempty" json:"SW,omitempty" yaml:"SwOpts"`
-	PluginOpts   *PluginOpts        `mapstructure:"PLUGIN,omitempty" json:"PLUGIN,omitempty" yaml:"PluginOpts"`
-	Pkcs11Opts   *pkcs11.PKCS11Opts `mapstructure:"PKCS11,omitempty" json:"PKCS11,omitempty" yaml:"PKCS11"`
-}
 
 // InitFactories must be called before using factory interfaces
 // It is acceptable to call with config = nil, in which case

--- a/common/viperutil/config_util.go
+++ b/common/viperutil/config_util.go
@@ -315,7 +315,7 @@ func bccspHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, e
 
 	err := mapstructure.Decode(data, config)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not decode bcssp type")
+		return nil, errors.Wrap(err, "could not decode bccsp type")
 	}
 
 	return config, nil

--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -94,6 +94,12 @@ peer:
       Security: 256
       FileKeyStore:
         KeyStore:
+    PKCS11:
+      Hash: SHA2
+      Security: 256
+      Library:
+      Label:
+      Pin:
   mspConfigPath: {{ .PeerLocalMSPDir Peer }}
   localMspId: {{ (.Organization Peer.Organization).MSPID }}
   deliveryclient:

--- a/integration/nwo/fabricconfig/core.go
+++ b/integration/nwo/fabricconfig/core.go
@@ -146,11 +146,20 @@ type Authentication struct {
 type BCCSP struct {
 	Default string            `yaml:"Default,omitempty"`
 	SW      *SoftwareProvider `yaml:"SW,omitempty"`
+	PKCS11  *PKCS11           `yaml:"PKCS11,omitempty"`
 }
 
 type SoftwareProvider struct {
 	Hash     string `yaml:"Hash,omitempty"`
 	Security int    `yaml:"Security,omitempty"`
+}
+
+type PKCS11 struct {
+	Hash     string `yaml:"Hash,omitempty"`
+	Security int    `yaml:"Security,omitempty"`
+	Pin      string `yaml:"Pin,omitempty"`
+	Label    string `yaml:"Label,omitempty"`
+	Library  string `yaml:"Library,omitempty"`
 }
 
 type DeliveryClient struct {

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -375,6 +375,28 @@ func (n *Network) userCryptoDir(org *Organization, nodeOrganizationType, user, c
 	)
 }
 
+// PeerOrgCADir returns the path to the folder containing the CA certificate(s) and/or
+// keys for the specified peer organization.
+func (n *Network) PeerOrgCADir(o *Organization) string {
+	return filepath.Join(
+		n.CryptoPath(),
+		"peerOrganizations",
+		o.Domain,
+		"ca",
+	)
+}
+
+// OrdererOrgCADir returns the path to the folder containing the CA certificate(s) and/or
+// keys for the specified orderer organization.
+func (n *Network) OrdererOrgCADir(o *Organization) string {
+	return filepath.Join(
+		n.CryptoPath(),
+		"ordererOrganizations",
+		o.Domain,
+		"ca",
+	)
+}
+
 // PeerUserMSPDir returns the path to the MSP directory containing the
 // certificates and keys for the specified user of the peer.
 func (n *Network) PeerUserMSPDir(p *Peer, user string) string {

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -707,6 +707,10 @@ func (n *Network) listTLSCACertificates() []string {
 // Cleanup attempts to cleanup docker related artifacts that may
 // have been created by the network.
 func (n *Network) Cleanup() {
+	if n == nil || n.DockerClient == nil {
+		return
+	}
+
 	nw, err := n.DockerClient.NetworkInfo(n.NetworkID)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/integration/nwo/orderer_template.go
+++ b/integration/nwo/orderer_template.go
@@ -52,6 +52,12 @@ General:
       Security: 256
       FileKeyStore:
         KeyStore:
+    PKCS11:
+      Hash: SHA2
+      Security: 256
+      Library:
+      Label:
+      Pin:
   Authentication:
     TimeWindow: 15m
 FileLedger:

--- a/integration/pkcs11/p11key.go
+++ b/integration/pkcs11/p11key.go
@@ -1,0 +1,62 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pkcs11
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"encoding/asn1"
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/miekg/pkcs11"
+)
+
+// P11ECDSAKey test implementation of crypto.Signer.
+type P11ECDSAKey struct {
+	ctx              *pkcs11.Ctx
+	session          pkcs11.SessionHandle
+	publicKey        *ecdsa.PublicKey
+	privateKeyHandle pkcs11.ObjectHandle
+}
+
+// Public returns the corresponding public key for the
+// private key.
+func (k *P11ECDSAKey) Public() crypto.PublicKey {
+	return k.publicKey
+}
+
+// Sign implements crypto.Signer Sign(). Signs the digest the with the private key and returns a byte signature.
+func (k *P11ECDSAKey) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	if len(digest) != opts.HashFunc().Size() {
+		return nil, fmt.Errorf("digest length does not equal hash function length")
+	}
+
+	mech := []*pkcs11.Mechanism{
+		pkcs11.NewMechanism(pkcs11.CKM_ECDSA, nil),
+	}
+
+	err = k.ctx.SignInit(k.session, mech, k.privateKeyHandle)
+	if err != nil {
+		return nil, fmt.Errorf("sign init failed: %s", err)
+	}
+
+	signature, err = k.ctx.Sign(k.session, digest)
+	if err != nil {
+		return nil, fmt.Errorf("sign failed: %s", err)
+	}
+
+	type ECDSASignature struct{ R, S *big.Int }
+
+	R := new(big.Int)
+	S := new(big.Int)
+	R.SetBytes(signature[0 : len(signature)/2])
+	S.SetBytes(signature[len(signature)/2:])
+
+	return asn1.Marshal(ECDSASignature{R: R, S: S})
+}

--- a/integration/pkcs11/pkcs11_suite_test.go
+++ b/integration/pkcs11/pkcs11_suite_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pkcs11
+
+import (
+	"encoding/json"
+	"testing"
+
+	bpkcs11 "github.com/hyperledger/fabric/bccsp/pkcs11"
+	"github.com/hyperledger/fabric/integration/nwo"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPKCS11(t *testing.T) {
+	RegisterFailHandler(Fail)
+	lib, pin, label := bpkcs11.FindPKCS11Lib()
+	if lib == "" || pin == "" || label == "" {
+		t.Skip("Skipping PKCS11 Suite: Required ENV variables not set")
+	}
+	RunSpecs(t, "PKCS11 Suite")
+}
+
+var components *nwo.Components
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	components = &nwo.Components{}
+	components.Build("-tags=pkcs11")
+
+	payload, err := json.Marshal(components)
+	Expect(err).NotTo(HaveOccurred())
+
+	return payload
+}, func(payload []byte) {
+	err := json.Unmarshal(payload, &components)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = SynchronizedAfterSuite(func() {
+}, func() {
+	components.Cleanup()
+})
+
+func BasePort() int {
+	return 40000 + 1000*GinkgoParallelNode()
+}

--- a/integration/pkcs11/pkcs11_test.go
+++ b/integration/pkcs11/pkcs11_test.go
@@ -1,0 +1,391 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package pkcs11
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	docker "github.com/fsouza/go-dockerclient"
+	bpkcs11 "github.com/hyperledger/fabric/bccsp/pkcs11"
+	"github.com/hyperledger/fabric/integration/nwo"
+	"github.com/hyperledger/fabric/integration/nwo/fabricconfig"
+	"github.com/miekg/pkcs11"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/tedsuo/ifrit"
+)
+
+var _ = Describe("Configures PKCS#11 for peer and orderer", func() {
+	var (
+		tempDir string
+		network *nwo.Network
+		client  *docker.Client
+		process ifrit.Process
+		orderer *nwo.Orderer
+	)
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = ioutil.TempDir("", "p11")
+		Expect(err).NotTo(HaveOccurred())
+
+		client, err = docker.NewClientFromEnv()
+		Expect(err).NotTo(HaveOccurred())
+
+		network = nwo.New(nwo.BasicSolo(), tempDir, client, BasePort(), components)
+		network.GenerateConfigTree()
+
+		orderer = network.Orderer("orderer")
+
+		lib, pin, label := bpkcs11.FindPKCS11Lib()
+		myBCCSP := &fabricconfig.BCCSP{
+			Default: "PKCS11",
+			PKCS11: &fabricconfig.PKCS11{
+				Security: 256,
+				Hash:     "SHA2",
+				Pin:      pin,
+				Label:    label,
+				Library:  lib,
+			},
+		}
+
+		By("Updating bccsp peer config")
+		for _, peer := range network.Peers {
+			peerConfig := network.ReadPeerConfig(peer)
+			peerConfig.Peer.BCCSP = myBCCSP
+			network.WritePeerConfig(peer, peerConfig)
+		}
+
+		By("Updating bccsp orderer config")
+		ordererConfig := network.ReadOrdererConfig(orderer)
+		ordererConfig.General.BCCSP = myBCCSP
+		network.WriteOrdererConfig(orderer, ordererConfig)
+
+		network.Bootstrap()
+
+		ctx, sess := setupPKCS11Ctx(lib, label, pin)
+		Expect(err).NotTo(HaveOccurred())
+		defer ctx.CloseSession(sess)
+
+		configurePeerPKCS11(ctx, sess, network)
+		configureOrdererPKCS11(ctx, sess, network)
+
+		By("Starting fabric processes")
+		networkRunner := network.NetworkGroupRunner()
+		process = ifrit.Invoke(networkRunner)
+		Eventually(process.Ready(), network.EventuallyTimeout).Should(BeClosed())
+	})
+
+	AfterEach(func() {
+		process.Signal(syscall.SIGTERM)
+		Eventually(process.Wait(), network.EventuallyTimeout).Should(Receive())
+
+		if network != nil {
+			network.Cleanup()
+		}
+		os.RemoveAll(tempDir)
+	})
+
+	It("Creates and join channel successfully", func() {
+		orderer := network.Orderer("orderer")
+		network.CreateAndJoinChannels(orderer)
+	})
+})
+
+func configurePeerPKCS11(ctx *pkcs11.Ctx, sess pkcs11.SessionHandle, network *nwo.Network) {
+	for _, peer := range network.Peers {
+		orgName := peer.Organization
+
+		peerPubKey, peerCSR, peerSerial := createCSR(ctx, sess, orgName, "peer")
+		adminPubKey, adminCSR, adminSerial := createCSR(ctx, sess, orgName, "admin")
+
+		domain := network.Organization(orgName).Domain
+
+		// Retrieves org CA cert
+		orgCAPath := network.PeerOrgCADir(network.Organization(orgName))
+		caBytes, err := ioutil.ReadFile(filepath.Join(orgCAPath, fmt.Sprintf("ca.%s-cert.pem", domain)))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Updating the peer signcerts")
+
+		newOrdererPemCert := buildCert(network, caBytes, orgCAPath, peerCSR, peerSerial, peerPubKey)
+		updateMSPFolder(network.PeerLocalMSPDir(peer), fmt.Sprintf("peer.%s-cert.pem", domain), newOrdererPemCert)
+
+		By("Updating the peer admin user signcerts")
+		newAdminPemCert := buildCert(network, caBytes, orgCAPath, adminCSR, adminSerial, adminPubKey)
+
+		orgAdminMSPPath := network.PeerUserMSPDir(peer, "Admin")
+		updateMSPFolder(orgAdminMSPPath, fmt.Sprintf("Admin@%s-cert.pem", domain), newAdminPemCert)
+	}
+}
+
+func configureOrdererPKCS11(ctx *pkcs11.Ctx, sess pkcs11.SessionHandle, network *nwo.Network) {
+	orderer := network.Orderer("orderer")
+	orgName := orderer.Organization
+	domain := network.Organization(orgName).Domain
+
+	ordererPubKey, ordererCSR, ordererSerial := createCSR(ctx, sess, orgName, "orderer")
+	adminPubKey, adminCSR, adminSerial := createCSR(ctx, sess, orgName, "admin")
+
+	// Retrieves org CA cert
+	orgCAPath := network.OrdererOrgCADir(network.Organization(orgName))
+	caBytes, err := ioutil.ReadFile(filepath.Join(orgCAPath, fmt.Sprintf("ca.%s-cert.pem", domain)))
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Updating the orderer signcerts")
+
+	newOrdererPemCert := buildCert(network, caBytes, orgCAPath, ordererCSR, ordererSerial, ordererPubKey)
+
+	updateMSPFolder(network.OrdererLocalMSPDir(orderer), fmt.Sprintf("orderer.%s-cert.pem", domain), newOrdererPemCert)
+
+	By("Updating the orderer admin user signcerts")
+	newAdminPemCert := buildCert(network, caBytes, orgCAPath, adminCSR, adminSerial, adminPubKey)
+
+	orgAdminMSPPath := network.OrdererUserMSPDir(orderer, "Admin")
+	updateMSPFolder(orgAdminMSPPath, fmt.Sprintf("Admin@%s-cert.pem", domain), newAdminPemCert)
+}
+
+// Creates pkcs11 context and session
+func setupPKCS11Ctx(lib, label, pin string) (*pkcs11.Ctx, pkcs11.SessionHandle) {
+	ctx := pkcs11.New(lib)
+
+	err := ctx.Initialize()
+	Expect(err).NotTo(HaveOccurred())
+
+	slot := findPKCS11Slot(ctx, label)
+	Expect(slot).Should(BeNumerically(">", 0), "Could not find slot with label %s", label)
+
+	sess, err := ctx.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Login
+	err = ctx.Login(sess, pkcs11.CKU_USER, pin)
+	Expect(err).NotTo(HaveOccurred())
+
+	return ctx, sess
+}
+
+// Identifies pkcs11 slot using specified label
+func findPKCS11Slot(ctx *pkcs11.Ctx, label string) uint {
+	slots, err := ctx.GetSlotList(true)
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, s := range slots {
+		tokInfo, err := ctx.GetTokenInfo(s)
+		Expect(err).NotTo(HaveOccurred())
+
+		if tokInfo.Label == label {
+			return s
+		}
+	}
+
+	return 0
+}
+
+// Creates CSR for provided organization and organizational unit
+func createCSR(ctx *pkcs11.Ctx, sess pkcs11.SessionHandle, org, ou string) (*ecdsa.PublicKey, *x509.CertificateRequest, *big.Int) {
+	pubKey, pkcs11Key := generateKeyPair(ctx, sess)
+
+	csrTemplate := x509.CertificateRequest{
+		Subject: pkix.Name{
+			Country:            []string{"US"},
+			Province:           []string{"California"},
+			Locality:           []string{"San Francisco"},
+			Organization:       []string{fmt.Sprintf("%s.example.com", org)},
+			OrganizationalUnit: []string{ou},
+			CommonName:         fmt.Sprintf("peer.%s.example.com", org),
+		},
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
+	}
+
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &csrTemplate, pkcs11Key)
+	Expect(err).NotTo(HaveOccurred())
+
+	csr, err := x509.ParseCertificateRequest(csrBytes)
+	Expect(err).NotTo(HaveOccurred())
+	err = csr.CheckSignature()
+	Expect(err).NotTo(HaveOccurred())
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	Expect(err).NotTo(HaveOccurred())
+
+	return pubKey, csr, serialNumber
+}
+
+func buildCert(network *nwo.Network, caBytes []byte, org1CAPath string, csr *x509.CertificateRequest, serialNumber *big.Int, pubKey *ecdsa.PublicKey) []byte {
+	pemBlock, _ := pem.Decode(caBytes)
+	Expect(pemBlock).NotTo(BeNil())
+
+	caCert, err := x509.ParseCertificate(pemBlock.Bytes)
+	Expect(err).NotTo(HaveOccurred())
+
+	keyBytes, err := ioutil.ReadFile(filepath.Join(org1CAPath, "priv_sk"))
+	Expect(err).NotTo(HaveOccurred())
+
+	pemBlock, _ = pem.Decode(keyBytes)
+	Expect(pemBlock).NotTo(BeNil())
+	key, err := x509.ParsePKCS8PrivateKey(pemBlock.Bytes)
+	Expect(err).NotTo(HaveOccurred())
+	caKey := key.(*ecdsa.PrivateKey)
+
+	certTemplate := &x509.Certificate{
+		Signature:          csr.Signature,
+		SignatureAlgorithm: csr.SignatureAlgorithm,
+		PublicKey:          csr.PublicKey,
+		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
+
+		SerialNumber:          serialNumber,
+		NotBefore:             time.Now().Add(-1 * time.Minute).UTC(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour).UTC(),
+		BasicConstraintsValid: true,
+
+		Subject:     csr.Subject,
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{},
+	}
+
+	// Use root CA to create and sign cert
+	signedCert, err := x509.CreateCertificate(rand.Reader, certTemplate, caCert, pubKey, caKey)
+	Expect(err).NotTo(HaveOccurred())
+
+	return pem.EncodeToMemory(&pem.Block{Bytes: signedCert, Type: "CERTIFICATE"})
+}
+
+// Overwrites existing cert and removes private key from keystore folder
+func updateMSPFolder(path, certName string, cert []byte) {
+	// Overwrite existing certificate with new certificate
+	err := ioutil.WriteFile(filepath.Join(path, "signcerts", certName), cert, 0644)
+	Expect(err).NotTo(HaveOccurred())
+
+	// delete the existing private key - this is stored in the hsm
+	adminKSCert := filepath.Join(path, "keystore", "priv_sk")
+	err = os.Remove(adminKSCert)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+// Generating key pair in HSM, convert, and return keys
+func generateKeyPair(ctx *pkcs11.Ctx, sess pkcs11.SessionHandle) (*ecdsa.PublicKey, *P11ECDSAKey) {
+	publabel, privlabel := "BCPUB7", "BCPRV7"
+
+	curve := asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7} // secp256r1 Curve
+
+	marshaledOID, err := asn1.Marshal(curve)
+	Expect(err).NotTo(HaveOccurred())
+
+	pubAttrs := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_EC),
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PUBLIC_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_VERIFY, true),
+		pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, marshaledOID),
+
+		pkcs11.NewAttribute(pkcs11.CKA_ID, publabel),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, publabel),
+	}
+
+	privAttrs := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_EC),
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PRIVATE_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_SIGN, true),
+
+		pkcs11.NewAttribute(pkcs11.CKA_ID, privlabel),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, privlabel),
+
+		pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, false),
+		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, true),
+	}
+
+	pubK, privK, err := ctx.GenerateKeyPair(
+		sess,
+		[]*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_EC_KEY_PAIR_GEN, nil)},
+		pubAttrs,
+		privAttrs,
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	ecpt := ecPoint(ctx, sess, pubK)
+	Expect(ecpt).NotTo(BeEmpty(), "CKA_EC_POINT not found")
+
+	hash := sha256.Sum256(ecpt)
+	ski := hash[:]
+
+	setskiT := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_ID, ski),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, hex.EncodeToString(ski)),
+	}
+
+	err = ctx.SetAttributeValue(sess, pubK, setskiT)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = ctx.SetAttributeValue(sess, privK, setskiT)
+	Expect(err).NotTo(HaveOccurred())
+
+	// convert pub key to rsa types
+	nistCurve := elliptic.P256()
+	x, y := elliptic.Unmarshal(nistCurve, ecpt)
+	if x == nil {
+		Expect(x).NotTo(BeNil(), "Failed Unmarshaling Public Key")
+	}
+
+	pubKey := &ecdsa.PublicKey{Curve: nistCurve, X: x, Y: y}
+
+	pkcs11Key := &P11ECDSAKey{
+		ctx:              ctx,
+		session:          sess,
+		publicKey:        pubKey,
+		privateKeyHandle: privK,
+	}
+
+	return pubKey, pkcs11Key
+}
+
+// SoftHSM reports extra two bytes before the uncompressed point
+// see /bccsp/pkcs11/pkcs11.go::ecPoint() for additional details
+func ecPoint(pkcs11lib *pkcs11.Ctx, session pkcs11.SessionHandle, key pkcs11.ObjectHandle) (ecpt []byte) {
+	template := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_EC_POINT, nil),
+		pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, nil),
+	}
+
+	attr, err := pkcs11lib.GetAttributeValue(session, key, template)
+	if err != nil {
+		Expect(err).NotTo(HaveOccurred(), "PKCS11: get(EC point)")
+	}
+
+	for _, a := range attr {
+		if a.Type != pkcs11.CKA_EC_POINT {
+			continue
+		}
+
+		switch {
+		case ((len(a.Value) % 2) == 0) && (byte(0x04) == a.Value[0]) && (byte(0x04) == a.Value[len(a.Value)-1]):
+			ecpt = a.Value[0 : len(a.Value)-1] // Trim trailing 0x04
+		case byte(0x04) == a.Value[0] && byte(0x04) == a.Value[2]:
+			ecpt = a.Value[2:len(a.Value)]
+		default:
+			ecpt = a.Value
+		}
+	}
+
+	return ecpt
+}

--- a/integration/pkcs11/pkcs11_test.go
+++ b/integration/pkcs11/pkcs11_test.go
@@ -21,10 +21,10 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"time"
 
-	bpkcs11 "github.com/hyperledger/fabric/bccsp/pkcs11"
 	"github.com/hyperledger/fabric/integration/nwo"
 	"github.com/hyperledger/fabric/integration/nwo/fabricconfig"
 	"github.com/miekg/pkcs11"
@@ -50,12 +50,7 @@ var _ = Describe("PKCS11 enabled network", func() {
 		network.Bootstrap()
 
 		By("configuring PKCS11 artifacts")
-		setupPKCS11(network)
-
-		By("starting fabric processes")
-		networkRunner := network.NetworkGroupRunner()
-		process = ifrit.Invoke(networkRunner)
-		Eventually(process.Ready(), network.EventuallyTimeout).Should(BeClosed())
+		configurePKCS11(network)
 	})
 
 	AfterEach(func() {
@@ -67,7 +62,39 @@ var _ = Describe("PKCS11 enabled network", func() {
 		os.RemoveAll(tempDir)
 	})
 
-	It("executes transactions against a basic solo network", func() {
+	It("executes transactions against a basic solo network using yaml config", func() {
+		setPKCS11Config(network, bccspConfig)
+
+		By("starting fabric processes")
+		networkRunner := network.NetworkGroupRunner()
+		process = ifrit.Invoke(networkRunner)
+		Eventually(process.Ready(), network.EventuallyTimeout).Should(BeClosed())
+
+		chaincode := nwo.Chaincode{
+			Name:    "mycc",
+			Version: "0.0",
+			Path:    "github.com/hyperledger/fabric/integration/chaincode/simple/cmd",
+			Ctor:    `{"Args":["init","a","100","b","200"]}`,
+			Policy:  `AND ('Org1MSP.member','Org2MSP.member')`,
+		}
+
+		orderer := network.Orderer("orderer")
+		network.CreateAndJoinChannels(orderer)
+
+		nwo.EnableCapabilities(network, "testchannel", "Application", "V2_0", orderer, network.PeersWithChannel("testchannel")...)
+		nwo.DeployChaincode(network, "testchannel", orderer, chaincode)
+		runQueryInvokeQuery(network, orderer, network.Peer("Org1", "peer0"), "testchannel")
+	})
+
+	It("executes transactions against a basic solo network using environment variable config", func() {
+		envCleanup := setPKCS11ConfigWithEnvVariables(network, bccspConfig)
+		defer envCleanup()
+
+		By("starting fabric processes")
+		networkRunner := network.NetworkGroupRunner()
+		process = ifrit.Invoke(networkRunner)
+		Eventually(process.Ready(), network.EventuallyTimeout).Should(BeClosed())
+
 		chaincode := nwo.Chaincode{
 			Name:    "mycc",
 			Version: "0.0",
@@ -85,28 +112,12 @@ var _ = Describe("PKCS11 enabled network", func() {
 	})
 })
 
-func setupPKCS11(network *nwo.Network) {
-	lib, pin, label := bpkcs11.FindPKCS11Lib()
-
-	By("establishing a PKCS11 session")
-	ctx, sess := setupPKCS11Ctx(lib, label, pin)
-	defer ctx.Destroy()
-	defer ctx.CloseSession(sess)
-
+func configurePKCS11(network *nwo.Network) {
 	configurePeerPKCS11(ctx, sess, network)
 	configureOrdererPKCS11(ctx, sess, network)
+}
 
-	bccspConfig := &fabricconfig.BCCSP{
-		Default: "PKCS11",
-		PKCS11: &fabricconfig.PKCS11{
-			Security: 256,
-			Hash:     "SHA2",
-			Pin:      pin,
-			Label:    label,
-			Library:  lib,
-		},
-	}
-
+func setPKCS11Config(network *nwo.Network, bccspConfig *fabricconfig.BCCSP) {
 	By("updating bccsp peer config")
 	for _, peer := range network.Peers {
 		peerConfig := network.ReadPeerConfig(peer)
@@ -119,6 +130,39 @@ func setupPKCS11(network *nwo.Network) {
 	ordererConfig := network.ReadOrdererConfig(orderer)
 	ordererConfig.General.BCCSP = bccspConfig
 	network.WriteOrdererConfig(orderer, ordererConfig)
+}
+
+func setPKCS11ConfigWithEnvVariables(network *nwo.Network, bccspConfig *fabricconfig.BCCSP) (cleanup func()) {
+	By("setting bccsp peer config via environment variables")
+	os.Setenv("CORE_PEER_BCCSP_DEFAULT", bccspConfig.Default)
+	os.Setenv("CORE_PEER_BCCSP_PKCS11_SECURITY", strconv.Itoa(bccspConfig.PKCS11.Security))
+	os.Setenv("CORE_PEER_BCCSP_PKCS11_HASH", bccspConfig.PKCS11.Hash)
+	os.Setenv("CORE_PEER_BCCSP_PKCS11_PIN", bccspConfig.PKCS11.Pin)
+	os.Setenv("CORE_PEER_BCCSP_PKCS11_LABEL", bccspConfig.PKCS11.Label)
+	os.Setenv("CORE_PEER_BCCSP_PKCS11_LIBRARY", bccspConfig.PKCS11.Library)
+
+	By("setting bccsp orderer config via environment variables")
+	os.Setenv("ORDERER_GENERAL_BCCSP_DEFAULT", bccspConfig.Default)
+	os.Setenv("ORDERER_GENERAL_BCCSP_PKCS11_SECURITY", strconv.Itoa(bccspConfig.PKCS11.Security))
+	os.Setenv("ORDERER_GENERAL_BCCSP_PKCS11_HASH", bccspConfig.PKCS11.Hash)
+	os.Setenv("ORDERER_GENERAL_BCCSP_PKCS11_PIN", bccspConfig.PKCS11.Pin)
+	os.Setenv("ORDERER_GENERAL_BCCSP_PKCS11_LABEL", bccspConfig.PKCS11.Label)
+	os.Setenv("ORDERER_GENERAL_BCCSP_PKCS11_LIBRARY", bccspConfig.PKCS11.Library)
+
+	return func() {
+		os.Unsetenv("CORE_PEER_BCCSP_DEFAULT")
+		os.Unsetenv("CORE_PEER_BCCSP_PKCS11_SECURITY")
+		os.Unsetenv("CORE_PEER_BCCSP_PKCS11_HASH")
+		os.Unsetenv("CORE_PEER_BCCSP_PKCS11_PIN")
+		os.Unsetenv("CORE_PEER_BCCSP_PKCS11_LABEL")
+		os.Unsetenv("CORE_PEER_BCCSP_PKCS11_LIBRARY")
+		os.Unsetenv("ORDERER_GENERAL_BCCSP_DEFAULT")
+		os.Unsetenv("ORDERER_GENERAL_BCCSP_PKCS11_SECURITY")
+		os.Unsetenv("ORDERER_GENERAL_BCCSP_PKCS11_HASH")
+		os.Unsetenv("ORDERER_GENERAL_BCCSP_PKCS11_PIN")
+		os.Unsetenv("ORDERER_GENERAL_BCCSP_PKCS11_LABEL")
+		os.Unsetenv("ORDERER_GENERAL_BCCSP_PKCS11_LIBRARY")
+	}
 }
 
 func configurePeerPKCS11(ctx *pkcs11.Ctx, sess pkcs11.SessionHandle, network *nwo.Network) {
@@ -173,43 +217,6 @@ func configureOrdererPKCS11(ctx *pkcs11.Ctx, sess pkcs11.SessionHandle, network 
 	newAdminPemCert := buildCert(caBytes, orgCAPath, adminCSR, adminSerial, adminPubKey)
 	orgAdminMSPPath := network.OrdererUserMSPDir(orderer, "Admin")
 	updateMSPFolder(orgAdminMSPPath, fmt.Sprintf("Admin@%s-cert.pem", domain), newAdminPemCert)
-}
-
-// Creates pkcs11 context and session
-func setupPKCS11Ctx(lib, label, pin string) (*pkcs11.Ctx, pkcs11.SessionHandle) {
-	ctx := pkcs11.New(lib)
-
-	err := ctx.Initialize()
-	Expect(err).NotTo(HaveOccurred())
-
-	slot := findPKCS11Slot(ctx, label)
-	Expect(slot).Should(BeNumerically(">", 0), "Could not find slot with label %s", label)
-
-	sess, err := ctx.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Login
-	err = ctx.Login(sess, pkcs11.CKU_USER, pin)
-	Expect(err).NotTo(HaveOccurred())
-
-	return ctx, sess
-}
-
-// Identifies pkcs11 slot using specified label
-func findPKCS11Slot(ctx *pkcs11.Ctx, label string) uint {
-	slots, err := ctx.GetSlotList(true)
-	Expect(err).NotTo(HaveOccurred())
-
-	for _, s := range slots {
-		tokInfo, err := ctx.GetTokenInfo(s)
-		Expect(err).NotTo(HaveOccurred())
-
-		if tokInfo.Label == label {
-			return s
-		}
-	}
-
-	return 0
 }
 
 // Creates CSR for provided organization and organizational unit

--- a/integration/pkcs11/pkcs11_test.go
+++ b/integration/pkcs11/pkcs11_test.go
@@ -126,11 +126,11 @@ func configurePeerPKCS11(ctx *pkcs11.Ctx, sess pkcs11.SessionHandle, network *nw
 
 		By("Updating the peer signcerts")
 
-		newOrdererPemCert := buildCert(network, caBytes, orgCAPath, peerCSR, peerSerial, peerPubKey)
+		newOrdererPemCert := buildCert(caBytes, orgCAPath, peerCSR, peerSerial, peerPubKey)
 		updateMSPFolder(network.PeerLocalMSPDir(peer), fmt.Sprintf("peer.%s-cert.pem", domain), newOrdererPemCert)
 
 		By("Updating the peer admin user signcerts")
-		newAdminPemCert := buildCert(network, caBytes, orgCAPath, adminCSR, adminSerial, adminPubKey)
+		newAdminPemCert := buildCert(caBytes, orgCAPath, adminCSR, adminSerial, adminPubKey)
 
 		orgAdminMSPPath := network.PeerUserMSPDir(peer, "Admin")
 		updateMSPFolder(orgAdminMSPPath, fmt.Sprintf("Admin@%s-cert.pem", domain), newAdminPemCert)
@@ -152,12 +152,12 @@ func configureOrdererPKCS11(ctx *pkcs11.Ctx, sess pkcs11.SessionHandle, network 
 
 	By("Updating the orderer signcerts")
 
-	newOrdererPemCert := buildCert(network, caBytes, orgCAPath, ordererCSR, ordererSerial, ordererPubKey)
+	newOrdererPemCert := buildCert(caBytes, orgCAPath, ordererCSR, ordererSerial, ordererPubKey)
 
 	updateMSPFolder(network.OrdererLocalMSPDir(orderer), fmt.Sprintf("orderer.%s-cert.pem", domain), newOrdererPemCert)
 
 	By("Updating the orderer admin user signcerts")
-	newAdminPemCert := buildCert(network, caBytes, orgCAPath, adminCSR, adminSerial, adminPubKey)
+	newAdminPemCert := buildCert(caBytes, orgCAPath, adminCSR, adminSerial, adminPubKey)
 
 	orgAdminMSPPath := network.OrdererUserMSPDir(orderer, "Admin")
 	updateMSPFolder(orgAdminMSPPath, fmt.Sprintf("Admin@%s-cert.pem", domain), newAdminPemCert)
@@ -231,7 +231,7 @@ func createCSR(ctx *pkcs11.Ctx, sess pkcs11.SessionHandle, org, ou string) (*ecd
 	return pubKey, csr, serialNumber
 }
 
-func buildCert(network *nwo.Network, caBytes []byte, org1CAPath string, csr *x509.CertificateRequest, serialNumber *big.Int, pubKey *ecdsa.PublicKey) []byte {
+func buildCert(caBytes []byte, org1CAPath string, csr *x509.CertificateRequest, serialNumber *big.Int, pubKey *ecdsa.PublicKey) []byte {
 	pemBlock, _ := pem.Decode(caBytes)
 	Expect(pemBlock).NotTo(BeNil())
 


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update

#### Description

First three commits:
- backport PKCS11 test to release-1.4

Fourth commit:
- backport BCCSP changes to enable environment variable override of PKCS11 configuration

#### Related issues

[FAB-17969](https://jira.hyperledger.org/browse/FAB-17969)