### PR TITLE
Improve Consistency When Generating Errors / Stacks on Channel Participation

### DIFF
--- a/orderer/common/channelparticipation/restapi.go
+++ b/orderer/common/channelparticipation/restapi.go
@@ -166,7 +166,7 @@ func (h *HTTPHandler) serveJoin(resp http.ResponseWriter, req *http.Request) {
 
 	channelID, isAppChannel, err := ValidateJoinBlock(block)
 	if err != nil {
-		h.sendResponseJsonError(resp, http.StatusBadRequest, errors.Wrap(err, "invalid join block"))
+		h.sendResponseJsonError(resp, http.StatusBadRequest, errors.WithMessage(err, "invalid join block"))
 		return
 	}
 
@@ -237,7 +237,7 @@ func (h *HTTPHandler) extractChannelID(req *http.Request, resp http.ResponseWrit
 	}
 
 	if err := configtx.ValidateChannelID(channelID); err != nil {
-		err = errors.Wrap(err, "invalid channel ID")
+		err = errors.WithMessage(err, "invalid channel ID")
 		h.sendResponseJsonError(resp, http.StatusBadRequest, err)
 		return "", err
 	}
@@ -249,16 +249,16 @@ func (h *HTTPHandler) sendJoinError(err error, resp http.ResponseWriter) {
 	switch err {
 	case types.ErrSystemChannelExists:
 		// The client is trying to join an app-channel, but the system channel exists: only GET is allowed on app channels.
-		h.sendResponseNotAllowed(resp, errors.Wrap(err, "cannot join"), http.MethodGet)
+		h.sendResponseNotAllowed(resp, errors.WithMessage(err, "cannot join"), http.MethodGet)
 	case types.ErrChannelAlreadyExists:
 		// The client is trying to join an app-channel that exists, but the system channel does not;
 		// The client is trying to join the system-channel, and it exists. GET & DELETE are allowed on the channel.
-		h.sendResponseNotAllowed(resp, errors.Wrap(err, "cannot join"), http.MethodGet, http.MethodDelete)
+		h.sendResponseNotAllowed(resp, errors.WithMessage(err, "cannot join"), http.MethodGet, http.MethodDelete)
 	case types.ErrAppChannelsAlreadyExists:
 		// The client is trying to join the system-channel that does not exist, but app channels exist.
-		h.sendResponseJsonError(resp, http.StatusForbidden, errors.Wrap(err, "cannot join"))
+		h.sendResponseJsonError(resp, http.StatusForbidden, errors.WithMessage(err, "cannot join"))
 	default:
-		h.sendResponseJsonError(resp, http.StatusBadRequest, errors.Wrap(err, "cannot join"))
+		h.sendResponseJsonError(resp, http.StatusBadRequest, errors.WithMessage(err, "cannot join"))
 	}
 }
 
@@ -286,11 +286,11 @@ func (h *HTTPHandler) serveRemove(resp http.ResponseWriter, req *http.Request) {
 
 	switch err {
 	case types.ErrSystemChannelExists:
-		h.sendResponseNotAllowed(resp, errors.Wrap(err, "cannot remove"), http.MethodGet)
+		h.sendResponseNotAllowed(resp, errors.WithMessage(err, "cannot remove"), http.MethodGet)
 	case types.ErrChannelNotExist:
-		h.sendResponseJsonError(resp, http.StatusNotFound, errors.Wrap(err, "cannot remove"))
+		h.sendResponseJsonError(resp, http.StatusNotFound, errors.WithMessage(err, "cannot remove"))
 	default:
-		h.sendResponseJsonError(resp, http.StatusBadRequest, errors.Wrap(err, "cannot remove"))
+		h.sendResponseJsonError(resp, http.StatusBadRequest, errors.WithMessage(err, "cannot remove"))
 	}
 }
 

--- a/orderer/common/filerepo/filerepo.go
+++ b/orderer/common/filerepo/filerepo.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package filerepo
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -91,7 +90,7 @@ func (r *Repo) Save(baseName string, content []byte) error {
 	dest := r.baseToFilePath(baseName)
 
 	if _, err := os.Stat(dest); err == nil {
-		return fmt.Errorf("file already exists at %s", dest)
+		return errors.Errorf("file already exists at %s", dest)
 	}
 
 	tmpFileName := fileName + r.transientFileMarker
@@ -162,7 +161,7 @@ func (r *Repo) baseToFilePath(baseName string) string {
 }
 
 func (r *Repo) baseToFileName(baseName string) string {
-	return fmt.Sprintf("%s.%s", baseName, r.fileSuffix)
+	return baseName + "." + r.fileSuffix
 }
 
 func validateFileSuffix(fileSuffix string) error {
@@ -171,7 +170,7 @@ func validateFileSuffix(fileSuffix string) error {
 	}
 
 	if strings.Contains(fileSuffix, string(os.PathSeparator)) {
-		return fmt.Errorf("fileSuffix [%s] illegal, cannot contain os path separator", fileSuffix)
+		return errors.Errorf("fileSuffix [%s] illegal, cannot contain os path separator", fileSuffix)
 	}
 
 	return nil

--- a/orderer/common/follower/block_puller.go
+++ b/orderer/common/follower/block_puller.go
@@ -91,7 +91,7 @@ func (creator *BlockPullerCreator) BlockPuller(configBlock *common.Block) (Chann
 	// Extract the TLS CA certs and endpoints from the join-block
 	endpoints, err := cluster.EndpointconfigFromConfigBlock(configBlock, creator.bccsp)
 	if err != nil {
-		return nil, errors.Wrap(err, "error extracting endpoints from config block")
+		return nil, errors.WithMessage(err, "error extracting endpoints from config block")
 	}
 
 	bp := &cluster.BlockPuller{
@@ -116,11 +116,11 @@ func (creator *BlockPullerCreator) BlockPuller(configBlock *common.Block) (Chann
 func (creator *BlockPullerCreator) UpdateVerifierFromConfigBlock(configBlock *common.Block) error {
 	configEnv, err := cluster.ConfigFromBlock(configBlock)
 	if err != nil {
-		return errors.Wrap(err, "failed to extract config envelope from block")
+		return errors.WithMessage(err, "failed to extract config envelope from block")
 	}
 	verifier, err := creator.blockSigVerifierFactory.VerifierFromConfig(configEnv, creator.channelID)
 	if err != nil {
-		return errors.Wrap(err, "failed to construct a block signature verifier from config envelope")
+		return errors.WithMessage(err, "failed to construct a block signature verifier from config envelope")
 	}
 	creator.blockSigVerifier = verifier
 	return nil
@@ -141,13 +141,13 @@ func (creator *BlockPullerCreator) VerifyBlockSequence(blocks []*common.Block, _
 	if blocks[0].Header.Number == 0 {
 		configEnv, err := cluster.ConfigFromBlock(blocks[0])
 		if err != nil {
-			return errors.Wrap(err, "failed to extract config envelope from genesis block")
+			return errors.WithMessage(err, "failed to extract config envelope from genesis block")
 		}
 		// Bootstrap the verifier from the genesis block, as it will be used to verify
 		// the subsequent blocks in the batch.
 		creator.blockSigVerifier, err = creator.blockSigVerifierFactory.VerifierFromConfig(configEnv, creator.channelID)
 		if err != nil {
-			return errors.Wrap(err, "failed to construct a block signature verifier from genesis block")
+			return errors.WithMessage(err, "failed to construct a block signature verifier from genesis block")
 		}
 		blocksAfterGenesis := blocks[1:]
 		if len(blocksAfterGenesis) == 0 {

--- a/orderer/common/follower/follower_chain.go
+++ b/orderer/common/follower/follower_chain.go
@@ -169,7 +169,7 @@ func NewChain(
 		// the endpoints from the join-block.
 		puller, err := blockPullerFactory.BlockPuller(joinBlock)
 		if err != nil {
-			return nil, errors.Wrap(err, "error creating a block puller from join-block")
+			return nil, errors.WithMessage(err, "error creating a block puller from join-block")
 		}
 		puller.Close()
 
@@ -317,7 +317,7 @@ func (c *Chain) pull() error {
 	if c.joinBlock != nil {
 		err = c.pullUpToJoin()
 		if err != nil {
-			return errors.Wrap(err, "failed to pull up to join block")
+			return errors.WithMessage(err, "failed to pull up to join block")
 		}
 
 		// The join block never returns an error. This is checked before the follower is started.
@@ -334,7 +334,7 @@ func (c *Chain) pull() error {
 		c.joinBlock = nil
 		err = c.loadLastConfig()
 		if err != nil {
-			return errors.Wrap(err, "failed to load last config block")
+			return errors.WithMessage(err, "failed to load last config block")
 		}
 
 		c.logger.Info("Onboarding finished successfully, continuing to pull blocks after join-block")
@@ -342,7 +342,7 @@ func (c *Chain) pull() error {
 
 	err = c.pullAfterJoin()
 	if err != nil {
-		return errors.Wrap(err, "failed to pull after join block")
+		return errors.WithMessage(err, "failed to pull after join block")
 	}
 
 	// Trigger creation of a new consensus.Chain.
@@ -367,7 +367,7 @@ func (c *Chain) pullUpToJoin() error {
 	// Block puller created with endpoints from the join-block.
 	c.blockPuller, err = c.blockPullerFactory.BlockPuller(c.joinBlock)
 	if err != nil { //This should never happen since we check the join-block before we start.
-		return errors.Wrapf(err, "error creating block puller")
+		return errors.WithMessagef(err, "error creating block puller")
 	}
 	defer c.blockPuller.Close()
 	// Since we created the block-puller with the join-block, do not update the endpoints from the
@@ -390,7 +390,7 @@ func (c *Chain) pullAfterJoin() error {
 
 	c.blockPuller, err = c.blockPullerFactory.BlockPuller(c.lastConfig)
 	if err != nil {
-		return errors.Wrap(err, "error creating block puller")
+		return errors.WithMessage(err, "error creating block puller")
 	}
 	defer c.blockPuller.Close()
 
@@ -399,7 +399,7 @@ func (c *Chain) pullAfterJoin() error {
 		// Check membership
 		isMember, errMem := c.clusterConsenter.IsChannelMember(c.lastConfig)
 		if errMem != nil {
-			return errors.Wrap(err, "failed to determine channel membership from last config")
+			return errors.WithMessage(err, "failed to determine channel membership from last config")
 		}
 		if isMember {
 			c.setStatusReport(types.ClusterRelationMember, types.StatusActive)
@@ -506,7 +506,7 @@ func (c *Chain) pullUntilTarget(targetHeight uint64, updateEndpoints bool) (uint
 		default:
 			nextBlock := c.blockPuller.PullBlock(seq)
 			if nextBlock == nil {
-				return n, errors.Wrapf(cluster.ErrRetryCountExhausted, "failed to pull block %d", seq)
+				return n, errors.WithMessagef(cluster.ErrRetryCountExhausted, "failed to pull block %d", seq)
 			}
 			reportedPrevHash := nextBlock.Header.PreviousHash
 			if (nextBlock.Header.Number > 0) && !bytes.Equal(reportedPrevHash, actualPrevHash) {
@@ -515,19 +515,19 @@ func (c *Chain) pullUntilTarget(targetHeight uint64, updateEndpoints bool) (uint
 			}
 			actualPrevHash = protoutil.BlockHeaderHash(nextBlock.Header)
 			if err := c.ledgerResources.Append(nextBlock); err != nil {
-				return n, errors.Wrapf(err, "failed to append block %d to the ledger", nextBlock.Header.Number)
+				return n, errors.WithMessagef(err, "failed to append block %d to the ledger", nextBlock.Header.Number)
 			}
 
 			if protoutil.IsConfigBlock(nextBlock) {
 				c.logger.Debugf("Pulled blocks from %d to %d, last block is config", firstBlockToPull, nextBlock.Header.Number)
 				c.lastConfig = nextBlock
 				if err := c.blockPullerFactory.UpdateVerifierFromConfigBlock(nextBlock); err != nil {
-					return n, errors.Wrapf(err, "failed to update verifier from last config,  block number: %d", nextBlock.Header.Number)
+					return n, errors.WithMessagef(err, "failed to update verifier from last config,  block number: %d", nextBlock.Header.Number)
 				}
 				if updateEndpoints {
 					endpoints, err := cluster.EndpointconfigFromConfigBlock(nextBlock, c.cryptoProvider)
 					if err != nil {
-						return n, errors.Wrapf(err, "failed to extract endpoints from last config,  block number: %d", nextBlock.Header.Number)
+						return n, errors.WithMessagef(err, "failed to extract endpoints from last config,  block number: %d", nextBlock.Header.Number)
 					}
 					c.blockPuller.UpdateEndpoints(endpoints)
 				}
@@ -546,11 +546,11 @@ func (c *Chain) loadLastConfig() error {
 	lastBlock := c.ledgerResources.Block(height - 1)
 	index, err := protoutil.GetLastConfigIndexFromBlock(lastBlock)
 	if err != nil {
-		return errors.Wrap(err, "chain does have appropriately encoded last config in its latest block")
+		return errors.WithMessage(err, "chain does have appropriately encoded last config in its latest block")
 	}
 	lastConfig := c.ledgerResources.Block(index)
 	if lastConfig == nil {
-		return errors.Wrapf(err, "could not retrieve config block from index %d", index)
+		return errors.WithMessagef(err, "could not retrieve config block from index %d", index)
 	}
 	c.lastConfig = lastConfig
 	return nil

--- a/orderer/common/multichannel/chainsupport.go
+++ b/orderer/common/multichannel/chainsupport.go
@@ -56,7 +56,7 @@ func newChainSupport(
 	// Assuming a block created with cb.NewBlock(), this should not
 	// error even if the orderer metadata is an empty byte slice
 	if err != nil {
-		return nil, errors.Wrapf(err, "error extracting orderer metadata for channel: %s", ledgerResources.ConfigtxValidator().ChannelID())
+		return nil, errors.WithMessagef(err, "error extracting orderer metadata for channel: %s", ledgerResources.ConfigtxValidator().ChannelID())
 	}
 
 	// Construct limited support needed as a parameter for additional support
@@ -86,7 +86,7 @@ func newChainSupport(
 
 	cs.Chain, err = consenter.HandleChain(cs, metadata)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error creating consenter for channel: %s", cs.ChannelID())
+		return nil, errors.WithMessagef(err, "error creating consenter for channel: %s", cs.ChannelID())
 	}
 
 	cs.MetadataValidator, ok = cs.Chain.(consensus.MetadataValidator)
@@ -141,7 +141,7 @@ func (cs *ChainSupport) ProposeConfigUpdate(configtx *cb.Envelope) (*cb.ConfigEn
 	}
 
 	if err = checkResources(bundle); err != nil {
-		return nil, errors.Wrap(err, "config update is not compatible")
+		return nil, errors.WithMessage(err, "config update is not compatible")
 	}
 
 	if err = cs.ValidateNew(bundle); err != nil {
@@ -160,7 +160,7 @@ func (cs *ChainSupport) ProposeConfigUpdate(configtx *cb.Envelope) (*cb.ConfigEn
 	}
 
 	if err = cs.ValidateConsensusMetadata(oldOrdererConfig, newOrdererConfig, false); err != nil {
-		return nil, errors.Wrap(err, "consensus metadata update for channel config update is invalid")
+		return nil, errors.WithMessage(err, "consensus metadata update for channel config update is invalid")
 	}
 	return env, nil
 }

--- a/orderer/common/multichannel/ledger_resources.go
+++ b/orderer/common/multichannel/ledger_resources.go
@@ -24,10 +24,10 @@ func checkResources(res channelconfig.Resources) error {
 		return errors.New("config does not contain orderer config")
 	}
 	if err := oc.Capabilities().Supported(); err != nil {
-		return errors.Wrapf(err, "config requires unsupported orderer capabilities: %s", err)
+		return errors.WithMessagef(err, "config requires unsupported orderer capabilities: %s", err)
 	}
 	if err := res.ChannelConfig().Capabilities().Supported(); err != nil {
-		return errors.Wrapf(err, "config requires unsupported channel capabilities: %s", err)
+		return errors.WithMessagef(err, "config requires unsupported channel capabilities: %s", err)
 	}
 	return nil
 }
@@ -96,7 +96,7 @@ func (lr *ledgerResources) VerifyBlockSignature(sd []*protoutil.SignedData, enve
 	}
 	err := policy.EvaluateSignedData(sd)
 	if err != nil {
-		return errors.Wrap(err, "block verification failed")
+		return errors.WithMessage(err, "block verification failed")
 	}
 	return nil
 }


### PR DESCRIPTION
<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (improvement to code, performance, etc)
#### Description

<!--- Describe your changes in detail, including motivation. -->

- Use errors.Wrap() for errors that were generated by an external (vendored) package (to ensure we generate a stack) and use errors.WithMessage() for errors that were generated by fabric (to ensure we don't generate another stack). Also, use errors.Errorf() for errors that are currently coded to use fmt.Errorf().

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

[FAB-18229](https://jira.hyperledger.org/browse/FAB-18229)

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
