### PR TITLE
[FAB-18270] Disable debug of CouchDB response body

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb.go
@@ -890,11 +890,12 @@ func (dbclient *couchDatabase) readDocRange(startKey, endKey string, limit int32
 	defer closeResponseBody(resp)
 
 	if couchdbLogger.IsEnabledFor(zapcore.DebugLevel) {
-		dump, err2 := httputil.DumpResponse(resp, true)
+		dump, err2 := httputil.DumpResponse(resp, false)
 		if err2 != nil {
 			log.Fatal(err2)
 		}
-		couchdbLogger.Debugf("[%s] %s", dbclient.dbName, dump)
+		// compact debug log by replacing carriage return / line feed with dashes to separate http headers
+		couchdbLogger.Debugf("[%s] HTTP Response: %s", dbclient.dbName, bytes.Replace(dump, []byte{0x0d, 0x0a}, []byte{0x20, 0x7c, 0x20}, -1))
 	}
 
 	//handle as JSON document
@@ -1026,11 +1027,12 @@ func (dbclient *couchDatabase) queryDocuments(query string) ([]*queryResult, str
 	defer closeResponseBody(resp)
 
 	if couchdbLogger.IsEnabledFor(zapcore.DebugLevel) {
-		dump, err2 := httputil.DumpResponse(resp, true)
+		dump, err2 := httputil.DumpResponse(resp, false)
 		if err2 != nil {
 			log.Fatal(err2)
 		}
-		couchdbLogger.Debugf("[%s] %s", dbclient.dbName, dump)
+		// compact debug log by replacing carriage return / line feed with dashes to separate http headers
+		couchdbLogger.Debugf("[%s] HTTP Response: %s", dbclient.dbName, bytes.Replace(dump, []byte{0x0d, 0x0a}, []byte{0x20, 0x7c, 0x20}, -1))
 	}
 
 	//handle as JSON document


### PR DESCRIPTION
#### Type of change

- Improvement to debug logging

#### Description

The CouchDB query response body should not be added to debug log.
This change reduces the debug to the HTTP headers only, so that
the peer debug log can still be associated with the CouchDB logs, without
logging the full response content.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>