### PR TITLE
Update tests to use CouchDB 3.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ BASE_VERSION = 2.3.0
 
 # 3rd party image version
 # These versions are also set in the runners in ./integration/runners/
-COUCHDB_VER ?= 3.1
+COUCHDB_VER ?= 3.1.1
 KAFKA_VER ?= 5.3.1
 ZOOKEEPER_VER ?= 5.3.1
 

--- a/integration/runner/couchdb.go
+++ b/integration/runner/couchdb.go
@@ -23,7 +23,7 @@ import (
 	"github.com/tedsuo/ifrit"
 )
 
-const CouchDBDefaultImage = "couchdb:3.1"
+const CouchDBDefaultImage = "couchdb:3.1.1"
 const CouchDBUsername = "admin"
 const CouchDBPassword = "adminpw"
 


### PR DESCRIPTION
#### Type of change

- Dependency update

#### Description

<!--- Describe your changes in detail, including motivation. -->

In addition to fixes, CouchDB 3.1.1 adds buffered view
queries which Fabric may decide to utilize.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
