### PR TITLE
Remove common name from private data doc

### DIFF
--- a/docs/source/private_data_tutorial.rst
+++ b/docs/source/private_data_tutorial.rst
@@ -674,14 +674,14 @@ When successful, the command will return the following result:
 
     {"objectType":"asset","assetID":"asset1","color":"green","size":20,"owner":"eDUwOTo6Q049b3JnMWFkbWluLE9VPWFkbWluLE89SHlwZXJsZWRnZXIsU1Q9Tm9ydGggQ2Fyb2xpbmEsQz1VUzo6Q049Y2Eub3JnMS5leGFtcGxlLmNvbSxPPW9yZzEuZXhhbXBsZS5jb20sTD1EdXJoYW0sU1Q9Tm9ydGggQ2Fyb2xpbmEsQz1VUw=="}
 
-The `"owner"` of the asset is the identity that created the asset by invoking the smart contract. The private data smart contract uses the ``GetClientIdentity().GetID()`` API to read the common name and issuer of the identity certificate.
+The `"owner"` of the asset is the identity that created the asset by invoking the smart contract. The private data smart contract uses the ``GetClientIdentity().GetID()`` API to read the name and issuer of the identity certificate.
 You can see that information by decoding the owner string out of base64 format:
 
 .. code:: bash
 
     echo eDUwOTo6Q049b3JnMWFkbWluLE9VPWFkbWluLE89SHlwZXJsZWRnZXIsU1Q9Tm9ydGggQ2Fyb2xpbmEsQz1VUzo6Q049Y2Eub3JnMS5leGFtcGxlLmNvbSxPPW9yZzEuZXhhbXBsZS5jb20sTD1EdXJoYW0sU1Q9Tm9ydGggQ2Fyb2xpbmEsQz1VUw== | base64 --decode
 
-The result will show the common name and issuer of the owner certificate:
+The result will show the name and issuer of the owner certificate:
 
 .. code:: bash
 


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <ngupta@symbridge.com>



#### Type of change

- Documentation

#### Description

The identity name retrieved from the certificate from the chaincode is actually the distinguished name, rather than the common name. This PR removes this mistake from the private data tutorial, and just uses name for simplicity (and to avoid throwing out too much cert terminology in the intro tutorials)