### PR TITLE
FAB-18291 Ch.Part.API: BlockPuller that can be stopped, improve follower Halt() responsiveness

### DIFF
--- a/orderer/common/cluster/replication.go
+++ b/orderer/common/cluster/replication.go
@@ -400,6 +400,7 @@ func BlockPullerFromConfigBlock(conf PullerConfig, block *common.Block, verifier
 		FetchTimeout:        conf.Timeout,
 		Channel:             conf.Channel,
 		Signer:              conf.Signer,
+		StopChannel:         make(chan struct{}),
 	}, nil
 }
 

--- a/orderer/common/follower/block_puller.go
+++ b/orderer/common/follower/block_puller.go
@@ -87,7 +87,7 @@ func NewBlockPullerCreator(
 }
 
 // BlockPuller creates a block puller on demand, taking the endpoints from the config block.
-func (creator *BlockPullerCreator) BlockPuller(configBlock *common.Block) (ChannelPuller, error) {
+func (creator *BlockPullerCreator) BlockPuller(configBlock *common.Block, stopChannel chan struct{}) (ChannelPuller, error) {
 	// Extract the TLS CA certs and endpoints from the join-block
 	endpoints, err := cluster.EndpointconfigFromConfigBlock(configBlock, creator.bccsp)
 	if err != nil {
@@ -106,6 +106,7 @@ func (creator *BlockPullerCreator) BlockPuller(configBlock *common.Block) (Chann
 		TLSCert:             creator.der.Bytes,
 		Channel:             creator.channelID,
 		Dialer:              creator.stdDialer,
+		StopChannel:         stopChannel,
 	}
 
 	return bp, nil

--- a/orderer/common/follower/block_puller_test.go
+++ b/orderer/common/follower/block_puller_test.go
@@ -101,13 +101,13 @@ func TestBlockPullerFactory_BlockPuller(t *testing.T) {
 	t.Run("good", func(t *testing.T) {
 		joinBlockAppRaft := generateJoinBlock(t, tlsCA, channelID, 10)
 		require.NotNil(t, joinBlockAppRaft)
-		bp, err := factory.BlockPuller(joinBlockAppRaft)
+		bp, err := factory.BlockPuller(joinBlockAppRaft, make(chan struct{}))
 		require.NoError(t, err)
 		require.NotNil(t, bp)
 	})
 
 	t.Run("bad join block", func(t *testing.T) {
-		bp, err := factory.BlockPuller(&cb.Block{Header: &cb.BlockHeader{}})
+		bp, err := factory.BlockPuller(&cb.Block{Header: &cb.BlockHeader{}}, make(chan struct{}))
 		require.EqualError(t, err, "error extracting endpoints from config block: block data is nil")
 		require.Nil(t, bp)
 	})

--- a/orderer/common/follower/mocks/block_puller_factory.go
+++ b/orderer/common/follower/mocks/block_puller_factory.go
@@ -9,10 +9,11 @@ import (
 )
 
 type BlockPullerFactory struct {
-	BlockPullerStub        func(*common.Block) (follower.ChannelPuller, error)
+	BlockPullerStub        func(*common.Block, chan struct{}) (follower.ChannelPuller, error)
 	blockPullerMutex       sync.RWMutex
 	blockPullerArgsForCall []struct {
 		arg1 *common.Block
+		arg2 chan struct{}
 	}
 	blockPullerReturns struct {
 		result1 follower.ChannelPuller
@@ -37,16 +38,17 @@ type BlockPullerFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *BlockPullerFactory) BlockPuller(arg1 *common.Block) (follower.ChannelPuller, error) {
+func (fake *BlockPullerFactory) BlockPuller(arg1 *common.Block, arg2 chan struct{}) (follower.ChannelPuller, error) {
 	fake.blockPullerMutex.Lock()
 	ret, specificReturn := fake.blockPullerReturnsOnCall[len(fake.blockPullerArgsForCall)]
 	fake.blockPullerArgsForCall = append(fake.blockPullerArgsForCall, struct {
 		arg1 *common.Block
-	}{arg1})
-	fake.recordInvocation("BlockPuller", []interface{}{arg1})
+		arg2 chan struct{}
+	}{arg1, arg2})
+	fake.recordInvocation("BlockPuller", []interface{}{arg1, arg2})
 	fake.blockPullerMutex.Unlock()
 	if fake.BlockPullerStub != nil {
-		return fake.BlockPullerStub(arg1)
+		return fake.BlockPullerStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -61,17 +63,17 @@ func (fake *BlockPullerFactory) BlockPullerCallCount() int {
 	return len(fake.blockPullerArgsForCall)
 }
 
-func (fake *BlockPullerFactory) BlockPullerCalls(stub func(*common.Block) (follower.ChannelPuller, error)) {
+func (fake *BlockPullerFactory) BlockPullerCalls(stub func(*common.Block, chan struct{}) (follower.ChannelPuller, error)) {
 	fake.blockPullerMutex.Lock()
 	defer fake.blockPullerMutex.Unlock()
 	fake.BlockPullerStub = stub
 }
 
-func (fake *BlockPullerFactory) BlockPullerArgsForCall(i int) *common.Block {
+func (fake *BlockPullerFactory) BlockPullerArgsForCall(i int) (*common.Block, chan struct{}) {
 	fake.blockPullerMutex.RLock()
 	defer fake.blockPullerMutex.RUnlock()
 	argsForCall := fake.blockPullerArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *BlockPullerFactory) BlockPullerReturns(result1 follower.ChannelPuller, result2 error) {

--- a/orderer/consensus/etcdraft/blockpuller.go
+++ b/orderer/consensus/etcdraft/blockpuller.go
@@ -99,6 +99,7 @@ func NewBlockPuller(support consensus.ConsenterSupport,
 		TLSCert:             der.Bytes,
 		Channel:             support.ChannelID(),
 		Dialer:              stdDialer,
+		StopChannel:         make(chan struct{}),
 	}
 
 	return &LedgerBlockPuller{


### PR DESCRIPTION
When a follower is started with a block that has bad endpoints,
it will cause the internal BlockPuller to retry a lot of times.
Calling Halt() on said follower will block until the BlockPuller
gives up, which can take a very long time. This causes an attempt
to Remove that channel via the participation API to block for too long.

This commit improves the BlockPuller by adding a channel to signal
it to stop retrying and exit. It also integrates with the
follower.Chain to make it more responsive to Halt().

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: I49354d94a28402ce69a469689c12ea595b3e0a7e

#### Type of change
- Bug fix
- Improvement (improvement to code, performance, etc)

#### Related issues
FAB-18291
