### PR TITLE
Rename channel particicpation CFT filerepo directory to pendingops

### DIFF
--- a/common/ledger/blockledger/fileledger/factory.go
+++ b/common/ledger/blockledger/fileledger/factory.go
@@ -110,7 +110,7 @@ func New(directory string, metricsProvider metrics.Provider) (blockledger.Factor
 		return nil, err
 	}
 
-	fileRepo, err := filerepo.New(filepath.Join(directory, "filerepo"), "remove")
+	fileRepo, err := filerepo.New(filepath.Join(directory, "pendingops"), "remove")
 	if err != nil {
 		return nil, err
 	}

--- a/common/ledger/blockledger/fileledger/factory_test.go
+++ b/common/ledger/blockledger/fileledger/factory_test.go
@@ -61,7 +61,7 @@ func TestBlockStoreProviderErrors(t *testing.T) {
 		dir, err := ioutil.TempDir("", "fileledger")
 		require.NoError(t, err, "Error creating temp dir: %s", err)
 		defer os.RemoveAll(dir)
-		fileRepo, err := filerepo.New(filepath.Join(dir, "filerepo"), "remove")
+		fileRepo, err := filerepo.New(filepath.Join(dir, "pendingops"), "remove")
 		require.NoError(t, err, "Error creating temp file repo: %s", err)
 
 		t.Run("ledger doesn't exist", func(t *testing.T) {
@@ -117,7 +117,7 @@ func TestMultiReinitialization(t *testing.T) {
 	require.Equal(t, 3, len(f.ChannelIDs()), "Expected channel to be recovered")
 	f.Close()
 
-	bar2FileRepoDir := filepath.Join(dir, "filerepo", "remove", "bar2.remove")
+	bar2FileRepoDir := filepath.Join(dir, "pendingops", "remove", "bar2.remove")
 	_, err = os.Create(bar2FileRepoDir)
 	require.NoError(t, err, "Error creating temp file: %s", err)
 
@@ -153,14 +153,14 @@ func TestNewErrors(t *testing.T) {
 		require.NoError(t, err, "Error creating temp dir: %s", err)
 		defer os.RemoveAll(dir)
 
-		fileRepoDir := filepath.Join(dir, "filerepo", "remove")
+		fileRepoDir := filepath.Join(dir, "pendingops", "remove")
 		err = os.MkdirAll(fileRepoDir, 0700)
 		require.NoError(t, err, "Error creating temp dir: %s", err)
 		removeFile := filepath.Join(fileRepoDir, "rojo.remove")
 		_, err = os.Create(removeFile)
 		require.NoError(t, err, "Error creating temp file: %s", err)
 		err = os.Chmod(removeFile, 0444)
-		err = os.Chmod(filepath.Join(dir, "filerepo", "remove"), 0444)
+		err = os.Chmod(filepath.Join(dir, "pendingops", "remove"), 0444)
 		require.NoError(t, err, "Error changing permissions of temp file: %s", err)
 
 		_, err = New(dir, metricsProvider)
@@ -172,14 +172,14 @@ func TestNewErrors(t *testing.T) {
 		require.NoError(t, err, "Error creating temp dir: %s", err)
 		defer os.RemoveAll(dir)
 
-		fileRepoDir := filepath.Join(dir, "filerepo", "remove")
+		fileRepoDir := filepath.Join(dir, "pendingops", "remove")
 		err = os.MkdirAll(fileRepoDir, 0777)
 		require.NoError(t, err, "Error creating temp dir: %s", err)
 		removeFile := filepath.Join(fileRepoDir, "rojo.remove")
 		_, err = os.Create(removeFile)
 		require.NoError(t, err, "Error creating temp file: %s", err)
 		err = os.Chmod(removeFile, 0444)
-		err = os.Chmod(filepath.Join(dir, "filerepo", "remove"), 0544)
+		err = os.Chmod(filepath.Join(dir, "pendingops", "remove"), 0544)
 		require.NoError(t, err, "Error changing permissions of temp file: %s", err)
 
 		_, err = New(dir, metricsProvider)
@@ -193,7 +193,7 @@ func TestRemove(t *testing.T) {
 	require.NoError(t, err, "Error creating temp dir: %s", err)
 	defer os.RemoveAll(dir)
 
-	fileRepo, err := filerepo.New(filepath.Join(dir, "filerepo"), "remove")
+	fileRepo, err := filerepo.New(filepath.Join(dir, "pendingops"), "remove")
 	require.NoError(t, err, "Error creating temp file repo: %s", err)
 	f := &fileLedgerFactory{
 		blkstorageProvider: mockBlockStore,
@@ -203,7 +203,7 @@ func TestRemove(t *testing.T) {
 	defer f.Close()
 
 	t.Run("success", func(t *testing.T) {
-		dest := filepath.Join(dir, "filerepo", "remove", "foo.remove")
+		dest := filepath.Join(dir, "pendingops", "remove", "foo.remove")
 		mockBlockStore.DropCalls(func(string) error {
 			_, err = os.Stat(dest)
 			require.NoError(t, err, "Expected foo.remove to exist")
@@ -222,15 +222,15 @@ func TestRemove(t *testing.T) {
 		err = f.Remove("foo")
 		require.EqualError(t, err, "oogie")
 
-		dest := filepath.Join(dir, "filerepo", "remove", "foo.remove")
+		dest := filepath.Join(dir, "pendingops", "remove", "foo.remove")
 		_, err = os.Stat(dest)
 		require.NoError(t, err, "Expected foo.remove to exist")
 	})
 
-	t.Run("saving to file repo fails", func(t *testing.T) {
+	t.Run("saving to pending ops fails", func(t *testing.T) {
 		os.RemoveAll(dir)
 		mockBlockStore.DropReturns(nil)
 		err = f.Remove("foo")
-		require.EqualError(t, err, fmt.Sprintf("error while creating file:%s/filerepo/remove/foo.remove~: open %s/filerepo/remove/foo.remove~: no such file or directory", dir, dir))
+		require.EqualError(t, err, fmt.Sprintf("error while creating file:%s/pendingops/remove/foo.remove~: open %s/pendingops/remove/foo.remove~: no such file or directory", dir, dir))
 	})
 }

--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -118,7 +118,7 @@ func NewRegistrar(
 // InitJoinBlockFileRepo initialize the channel participation API joinblock file repo. This creates
 // the fileRepoDir on the filesystem if it does not already exist.
 func InitJoinBlockFileRepo(config *localconfig.TopLevel) (*filerepo.Repo, error) {
-	fileRepoDir := filepath.Join(config.FileLedger.Location, "filerepo")
+	fileRepoDir := filepath.Join(config.FileLedger.Location, "pendingops")
 	logger.Infof("Channel Participation API enabled, registrar initializing with file repo %s", fileRepoDir)
 
 	joinBlockFileRepo, err := filerepo.New(fileRepoDir, "joinblock")

--- a/orderer/common/multichannel/registrar_test.go
+++ b/orderer/common/multichannel/registrar_test.go
@@ -552,7 +552,7 @@ func TestNewRegistrarWithFileRepo(t *testing.T) {
 		}, "Should not panic when file repo dir exists and is read writable")
 		require.NotNil(t, manager)
 		require.NotNil(t, manager.joinBlockFileRepo)
-		require.DirExists(t, filepath.Join(tmpdir, "filerepo"))
+		require.DirExists(t, filepath.Join(tmpdir, "pendingops"))
 
 		list := manager.ChannelList()
 		require.Nil(t, list.SystemChannel)
@@ -574,7 +574,7 @@ type joinBlock struct {
 }
 
 func createJoinBlockFileRepoDirWithBlocks(t *testing.T, tmpdir string, joinBlocks ...*joinBlock) {
-	joinBlockRepoPath := filepath.Join(tmpdir, "filerepo", "joinblock")
+	joinBlockRepoPath := filepath.Join(tmpdir, "pendingops", "joinblock")
 	err := os.MkdirAll(joinBlockRepoPath, 0755)
 	require.NoError(t, err)
 	for _, jb := range joinBlocks {
@@ -950,7 +950,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		info, err := registrar.JoinChannel("some-app-channel", &cb.Block{}, true)
 		require.EqualError(t, err, "system channel exists")
 		require.Equal(t, types.ChannelInfo{}, info)
-		joinBlockPath := filepath.Join(tmpdir, "filerepo", "joinblock", "some-app-channel.joinblock")
+		joinBlockPath := filepath.Join(tmpdir, "pendingops", "joinblock", "some-app-channel.joinblock")
 		_, err = os.Stat(joinBlockPath)
 		require.True(t, os.IsNotExist(err))
 	})
@@ -975,7 +975,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		info, err := registrar.JoinChannel("my-raft-channel", &cb.Block{}, true)
 		require.EqualError(t, err, "channel already exists")
 		require.Equal(t, types.ChannelInfo{}, info)
-		joinBlockPath := filepath.Join(tmpdir, "filerepo", "joinblock", "my-channel.joinblock")
+		joinBlockPath := filepath.Join(tmpdir, "pendingops", "joinblock", "my-channel.joinblock")
 		_, err = os.Stat(joinBlockPath)
 		require.True(t, os.IsNotExist(err))
 	})
@@ -1000,7 +1000,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		info, err := registrar.JoinChannel("sys-channel", &cb.Block{}, false)
 		require.EqualError(t, err, "application channels already exist")
 		require.Equal(t, types.ChannelInfo{}, info)
-		joinBlockPath := filepath.Join(tmpdir, "filerepo", "joinblock", "sys-channel.joinblock")
+		joinBlockPath := filepath.Join(tmpdir, "pendingops", "joinblock", "sys-channel.joinblock")
 		_, err = os.Stat(joinBlockPath)
 		require.True(t, os.IsNotExist(err))
 	})
@@ -1027,7 +1027,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 
 			// After join failure, check that everything has been cleaned up
 			require.Empty(t, ledgerFactory.ChannelIDs())
-			joinBlockPath := filepath.Join(tmpdir, "filerepo", "joinblock", "my-raft-channel.joinblock")
+			joinBlockPath := filepath.Join(tmpdir, "pendingops", "joinblock", "my-raft-channel.joinblock")
 			_, err = os.Stat(joinBlockPath)
 			require.True(t, os.IsNotExist(err))
 			require.Nil(t, registrar.GetChain("my-raft-channel"))
@@ -1050,7 +1050,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 
 			// After join failure, check that everything has been cleaned up
 			require.Empty(t, ledgerFactory.ChannelIDs())
-			joinBlockPath := filepath.Join(tmpdir, "filerepo", "joinblock", "my-raft-channel.joinblock")
+			joinBlockPath := filepath.Join(tmpdir, "pendingops", "joinblock", "my-raft-channel.joinblock")
 			_, err = os.Stat(joinBlockPath)
 			require.True(t, os.IsNotExist(err))
 			require.Nil(t, registrar.GetChain("my-raft-channel"))
@@ -1075,7 +1075,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 			require.Equal(t, 1, len(channelList.Channels))
 			require.Equal(t, "my-raft-channel", channelList.Channels[0].Name)
 			require.Nil(t, channelList.SystemChannel)
-			joinBlockPath := filepath.Join(tmpdir, "filerepo", "joinblock", "my-raft-channel.joinblock")
+			joinBlockPath := filepath.Join(tmpdir, "pendingops", "joinblock", "my-raft-channel.joinblock")
 			_, err = os.Stat(joinBlockPath)
 			require.True(t, os.IsNotExist(err))
 		})
@@ -1171,7 +1171,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		fChain.Halt()
 
 		// join-block exists before switching from follower to member
-		joinBlockPath := filepath.Join(tmpdir, "filerepo", "joinblock", "my-raft-channel.joinblock")
+		joinBlockPath := filepath.Join(tmpdir, "pendingops", "joinblock", "my-raft-channel.joinblock")
 		_, err = os.Stat(joinBlockPath)
 		require.NoError(t, err)
 
@@ -1270,7 +1270,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		require.NotNil(t, cs)
 
 		// join-block exists
-		joinBlockPath := filepath.Join(tmpdir, "filerepo", "joinblock", "sys-raft-channel.joinblock")
+		joinBlockPath := filepath.Join(tmpdir, "pendingops", "joinblock", "sys-raft-channel.joinblock")
 		_, err = os.Stat(joinBlockPath)
 		require.NoError(t, err)
 
@@ -1307,7 +1307,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		require.NotNil(t, cs)
 
 		// join-block exists
-		joinBlockPath := filepath.Join(tmpdir, "filerepo", "joinblock", "sys-raft-channel.joinblock")
+		joinBlockPath := filepath.Join(tmpdir, "pendingops", "joinblock", "sys-raft-channel.joinblock")
 		_, err = os.Stat(joinBlockPath)
 		require.NoError(t, err)
 

--- a/orderer/common/server/etcdraft_test.go
+++ b/orderer/common/server/etcdraft_test.go
@@ -160,7 +160,7 @@ func testEtcdRaftOSNJoinSysChan(gt *GomegaWithT, configPath, configtxgen, ordere
 	genesisBlockPath := generateBootstrapBlock(gt, configPath, configtxgen, "system", "SampleEtcdRaftSystemChannel")
 	genesisBlockBytes, err := ioutil.ReadFile(genesisBlockPath)
 	gt.Expect(err).NotTo(HaveOccurred())
-	fileRepoDir := filepath.Join(tempDir, "ledger", "filerepo", "joinblock")
+	fileRepoDir := filepath.Join(tempDir, "ledger", "pendingops", "joinblock")
 	joinBlockPath := filepath.Join(fileRepoDir, "system.joinblock")
 	err = ioutil.WriteFile(joinBlockPath, genesisBlockBytes, 0644)
 	gt.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION


<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (improvement to code, performance, etc)

#### Description

<!--- Describe your changes in detail, including motivation. -->

- Renamed the filerepo directory associated with storing pending operations for channel participation CFT to pendingops for better context


<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->


#### Related issues

[FAB-18280](https://jira.hyperledger.org/browse/FAB-18280)


<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
