### PR TITLE
Allow tick interval override via orderer.yaml

### DIFF
--- a/docs/source/raft_configuration.md
+++ b/docs/source/raft_configuration.md
@@ -133,8 +133,8 @@ used to further fine tune the cluster communication or replication mechanisms:
   * `SnapDir`: specifies the location at which snapshots for `etcd/raft` are stored.
   Each channel will have its own subdirectory named after the channel ID.
 
-There is also a hidden configuration parameter that can be set by adding it to
-the consensus section in the `orderer.yaml`:
+There are also two hidden configuration parameters that can each be set by adding
+them the consensus section in the `orderer.yaml`:
 
   * `EvictionSuspicion`: The cumulative period of time of channel eviction
   suspicion that triggers the node to pull blocks from other nodes and see if it
@@ -143,6 +143,10 @@ the consensus section in the `orderer.yaml`:
   certificate), the node halts its operation for that channel. A node suspects
   its channel eviction when it doesn't know about any elected leader nor can be
   elected as leader in the channel. Defaults to 10 minutes.
+  * `TickIntervalOverride`: If set, this value will be preferred over the tick
+  interval configured in all channels where this ordering node is a consenter.
+  This value should be set only with great care, as a mismatch in tick interval
+  across orderers could result in a loss of quorum for one or more channels.
 
 ### Channel configuration
 

--- a/integration/nwo/fabricconfig/orderer.go
+++ b/integration/nwo/fabricconfig/orderer.go
@@ -14,6 +14,7 @@ type Orderer struct {
 	Kafka                *Kafka                `yaml:"Kafka,omitempty"`
 	Operations           *OrdererOperations    `yaml:"Operations,omitempty"`
 	ChannelParticipation *ChannelParticipation `yaml:"ChannelParticipation,omitempty"`
+	Consensus            map[string]string     `yaml:"Consensus,omitempty"`
 
 	ExtraProperties map[string]interface{} `yaml:",inline,omitempty"`
 }

--- a/integration/raft/config_test.go
+++ b/integration/raft/config_test.go
@@ -420,6 +420,30 @@ var _ = Describe("EndToEnd reconfiguration and onboarding", func() {
 		})
 	})
 
+	When("a single node cluster has the tick interval overridden", func() {
+		It("reflects this in its startup logs", func() {
+			network = nwo.New(nwo.BasicEtcdRaft(), testDir, client, StartPort(), components)
+			network.GenerateConfigTree()
+			network.Bootstrap()
+
+			orderer := network.Orderer("orderer")
+			ordererConfig := network.ReadOrdererConfig(orderer)
+			ordererConfig.Consensus["TickIntervalOverride"] = "642ms"
+			network.WriteOrdererConfig(orderer, ordererConfig)
+
+			By("Launching the orderer")
+			runner := network.OrdererRunner(orderer)
+			ordererRunners = append(ordererRunners, runner)
+
+			process := ifrit.Invoke(runner)
+			Eventually(process.Ready(), network.EventuallyTimeout).Should(BeClosed())
+			ordererProcesses = append(ordererProcesses, process)
+
+			Eventually(runner.Err()).Should(gbytes.Say("TickIntervalOverride is set, overriding channel configuration tick interval to 642ms"))
+
+		})
+	})
+
 	When("the orderer certificates are all rotated", func() {
 		It("is possible to rotate certificate by adding & removing cert in single config", func() {
 			layout := nwo.MultiNodeEtcdRaft()


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

If a raft network becomes unstable, sometimes, adjusting the tick
interval can be effective to restore it.  However, the tick interval is
stored in the channel config, so if the network is not operational,
modifying it is very challenging.  This commit adds a new option to the
orderer etcdraft consensus config, allowing the channel config parameter
to be overridden from the local configuration.