### PR TITLE
Print Channel Name as String in Gossip Log

### DIFF
--- a/gossip/common/common.go
+++ b/gossip/common/common.go
@@ -45,6 +45,10 @@ type Payload struct {
 // ChannelID defines the identity representation of a chain
 type ChannelID []byte
 
+func (c ChannelID) String() string {
+	return string(c)
+}
+
 // MessageReplacingPolicy Returns:
 // MESSAGE_INVALIDATES if this message invalidates that
 // MESSAGE_INVALIDATED if this message is invalidated by that

--- a/gossip/gossip/gossip_impl.go
+++ b/gossip/gossip/gossip_impl.go
@@ -192,7 +192,7 @@ func (g *Node) JoinChan(joinMsg api.JoinChannelMessage, channelID common.Channel
 	// joinMsg is supposed to have been already verified
 	g.chanState.joinChannel(joinMsg, channelID, g.gossipMetrics.MembershipMetrics)
 
-	g.logger.Info("Joining gossip network of channel", string(channelID), "with", len(joinMsg.Members()), "organizations")
+	g.logger.Info("Joining gossip network of channel", channelID, "with", len(joinMsg.Members()), "organizations")
 	for _, org := range joinMsg.Members() {
 		g.learnAnchorPeers(string(channelID), org, joinMsg.AnchorPeersOf(org))
 	}
@@ -623,14 +623,14 @@ func (g *Node) SendByCriteria(msg *protoext.SignedGossipMessage, criteria SendCr
 	if len(criteria.Channel) > 0 {
 		gc := g.chanState.getGossipChannelByChainID(criteria.Channel)
 		if gc == nil {
-			return fmt.Errorf("Requested to Send for channel %s, but no such channel exists", string(criteria.Channel))
+			return fmt.Errorf("requested to Send for channel %s, but no such channel exists", criteria.Channel)
 		}
 		membership = gc.GetPeers()
 	}
 
 	peers2send := filter.SelectPeers(criteria.MaxPeers, membership, criteria.IsEligible)
 	if len(peers2send) < criteria.MinAck {
-		return fmt.Errorf("Requested to send to at least %d peers, but know only of %d suitable peers", criteria.MinAck, len(peers2send))
+		return fmt.Errorf("requested to send to at least %d peers, but know only of %d suitable peers", criteria.MinAck, len(peers2send))
 	}
 
 	results := g.comm.SendWithAck(msg, criteria.Timeout, criteria.MinAck, peers2send...)
@@ -742,7 +742,7 @@ func (g *Node) SelfChannelInfo(chain common.ChannelID) *protoext.SignedGossipMes
 func (g *Node) PeerFilter(channel common.ChannelID, messagePredicate api.SubChannelSelectionCriteria) (filter.RoutingFilter, error) {
 	gc := g.chanState.getGossipChannelByChainID(channel)
 	if gc == nil {
-		return nil, errors.Errorf("Channel %s doesn't exist", string(channel))
+		return nil, errors.Errorf("Channel %s doesn't exist", channel)
 	}
 	return gc.PeerFilter(messagePredicate), nil
 }

--- a/gossip/gossip/gossip_test.go
+++ b/gossip/gossip/gossip_test.go
@@ -1286,7 +1286,7 @@ func TestSendByCriteria(t *testing.T) {
 	criteria.MinAck = 10
 	err = g1.SendByCriteria(msg, criteria)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Requested to send to at least 10 peers, but know only of")
+	require.Contains(t, err.Error(), "requested to send to at least 10 peers, but know only of")
 
 	// We send to a minimum of 3 peers with acknowledgement, while no peer acknowledges the messages.
 	// Wait until g1 sees the rest of the peers in the channel


### PR DESCRIPTION
Channel names are currently byte arrays in the logs, convert them to string.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
