### PR TITLE
Log TLS hanshake duration

### DIFF
--- a/core/comm/creds_test.go
+++ b/core/comm/creds_test.go
@@ -93,7 +93,7 @@ func TestCreds(t *testing.T) {
 	})
 	wg.Wait()
 	assert.Contains(t, err.Error(), "protocol version not supported")
-	assert.Contains(t, recorder.Messages()[0], "TLS handshake failed with error")
+	assert.Contains(t, recorder.Messages()[1], "TLS handshake failed")
 }
 
 func TestNewTLSConfig(t *testing.T) {


### PR DESCRIPTION
This commit adds logging to the duration of the TLS handshakes, both client and server.

Change-Id: I5f630a62362e2131882542c78d3f321aed7fc2d2
Signed-off-by: yacovm <yacovm@il.ibm.com>
