### PR TITLE
Cherry-Pick -- Always Finalize the PKCS11 FindObject Operation

### DIFF
--- a/bccsp/pkcs11/pkcs11.go
+++ b/bccsp/pkcs11/pkcs11.go
@@ -490,15 +490,14 @@ func (csp *impl) findKeyPairFromSKI(session pkcs11.SessionHandle, ski []byte, ke
 	if err := csp.ctx.FindObjectsInit(session, template); err != nil {
 		return 0, err
 	}
+	defer csp.ctx.FindObjectsFinal(session)
 
 	// single session instance, assume one hit only
 	objs, _, err := csp.ctx.FindObjects(session, 1)
 	if err != nil {
 		return 0, err
 	}
-	if err = csp.ctx.FindObjectsFinal(session); err != nil {
-		return 0, err
-	}
+
 	if len(objs) == 0 {
 		return 0, fmt.Errorf("Key not found [%s]", hex.Dump(keyId))
 	}


### PR DESCRIPTION
There are 6 pkcs11 operations that require the session
handle to be finalized before a session can be reused.
These operations are: Encrypt, Decrypt, Sign, Verify,
Find, and Digest. The bccsp/pkcs11 package makes use
of three of these operations: sign, verify, and find.
Each of these operations has an init function, i.e.,
SignInit, VerifyInit and FindObjectInit, each are part
of the cryptoki implementation. If the Init functions
fail, the session handle is never initialized and
the finalize function do not need to be called.

For SignInit and VerifyInit, the next operation
we call are the Sign or Verify functions, which also
atomically finalized the session. For the FindObjectInit
operation however, we must explicitly call the FindObjectFinal
function to release the lock on the session handle.

The current implementation makes a call to FindObject in between
FindObjectInit and FindObjectFinal which has an error path.
In the current implementation FindObjectFinal is not called
on the error path, leaving the session in a state that it can't
be used again.

This change ensures FindObjectFinal is always called, even
on the error path.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
