### PR TITLE
Log TLS handshake duration

### DIFF
--- a/internal/pkg/comm/creds_test.go
+++ b/internal/pkg/comm/creds_test.go
@@ -95,7 +95,7 @@ func TestCreds(t *testing.T) {
 	})
 	wg.Wait()
 	require.Contains(t, err.Error(), "protocol version not supported")
-	require.Contains(t, recorder.Messages()[0], "TLS handshake failed with error")
+	require.Contains(t, recorder.Messages()[1], "TLS handshake failed")
 }
 
 func TestNewTLSConfig(t *testing.T) {


### PR DESCRIPTION
This commit adds logging to the duration of the TLS handshakes, both client and server.

Change-Id: Ia54551b874db8356c3332b456e59f58b7f428bfe
Signed-off-by: yacovm <yacovm@il.ibm.com>
