### PR TITLE
[FAB-17953] IT: verify pvtdata reconciliation when bootstrapping by snapshot

### DIFF
--- a/integration/ledger/snapshot_test.go
+++ b/integration/ledger/snapshot_test.go
@@ -20,9 +20,11 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric/core/ledger/util"
 	"github.com/hyperledger/fabric/integration/chaincode/kvexecutor"
 	"github.com/hyperledger/fabric/integration/nwo"
 	"github.com/hyperledger/fabric/integration/nwo/commands"
+	"github.com/hyperledger/fabric/integration/pvtdata/marblechaincodeutil"
 	"github.com/hyperledger/fabric/integration/runner"
 	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/ginkgo"
@@ -47,7 +49,7 @@ var _ bool = Describe("Snapshot Generation and Bootstrap", func() {
 
 	BeforeEach(func() {
 		By("initializing and starting the network")
-		setup = initAndStartMultiOrgsNetwork()
+		setup = initAndStartFourOrgsNetwork()
 
 		helper = &marblesTestHelper{
 			networkHelper: &networkHelper{
@@ -58,30 +60,6 @@ var _ bool = Describe("Snapshot Generation and Bootstrap", func() {
 				channelID: setup.channelID,
 			},
 		}
-
-		legacyChaincode = nwo.Chaincode{
-			Name:        "marbles",
-			Version:     "0.0",
-			Path:        chaincodePathWithIndex,
-			Ctor:        `{"Args":[]}`,
-			Policy:      `OR ('Org1MSP.member','Org2MSP.member','Org3MSP.member','Org4MSP.member')`,
-			PackageFile: filepath.Join(setup.testDir, "marbles_legacy.tar.gz"),
-		}
-
-		newlifecycleChaincode = nwo.Chaincode{
-			Name:            "marbles",
-			Version:         "0.0",
-			Path:            components.Build(chaincodePathWithIndex),
-			Lang:            "binary",
-			CodeFiles:       filesWithIndex,
-			PackageFile:     filepath.Join(setup.testDir, "marbles.tar.gz"),
-			SignaturePolicy: `OR ('Org1MSP.member','Org2MSP.member','Org3MSP.member','Org4MSP.member')`,
-			Sequence:        "1",
-			Label:           "marbles",
-		}
-
-		By("deploying legacy chaincode on initial peers (stateleveldb)")
-		nwo.DeployChaincodeLegacy(setup.network, testchannelID, setup.orderer, legacyChaincode)
 	})
 
 	AfterEach(func() {
@@ -93,184 +71,396 @@ var _ bool = Describe("Snapshot Generation and Bootstrap", func() {
 		os.RemoveAll(setup.network.RootDir)
 	})
 
-	// Below test does the following when peers are using either leveldb or couchdb.
-	// Note that we do not support a channel with mixed DBs. However, for testing,
-	// it would be fine to use mixed DBs to test with both couchdb and leveldb
-	// - create snapshots on the 2 peers and verify they are same
-	// - bootstrap a peer (couchdb) in an existing org from the snapshot
-	// - bootstrap a peer (leveldb) in a new org from the snapshot
-	// - verify couchdb index exists
-	// - verify chaincode invocation, history, qscc, channel config update
-	// - upgrade to new lifecycle chaincode
-	// - create a new snapshot from a peer (couchdb) bootstrapped from a snapshot
-	// - bootstrap peers (couchdb) in existing org and new org from the new snapshot
-	// - verify couchdb index exists
-	// - verify chaincode invocation, history, qscc, channel config update
-	// - verify chaincode upgrade and new chaincode install on all peers
-	It("generates snapshot and bootstraps from snapshots with statecouchdb", func() {
-		org1peer0 := setup.network.Peer("Org1", "peer0")
-		org2peer0 := setup.network.Peer("Org2", "peer0")
+	When("chaincode has no private data collections", func() {
+		BeforeEach(func() {
+			legacyChaincode = nwo.Chaincode{
+				Name:        "marbles",
+				Version:     "0.0",
+				Path:        chaincodePathWithIndex,
+				Ctor:        `{"Args":[]}`,
+				Policy:      `OR ('Org1MSP.member','Org2MSP.member','Org3MSP.member','Org4MSP.member')`,
+				PackageFile: filepath.Join(setup.testDir, "marbles_legacy.tar.gz"),
+			}
 
-		By("invoking marbles chaincode")
-		testKey := "marble-0"
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "initMarble", "marble-0", "blue", "35", "tom")
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "initMarble", "marble-1", "red", "100", "tom")
+			newlifecycleChaincode = nwo.Chaincode{
+				Name:            "marbles",
+				Version:         "0.0",
+				Path:            components.Build(chaincodePathWithIndex),
+				Lang:            "binary",
+				CodeFiles:       filesWithIndex,
+				PackageFile:     filepath.Join(setup.testDir, "marbles.tar.gz"),
+				SignaturePolicy: `OR ('Org1MSP.member','Org2MSP.member','Org3MSP.member','Org4MSP.member')`,
+				Sequence:        "1",
+				Label:           "marbles",
+			}
 
-		By("getting an txid from a block before snapshot is generated")
-		txidBeforeSnapshot := getTxIDFromLastBlock(setup.network, org1peer0)
+			By("deploying legacy chaincode on initial peers (stateleveldb)")
+			nwo.DeployChaincodeLegacy(setup.network, testchannelID, setup.orderer, legacyChaincode)
+		})
 
-		// verify snapshot commands with different parameters")
-		blockNum := nwo.GetLedgerHeight(setup.network, org1peer0, testchannelID) - 1
-		verifySnapshotRequestCmds(setup.network, org1peer0, testchannelID, blockNum)
+		// Below test does the following when peers are using either leveldb or couchdb.
+		// Note that we do not support a channel with mixed DBs. However, for testing,
+		// it would be fine to use mixed DBs to test with both couchdb and leveldb
+		// - create snapshots on the 2 peers and verify they are same
+		// - bootstrap a peer (couchdb) in an existing org from the snapshot
+		// - bootstrap a peer (leveldb) in a new org from the snapshot
+		// - verify couchdb index exists
+		// - verify chaincode invocation, history, qscc, channel config update
+		// - upgrade to new lifecycle chaincode
+		// - create a new snapshot again from a peer (couchdb) bootstrapped from a snapshot
+		// - bootstrap peers (couchdb) in existing org and new org from the new snapshot
+		// - verify couchdb index exists
+		// - verify chaincode invocation, history, qscc
+		// - verify chaincode upgrade and new chaincode install on all peers
+		It("generates snapshot and bootstraps from snapshots", func() {
+			org1peer0 := setup.network.Peer("Org1", "peer0")
+			org2peer0 := setup.network.Peer("Org2", "peer0")
 
-		// test 1: generate snapshots on 2 peers for the same blockNum and verify they are same
-		_, snapshotDir2 := generateAndCompareSnapshots(setup.network, org1peer0, org2peer0, blockNum)
+			By("invoking marbles chaincode")
+			testKey := "marble-0"
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "initMarble", "marble-0", "blue", "35", "tom")
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "initMarble", "marble-1", "red", "100", "tom")
 
-		// test 2: bootstrap a peer in an existing org from snapshot and verify
-		By("starting new peer org2peer1 in existing org2 (couchdb)")
-		org2peer1, couchProc := startPeer(setup, "Org2", "peer1", testchannelID, true)
-		couchProcess = append(couchProcess, couchProc)
+			By("getting an txid from a block before snapshot is generated")
+			txidBeforeSnapshot := getTxIDFromLastBlock(setup.network, org1peer0)
 
-		By("installing legacy chaincode on new peer org2peer1")
-		nwo.InstallChaincodeLegacy(setup.network, legacyChaincode, org2peer1)
+			// verify snapshot commands with different parameters")
+			blockNum := nwo.GetLedgerHeight(setup.network, org1peer0, testchannelID) - 1
+			verifySnapshotRequestCmds(setup.network, org1peer0, testchannelID, blockNum)
 
-		By("joining new peer org2peer1 to the channel")
-		joinBySnapshot(setup.network, setup.orderer, org2peer1, testchannelID, snapshotDir2, blockNum)
+			// test 1: generate snapshots on 2 peers for the same blockNum and verify they are same
+			_, snapshotDir2 := generateAndCompareSnapshots(setup.network, org1peer0, org2peer0, blockNum)
 
-		By("verifying index created on org2peer1")
-		verifySizeIndexExists(setup.network, testchannelID, setup.orderer, org2peer1, "marbles")
+			// test 2: bootstrap a peer in an existing org from snapshot and verify
+			By("starting new peer org2peer1 in existing org2 (couchdb)")
+			org2peer1, couchProc := startPeer(setup, "Org2", "peer1", testchannelID, true)
+			couchProcess = append(couchProcess, couchProc)
 
-		By("invoking marbles chaincode on bootstrapped peer org2peer1")
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org2peer1, "transferMarble", testKey, "newowner2")
+			By("installing legacy chaincode on new peer org2peer1")
+			nwo.InstallChaincodeLegacy(setup.network, legacyChaincode, org2peer1)
 
-		By("verifying history on peer org2peer1")
-		expectedHistory := []*marbleHistoryResult{
-			{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner2")},
-		}
-		helper.assertGetHistoryForMarble(legacyChaincode.Name, org2peer1, expectedHistory, testKey)
+			By("joining new peer org2peer1 to the channel")
+			joinBySnapshot(setup.network, setup.orderer, org2peer1, testchannelID, snapshotDir2, blockNum)
 
-		verifyQSCC(setup.network, org2peer1, testchannelID, blockNum, txidBeforeSnapshot)
+			By("verifying index created on org2peer1")
+			verifySizeIndexExists(setup.network, testchannelID, setup.orderer, org2peer1, "marbles")
 
-		// test 3: bootstrap a peer in a new org from snapshot and verify
-		By("starting a peer Org3.peer0 in new org3 (stateleveldb)")
-		org3peer0, _ := startPeer(setup, "Org3", "peer0", testchannelID, false)
+			By("invoking marbles chaincode on bootstrapped peer org2peer1")
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org2peer1, "transferMarble", testKey, "newowner2")
 
-		By("installing legacy chaincode on new peer org3peer0")
-		nwo.InstallChaincodeLegacy(setup.network, legacyChaincode, org3peer0)
+			By("verifying history on peer org2peer1")
+			expectedHistory := []*marbleHistoryResult{
+				{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner2")},
+			}
+			helper.assertGetHistoryForMarble(legacyChaincode.Name, org2peer1, expectedHistory, testKey)
 
-		By("joining new peer org3peer0 to the channel")
-		joinBySnapshot(setup.network, setup.orderer, org3peer0, testchannelID, snapshotDir2, blockNum)
+			verifyQSCC(setup.network, org2peer1, testchannelID, blockNum, txidBeforeSnapshot)
 
-		By("invoking marbles chaincode on bootstrapped peer org3peer0")
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org3peer0, "transferMarble", testKey, "newowner3")
+			// test 3: bootstrap a peer in a new org from snapshot and verify
+			By("starting a peer Org3.peer0 in new org3 (stateleveldb)")
+			org3peer0, _ := startPeer(setup, "Org3", "peer0", testchannelID, false)
 
-		By("verifying history on peer org3peer0")
-		expectedHistory = []*marbleHistoryResult{
-			{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner3")},
-			{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner2")},
-		}
-		helper.assertGetHistoryForMarble(legacyChaincode.Name, org3peer0, expectedHistory, testKey)
+			By("installing legacy chaincode on new peer org3peer0")
+			nwo.InstallChaincodeLegacy(setup.network, legacyChaincode, org3peer0)
 
-		verifyQSCC(setup.network, org3peer0, testchannelID, blockNum, txidBeforeSnapshot)
+			By("joining new peer org3peer0 to the channel")
+			joinBySnapshot(setup.network, setup.orderer, org3peer0, testchannelID, snapshotDir2, blockNum)
 
-		// test 4: upgrade legacy chaincode to new lifecycle
-		By("enabling V2_0 capabilities")
-		channelPeers := setup.network.PeersWithChannel(testchannelID)
-		nwo.EnableCapabilities(setup.network, testchannelID, "Application", "V2_0", setup.orderer, channelPeers...)
+			By("invoking marbles chaincode on bootstrapped peer org3peer0")
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org3peer0, "transferMarble", testKey, "newowner3")
 
-		By("upgrading legacy chaincode to new lifecycle chaincode")
-		nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, newlifecycleChaincode, channelPeers...)
+			By("verifying history on peer org3peer0")
+			expectedHistory = []*marbleHistoryResult{
+				{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner3")},
+				{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner2")},
+			}
+			helper.assertGetHistoryForMarble(legacyChaincode.Name, org3peer0, expectedHistory, testKey)
 
-		By("invoking chaincode after upgraded to new lifecycle chaincode")
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "initMarble", "marble-upgrade", "blue", "35", "tom")
+			verifyQSCC(setup.network, org3peer0, testchannelID, blockNum, txidBeforeSnapshot)
 
-		// test 5: generate snapshot again on a peer bootstrapped from a snapshot and upgraded to new lifecycle chaincode
-		blockNumForNextSnapshot := nwo.GetLedgerHeight(setup.network, org2peer1, testchannelID)
-		By(fmt.Sprintf("generating a snapshot at blockNum %d on org2peer1 that was bootstrapped by a snapshot", blockNumForNextSnapshot))
-		submitSnapshotRequest(setup.network, testchannelID, blockNumForNextSnapshot, org2peer1, false, "Snapshot request submitted successfully")
+			// test 4: upgrade legacy chaincode to new lifecycle
+			By("enabling V2_0 capabilities")
+			channelPeers := setup.network.PeersWithChannel(testchannelID)
+			nwo.EnableCapabilities(setup.network, testchannelID, "Application", "V2_0", setup.orderer, channelPeers...)
 
-		// invoke chaincode to trigger snapshot generation
-		// 1st call should be committed before snapshot generation, 2nd call should be committed after snapshot generation
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "transferMarble", testKey, "newowner_beforesnapshot")
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "transferMarble", testKey, "newowner_aftersnapshot")
+			By("upgrading legacy chaincode to new lifecycle chaincode")
+			nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, newlifecycleChaincode, channelPeers...)
 
-		By("verifying snapshot completed on org2peer1")
-		verifyNoPendingSnapshotRequest(setup.network, org2peer1, testchannelID)
-		snapshotDir := filepath.Join(setup.network.PeerDir(org2peer1), "filesystem", "snapshots", "completed", testchannelID, strconv.Itoa(blockNumForNextSnapshot))
+			By("invoking chaincode after upgraded to new lifecycle chaincode")
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "initMarble", "marble-upgrade", "blue", "35", "tom")
 
-		// test 6: bootstrap a peer in a different org from the new snapshot
-		By("starting a peer (org1peer1) in existing org1 (couchdb)")
-		org1peer1, couchProc := startPeer(setup, "Org1", "peer1", testchannelID, true)
-		couchProcess = append(couchProcess, couchProc)
+			// test 5: generate snapshot again on a peer bootstrapped from a snapshot and upgraded to new lifecycle chaincode
+			blockNumForNextSnapshot := nwo.GetLedgerHeight(setup.network, org2peer1, testchannelID)
+			By(fmt.Sprintf("generating a snapshot at blockNum %d on org2peer1 that was bootstrapped by a snapshot", blockNumForNextSnapshot))
+			submitSnapshotRequest(setup.network, testchannelID, blockNumForNextSnapshot, org2peer1, false, "Snapshot request submitted successfully")
 
-		By("installing new lifecycle chaincode on peer org1peer1")
-		nwo.InstallChaincode(setup.network, newlifecycleChaincode, org1peer1)
+			// invoke chaincode to trigger snapshot generation
+			// 1st call should be committed before snapshot generation, 2nd call should be committed after snapshot generation
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "transferMarble", testKey, "newowner_beforesnapshot")
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "transferMarble", testKey, "newowner_aftersnapshot")
 
-		By("joining new peer org1peer1 to the channel")
-		joinBySnapshot(setup.network, setup.orderer, org1peer1, testchannelID, snapshotDir, blockNumForNextSnapshot)
+			By("verifying snapshot completed on org2peer1")
+			verifyNoPendingSnapshotRequest(setup.network, org2peer1, testchannelID)
+			snapshotDir := filepath.Join(setup.network.PeerDir(org2peer1), "filesystem", "snapshots", "completed", testchannelID, strconv.Itoa(blockNumForNextSnapshot))
 
-		By("verifying index created on org1peer1")
-		verifySizeIndexExists(setup.network, testchannelID, setup.orderer, org1peer1, "marbles")
+			// test 6: bootstrap a peer in a different org from the new snapshot
+			By("starting a peer (org1peer1) in existing org1 (couchdb)")
+			org1peer1, couchProc := startPeer(setup, "Org1", "peer1", testchannelID, true)
+			couchProcess = append(couchProcess, couchProc)
 
-		By("verifying history on peer org1peer1")
-		expectedHistory = []*marbleHistoryResult{
-			{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner_aftersnapshot")},
-		}
-		helper.assertGetHistoryForMarble(legacyChaincode.Name, org1peer1, expectedHistory, testKey)
+			By("installing new lifecycle chaincode on peer org1peer1")
+			nwo.InstallChaincode(setup.network, newlifecycleChaincode, org1peer1)
 
-		verifyQSCC(setup.network, org1peer1, testchannelID, blockNumForNextSnapshot, txidBeforeSnapshot)
+			By("joining new peer org1peer1 to the channel")
+			joinBySnapshot(setup.network, setup.orderer, org1peer1, testchannelID, snapshotDir, blockNumForNextSnapshot)
 
-		// test 7: bootstrap a peer in a new org from the new snapshot
-		By("starting a peer (org4peer0) in new org4 (couchdb)")
-		org4peer0, couchProc := startPeer(setup, "Org4", "peer0", testchannelID, true)
-		couchProcess = append(couchProcess, couchProc)
+			By("verifying index created on org1peer1")
+			verifySizeIndexExists(setup.network, testchannelID, setup.orderer, org1peer1, "marbles")
 
-		By("joining new peer org4peer0 to the channel")
-		joinBySnapshot(setup.network, setup.orderer, org4peer0, testchannelID, snapshotDir, blockNumForNextSnapshot)
+			By("verifying history on peer org1peer1")
+			expectedHistory = []*marbleHistoryResult{
+				{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner_aftersnapshot")},
+			}
+			helper.assertGetHistoryForMarble(legacyChaincode.Name, org1peer1, expectedHistory, testKey)
 
-		By("installing and approving chaincode on new peer org4peer0")
-		installAndApproveChaincode(setup.network, setup.orderer, org4peer0, testchannelID, newlifecycleChaincode, []string{"Org1", "Org2", "Org3", "Org4"})
+			verifyQSCC(setup.network, org1peer1, testchannelID, blockNumForNextSnapshot, txidBeforeSnapshot)
 
-		By("verifying index created on org4peer0")
-		verifySizeIndexExists(setup.network, testchannelID, setup.orderer, org2peer1, "marbles")
+			// test 7: bootstrap a peer in a new org from the new snapshot
+			By("starting a peer (org4peer0) in new org4 (couchdb)")
+			org4peer0, couchProc := startPeer(setup, "Org4", "peer0", testchannelID, true)
+			couchProcess = append(couchProcess, couchProc)
 
-		By("invoking chaincode on bootstrapped peer org4peer0")
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org4peer0, "delete", testKey)
+			By("joining new peer org4peer0 to the channel")
+			joinBySnapshot(setup.network, setup.orderer, org4peer0, testchannelID, snapshotDir, blockNumForNextSnapshot)
 
-		By("verifying history on peer org4peer0")
-		expectedHistory = []*marbleHistoryResult{
-			{IsDelete: "true"},
-			{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner_aftersnapshot")},
-		}
-		helper.assertGetHistoryForMarble(legacyChaincode.Name, org4peer0, expectedHistory, testKey)
+			By("installing and approving chaincode on new peer org4peer0")
+			installAndApproveChaincode(setup.network, setup.orderer, org4peer0, testchannelID, newlifecycleChaincode, []string{"Org1", "Org2", "Org3", "Org4"})
 
-		verifyQSCC(setup.network, org4peer0, testchannelID, blockNumForNextSnapshot, txidBeforeSnapshot)
+			By("verifying index created on org4peer0")
+			verifySizeIndexExists(setup.network, testchannelID, setup.orderer, org2peer1, "marbles")
 
-		// test 8: verify chaincode upgrade and install after bootstrapping
-		By("upgrading chaincode to version 2.0 on all peers after bootstrapping from snapshot")
-		newlifecycleChaincode.Version = "2.0"
-		newlifecycleChaincode.Sequence = "2"
-		nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, newlifecycleChaincode)
+			By("invoking chaincode on bootstrapped peer org4peer0")
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org4peer0, "delete", testKey)
 
-		By("deploying a new chaincode on all the peers after bootstrapping from snapshot")
-		cc2 := nwo.Chaincode{
-			Name:            "kvexecutor",
-			Version:         "1.0",
-			Path:            components.Build("github.com/hyperledger/fabric/integration/chaincode/kvexecutor/cmd"),
-			Lang:            "binary",
-			SignaturePolicy: `OR ('Org1MSP.member','Org2MSP.member', 'Org3MSP.member', 'Org4MSP.member')`,
-			PackageFile:     filepath.Join(setup.testDir, "kvexcutor20.tar.gz"),
-			Label:           "kvexecutor-20",
-			Sequence:        "1",
-		}
-		nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, cc2)
+			By("verifying history on peer org4peer0")
+			expectedHistory = []*marbleHistoryResult{
+				{IsDelete: "true"},
+				{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner_aftersnapshot")},
+			}
+			helper.assertGetHistoryForMarble(legacyChaincode.Name, org4peer0, expectedHistory, testKey)
 
-		By("invoking the new chaincode")
-		kvdata := []kvexecutor.KVData{
-			{Key: "key1", Value: "value1"},
-			{Key: "key2", Value: "value2"},
-		}
-		invokeAndQueryKVExecutorChaincode(setup.network, setup.orderer, testchannelID, cc2, kvdata, setup.network.PeersWithChannel(testchannelID)...)
+			verifyQSCC(setup.network, org4peer0, testchannelID, blockNumForNextSnapshot, txidBeforeSnapshot)
+
+			// test 8: verify chaincode upgrade and install after bootstrapping
+			By("upgrading chaincode to version 2.0 on all peers after bootstrapping from snapshot")
+			newlifecycleChaincode.Version = "2.0"
+			newlifecycleChaincode.Sequence = "2"
+			nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, newlifecycleChaincode)
+
+			By("deploying a new chaincode on all the peers after bootstrapping from snapshot")
+			cc2 := nwo.Chaincode{
+				Name:            "kvexecutor",
+				Version:         "1.0",
+				Path:            components.Build("github.com/hyperledger/fabric/integration/chaincode/kvexecutor/cmd"),
+				Lang:            "binary",
+				SignaturePolicy: `OR ('Org1MSP.member','Org2MSP.member', 'Org3MSP.member', 'Org4MSP.member')`,
+				PackageFile:     filepath.Join(setup.testDir, "kvexcutor20.tar.gz"),
+				Label:           "kvexecutor-20",
+				Sequence:        "1",
+			}
+			nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, cc2)
+
+			By("invoking the new chaincode")
+			kvdata := []kvexecutor.KVData{
+				{Key: "key1", Value: "value1"},
+				{Key: "key2", Value: "value2"},
+			}
+			invokeAndQueryKVExecutorChaincode(setup.network, setup.orderer, testchannelID, cc2, kvdata, setup.network.PeersWithChannel(testchannelID)...)
+		})
+	})
+
+	When("chaincode has private data collections", func() {
+		BeforeEach(func() {
+			newlifecycleChaincode = nwo.Chaincode{
+				Name:              "marblesp",
+				Version:           "1.0",
+				Path:              components.Build("github.com/hyperledger/fabric/integration/chaincode/marbles_private/cmd"),
+				Lang:              "binary",
+				PackageFile:       filepath.Join(setup.testDir, "marbles-pvtdata.tar.gz"),
+				Label:             "marbles-private-20",
+				SignaturePolicy:   `OR ('Org1MSP.member','Org2MSP.member')`,
+				CollectionsConfig: filepath.Join("testdata", "collection_configs", "collections_config1.json"),
+				Sequence:          "1",
+			}
+
+			// start org3peer0 so that we have majority number of orgs (3 out of 4) to satify the channel config update policy
+			org3peer0, _ := startPeer(setup, "Org3", "peer0", testchannelID, false)
+			setup.network.JoinChannel(testchannelID, setup.orderer, org3peer0)
+
+			By("enabling V2_0 capabilities")
+			channelPeers := setup.network.PeersWithChannel(testchannelID)
+			nwo.EnableCapabilities(setup.network, testchannelID, "Application", "V2_0", setup.orderer, channelPeers...)
+
+			By("deploying newlifecycle chaincode2 on initial peers (leveldb)")
+			nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, newlifecycleChaincode)
+		})
+
+		// Below test verifies private data reconciliation on peers bootstrapped from a snapshot.
+		FIt("generates snapshot and bootstraps from snapshots", func() {
+			org1peer0 := setup.network.Peer("Org1", "peer0")
+			org2peer0 := setup.network.Peer("Org2", "peer0")
+			channelPeers := setup.network.PeersWithChannel(testchannelID)
+
+			// prepare test data: add and delete marble1, add and transfer marble1
+			By("adding marble1")
+			marblechaincodeutil.AddMarble(setup.network, setup.orderer, testchannelID, newlifecycleChaincode.Name,
+				`{"name":"marble1", "color":"blue", "size":35, "owner":"tom", "price":99}`, org2peer0)
+			By("deleting marble1")
+			marblechaincodeutil.DeleteMarble(setup.network, setup.orderer, testchannelID, newlifecycleChaincode.Name,
+				`{"name":"marble1"}`, org2peer0)
+
+			By("verifying the deletion of marble1")
+			marblechaincodeutil.AssertDoesNotExistInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", channelPeers...)
+			marblechaincodeutil.AssertDoesNotExistInCollectionMPD(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", channelPeers...)
+
+			By("adding marble2")
+			marblechaincodeutil.AddMarble(setup.network, setup.orderer, testchannelID, newlifecycleChaincode.Name,
+				`{"name":"marble2", "color":"blue", "size":35, "owner":"tom", "price":99}`, org2peer0)
+			By("transferring marble2")
+			marblechaincodeutil.TransferMarble(setup.network, setup.orderer, testchannelID, newlifecycleChaincode.Name,
+				`{"name":"marble2", "owner":"jerry"}`, org2peer0)
+
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble2")
+
+			By("verifying the new ownership of marble2")
+			marblechaincodeutil.AssertOwnershipInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble2", "jerry", org1peer0, org2peer0)
+
+			// test 1: generate snapshots on 2 peers for the same blockNum and verify they are same
+			blockNum := nwo.GetLedgerHeight(setup.network, org2peer0, testchannelID) - 1
+			_, snapshotDir2 := generateAndCompareSnapshots(setup.network, org1peer0, org2peer0, blockNum)
+
+			// test 2: bootstrap a new peer org2peer1 from snapshot and verify pvtdata
+			By("starting new peer org2peer1 (couchdb)")
+			org2peer1, couchProc := startPeer(setup, "Org2", "peer1", testchannelID, true)
+			couchProcess = append(couchProcess, couchProc)
+
+			By("installing chaincode on peer org2peer1")
+			nwo.InstallChaincode(setup.network, newlifecycleChaincode, org2peer1)
+
+			By("joining peer org2peer1 to the channel by snapshot")
+			joinBySnapshot(setup.network, setup.orderer, org2peer1, testchannelID, snapshotDir2, blockNum)
+
+			By("waiting for pvtdata to be reconciled on org2peer1")
+			waitForMarblePvtdataReconciliation(setup.network, org2peer1, testchannelID, newlifecycleChaincode.Name, "marble2")
+
+			// verify pvtdata reconciliation after joinbysnapshot
+			By("verifying marble2 pvtdata reconciliation on org2peer1")
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble2", org2peer1)
+			By("verifying the new ownership of marble2")
+			marblechaincodeutil.AssertOwnershipInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble2", "jerry", org2peer1)
+
+			By("verifying marble1 does not exist")
+			marblechaincodeutil.AssertDoesNotExistInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", org2peer1)
+			marblechaincodeutil.AssertDoesNotExistInCollectionMPD(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", org2peer1)
+
+			// test 3: submit a request to generate snapshot again on a peer (org2peer1) bootstrapped from a snapshot
+			blockNumForNextSnapshot := nwo.GetLedgerHeight(setup.network, org2peer1, testchannelID)
+			By(fmt.Sprintf("generating a snapshot at blockNum %d on org2peer1 that was bootstrapped by a snapshot", blockNumForNextSnapshot))
+			submitSnapshotRequest(setup.network, testchannelID, blockNumForNextSnapshot, org2peer1, false, "Snapshot request submitted successfully")
+
+			// block for marble3 tx is in snapshot, but block for marble4 tx is post snapshot
+			By("adding marble3")
+			marblechaincodeutil.AddMarble(setup.network, setup.orderer, testchannelID, newlifecycleChaincode.Name,
+				`{"name":"marble3", "color":"blue", "size":35, "owner":"tom", "price":99}`, org2peer1)
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble3")
+
+			By("adding marble4")
+			marblechaincodeutil.AddMarble(setup.network, setup.orderer, testchannelID, newlifecycleChaincode.Name,
+				`{"name":"marble4", "color":"blue", "size":35, "owner":"tom", "price":99}`, org2peer1)
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble4")
+
+			By("verifying snapshot completed on org2peer1")
+			verifyNoPendingSnapshotRequest(setup.network, org2peer1, testchannelID)
+			snapshotDir := filepath.Join(setup.network.PeerDir(org2peer1), "filesystem", "snapshots", "completed", testchannelID, strconv.Itoa(blockNumForNextSnapshot))
+
+			// stop all the peers and only restart org2peer1
+			setup.stopPeers()
+			setup.startPeer(org2peer1)
+			setup.peers = []*nwo.Peer{org2peer1}
+			setup.network.Peers = setup.peers
+
+			// test 4: bootstrap a new peer org2peer2 by snapshot and verify pvtdata reconciliation
+			By("starting a peer (org2peer2) in existing org (leveldb)")
+			org2peer2, _ := startPeer(setup, "Org2", "peer2", testchannelID, false)
+
+			By("installing new lifecycle chaincode2 on peer org2peer2")
+			nwo.InstallChaincode(setup.network, newlifecycleChaincode, org2peer2)
+
+			By("joining peer org2peer2 to the channel by snapshot")
+			joinBySnapshot(setup.network, setup.orderer, org2peer2, testchannelID, snapshotDir, blockNumForNextSnapshot)
+
+			By("waiting for pvtdata to be reconciled on org2peer2")
+			waitForMarblePvtdataReconciliation(setup.network, org2peer2, testchannelID, newlifecycleChaincode.Name, "marble2")
+
+			By("verifying marble4 pvtdata reconciliation on org2peer2")
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble4", org2peer2)
+			By("verifying marble3 pvtdata reconciliation on org2peer2")
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble3", org2peer2)
+			By("verifying marble2 pvtdata reconciliation on org2peer2")
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble2", org2peer2)
+			By("verifying the new ownership of marble2")
+			marblechaincodeutil.AssertOwnershipInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble2", "jerry", org2peer2)
+			By("verifying marble1 does not exist")
+			marblechaincodeutil.AssertDoesNotExistInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", org2peer2)
+			marblechaincodeutil.AssertDoesNotExistInCollectionMPD(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", org2peer2)
+
+			// test 5: bootstrap a new peer Org2peer3 from genesis block to verify pvtdata reconciliation
+			By("startinging a peer Org2peer3 in an new org (leveldb)")
+			org2peer3, _ := startPeer(setup, "Org2", "peer3", testchannelID, false)
+
+			By("installing newlifecycleChaincode on new peer Org2peer3")
+			nwo.InstallChaincode(setup.network, newlifecycleChaincode, org2peer3)
+
+			By("joining peer Org2peer3 to the channel by genesis block")
+			setup.network.JoinChannel(testchannelID, setup.orderer, org2peer3)
+
+			By("waiting for the new peer to have the same ledger height")
+			channelHeight := nwo.GetMaxLedgerHeight(setup.network, testchannelID, org2peer1)
+			nwo.WaitUntilEqualLedgerHeight(setup.network, testchannelID, channelHeight, org2peer3)
+
+			By("waiting for pvtdata to be reconciled on org2peer3")
+			waitForMarblePvtdataReconciliation(setup.network, org2peer3, testchannelID, newlifecycleChaincode.Name, "marble2")
+
+			By("verifying marble4 pvtdata reconciliation on org2peer3")
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble4", org2peer3)
+			By("verifying marble3 pvtdata reconciliation on org2peer3")
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble3", org2peer3)
+			By("verifying marble2 pvtdata reconciliation on org2peer3")
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble2", org2peer3)
+			By("verifying the new ownership of marble2")
+			marblechaincodeutil.AssertOwnershipInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble2", "jerry", org2peer3)
+			By("verifying marble1 does not exist")
+			marblechaincodeutil.AssertDoesNotExistInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", org2peer3)
+			marblechaincodeutil.AssertDoesNotExistInCollectionMPD(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", org2peer3)
+
+			// verify pvtdata hash on bootstrapped peers
+			peers := []*nwo.Peer{org2peer1, org2peer2, org2peer3}
+			for i := 2; i <= 4; i++ {
+				name := fmt.Sprintf("marble%d", i)
+				owner := "tom"
+				if name == "marble2" {
+					owner = "jerry"
+				}
+
+				By(fmt.Sprintf("verifying getMarbleHash for %s from all peers that has the chaincode instantiated", name))
+				expectedBytes := util.ComputeStringHash(fmt.Sprintf(`{"docType":"marble","name":"%s","color":"blue","size":35,"owner":"%s"}`, name, owner))
+				marblechaincodeutil.AssertMarblesPrivateHashM(setup.network, testchannelID, newlifecycleChaincode.Name, name, expectedBytes, peers)
+
+				By(fmt.Sprintf("verifying getMarblePrivateDetailsHash for %s from all peers that has the chaincode instantiated", name))
+				expectedBytes = util.ComputeStringHash(fmt.Sprintf(`{"docType":"marblePrivateDetails","name":"%s","price":99}`, name))
+				marblechaincodeutil.AssertMarblesPrivateDetailsHashMPD(setup.network, testchannelID, newlifecycleChaincode.Name, name, expectedBytes, peers)
+			}
+		})
 	})
 })
 
@@ -290,11 +480,11 @@ func configPeerWithCouchDB(s *setup, peer *nwo.Peer) ifrit.Process {
 	return couchProc
 }
 
-// initAndStartMultiOrgsNetwork creates a network with multiple orgs.
+// initAndStartFourOrgsNetwork creates a network with multiple orgs.
 // Initially only start Org1.peer0 and Org2.peer0 are started and join the channel.
-func initAndStartMultiOrgsNetwork() *setup {
+func initAndStartFourOrgsNetwork() *setup {
 	var err error
-	testDir, err := ioutil.TempDir("", "reset-rollback")
+	testDir, err := ioutil.TempDir("", "snapshot")
 	Expect(err).NotTo(HaveOccurred())
 
 	client, err := docker.NewClientFromEnv()
@@ -325,6 +515,16 @@ func initAndStartMultiOrgsNetwork() *setup {
 			Organization: "Org2",
 			Channels:     []*nwo.PeerChannel{},
 		},
+		&nwo.Peer{
+			Name:         "peer2",
+			Organization: "Org2",
+			Channels:     []*nwo.PeerChannel{},
+		},
+		&nwo.Peer{
+			Name:         "peer3",
+			Organization: "Org2",
+			Channels:     []*nwo.PeerChannel{},
+		},
 	)
 
 	// add org3 with one peer
@@ -341,7 +541,9 @@ func initAndStartMultiOrgsNetwork() *setup {
 	config.Peers = append(config.Peers, &nwo.Peer{
 		Name:         "peer0",
 		Organization: "Org3",
-		Channels:     []*nwo.PeerChannel{},
+		Channels: []*nwo.PeerChannel{
+			{Name: testchannelID, Anchor: true},
+		},
 	})
 
 	// add org4 with one peer
@@ -358,12 +560,28 @@ func initAndStartMultiOrgsNetwork() *setup {
 	config.Peers = append(config.Peers, &nwo.Peer{
 		Name:         "peer0",
 		Organization: "Org4",
-		Channels:     []*nwo.PeerChannel{},
-	})
+		Channels: []*nwo.PeerChannel{
+			{Name: testchannelID, Anchor: true},
+		}})
 
 	n := nwo.New(config, testDir, client, StartPort(), components)
 	n.GenerateConfigTree()
 	n.Bootstrap()
+
+	// set ReconcileSleepInterval to 1 second to reconcile pvtdata faster
+	for _, p := range n.Peers {
+		core := n.ReadPeerConfig(p)
+		core.Peer.Gossip.PvtData.ReconcileSleepInterval = 1 * time.Second
+		n.WritePeerConfig(p, core)
+	}
+
+	// set org2peer2 and org2peer3's gossip bootstrap endpoints pointing to org2peer1
+	org2peer1 := n.Peer("Org2", "peer1")
+	for _, p := range []*nwo.Peer{n.Peer("Org2", "peer2"), n.Peer("Org2", "peer3")} {
+		core := n.ReadPeerConfig(p)
+		core.Peer.Gossip.Bootstrap = n.PeerAddress(org2peer1, nwo.ListenPort)
+		n.WritePeerConfig(p, core)
+	}
 
 	// only keep Org1.peer0 and Org2.peer0 so we can add other peers back later to test join channel by snapshot
 	peers := []*nwo.Peer{}
@@ -713,4 +931,48 @@ func toCLIChaincodeArgs(args ...string) string {
 	cArgsJSON, err := json.Marshal(cArgs)
 	Expect(err).NotTo(HaveOccurred())
 	return string(cArgsJSON)
+}
+
+// waitForMarblePvtdataReconciliation queries the chaincode until it returns a success exit code, which means the data is available.
+func waitForMarblePvtdataReconciliation(n *nwo.Network, peer *nwo.Peer, channelID, chaincodeName, marbleName string) {
+	query := fmt.Sprintf(`{"Args":["readMarble","%s"]}`, marbleName)
+	command := commands.ChaincodeQuery{
+		ChannelID: channelID,
+		Name:      chaincodeName,
+		Ctor:      query,
+	}
+
+	queryData := func() int {
+		sess, err := n.PeerUserSession(peer, "User1", command)
+		Expect(err).NotTo(HaveOccurred())
+		return sess.Wait(n.EventuallyTimeout).ExitCode()
+	}
+	Eventually(queryData, n.EventuallyTimeout).Should(Equal(0))
+}
+
+func assertPvtdataPresencePerCollectionConfig1(n *nwo.Network, chaincodeName, marbleName string, peers ...*nwo.Peer) {
+	if len(peers) == 0 {
+		peers = n.Peers
+	}
+	for _, peer := range peers {
+		switch peer.Organization {
+		case "Org1":
+			By("asserting collection data M in org1 peer " + peer.ID() + " for " + marbleName)
+			marblechaincodeutil.AssertPresentInCollectionM(n, testchannelID, chaincodeName, marbleName, peer)
+			By("asserting no collection data MPD in org1 peer " + peer.ID() + " for " + marbleName)
+			marblechaincodeutil.AssertNotPresentInCollectionMPD(n, testchannelID, chaincodeName, marbleName, peer)
+
+		case "Org2":
+			By("asserting collection data M in org2 peer " + peer.ID() + " for " + marbleName)
+			marblechaincodeutil.AssertPresentInCollectionM(n, testchannelID, chaincodeName, marbleName, peer)
+			By("asserting collection data MPD in org2 peer " + peer.ID() + " for " + marbleName)
+			marblechaincodeutil.AssertPresentInCollectionMPD(n, testchannelID, chaincodeName, marbleName, peer)
+
+		case "Org3":
+			By("asserting no collection data M in org3 peer " + peer.ID() + " for " + marbleName)
+			marblechaincodeutil.AssertNotPresentInCollectionM(n, testchannelID, chaincodeName, marbleName, peer)
+			By("asserting collection data MPD in org3 peer " + peer.ID() + " for " + marbleName)
+			marblechaincodeutil.AssertPresentInCollectionMPD(n, testchannelID, chaincodeName, marbleName, peer)
+		}
+	}
 }

--- a/integration/ledger/snapshot_test.go
+++ b/integration/ledger/snapshot_test.go
@@ -305,8 +305,10 @@ var _ bool = Describe("Snapshot Generation and Bootstrap", func() {
 			nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, newlifecycleChaincode)
 		})
 
-		// Below test verifies private data reconciliation on peers bootstrapped from a snapshot.
-		FIt("generates snapshot and bootstraps from snapshots", func() {
+		// This test verifies the following:
+		// bootstrapped peer can pull private data
+		// bootstrapped peer can supply private data to other bootstrapped peer
+		It("generates snapshot and bootstraps from snapshots", func() {
 			org1peer0 := setup.network.Peer("Org1", "peer0")
 			org2peer0 := setup.network.Peer("Org2", "peer0")
 			channelPeers := setup.network.PeersWithChannel(testchannelID)

--- a/integration/pvtdata/marblechaincodeutil/testutil.go
+++ b/integration/pvtdata/marblechaincodeutil/testutil.go
@@ -1,0 +1,252 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package marblechaincodeutil
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/hyperledger/fabric/integration/nwo"
+	"github.com/hyperledger/fabric/integration/nwo/commands"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+)
+
+// AddMarble invokes marbles_private chaincode to add a marble
+func AddMarble(n *nwo.Network, orderer *nwo.Orderer, channelID, chaincodeName, marbleDetails string, peer *nwo.Peer) {
+	marbleDetailsBase64 := base64.StdEncoding.EncodeToString([]byte(marbleDetails))
+
+	command := commands.ChaincodeInvoke{
+		ChannelID: channelID,
+		Orderer:   n.OrdererAddress(orderer, nwo.ListenPort),
+		Name:      chaincodeName,
+		Ctor:      `{"Args":["initMarble"]}`,
+		Transient: fmt.Sprintf(`{"marble":"%s"}`, marbleDetailsBase64),
+		PeerAddresses: []string{
+			n.PeerAddress(peer, nwo.ListenPort),
+		},
+		WaitForEvent: true,
+	}
+	invokeChaincode(n, peer, command)
+	nwo.WaitUntilEqualLedgerHeight(n, channelID, nwo.GetLedgerHeight(n, peer, channelID), n.Peers...)
+}
+
+// DeleteMarble invokes marbles_private chaincode to delete a marble
+func DeleteMarble(n *nwo.Network, orderer *nwo.Orderer, channelID, chaincodeName, marbleDelete string, peer *nwo.Peer) {
+	marbleDeleteBase64 := base64.StdEncoding.EncodeToString([]byte(marbleDelete))
+
+	command := commands.ChaincodeInvoke{
+		ChannelID: channelID,
+		Orderer:   n.OrdererAddress(orderer, nwo.ListenPort),
+		Name:      chaincodeName,
+		Ctor:      `{"Args":["delete"]}`,
+		Transient: fmt.Sprintf(`{"marble_delete":"%s"}`, marbleDeleteBase64),
+		PeerAddresses: []string{
+			n.PeerAddress(peer, nwo.ListenPort),
+		},
+		WaitForEvent: true,
+	}
+	invokeChaincode(n, peer, command)
+	nwo.WaitUntilEqualLedgerHeight(n, channelID, nwo.GetLedgerHeight(n, peer, channelID), n.Peers...)
+}
+
+// TransferMarble invokes marbles_private chaincode to transfer marble's ownership
+func TransferMarble(n *nwo.Network, orderer *nwo.Orderer, channelID, chaincodeName, marbleOwner string, peer *nwo.Peer) {
+	marbleOwnerBase64 := base64.StdEncoding.EncodeToString([]byte(marbleOwner))
+
+	command := commands.ChaincodeInvoke{
+		ChannelID: channelID,
+		Orderer:   n.OrdererAddress(orderer, nwo.ListenPort),
+		Name:      chaincodeName,
+		Ctor:      `{"Args":["transferMarble"]}`,
+		Transient: fmt.Sprintf(`{"marble_owner":"%s"}`, marbleOwnerBase64),
+		PeerAddresses: []string{
+			n.PeerAddress(peer, nwo.ListenPort),
+		},
+		WaitForEvent: true,
+	}
+	invokeChaincode(n, peer, command)
+	nwo.WaitUntilEqualLedgerHeight(n, channelID, nwo.GetLedgerHeight(n, peer, channelID), n.Peers...)
+}
+
+// AssertGetMarblesByRange asserts that
+func AssertGetMarblesByRange(n *nwo.Network, channelID, chaincodeName, marbleRange, expectedMsg string, peer *nwo.Peer) {
+	query := fmt.Sprintf(`{"Args":["getMarblesByRange", %s]}`, marbleRange)
+	queryChaincodePerPeer(n, query, channelID, chaincodeName, expectedMsg, true, peer)
+}
+
+// AssertPresentInCollectionM asserts that the private data for given marble is present in collection
+// 'readMarble' at the given peers
+func AssertPresentInCollectionM(n *nwo.Network, channelID, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
+	query := fmt.Sprintf(`{"Args":["readMarble","%s"]}`, marbleName)
+	expectedMsg := fmt.Sprintf(`"docType":"marble","name":"%s"`, marbleName)
+	queryChaincodePerPeer(n, query, channelID, chaincodeName, expectedMsg, true, peerList...)
+}
+
+// AssertPresentInCollectionMPD asserts that the private data for given marble is present
+// in collection 'readMarblePrivateDetails' at the given peers
+func AssertPresentInCollectionMPD(n *nwo.Network, channelID, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
+	query := fmt.Sprintf(`{"Args":["readMarblePrivateDetails","%s"]}`, marbleName)
+	expectedMsg := fmt.Sprintf(`"docType":"marblePrivateDetails","name":"%s"`, marbleName)
+	queryChaincodePerPeer(n, query, channelID, chaincodeName, expectedMsg, true, peerList...)
+}
+
+// CheckPresentInCollectionM checks then number of peers that have the private data for given marble
+// in collection 'readMarble'
+func CheckPresentInCollectionM(n *nwo.Network, channelID, chaincodeName, marbleName string, peerList ...*nwo.Peer) int {
+	query := fmt.Sprintf(`{"Args":["readMarble","%s"]}`, marbleName)
+	expectedMsg := fmt.Sprintf(`{"docType":"marble","name":"%s"`, marbleName)
+	command := commands.ChaincodeQuery{
+		ChannelID: channelID,
+		Name:      chaincodeName,
+		Ctor:      query,
+	}
+	present := 0
+	for _, peer := range peerList {
+		sess, err := n.PeerUserSession(peer, "User1", command)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit())
+		if bytes.Contains(sess.Buffer().Contents(), []byte(expectedMsg)) {
+			present++
+		}
+	}
+	return present
+}
+
+// CheckPresentInCollectionMPD checks the number of peers that have the private data for given marble
+// in collection 'readMarblePrivateDetails'
+func CheckPresentInCollectionMPD(n *nwo.Network, channelID, chaincodeName, marbleName string, peerList ...*nwo.Peer) int {
+	query := fmt.Sprintf(`{"Args":["readMarblePrivateDetails","%s"]}`, marbleName)
+	expectedMsg := fmt.Sprintf(`{"docType":"marblePrivateDetails","name":"%s"`, marbleName)
+	command := commands.ChaincodeQuery{
+		ChannelID: channelID,
+		Name:      chaincodeName,
+		Ctor:      query,
+	}
+	present := 0
+	for _, peer := range peerList {
+		sess, err := n.PeerUserSession(peer, "User1", command)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit())
+		if bytes.Contains(sess.Buffer().Contents(), []byte(expectedMsg)) {
+			present++
+		}
+	}
+	return present
+}
+
+// AssertNotPresentInCollectionM asserts that the private data for given marble is NOT present
+// in collection 'readMarble' at the given peers
+func AssertNotPresentInCollectionM(n *nwo.Network, channelID, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
+	query := fmt.Sprintf(`{"Args":["readMarble","%s"]}`, marbleName)
+	expectedMsg := "private data matching public hash version is not available"
+	queryChaincodePerPeer(n, query, channelID, chaincodeName, expectedMsg, false, peerList...)
+}
+
+// AssertNotPresentInCollectionMPD asserts that the private data for given marble is NOT present
+// in collection 'readMarblePrivateDetails' at the given peers
+func AssertNotPresentInCollectionMPD(n *nwo.Network, channelID, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
+	query := fmt.Sprintf(`{"Args":["readMarblePrivateDetails","%s"]}`, marbleName)
+	expectedMsg := "private data matching public hash version is not available"
+	queryChaincodePerPeer(n, query, channelID, chaincodeName, expectedMsg, false, peerList...)
+}
+
+// AssertDoesNotExistInCollectionM asserts that the private data for given marble
+// does not exist in collection 'readMarble' (i.e., is never created/has been deleted/has been purged)
+func AssertDoesNotExistInCollectionM(n *nwo.Network, channelID, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
+	query := fmt.Sprintf(`{"Args":["readMarble","%s"]}`, marbleName)
+	expectedMsg := "Marble does not exist"
+	queryChaincodePerPeer(n, query, channelID, chaincodeName, expectedMsg, false, peerList...)
+}
+
+// AssertDoesNotExistInCollectionMPD asserts that the private data for given marble
+// does not exist in collection 'readMarblePrivateDetails' (i.e., is never created/has been deleted/has been purged)
+func AssertDoesNotExistInCollectionMPD(n *nwo.Network, channelID, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
+	query := fmt.Sprintf(`{"Args":["readMarblePrivateDetails","%s"]}`, marbleName)
+	expectedMsg := "Marble private details does not exist"
+	queryChaincodePerPeer(n, query, channelID, chaincodeName, expectedMsg, false, peerList...)
+}
+
+// AssertOwnershipInCollectionM asserts that the private data for given marble is present
+// in collection 'readMarble' at the given peers
+func AssertOwnershipInCollectionM(n *nwo.Network, channelID, chaincodeName, marbleName, owner string, peerList ...*nwo.Peer) {
+	query := fmt.Sprintf(`{"Args":["readMarble","%s"]}`, marbleName)
+	expectedMsg := fmt.Sprintf(`"owner":"%s"`, owner)
+	queryChaincodePerPeer(n, query, channelID, chaincodeName, expectedMsg, true, peerList...)
+}
+
+// AssertNoReadAccessToCollectionMPD asserts that the orgs of the given peers do not have
+// read access to private data for the collection readMarblePrivateDetails
+func AssertNoReadAccessToCollectionMPD(n *nwo.Network, channelID, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
+	query := fmt.Sprintf(`{"Args":["readMarblePrivateDetails","%s"]}`, marbleName)
+	expectedMsg := "tx creator does not have read access permission"
+	queryChaincodePerPeer(n, query, channelID, chaincodeName, expectedMsg, false, peerList...)
+}
+
+func queryChaincodePerPeer(n *nwo.Network, query, channelID, chaincodeName, expectedMsg string, expectSuccess bool, peerList ...*nwo.Peer) {
+	command := commands.ChaincodeQuery{
+		ChannelID: channelID,
+		Name:      chaincodeName,
+		Ctor:      query,
+	}
+	for _, peer := range peerList {
+		queryChaincode(n, peer, command, expectedMsg, expectSuccess)
+	}
+}
+
+// AssertMarblesPrivateHashM asserts that getMarbleHash is accessible from all peers that has the chaincode instantiated
+func AssertMarblesPrivateHashM(n *nwo.Network, channelID, chaincodeName, marbleName string, expectedBytes []byte, peerList []*nwo.Peer) {
+	query := fmt.Sprintf(`{"Args":["getMarbleHash","%s"]}`, marbleName)
+	verifyPvtdataHash(n, query, channelID, chaincodeName, peerList, expectedBytes)
+}
+
+// AssertMarblesPrivateDetailsHashMPD asserts that getMarblePrivateDetailsHash is accessible from all peers that has the chaincode instantiated
+func AssertMarblesPrivateDetailsHashMPD(n *nwo.Network, channelID, chaincodeName, marbleName string, expectedBytes []byte, peerList []*nwo.Peer) {
+	query := fmt.Sprintf(`{"Args":["getMarblePrivateDetailsHash","%s"]}`, marbleName)
+	verifyPvtdataHash(n, query, channelID, chaincodeName, peerList, expectedBytes)
+}
+
+func invokeChaincode(n *nwo.Network, peer *nwo.Peer, command commands.ChaincodeInvoke) {
+	sess, err := n.PeerUserSession(peer, "User1", command)
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
+	Expect(sess.Err).To(gbytes.Say("Chaincode invoke successful."))
+}
+
+func queryChaincode(n *nwo.Network, peer *nwo.Peer, command commands.ChaincodeQuery, expectedMessage string, expectSuccess bool) {
+	sess, err := n.PeerUserSession(peer, "User1", command)
+	Expect(err).NotTo(HaveOccurred())
+	if expectSuccess {
+		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
+		Expect(sess).To(gbytes.Say(expectedMessage))
+	} else {
+		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit())
+		Expect(sess.Err).To(gbytes.Say(expectedMessage))
+	}
+}
+
+// verifyPvtdataHash verifies the private data hash matches the expected bytes.
+// Cannot reuse verifyAccess because the hash bytes are not valid utf8 causing gbytes.Say to fail.
+func verifyPvtdataHash(n *nwo.Network, query, channelID, chaincodeName string, peers []*nwo.Peer, expected []byte) {
+	command := commands.ChaincodeQuery{
+		ChannelID: channelID,
+		Name:      chaincodeName,
+		Ctor:      query,
+	}
+
+	for _, peer := range peers {
+		sess, err := n.PeerUserSession(peer, "User1", command)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
+		actual := sess.Buffer().Contents()
+		// verify actual bytes contain expected bytes - cannot use equal because session may contain extra bytes
+		Expect(bytes.Contains(actual, expected)).To(Equal(true))
+	}
+}

--- a/integration/pvtdata/pvtdata_test.go
+++ b/integration/pvtdata/pvtdata_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package pvtdata
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -40,6 +39,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/util"
 	"github.com/hyperledger/fabric/integration/nwo"
 	"github.com/hyperledger/fabric/integration/nwo/commands"
+	"github.com/hyperledger/fabric/integration/pvtdata/marblechaincodeutil"
 	"github.com/hyperledger/fabric/internal/pkg/comm"
 	"github.com/hyperledger/fabric/msp"
 	"github.com/hyperledger/fabric/protoutil"
@@ -103,7 +103,7 @@ var _ bool = Describe("PrivateData", func() {
 				isLegacy: true,
 			}
 			deployChaincode(network, orderer, testChaincode)
-			addMarble(network, orderer, testChaincode.Name,
+			marblechaincodeutil.AddMarble(network, orderer, channelID, testChaincode.Name,
 				`{"name":"marble1", "color":"blue", "size":35, "owner":"tom", "price":99}`,
 				network.Peer("Org1", "peer0"),
 			)
@@ -162,7 +162,7 @@ var _ bool = Describe("PrivateData", func() {
 				deployChaincode(network, orderer, testChaincode)
 				peer := network.Peer("Org1", "peer0")
 				By("adding marble1")
-				addMarble(network, orderer, testChaincode.Name,
+				marblechaincodeutil.AddMarble(network, orderer, channelID, testChaincode.Name,
 					`{"name":"marble1", "color":"blue", "size":35, "owner":"tom", "price":99}`,
 					peer,
 				)
@@ -230,7 +230,7 @@ var _ bool = Describe("PrivateData", func() {
 			By("adding marble1 with an org 1 peer as endorser")
 			peer := network.Peer("Org1", "peer0")
 			marbleDetails := `{"name":"marble1", "color":"blue", "size":35, "owner":"tom", "price":99}`
-			addMarble(network, orderer, testChaincode.Name, marbleDetails, peer)
+			marblechaincodeutil.AddMarble(network, orderer, channelID, testChaincode.Name, marbleDetails, peer)
 
 			By("waiting for block to propagate")
 			nwo.WaitUntilEqualLedgerHeight(network, channelID, nwo.GetLedgerHeight(network, network.Peers[0], channelID), network.Peers...)
@@ -458,7 +458,7 @@ var _ bool = Describe("PrivateData", func() {
 					isLegacy:  true,
 				}
 				deployChaincode(network, orderer, testChaincode)
-				addMarble(network, orderer, testChaincode.Name,
+				marblechaincodeutil.AddMarble(network, orderer, channelID, testChaincode.Name,
 					`{"name":"marble1", "color":"blue", "size":35, "owner":"tom", "price":99}`,
 					network.Peer("Org1", "peer0"),
 				)
@@ -489,7 +489,7 @@ var _ bool = Describe("PrivateData", func() {
 							testChaincode.Sequence = "2"
 						}
 						upgradeChaincode(network, orderer, testChaincode)
-						addMarble(network, orderer, testChaincode.Name,
+						marblechaincodeutil.AddMarble(network, orderer, channelID, testChaincode.Name,
 							`{"name":"marble2", "color":"yellow", "size":53, "owner":"jerry", "price":22}`,
 							network.Peer("Org2", "peer0"),
 						)
@@ -543,33 +543,33 @@ var _ bool = Describe("PrivateData", func() {
 
 				testChaincode.CollectionsConfig = collectionConfig("short_btl_config.json")
 				deployChaincode(network, orderer, testChaincode)
-				addMarble(network, orderer, testChaincode.Name, `{"name":"marble1", "color":"blue", "size":35, "owner":"tom", "price":99}`, network.Peer("Org2", "peer0"))
+				marblechaincodeutil.AddMarble(network, orderer, channelID, testChaincode.Name, `{"name":"marble1", "color":"blue", "size":35, "owner":"tom", "price":99}`, network.Peer("Org2", "peer0"))
 
 				eligiblePeer := network.Peer("Org2", "peer0")
 				ccName := testChaincode.Name
 				By("adding three blocks")
 				for i := 0; i < 3; i++ {
-					addMarble(network, orderer, ccName, fmt.Sprintf(`{"name":"test-marble-%d", "color":"blue", "size":35, "owner":"tom", "price":99}`, i), eligiblePeer)
+					marblechaincodeutil.AddMarble(network, orderer, channelID, ccName, fmt.Sprintf(`{"name":"test-marble-%d", "color":"blue", "size":35, "owner":"tom", "price":99}`, i), eligiblePeer)
 				}
 
 				By("verifying that marble1 still not purged in collection MarblesPD")
-				assertPresentInCollectionMPD(network, ccName, "marble1", eligiblePeer)
+				marblechaincodeutil.AssertPresentInCollectionMPD(network, channelID, ccName, "marble1", eligiblePeer)
 
 				By("adding one more block")
-				addMarble(network, orderer, ccName, `{"name":"fun-marble-3", "color":"blue", "size":35, "owner":"tom", "price":99}`, eligiblePeer)
+				marblechaincodeutil.AddMarble(network, orderer, channelID, ccName, `{"name":"fun-marble-3", "color":"blue", "size":35, "owner":"tom", "price":99}`, eligiblePeer)
 
 				By("verifying that marble1 purged in collection MarblesPD")
-				assertDoesNotExistInCollectionMPD(network, ccName, "marble1", eligiblePeer)
+				marblechaincodeutil.AssertDoesNotExistInCollectionMPD(network, channelID, ccName, "marble1", eligiblePeer)
 
 				By("verifying that marble1 still not purged in collection Marbles")
-				assertPresentInCollectionM(network, ccName, "marble1", eligiblePeer)
+				marblechaincodeutil.AssertPresentInCollectionM(network, channelID, ccName, "marble1", eligiblePeer)
 
 				By("adding new peer that is eligible to receive data")
 				newPeerProcess = addPeer(network, orderer, org2Peer1)
 				installChaincode(network, testChaincode, org2Peer1)
 				network.VerifyMembership(network.Peers, channelID, ccName)
-				assertPresentInCollectionM(network, ccName, "marble1", org2Peer1)
-				assertDoesNotExistInCollectionMPD(network, ccName, "marble1", org2Peer1)
+				marblechaincodeutil.AssertPresentInCollectionM(network, channelID, ccName, "marble1", org2Peer1)
+				marblechaincodeutil.AssertDoesNotExistInCollectionMPD(network, channelID, ccName, "marble1", org2Peer1)
 			})
 		})
 
@@ -582,7 +582,7 @@ var _ bool = Describe("PrivateData", func() {
 					testChaincode.Sequence = "2"
 				}
 				upgradeChaincode(network, orderer, testChaincode)
-				addMarble(network, orderer, testChaincode.Name, `{"name":"marble2", "color":"yellow", "size":53, "owner":"jerry", "price":22}`, network.Peer("Org2", "peer0"))
+				marblechaincodeutil.AddMarble(network, orderer, channelID, testChaincode.Name, `{"name":"marble2", "color":"yellow", "size":53, "owner":"jerry", "price":22}`, network.Peer("Org2", "peer0"))
 				assertPvtdataPresencePerCollectionConfig1(network, testChaincode.Name, "marble2")
 			}
 
@@ -595,7 +595,7 @@ var _ bool = Describe("PrivateData", func() {
 				nwo.EnableCapabilities(network, channelID, "Application", "V2_0", orderer, network.Peers...)
 				testChaincode.CollectionsConfig = collectionConfig("collections_config2.json")
 				deployChaincode(network, orderer, testChaincode)
-				addMarble(network, orderer, testChaincode.Name, `{"name":"marble1", "color":"blue", "size":35, "owner":"tom", "price":99}`, network.Peer("Org2", "peer0"))
+				marblechaincodeutil.AddMarble(network, orderer, channelID, testChaincode.Name, `{"name":"marble1", "color":"blue", "size":35, "owner":"tom", "price":99}`, network.Peer("Org2", "peer0"))
 				assertPvtdataPresencePerCollectionConfig2(network, testChaincode.Name, "marble1")
 
 				assertOrgRemovalBehavior()
@@ -640,7 +640,7 @@ var _ bool = Describe("PrivateData", func() {
 					By("adding marble1 with an org 1 peer as endorser")
 					peer := network.Peer("Org1", "peer0")
 					marbleDetails := `{"name":"marble1", "color":"blue", "size":35, "owner":"tom", "price":99}`
-					addMarble(network, orderer, testChaincode.Name, marbleDetails, peer)
+					marblechaincodeutil.AddMarble(network, orderer, channelID, testChaincode.Name, marbleDetails, peer)
 				})
 			})
 
@@ -703,7 +703,7 @@ var _ bool = Describe("PrivateData", func() {
 							By("adding marble1 with an org3 peer as endorser")
 							peer := network.Peer("Org3", "peer0")
 							marbleDetails := `{"name":"marble1", "color":"blue", "size":35, "owner":"tom", "price":99}`
-							addMarble(network, orderer, testChaincode.Name, marbleDetails, peer)
+							marblechaincodeutil.AddMarble(network, orderer, channelID, testChaincode.Name, marbleDetails, peer)
 						})
 					})
 
@@ -722,7 +722,7 @@ var _ bool = Describe("PrivateData", func() {
 							By("adding marble1 with an org3 peer as endorser")
 							peer := network.Peer("Org3", "peer0")
 							marbleDetails := `{"name":"marble1", "color":"blue", "size":35, "owner":"tom", "price":99}`
-							addMarble(network, orderer, testChaincode.Name, marbleDetails, peer)
+							marblechaincodeutil.AddMarble(network, orderer, channelID, testChaincode.Name, marbleDetails, peer)
 						})
 					})
 				})
@@ -805,23 +805,24 @@ var _ bool = Describe("PrivateData", func() {
 
 			By("adding five marbles")
 			for i := 0; i < 5; i++ {
-				addMarble(network, orderer, ccName, fmt.Sprintf(`{"name":"test-marble-%d", "color":"blue", "size":35, "owner":"tom", "price":99}`, i), eligiblePeer)
+				marblechaincodeutil.AddMarble(network, orderer, channelID, ccName, fmt.Sprintf(`{"name":"test-marble-%d", "color":"blue", "size":35, "owner":"tom", "price":99}`, i), eligiblePeer)
 			}
 
 			By("getting marbles by range")
-			assertGetMarblesByRange(network, ccName, `"test-marble-0", "test-marble-2"`, eligiblePeer)
+			expectedMsg := `\Q[{"Key":"test-marble-0", "Record":{"docType":"marble","name":"test-marble-0","color":"blue","size":35,"owner":"tom"}},{"Key":"test-marble-1", "Record":{"docType":"marble","name":"test-marble-1","color":"blue","size":35,"owner":"tom"}}]\E`
+			marblechaincodeutil.AssertGetMarblesByRange(network, channelID, ccName, `"test-marble-0", "test-marble-2"`, expectedMsg, eligiblePeer)
 
 			By("transferring test-marble-0 to jerry")
-			transferMarble(network, orderer, ccName, `{"name":"test-marble-0", "owner":"jerry"}`, eligiblePeer)
+			marblechaincodeutil.TransferMarble(network, orderer, channelID, ccName, `{"name":"test-marble-0", "owner":"jerry"}`, eligiblePeer)
 
 			By("verifying the new ownership of test-marble-0")
-			assertOwnershipInCollectionM(network, ccName, `test-marble-0`, eligiblePeer)
+			marblechaincodeutil.AssertOwnershipInCollectionM(network, channelID, ccName, `test-marble-0`, "jerry", eligiblePeer)
 
 			By("deleting test-marble-0")
-			deleteMarble(network, orderer, ccName, `{"name":"test-marble-0"}`, eligiblePeer)
+			marblechaincodeutil.DeleteMarble(network, orderer, channelID, ccName, `{"name":"test-marble-0"}`, eligiblePeer)
 
 			By("verifying the deletion of test-marble-0")
-			assertDoesNotExistInCollectionM(network, ccName, `test-marble-0`, eligiblePeer)
+			marblechaincodeutil.AssertDoesNotExistInCollectionM(network, channelID, ccName, `test-marble-0`, eligiblePeer)
 
 			// This section verifies that chaincode can return private data hash.
 			// Unlike private data that can only be accessed from authorized peers as defined in the collection config,
@@ -836,17 +837,17 @@ var _ bool = Describe("PrivateData", func() {
 
 			By("verifying getMarbleHash is accessible from all peers that has the chaincode instantiated")
 			expectedBytes := util.ComputeStringHash(`{"docType":"marble","name":"test-marble-1","color":"blue","size":35,"owner":"tom"}`)
-			assertMarblesPrivateHashM(network, ccName, "test-marble-1", expectedBytes, peerList)
+			marblechaincodeutil.AssertMarblesPrivateHashM(network, channelID, ccName, "test-marble-1", expectedBytes, peerList)
 
 			By("verifying getMarblePrivateDetailsHash is accessible from all peers that has the chaincode instantiated")
 			expectedBytes = util.ComputeStringHash(`{"docType":"marblePrivateDetails","name":"test-marble-1","price":99}`)
-			assertMarblesPrivateDetailsHashMPD(network, ccName, "test-marble-1", expectedBytes, peerList)
+			marblechaincodeutil.AssertMarblesPrivateDetailsHashMPD(network, channelID, ccName, "test-marble-1", expectedBytes, peerList)
 
 			// collection ACL while reading private data: not allowed to non-members
 			// collections_config3: collectionMarblePrivateDetails - member_only_read is set to true
 
 			By("querying collectionMarblePrivateDetails on org1-peer0 by org1-user1, shouldn't have read access")
-			assertNoReadAccessToCollectionMPD(network, testChaincode.Name, "test-marble-1", network.Peer("Org1", "peer0"))
+			marblechaincodeutil.AssertNoReadAccessToCollectionMPD(network, channelID, testChaincode.Name, "test-marble-1", network.Peer("Org1", "peer0"))
 		}
 
 		// verify DeliverWithPrivateData sends private data based on the ACL in collection config
@@ -857,7 +858,7 @@ var _ bool = Describe("PrivateData", func() {
 
 			By("adding a marble")
 			peer := network.Peer("Org2", "peer0")
-			addMarble(network, orderer, testChaincode.Name, `{"name":"marble11", "color":"blue", "size":35, "owner":"tom", "price":99}`, peer)
+			marblechaincodeutil.AddMarble(network, orderer, channelID, testChaincode.Name, `{"name":"marble11", "color":"blue", "size":35, "owner":"tom", "price":99}`, peer)
 
 			By("getting the deliver event for newest block")
 			event := getEventFromDeliverService(network, peer, channelID, signingIdentity, 0)
@@ -887,7 +888,7 @@ var _ bool = Describe("PrivateData", func() {
 			assertPrivateDataAsExpected(event.BlockAndPvtData.PrivateDataMap, expectedKVWritesMap)
 
 			By("adding a new marble after upgrade")
-			addMarble(network, orderer, testChaincode.Name,
+			marblechaincodeutil.AddMarble(network, orderer, channelID, testChaincode.Name,
 				`{"name":"marble12", "color":"blue", "size":35, "owner":"tom", "price":99}`,
 				network.Peer("Org1", "peer0"),
 			)
@@ -1076,25 +1077,6 @@ func installChaincode(n *nwo.Network, chaincode chaincode, peer *nwo.Peer) {
 	}
 }
 
-func queryChaincode(n *nwo.Network, peer *nwo.Peer, command commands.ChaincodeQuery, expectedMessage string, expectSuccess bool) {
-	sess, err := n.PeerUserSession(peer, "User1", command)
-	Expect(err).NotTo(HaveOccurred())
-	if expectSuccess {
-		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
-		Expect(sess).To(gbytes.Say(expectedMessage))
-	} else {
-		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit())
-		Expect(sess.Err).To(gbytes.Say(expectedMessage))
-	}
-}
-
-func invokeChaincode(n *nwo.Network, peer *nwo.Peer, command commands.ChaincodeInvoke) {
-	sess, err := n.PeerUserSession(peer, "User1", command)
-	Expect(err).NotTo(HaveOccurred())
-	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
-	Expect(sess.Err).To(gbytes.Say("Chaincode invoke successful."))
-}
-
 func invokeChaincodeExpectErr(n *nwo.Network, peer *nwo.Peer, command commands.ChaincodeInvoke, expectedErrMsg string) {
 	sess, err := n.PeerUserSession(peer, "User1", command)
 	Expect(err).NotTo(HaveOccurred())
@@ -1129,60 +1111,6 @@ func approveChaincodeForMyOrgExpectErr(n *nwo.Network, orderer *nwo.Orderer, cha
 	}
 }
 
-func addMarble(n *nwo.Network, orderer *nwo.Orderer, chaincodeName, marbleDetails string, peer *nwo.Peer) {
-	marbleDetailsBase64 := base64.StdEncoding.EncodeToString([]byte(marbleDetails))
-
-	command := commands.ChaincodeInvoke{
-		ChannelID: channelID,
-		Orderer:   n.OrdererAddress(orderer, nwo.ListenPort),
-		Name:      chaincodeName,
-		Ctor:      `{"Args":["initMarble"]}`,
-		Transient: fmt.Sprintf(`{"marble":"%s"}`, marbleDetailsBase64),
-		PeerAddresses: []string{
-			n.PeerAddress(peer, nwo.ListenPort),
-		},
-		WaitForEvent: true,
-	}
-	invokeChaincode(n, peer, command)
-	nwo.WaitUntilEqualLedgerHeight(n, channelID, nwo.GetLedgerHeight(n, peer, channelID), n.Peers...)
-}
-
-func deleteMarble(n *nwo.Network, orderer *nwo.Orderer, chaincodeName, marbleDelete string, peer *nwo.Peer) {
-	marbleDeleteBase64 := base64.StdEncoding.EncodeToString([]byte(marbleDelete))
-
-	command := commands.ChaincodeInvoke{
-		ChannelID: channelID,
-		Orderer:   n.OrdererAddress(orderer, nwo.ListenPort),
-		Name:      chaincodeName,
-		Ctor:      `{"Args":["delete"]}`,
-		Transient: fmt.Sprintf(`{"marble_delete":"%s"}`, marbleDeleteBase64),
-		PeerAddresses: []string{
-			n.PeerAddress(peer, nwo.ListenPort),
-		},
-		WaitForEvent: true,
-	}
-	invokeChaincode(n, peer, command)
-	nwo.WaitUntilEqualLedgerHeight(n, channelID, nwo.GetLedgerHeight(n, peer, channelID), n.Peers...)
-}
-
-func transferMarble(n *nwo.Network, orderer *nwo.Orderer, chaincodeName, marbleOwner string, peer *nwo.Peer) {
-	marbleOwnerBase64 := base64.StdEncoding.EncodeToString([]byte(marbleOwner))
-
-	command := commands.ChaincodeInvoke{
-		ChannelID: channelID,
-		Orderer:   n.OrdererAddress(orderer, nwo.ListenPort),
-		Name:      chaincodeName,
-		Ctor:      `{"Args":["transferMarble"]}`,
-		Transient: fmt.Sprintf(`{"marble_owner":"%s"}`, marbleOwnerBase64),
-		PeerAddresses: []string{
-			n.PeerAddress(peer, nwo.ListenPort),
-		},
-		WaitForEvent: true,
-	}
-	invokeChaincode(n, peer, command)
-	nwo.WaitUntilEqualLedgerHeight(n, channelID, nwo.GetLedgerHeight(n, peer, channelID), n.Peers...)
-}
-
 func assertPvtdataPresencePerCollectionConfig1(n *nwo.Network, chaincodeName, marbleName string, peers ...*nwo.Peer) {
 	if len(peers) == 0 {
 		peers = n.Peers
@@ -1191,16 +1119,16 @@ func assertPvtdataPresencePerCollectionConfig1(n *nwo.Network, chaincodeName, ma
 		switch peer.Organization {
 
 		case "Org1":
-			assertPresentInCollectionM(n, chaincodeName, marbleName, peer)
-			assertNotPresentInCollectionMPD(n, chaincodeName, marbleName, peer)
+			marblechaincodeutil.AssertPresentInCollectionM(n, channelID, chaincodeName, marbleName, peer)
+			marblechaincodeutil.AssertNotPresentInCollectionMPD(n, channelID, chaincodeName, marbleName, peer)
 
 		case "Org2":
-			assertPresentInCollectionM(n, chaincodeName, marbleName, peer)
-			assertPresentInCollectionMPD(n, chaincodeName, marbleName, peer)
+			marblechaincodeutil.AssertPresentInCollectionM(n, channelID, chaincodeName, marbleName, peer)
+			marblechaincodeutil.AssertPresentInCollectionMPD(n, channelID, chaincodeName, marbleName, peer)
 
 		case "Org3":
-			assertNotPresentInCollectionM(n, chaincodeName, marbleName, peer)
-			assertPresentInCollectionMPD(n, chaincodeName, marbleName, peer)
+			marblechaincodeutil.AssertNotPresentInCollectionM(n, channelID, chaincodeName, marbleName, peer)
+			marblechaincodeutil.AssertPresentInCollectionMPD(n, channelID, chaincodeName, marbleName, peer)
 		}
 	}
 }
@@ -1213,12 +1141,12 @@ func assertPvtdataPresencePerCollectionConfig2(n *nwo.Network, chaincodeName, ma
 		switch peer.Organization {
 
 		case "Org1":
-			assertPresentInCollectionM(n, chaincodeName, marbleName, peer)
-			assertNotPresentInCollectionMPD(n, chaincodeName, marbleName, peer)
+			marblechaincodeutil.AssertPresentInCollectionM(n, channelID, chaincodeName, marbleName, peer)
+			marblechaincodeutil.AssertNotPresentInCollectionMPD(n, channelID, chaincodeName, marbleName, peer)
 
 		case "Org2", "Org3":
-			assertPresentInCollectionM(n, chaincodeName, marbleName, peer)
-			assertPresentInCollectionMPD(n, chaincodeName, marbleName, peer)
+			marblechaincodeutil.AssertPresentInCollectionM(n, channelID, chaincodeName, marbleName, peer)
+			marblechaincodeutil.AssertPresentInCollectionMPD(n, channelID, chaincodeName, marbleName, peer)
 		}
 	}
 }
@@ -1235,178 +1163,21 @@ func assertPvtdataPresencePerCollectionConfig7(n *nwo.Network, chaincodeName, ma
 			switch peer.Organization {
 
 			case "Org1":
-				collectionMPresence += checkPresentInCollectionM(n, chaincodeName, marbleName, peer)
-				assertNotPresentInCollectionMPD(n, chaincodeName, marbleName, peer)
+				collectionMPresence += marblechaincodeutil.CheckPresentInCollectionM(n, channelID, chaincodeName, marbleName, peer)
+				marblechaincodeutil.AssertNotPresentInCollectionMPD(n, channelID, chaincodeName, marbleName, peer)
 
 			case "Org2":
-				collectionMPresence += checkPresentInCollectionM(n, chaincodeName, marbleName, peer)
-				collectionMPDPresence += checkPresentInCollectionMPD(n, chaincodeName, marbleName, peer)
+				collectionMPresence += marblechaincodeutil.CheckPresentInCollectionM(n, channelID, chaincodeName, marbleName, peer)
+				collectionMPDPresence += marblechaincodeutil.CheckPresentInCollectionMPD(n, channelID, chaincodeName, marbleName, peer)
 			case "Org3":
-				assertNotPresentInCollectionM(n, chaincodeName, marbleName, peer)
-				collectionMPDPresence += checkPresentInCollectionMPD(n, chaincodeName, marbleName, peer)
+				marblechaincodeutil.AssertNotPresentInCollectionM(n, channelID, chaincodeName, marbleName, peer)
+				collectionMPDPresence += marblechaincodeutil.CheckPresentInCollectionMPD(n, channelID, chaincodeName, marbleName, peer)
 			}
 		}
 	}
 	Expect(collectionMPresence).To(Equal(1))
 	Expect(collectionMPDPresence).To(Equal(1))
 
-}
-
-// assertGetMarblesByRange asserts that
-func assertGetMarblesByRange(n *nwo.Network, chaincodeName, marbleRange string, peer *nwo.Peer) {
-	query := fmt.Sprintf(`{"Args":["getMarblesByRange", %s]}`, marbleRange)
-	expectedMsg := `\Q[{"Key":"test-marble-0", "Record":{"docType":"marble","name":"test-marble-0","color":"blue","size":35,"owner":"tom"}},{"Key":"test-marble-1", "Record":{"docType":"marble","name":"test-marble-1","color":"blue","size":35,"owner":"tom"}}]\E`
-	queryChaincodePerPeer(n, query, chaincodeName, expectedMsg, true, peer)
-}
-
-// assertPresentInCollectionM asserts that the private data for given marble is present in collection
-// 'readMarble' at the given peers
-func assertPresentInCollectionM(n *nwo.Network, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
-	query := fmt.Sprintf(`{"Args":["readMarble","%s"]}`, marbleName)
-	expectedMsg := fmt.Sprintf(`{"docType":"marble","name":"%s"`, marbleName)
-	queryChaincodePerPeer(n, query, chaincodeName, expectedMsg, true, peerList...)
-}
-
-// assertPresentInCollectionMPD asserts that the private data for given marble is present
-// in collection 'readMarblePrivateDetails' at the given peers
-func assertPresentInCollectionMPD(n *nwo.Network, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
-	query := fmt.Sprintf(`{"Args":["readMarblePrivateDetails","%s"]}`, marbleName)
-	expectedMsg := fmt.Sprintf(`{"docType":"marblePrivateDetails","name":"%s"`, marbleName)
-	queryChaincodePerPeer(n, query, chaincodeName, expectedMsg, true, peerList...)
-}
-
-// checkPresentInCollectionM checks then number of peers that have the private data for given marble
-// in collection 'readMarble'
-func checkPresentInCollectionM(n *nwo.Network, chaincodeName, marbleName string, peerList ...*nwo.Peer) int {
-	query := fmt.Sprintf(`{"Args":["readMarble","%s"]}`, marbleName)
-	expectedMsg := fmt.Sprintf(`{"docType":"marble","name":"%s"`, marbleName)
-	command := commands.ChaincodeQuery{
-		ChannelID: channelID,
-		Name:      chaincodeName,
-		Ctor:      query,
-	}
-	present := 0
-	for _, peer := range peerList {
-		sess, err := n.PeerUserSession(peer, "User1", command)
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit())
-		if bytes.Contains(sess.Buffer().Contents(), []byte(expectedMsg)) {
-			present++
-		}
-	}
-	return present
-}
-
-// checkPresentInCollectionMPD checks the number of peers that have the private data for given marble
-// in collection 'readMarblePrivateDetails'
-func checkPresentInCollectionMPD(n *nwo.Network, chaincodeName, marbleName string, peerList ...*nwo.Peer) int {
-	query := fmt.Sprintf(`{"Args":["readMarblePrivateDetails","%s"]}`, marbleName)
-	expectedMsg := fmt.Sprintf(`{"docType":"marblePrivateDetails","name":"%s"`, marbleName)
-	command := commands.ChaincodeQuery{
-		ChannelID: channelID,
-		Name:      chaincodeName,
-		Ctor:      query,
-	}
-	present := 0
-	for _, peer := range peerList {
-		sess, err := n.PeerUserSession(peer, "User1", command)
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit())
-		if bytes.Contains(sess.Buffer().Contents(), []byte(expectedMsg)) {
-			present++
-		}
-	}
-	return present
-}
-
-// assertNotPresentInCollectionM asserts that the private data for given marble is NOT present
-// in collection 'readMarble' at the given peers
-func assertNotPresentInCollectionM(n *nwo.Network, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
-	query := fmt.Sprintf(`{"Args":["readMarble","%s"]}`, marbleName)
-	expectedMsg := "private data matching public hash version is not available"
-	queryChaincodePerPeer(n, query, chaincodeName, expectedMsg, false, peerList...)
-}
-
-// assertNotPresentInCollectionMPD asserts that the private data for given marble is NOT present
-// in collection 'readMarblePrivateDetails' at the given peers
-func assertNotPresentInCollectionMPD(n *nwo.Network, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
-	query := fmt.Sprintf(`{"Args":["readMarblePrivateDetails","%s"]}`, marbleName)
-	expectedMsg := "private data matching public hash version is not available"
-	queryChaincodePerPeer(n, query, chaincodeName, expectedMsg, false, peerList...)
-}
-
-// assertDoesNotExistInCollectionM asserts that the private data for given marble
-// does not exist in collection 'readMarble' (i.e., is never created/has been deleted/has been purged)
-func assertDoesNotExistInCollectionM(n *nwo.Network, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
-	query := fmt.Sprintf(`{"Args":["readMarble","%s"]}`, marbleName)
-	expectedMsg := "Marble does not exist"
-	queryChaincodePerPeer(n, query, chaincodeName, expectedMsg, false, peerList...)
-}
-
-// assertDoesNotExistInCollectionMPD asserts that the private data for given marble
-// does not exist in collection 'readMarblePrivateDetails' (i.e., is never created/has been deleted/has been purged)
-func assertDoesNotExistInCollectionMPD(n *nwo.Network, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
-	query := fmt.Sprintf(`{"Args":["readMarblePrivateDetails","%s"]}`, marbleName)
-	expectedMsg := "Marble private details does not exist"
-	queryChaincodePerPeer(n, query, chaincodeName, expectedMsg, false, peerList...)
-}
-
-// assertOwnershipInCollectionM asserts that the private data for given marble is present
-// in collection 'readMarble' at the given peers
-func assertOwnershipInCollectionM(n *nwo.Network, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
-	query := fmt.Sprintf(`{"Args":["readMarble","%s"]}`, marbleName)
-	expectedMsg := `{"docType":"marble","name":"test-marble-0","color":"blue","size":35,"owner":"jerry"}`
-	queryChaincodePerPeer(n, query, chaincodeName, expectedMsg, true, peerList...)
-}
-
-// assertNoReadAccessToCollectionMPD asserts that the orgs of the given peers do not have
-// read access to private data for the collection readMarblePrivateDetails
-func assertNoReadAccessToCollectionMPD(n *nwo.Network, chaincodeName, marbleName string, peerList ...*nwo.Peer) {
-	query := fmt.Sprintf(`{"Args":["readMarblePrivateDetails","%s"]}`, marbleName)
-	expectedMsg := "tx creator does not have read access permission"
-	queryChaincodePerPeer(n, query, chaincodeName, expectedMsg, false, peerList...)
-}
-
-func queryChaincodePerPeer(n *nwo.Network, query, chaincodeName, expectedMsg string, expectSuccess bool, peerList ...*nwo.Peer) {
-	command := commands.ChaincodeQuery{
-		ChannelID: channelID,
-		Name:      chaincodeName,
-		Ctor:      query,
-	}
-	for _, peer := range peerList {
-		queryChaincode(n, peer, command, expectedMsg, expectSuccess)
-	}
-}
-
-// assertMarblesPrivateHashM asserts that getMarbleHash is accessible from all peers that has the chaincode instantiated
-func assertMarblesPrivateHashM(n *nwo.Network, chaincodeName, marbleName string, expectedBytes []byte, peerList []*nwo.Peer) {
-	query := fmt.Sprintf(`{"Args":["getMarbleHash","%s"]}`, marbleName)
-	verifyPvtdataHash(n, query, chaincodeName, peerList, expectedBytes)
-}
-
-// assertMarblesPrivateDetailsHashMPD asserts that getMarblePrivateDetailsHash is accessible from all peers that has the chaincode instantiated
-func assertMarblesPrivateDetailsHashMPD(n *nwo.Network, chaincodeName, marbleName string, expectedBytes []byte, peerList []*nwo.Peer) {
-	query := fmt.Sprintf(`{"Args":["getMarblePrivateDetailsHash","%s"]}`, marbleName)
-	verifyPvtdataHash(n, query, chaincodeName, peerList, expectedBytes)
-}
-
-// verifyPvtdataHash verifies the private data hash matches the expected bytes.
-// Cannot reuse verifyAccess because the hash bytes are not valid utf8 causing gbytes.Say to fail.
-func verifyPvtdataHash(n *nwo.Network, query, chaincodeName string, peers []*nwo.Peer, expected []byte) {
-	command := commands.ChaincodeQuery{
-		ChannelID: channelID,
-		Name:      chaincodeName,
-		Ctor:      query,
-	}
-
-	for _, peer := range peers {
-		sess, err := n.PeerUserSession(peer, "User1", command)
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
-		actual := sess.Buffer().Contents()
-		// verify actual bytes contain expected bytes - cannot use equal because session may contain extra bytes
-		Expect(bytes.Contains(actual, expected)).To(Equal(true))
-	}
 }
 
 // deliverEvent contains the response and related info from a DeliverWithPrivateData call


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- New feature

#### Description
Add IT tests to verify the following:
- bootstrapped peer can pull private data
- bootstrapped peer can supply private data to other bootstrapped peer

#### Related issues
https://jira.hyperledger.org/browse/FAB-17953