### PR TITLE
Corrected to capitalized function names in tutorials document

### DIFF
--- a/docs/source/deploy_chaincode.md
+++ b/docs/source/deploy_chaincode.md
@@ -198,7 +198,7 @@ class AssetTransfer extends Contract {
 
 The ``AssetTransfer`` class provides the transaction context for the functions defined within the smart contract that read and write data to the blockchain ledger.
 ```
-async createAsset(ctx, id, color, size, owner, appraisedValue) {
+async CreateAsset(ctx, id, color, size, owner, appraisedValue) {
         const asset = {
             ID: id,
             Color: color,
@@ -272,8 +272,8 @@ export class AssetTransfer extends Contract {
 
 The ``AssetTransfer`` class provides the transaction context for the functions defined within the smart contract that read and write data to the blockchain ledger.
 ```
- // createAsset issues a new asset to the world state with given details.
-    public async createAsset(ctx: Context, id: string, color: string, size: number, owner: string, appraisedValue: number) {
+ // CreateAsset issues a new asset to the world state with given details.
+    public async CreateAsset(ctx: Context, id: string, color: string, size: number, owner: string, appraisedValue: number) {
         const asset = {
             ID: id,
             Color: color,
@@ -586,11 +586,11 @@ CONTAINER ID        IMAGE                                                       
 ```
 If you used the `--init-required` flag, you need to invoke the Init function before you can use the upgraded chaincode. Because we did not request the execution of Init, we can test our new JavaScript chaincode by creating a new car:
 ```
-peer chaincode invoke -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile ${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem -C mychannel -n basic --peerAddresses localhost:7051 --tlsRootCertFiles ${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt --peerAddresses localhost:9051 --tlsRootCertFiles ${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt -c '{"function":"createAsset","Args":["asset8","blue","16","Kelley","750"]}'
+peer chaincode invoke -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile ${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem -C mychannel -n basic --peerAddresses localhost:7051 --tlsRootCertFiles ${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt --peerAddresses localhost:9051 --tlsRootCertFiles ${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt -c '{"function":"CreateAsset","Args":["asset8","blue","16","Kelley","750"]}'
 ```
 You can query all the cars on the ledger again to see the new car:
 ```
-peer chaincode query -C mychannel -n basic -c '{"Args":["getAllAssets"]}'
+peer chaincode query -C mychannel -n basic -c '{"Args":["GetAllAssets"]}'
 ```
 
 You should see the following result from the JavaScript chaincode:

--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -294,7 +294,7 @@ export CORE_PEER_ADDRESS=localhost:7051
 The `CORE_PEER_TLS_ROOTCERT_FILE` and `CORE_PEER_MSPCONFIGPATH` environment
 variables point to the Org1 crypto material in the `organizations` folder.
 
-If you used `./network.sh deployCC` to install and start the asset-transfer (basic) chaincode, you can invoke the `InitLedger` function of the (Go) chaincode to put an initial list of assets on the ledger (if using typescript or javascript `./network.sh deployCC -l javascript` for example, you will invoke the `initLedger` function of the respective chaincodes).
+If you used `./network.sh deployCC` to install and start the asset-transfer (basic) chaincode, you can invoke the `InitLedger` function of the (Go) chaincode to put an initial list of assets on the ledger (if using typescript or javascript `./network.sh deployCC -l javascript` for example, you will invoke the `InitLedger` function of the respective chaincodes).
 
 Run the following command to initialize the ledger with assets:
 ```


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description
when I proceed according to the current [deploy_chaincode tutorial](https://hyperledger-fabric.readthedocs.io/en/latest/deploy_chaincode.html), I get the following error.

```sh
Error: endorsement failure during invoke. response: status:500 message:"error in simulation: transaction returned with failure: Error: You've asked to invoke a function that does not exist: createAsset" 
make: *** [invoke] Error 1
```
`CreateAsset` instead of `createAsset` would have worked.

asset-transfer (basic) javascript chaincode function name is now capitalized in the following commit.
https://github.com/hyperledger/fabric-samples/commit/bd38f9220bbba049d7204833dfd36abf8f38cdb4

The tutorial documentation was still in the old function names, so I fixed it.
