### PR TITLE
Log TLS handshake duration

### DIFF
--- a/internal/pkg/comm/creds_test.go
+++ b/internal/pkg/comm/creds_test.go
@@ -16,6 +16,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hyperledger/fabric/common/flogging/floggingtest"
 	"github.com/hyperledger/fabric/internal/pkg/comm"
 	"github.com/stretchr/testify/assert"
@@ -94,8 +96,8 @@ func TestCreds(t *testing.T) {
 		MaxVersion: tls.VersionTLS10,
 	})
 	wg.Wait()
-	assert.Contains(t, err.Error(), "protocol version not supported")
-	assert.Contains(t, recorder.Messages()[0], "TLS handshake failed with error")
+	require.Contains(t, err.Error(), "protocol version not supported")
+	require.Contains(t, recorder.Messages()[1], "TLS handshake failed")
 }
 
 func TestNewTLSConfig(t *testing.T) {


### PR DESCRIPTION
This commit adds logging to the duration of the TLS handshakes, both client and server.

Change-Id: Ia54551b874db8356c3332b456e59f58b7f428bfe
Signed-off-by: yacovm <yacovm@il.ibm.com>
