### PR TITLE
Copy Keystore Password Into Correct Slice

### DIFF
--- a/bccsp/sw/fileks.go
+++ b/bccsp/sw/fileks.go
@@ -78,7 +78,7 @@ func (ks *fileBasedKeyStore) Init(pwd []byte, path string, readOnly bool) error 
 	ks.path = path
 
 	clone := make([]byte, len(pwd))
-	copy(ks.pwd, pwd)
+	copy(clone, pwd)
 	ks.pwd = clone
 	ks.readOnly = readOnly
 


### PR DESCRIPTION
A previous PR refactored the clone command but erroneously overwrote the cloned value.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
