### PR TITLE
Return errors in rollback/rebuild commands when using snapshots

### DIFF
--- a/core/ledger/kvledger/rebuild_dbs.go
+++ b/core/ledger/kvledger/rebuild_dbs.go
@@ -26,6 +26,15 @@ func RebuildDBs(config *ledger.Config) error {
 	}
 	defer fileLock.Unlock()
 
+	blockstorePath := BlockStorePath(rootFSPath)
+	ledgerIDs, err := blkstorage.GetLedgersBootstrappedFromSnapshot(blockstorePath)
+	if err != nil {
+		return errors.WithMessage(err, "error while checking if any ledger has been bootstrapped from snapshot")
+	}
+	if len(ledgerIDs) > 0 {
+		return errors.Errorf("cannot rebuild databases because the peer contains channel(s) %s that were bootstrapped from snapshot", ledgerIDs)
+	}
+
 	if config.StateDBConfig.StateDatabase == ledger.CouchDB {
 		if err := statecouchdb.DropApplicationDBs(config.StateDBConfig.CouchDB); err != nil {
 			return err
@@ -34,7 +43,5 @@ func RebuildDBs(config *ledger.Config) error {
 	if err := dropDBs(rootFSPath); err != nil {
 		return err
 	}
-
-	blockstorePath := BlockStorePath(rootFSPath)
 	return blkstorage.DeleteBlockStoreIndex(blockstorePath)
 }

--- a/core/ledger/kvledger/reset.go
+++ b/core/ledger/kvledger/reset.go
@@ -28,7 +28,7 @@ func ResetAllKVLedgers(rootFSPath string) error {
 		return err
 	}
 	if len(ledgerIDs) > 0 {
-		return errors.Errorf("cannot reset channels because at least one channel was bootstrapped from a snapshot: %+v", ledgerIDs)
+		return errors.Errorf("cannot reset channels because the peer contains channel(s) %s that were bootstrapped from snapshot", ledgerIDs)
 	}
 
 	logger.Info("Resetting all channel ledgers to genesis block")

--- a/core/ledger/kvledger/rollback.go
+++ b/core/ledger/kvledger/rollback.go
@@ -23,12 +23,12 @@ func RollbackKVLedger(rootFSPath, ledgerID string, blockNum uint64) error {
 	defer fileLock.Unlock()
 
 	blockstorePath := BlockStorePath(rootFSPath)
-	isFromSnapshot, err := blkstorage.IsBootstrappedFromSnapshot(blockstorePath, ledgerID)
+	ledgerIDs, err := blkstorage.GetLedgersBootstrappedFromSnapshot(blockstorePath)
 	if err != nil {
-		return err
+		return errors.WithMessage(err, "error while checking if any ledger has been bootstrapped from snapshot")
 	}
-	if isFromSnapshot {
-		return errors.Errorf("cannot rollback channel [%s] because it was bootstrapped from a snapshot", ledgerID)
+	if len(ledgerIDs) > 0 {
+		return errors.Errorf("cannot rollback any channel because the peer contains channel(s) %s that were bootstrapped from snapshot", ledgerIDs)
 	}
 
 	if err := blkstorage.ValidateRollbackParams(blockstorePath, ledgerID, blockNum); err != nil {

--- a/core/ledger/kvledger/tests/reset_test.go
+++ b/core/ledger/kvledger/tests/reset_test.go
@@ -9,7 +9,6 @@ package tests
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/common/ledger/blkstorage"
@@ -217,59 +216,4 @@ func TestResetLedgerWithoutDroppingDBs(t *testing.T) {
 	require.EqualError(t, err, "the state database [height=9] is ahead of the block store [height=1]. "+
 		"This is possible when the state database is not dropped after a ledger reset/rollback. "+
 		"The state database can safely be dropped and will be rebuilt up to block store height upon the next peer start")
-}
-
-func TestResetFailIfAnyLedgerBootstrappedFromSnapshot(t *testing.T) {
-	env := newEnv(t)
-	defer env.cleanup()
-	env.initLedgerMgmt()
-
-	// populate ledgers with sample data
-	ledgerID := "testLedgerFromSnapshot"
-	dataHelper := newSampleDataHelper(t)
-	h := env.newTestHelperCreateLgr(ledgerID, t)
-	dataHelper.populateLedger(h)
-	dataHelper.verifyLedgerContent(h)
-	bcInfo, err := h.lgr.GetBlockchainInfo()
-	require.NoError(t, err)
-
-	// create a sanapshot
-	blockNum := bcInfo.Height - 1
-	require.NoError(t, h.lgr.SubmitSnapshotRequest(blockNum))
-	// wait until snapshot is generated
-	snapshotGenerated := func() bool {
-		requests, err := h.lgr.PendingSnapshotRequests()
-		require.NoError(t, err)
-		return len(requests) == 0
-	}
-	require.Eventually(t, snapshotGenerated, time.Minute, 100*time.Millisecond)
-	snapshotDir := kvledger.SnapshotDirForLedgerBlockNum(env.initializer.Config.SnapshotsConfig.RootDir, ledgerID, blockNum)
-	env.closeLedgerMgmt()
-
-	// creates a new env with multiple ledgers, some from genesis block and some from a snapshot
-	env2 := newEnv(t)
-	defer env2.cleanup()
-	env2.initLedgerMgmt()
-
-	for i := 0; i < 2; i++ {
-		ledgerID := fmt.Sprintf("ledger-%d", i)
-		env2.newTestHelperCreateLgr(ledgerID, t)
-	}
-
-	callbackCounter := 0
-	callback := func(l ledger.PeerLedger, cid string) { callbackCounter++ }
-	require.NoError(t, env2.ledgerMgr.CreateLedgerFromSnapshot(snapshotDir, callback))
-
-	// wait until ledger creation is done
-	ledgerCreated := func() bool {
-		status := env2.ledgerMgr.JoinBySnapshotStatus()
-		return !status.InProgress && status.BootstrappingSnapshotDir == ""
-	}
-	require.Eventually(t, ledgerCreated, time.Minute, 100*time.Microsecond)
-	require.Equal(t, 1, callbackCounter)
-	env2.closeLedgerMgmt()
-
-	// reset should fail
-	err = kvledger.ResetAllKVLedgers(env2.initializer.Config.RootFSPath)
-	require.EqualError(t, err, "cannot reset channels because at least one channel was bootstrapped from a snapshot: [testLedgerFromSnapshot]")
 }

--- a/core/ledger/kvledger/tests/sanpshot_reset_rollback_rebuild_test.go
+++ b/core/ledger/kvledger/tests/sanpshot_reset_rollback_rebuild_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/ledger/kvledger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResetRollbackRebuildFailsIfAnyLedgerBootstrappedFromSnapshot(t *testing.T) {
+	env := newEnv(t)
+	defer env.cleanup()
+	env.initLedgerMgmt()
+
+	// populate ledgers with sample data
+	dataHelper := newSampleDataHelper(t)
+	h := env.newTestHelperCreateLgr("ledger_from_snapshot", t)
+	dataHelper.populateLedger(h)
+	dataHelper.verifyLedgerContent(h)
+	bcInfo, err := h.lgr.GetBlockchainInfo()
+	require.NoError(t, err)
+
+	// create a sanapshot
+	blockNum := bcInfo.Height - 1
+	require.NoError(t, h.lgr.SubmitSnapshotRequest(blockNum))
+	// wait until snapshot is generated
+	snapshotGenerated := func() bool {
+		requests, err := h.lgr.PendingSnapshotRequests()
+		require.NoError(t, err)
+		return len(requests) == 0
+	}
+	require.Eventually(t, snapshotGenerated, time.Minute, 100*time.Millisecond)
+	snapshotDir := kvledger.SnapshotDirForLedgerBlockNum(env.initializer.Config.SnapshotsConfig.RootDir, "ledger_from_snapshot", blockNum)
+	env.closeLedgerMgmt()
+
+	// creates a new env with multiple ledgers, some from genesis block and some from a snapshot
+	env2 := newEnv(t)
+	defer env2.cleanup()
+	env2.initLedgerMgmt()
+
+	env2.newTestHelperCreateLgr("ledger_from_genesis_block", t)
+
+	callbackCounter := 0
+	callback := func(l ledger.PeerLedger, cid string) { callbackCounter++ }
+	require.NoError(t, env2.ledgerMgr.CreateLedgerFromSnapshot(snapshotDir, callback))
+
+	// wait until ledger creation is done
+	ledgerCreated := func() bool {
+		status := env2.ledgerMgr.JoinBySnapshotStatus()
+		return !status.InProgress && status.BootstrappingSnapshotDir == ""
+	}
+	require.Eventually(t, ledgerCreated, time.Minute, 100*time.Microsecond)
+	require.Equal(t, 1, callbackCounter)
+	env2.closeLedgerMgmt()
+
+	config := env2.initializer.Config
+	rootFSPath := config.RootFSPath
+
+	t.Run("reset_fails", func(t *testing.T) {
+		err = kvledger.ResetAllKVLedgers(rootFSPath)
+		require.EqualError(t, err, "cannot reset channels because the peer contains channel(s) [ledger_from_snapshot] that were bootstrapped from snapshot")
+	})
+
+	t.Run("rollback_a_channel_fails", func(t *testing.T) {
+		err = kvledger.RollbackKVLedger(rootFSPath, "ledger_from_genesis_block", 1)
+		require.EqualError(t, err, "cannot rollback any channel because the peer contains channel(s) [ledger_from_snapshot] that were bootstrapped from snapshot")
+	})
+
+	t.Run("rebuild_fails", func(t *testing.T) {
+		err = kvledger.RebuildDBs(config)
+		require.EqualError(t, err, "cannot rebuild databases because the peer contains channel(s) [ledger_from_snapshot] that were bootstrapped from snapshot")
+	})
+
+	t.Run("manually_dropping_dbs_returns_error_on_start", func(t *testing.T) {
+		env2.closeAllLedgersAndRemoveDirContents(rebuildableStatedb)
+		_, err := env2.ledgerMgr.OpenLedger("ledger_from_snapshot")
+		require.EqualError(t, err, "recovery for DB [state] not possible. Ledger [ledger_from_snapshot] is created from a snapshot. Last block in snapshot = [8], DB needs block [0] onward")
+	})
+}

--- a/core/ledger/kvledger/upgrade_dbs_test.go
+++ b/core/ledger/kvledger/upgrade_dbs_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/hyperledger/fabric/common/ledger/dataformat"
 	"github.com/hyperledger/fabric/core/ledger/mock"
+	"github.com/hyperledger/fabric/internal/fileutil"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,11 +28,41 @@ func TestUpgradeWrongFormat(t *testing.T) {
 	provider.Close()
 	require.NoError(t, err)
 
+	stateDBPath := StateDBPath(conf.RootFSPath)
+	isEmpty, err := fileutil.DirEmpty(stateDBPath)
+	require.NoError(t, err)
+	require.False(t, isEmpty)
+
 	err = UpgradeDBs(conf)
-	expectedErr := &dataformat.ErrFormatMismatch{
-		ExpectedFormat: dataformat.PreviousFormat,
-		Format:         "x.0",
-		DBInfo:         fmt.Sprintf("leveldb for channel-IDs at [%s]", LedgerProviderPath(conf.RootFSPath)),
-	}
+	expectedErr := errors.WithMessage(
+		&dataformat.ErrFormatMismatch{
+			ExpectedFormat: dataformat.PreviousFormat,
+			Format:         "x.0",
+			DBInfo:         fmt.Sprintf("leveldb for channel-IDs at [%s]", LedgerProviderPath(conf.RootFSPath)),
+		},
+		"error while checking whether upgrade is required",
+	)
 	require.EqualError(t, err, expectedErr.Error())
+	isEmpty, err = fileutil.DirEmpty(stateDBPath)
+	require.NoError(t, err)
+	require.False(t, isEmpty)
+}
+
+func TestUpgradeAlreadyUptodateFormat(t *testing.T) {
+	conf, cleanup := testConfig(t)
+	conf.HistoryDBConfig.Enabled = false
+	defer cleanup()
+	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
+	provider.Close()
+
+	stateDBPath := StateDBPath(conf.RootFSPath)
+	isEmpty, err := fileutil.DirEmpty(stateDBPath)
+	require.NoError(t, err)
+	require.False(t, isEmpty)
+
+	err = UpgradeDBs(conf)
+	require.EqualError(t, err, "the data format is already up to date. No upgrade is required")
+	isEmpty, err = fileutil.DirEmpty(stateDBPath)
+	require.NoError(t, err)
+	require.False(t, isEmpty)
 }

--- a/internal/peer/node/rollback_test.go
+++ b/internal/peer/node/rollback_test.go
@@ -26,7 +26,7 @@ func TestRollbackCmd(t *testing.T) {
 		args := []string{"-c", "ch1", "-b", "10"}
 		cmd.SetArgs(args)
 		err := cmd.Execute()
-		expectedErr := "ledgerID [ch1] does not exist"
-		require.Equal(t, expectedErr, err.Error())
+		// this should return an error as no ledger has been set up
+		require.Contains(t, err.Error(), "error while checking if any ledger has been bootstrapped from snapshot")
 	})
 }

--- a/internal/peer/node/upgrade_dbs_test.go
+++ b/internal/peer/node/upgrade_dbs_test.go
@@ -21,5 +21,5 @@ func TestUpgradeDBsCmd(t *testing.T) {
 	defer os.RemoveAll(testPath)
 
 	cmd := upgradeDBsCmd()
-	require.NoError(t, cmd.Execute())
+	require.EqualError(t, cmd.Execute(), "the data format is already up to date. No upgrade is required")
 }


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- Bug fix

#### Description
- Returns errors in the rollback and rebuild-dbs commands if any channel is bootstrapped from snapshot.
- Checks for upgrade format before dropping the dbs

#### Additional details
see [FAB-17800](https://jira.hyperledger.org/browse/FAB-17800
