### PR TITLE
[FAB-18265] Always Use DummyKeystore For PKCS11 BCCSP Provider

### DIFF
--- a/bccsp/factory/pkcs11factory.go
+++ b/bccsp/factory/pkcs11factory.go
@@ -47,18 +47,6 @@ func (f *PKCS11Factory) Get(config *FactoryOpts) (bccsp.BCCSP, error) {
 	p11Opts := config.Pkcs11Opts
 
 	//TODO: PKCS11 does not need a keystore, but we have not migrated all of PKCS11 BCCSP to PKCS11 yet
-	var ks bccsp.KeyStore
-	if p11Opts.Ephemeral == true {
-		ks = sw.NewDummyKeyStore()
-	} else if p11Opts.FileKeystore != nil {
-		fks, err := sw.NewFileBasedKeyStore(nil, p11Opts.FileKeystore.KeyStorePath, false)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to initialize software key store")
-		}
-		ks = fks
-	} else {
-		// Default to DummyKeystore
-		ks = sw.NewDummyKeyStore()
-	}
+	ks := sw.NewDummyKeyStore()
 	return pkcs11.New(*p11Opts, ks)
 }


### PR DESCRIPTION
This change stops using a real keystore when the BCCSP provider
is of the PKCS11 type. PKCS11 doesn't require a keystore as the
private keys are stored in the HSM. For backwards compatibility
though we need some kind of keystore. So we should always use
the DummyKeystore implementation that exists and remove the path
for actually creating a local keystore on disk

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
