### PR TITLE
[FAB-18132] Ch.Part.API: Remove ledger resources asynchronously

### DIFF
--- a/common/ledger/blockledger/fileledger/factory.go
+++ b/common/ledger/blockledger/fileledger/factory.go
@@ -59,15 +59,15 @@ func (f *fileLedgerFactory) Remove(channelID string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
+	if err := f.removeFileRepo.Save(channelID, []byte{}); err != nil && err != os.ErrExist {
+		return err
+	}
+
 	// check cache for open blockstore and, if one exists,
 	// shut it down in order to avoid resource contention
 	ledger, ok := f.ledgers[channelID]
 	if ok {
 		ledger.blockStore.Shutdown()
-	}
-
-	if err := f.removeFileRepo.Save(channelID, []byte{}); err != nil && err != os.ErrExist {
-		return err
 	}
 
 	err := f.blkstorageProvider.Drop(channelID)

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -158,7 +158,9 @@ var _ = Describe("EndToEnd", func() {
 
 			By("setting up the channel")
 			network.CreateAndJoinChannel(orderer, "testchannel")
-			channelparticipation.List(network, orderer, []string{"testchannel"}, "systemchannel")
+			cl := channelparticipation.List(network, orderer)
+			channelparticipation.ChannelListMatcher(cl, []string{"testchannel"}, []string{"systemchannel"}...)
+
 			nwo.EnableCapabilities(network, "testchannel", "Application", "V2_0", orderer, network.Peer("Org1", "peer0"), network.Peer("Org2", "peer0"))
 
 			By("attempting to install unsupported chaincode without docker")
@@ -259,7 +261,9 @@ var _ = Describe("EndToEnd", func() {
 			orderer := network.Orderer("orderer")
 
 			network.CreateAndJoinChannel(orderer, "testchannel")
-			channelparticipation.List(network, orderer, []string{"testchannel"}, "systemchannel")
+			cl := channelparticipation.List(network, orderer)
+			channelparticipation.ChannelListMatcher(cl, []string{"testchannel"}, []string{"systemchannel"}...)
+
 			nwo.EnableCapabilities(network, "testchannel", "Application", "V2_0", orderer, network.Peer("Org1", "peer0"), network.Peer("Org2", "peer0"))
 
 			// package, install, and approve by org1 - module chaincode
@@ -395,7 +399,9 @@ var _ = Describe("EndToEnd", func() {
 
 			By("Create second channel and deploy chaincode")
 			network.CreateAndJoinChannel(orderer, "testchannel2")
-			channelparticipation.List(network, orderer, []string{"testchannel", "testchannel2"}, "systemchannel")
+			cl := channelparticipation.List(network, orderer)
+			channelparticipation.ChannelListMatcher(cl, []string{"testchannel", "testchannel2"}, []string{"systemchannel"}...)
+
 			peers := network.PeersWithChannel("testchannel2")
 			nwo.EnableCapabilities(network, "testchannel2", "Application", "V2_0", orderer, network.Peer("Org1", "peer0"), network.Peer("Org2", "peer0"))
 			nwo.ApproveChaincodeForMyOrg(network, "testchannel2", orderer, chaincode, peers...)

--- a/orderer/common/channelparticipation/restapi.go
+++ b/orderer/common/channelparticipation/restapi.go
@@ -257,6 +257,11 @@ func (h *HTTPHandler) sendJoinError(err error, resp http.ResponseWriter) {
 	case types.ErrAppChannelsAlreadyExists:
 		// The client is trying to join the system-channel that does not exist, but app channels exist.
 		h.sendResponseJsonError(resp, http.StatusForbidden, errors.WithMessage(err, "cannot join"))
+	case types.ErrChannelPendingRemoval:
+		// The client is trying to join a channel that is currently being removed.
+		h.sendResponseJsonError(resp, http.StatusConflict, errors.WithMessage(err, "cannot join"))
+	case types.ErrChannelRemovalFailure:
+		h.sendResponseJsonError(resp, http.StatusInternalServerError, errors.WithMessage(err, "cannot join"))
 	default:
 		h.sendResponseJsonError(resp, http.StatusBadRequest, errors.WithMessage(err, "cannot join"))
 	}
@@ -289,6 +294,10 @@ func (h *HTTPHandler) serveRemove(resp http.ResponseWriter, req *http.Request) {
 		h.sendResponseNotAllowed(resp, errors.WithMessage(err, "cannot remove"), http.MethodGet)
 	case types.ErrChannelNotExist:
 		h.sendResponseJsonError(resp, http.StatusNotFound, errors.WithMessage(err, "cannot remove"))
+	case types.ErrChannelPendingRemoval:
+		h.sendResponseJsonError(resp, http.StatusConflict, errors.WithMessage(err, "cannot remove"))
+	case types.ErrChannelRemovalFailure:
+		h.sendResponseJsonError(resp, http.StatusInternalServerError, errors.WithMessage(err, "cannot remove"))
 	default:
 		h.sendResponseJsonError(resp, http.StatusBadRequest, errors.WithMessage(err, "cannot remove"))
 	}

--- a/orderer/common/types/errors.go
+++ b/orderer/common/types/errors.go
@@ -21,3 +21,9 @@ var ErrAppChannelsAlreadyExists = errors.New("application channels already exist
 
 // ErrChannelNotExist is returned when trying to remove or list a channel that does not exist
 var ErrChannelNotExist = errors.New("channel does not exist")
+
+// ErrChannelPendingRemoval is returned when trying to remove or list a channel that is being removed.
+var ErrChannelPendingRemoval = errors.New("channel pending removal")
+
+// ErrChannelRemovalFailure is returned when a removal attempt failure has been recorded.
+var ErrChannelRemovalFailure = errors.New("channel removal failure")


### PR DESCRIPTION
#### Type of change

- New feature
- Improvement (improvement to code, performance, etc)

#### Description

Removes ledger resources in asynchronously when channel participation APIs remove is called.  

#### Related issues

[FAB-18132](https://jira.hyperledger.org/browse/FAB-18132)
