### PR TITLE
Fix a failing tick interval override test

### DIFF
--- a/orderer/consensus/etcdraft/consenter_test.go
+++ b/orderer/consensus/etcdraft/consenter_test.go
@@ -522,7 +522,7 @@ var _ = Describe("Consenter", func() {
 			consenter.EtcdRaftConfig.TickIntervalOverride = "seven"
 
 			_, err := consenter.HandleChain(support, nil)
-			Expect(err).To(MatchError("failed parsing Consensus.TickIntervalOverride: seven: time: invalid duration seven"))
+			Expect(err).To(MatchError("failed parsing Consensus.TickIntervalOverride: seven: time: invalid duration \"seven\""))
 		})
 	})
 


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description
Due to getting an invalid error message, TickIntervalOverride test failed. The error message includes a double quotation.
To make MatchError work correctly, a double quotation should be added to the expected error message.

----- Error message -----
Summarizing 1 Failure:

[Fail] Consenter when the TickIntervalOverride is invalid [It] returns an error 
/home/ec2-user/go/src/github.com/hyperledger/fabric/orderer/consensus/etcdraft/consenter_test.go:525

Ran 120 of 120 Specs in 17.227 seconds
FAIL! -- 119 Passed | 1 Failed | 0 Pending | 0 Skipped
--- FAIL: TestEtcdraft (17.23s)
2020-10-08 09:19:48.410 UTC [test] Stop -> INFO 04b Periodic check is stopping.
FAIL
FAIL    github.com/hyperledger/fabric/orderer/consensus/etcdraft        21.079s
FAIL