### PR TITLE
Deduplicate orderer server TLS root CAs

### DIFF
--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -920,15 +920,26 @@ func (mgr *caManager) updateClusterDialer(
 
 	// Iterate over all orderer root CAs for all chains and add them
 	// to the root CAs
-	var clusterRootCAs [][]byte
-	for _, roots := range mgr.ordererRootCAsByChain {
-		clusterRootCAs = append(clusterRootCAs, roots...)
+	clusterRootCAs := make(cluster.StringSet)
+	for _, orgRootCAs := range mgr.ordererRootCAsByChain {
+		for _, rootCA := range orgRootCAs {
+			clusterRootCAs[string(rootCA)] = struct{}{}
+		}
 	}
 
 	// Add the local root CAs too
-	clusterRootCAs = append(clusterRootCAs, localClusterRootCAs...)
+	for _, localRootCA := range localClusterRootCAs {
+		clusterRootCAs[string(localRootCA)] = struct{}{}
+	}
+
+	// Convert StringSet to byte slice
+	var clusterRootCAsBytes [][]byte
+	for root := range clusterRootCAs {
+		clusterRootCAsBytes = append(clusterRootCAsBytes, []byte(root))
+	}
+
 	// Update the cluster config with the new root CAs
-	clusterDialer.UpdateRootCAs(clusterRootCAs)
+	clusterDialer.UpdateRootCAs(clusterRootCAsBytes)
 }
 
 func prettyPrintStruct(i interface{}) {


### PR DESCRIPTION
When the orderer TLS root CAs are updated, an aggregation of all root TLS CA certificates over all channels is injected into the PredicateDialer.
Then, upon client TLS handshake, a fresh TLS config object is built (for orthogonal purposes), however the operation entails parsing of all
root CAs all over again.

In case the orderer is part of too many channels, this induces a high and unnecessary processing overhead.

This commit simply performs a deduplication of the bespoken TLS root CA certificates prior to updating the root CAs.

Change-Id: I21b2ed483afc9595c2ccd7fbe9ec0cf475cc5f62
Signed-off-by: yacovm <yacovm@il.ibm.com>
