### PR TITLE
[FAB-17953] IT: verify pvtdata reconciliation when bootstrapping by snapshot

### DIFF
--- a/integration/ledger/snapshot_test.go
+++ b/integration/ledger/snapshot_test.go
@@ -20,9 +20,11 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric/core/ledger/util"
 	"github.com/hyperledger/fabric/integration/chaincode/kvexecutor"
 	"github.com/hyperledger/fabric/integration/nwo"
 	"github.com/hyperledger/fabric/integration/nwo/commands"
+	"github.com/hyperledger/fabric/integration/pvtdata/marblechaincodeutil"
 	"github.com/hyperledger/fabric/integration/runner"
 	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/ginkgo"
@@ -47,7 +49,7 @@ var _ bool = Describe("Snapshot Generation and Bootstrap", func() {
 
 	BeforeEach(func() {
 		By("initializing and starting the network")
-		setup = initAndStartMultiOrgsNetwork()
+		setup = initAndStartFourOrgsNetwork()
 
 		helper = &marblesTestHelper{
 			networkHelper: &networkHelper{
@@ -58,30 +60,6 @@ var _ bool = Describe("Snapshot Generation and Bootstrap", func() {
 				channelID: setup.channelID,
 			},
 		}
-
-		legacyChaincode = nwo.Chaincode{
-			Name:        "marbles",
-			Version:     "0.0",
-			Path:        chaincodePathWithIndex,
-			Ctor:        `{"Args":[]}`,
-			Policy:      `OR ('Org1MSP.member','Org2MSP.member','Org3MSP.member','Org4MSP.member')`,
-			PackageFile: filepath.Join(setup.testDir, "marbles_legacy.tar.gz"),
-		}
-
-		newlifecycleChaincode = nwo.Chaincode{
-			Name:            "marbles",
-			Version:         "0.0",
-			Path:            components.Build(chaincodePathWithIndex),
-			Lang:            "binary",
-			CodeFiles:       filesWithIndex,
-			PackageFile:     filepath.Join(setup.testDir, "marbles.tar.gz"),
-			SignaturePolicy: `OR ('Org1MSP.member','Org2MSP.member','Org3MSP.member','Org4MSP.member')`,
-			Sequence:        "1",
-			Label:           "marbles",
-		}
-
-		By("deploying legacy chaincode on initial peers (stateleveldb)")
-		nwo.DeployChaincodeLegacy(setup.network, testchannelID, setup.orderer, legacyChaincode)
 	})
 
 	AfterEach(func() {
@@ -93,184 +71,398 @@ var _ bool = Describe("Snapshot Generation and Bootstrap", func() {
 		os.RemoveAll(setup.network.RootDir)
 	})
 
-	// Below test does the following when peers are using either leveldb or couchdb.
-	// Note that we do not support a channel with mixed DBs. However, for testing,
-	// it would be fine to use mixed DBs to test with both couchdb and leveldb
-	// - create snapshots on the 2 peers and verify they are same
-	// - bootstrap a peer (couchdb) in an existing org from the snapshot
-	// - bootstrap a peer (leveldb) in a new org from the snapshot
-	// - verify couchdb index exists
-	// - verify chaincode invocation, history, qscc, channel config update
-	// - upgrade to new lifecycle chaincode
-	// - create a new snapshot from a peer (couchdb) bootstrapped from a snapshot
-	// - bootstrap peers (couchdb) in existing org and new org from the new snapshot
-	// - verify couchdb index exists
-	// - verify chaincode invocation, history, qscc, channel config update
-	// - verify chaincode upgrade and new chaincode install on all peers
-	It("generates snapshot and bootstraps from snapshots with statecouchdb", func() {
-		org1peer0 := setup.network.Peer("Org1", "peer0")
-		org2peer0 := setup.network.Peer("Org2", "peer0")
+	When("chaincode has no private data collections", func() {
+		BeforeEach(func() {
+			legacyChaincode = nwo.Chaincode{
+				Name:        "marbles",
+				Version:     "0.0",
+				Path:        chaincodePathWithIndex,
+				Ctor:        `{"Args":[]}`,
+				Policy:      `OR ('Org1MSP.member','Org2MSP.member','Org3MSP.member','Org4MSP.member')`,
+				PackageFile: filepath.Join(setup.testDir, "marbles_legacy.tar.gz"),
+			}
 
-		By("invoking marbles chaincode")
-		testKey := "marble-0"
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "initMarble", "marble-0", "blue", "35", "tom")
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "initMarble", "marble-1", "red", "100", "tom")
+			newlifecycleChaincode = nwo.Chaincode{
+				Name:            "marbles",
+				Version:         "0.0",
+				Path:            components.Build(chaincodePathWithIndex),
+				Lang:            "binary",
+				CodeFiles:       filesWithIndex,
+				PackageFile:     filepath.Join(setup.testDir, "marbles.tar.gz"),
+				SignaturePolicy: `OR ('Org1MSP.member','Org2MSP.member','Org3MSP.member','Org4MSP.member')`,
+				Sequence:        "1",
+				Label:           "marbles",
+			}
 
-		By("getting an txid from a block before snapshot is generated")
-		txidBeforeSnapshot := getTxIDFromLastBlock(setup.network, org1peer0)
+			By("deploying legacy chaincode on initial peers (stateleveldb)")
+			nwo.DeployChaincodeLegacy(setup.network, testchannelID, setup.orderer, legacyChaincode)
+		})
 
-		// verify snapshot commands with different parameters")
-		blockNum := nwo.GetLedgerHeight(setup.network, org1peer0, testchannelID) - 1
-		verifySnapshotRequestCmds(setup.network, org1peer0, testchannelID, blockNum)
+		// Below test does the following when peers are using either leveldb or couchdb.
+		// Note that we do not support a channel with mixed DBs. However, for testing,
+		// it would be fine to use mixed DBs to test with both couchdb and leveldb
+		// - create snapshots on the 2 peers and verify they are same
+		// - bootstrap a peer (couchdb) in an existing org from the snapshot
+		// - bootstrap a peer (leveldb) in a new org from the snapshot
+		// - verify couchdb index exists
+		// - verify chaincode invocation, history, qscc, channel config update
+		// - upgrade to new lifecycle chaincode
+		// - create a new snapshot again from a peer (couchdb) bootstrapped from a snapshot
+		// - bootstrap peers (couchdb) in existing org and new org from the new snapshot
+		// - verify couchdb index exists
+		// - verify chaincode invocation, history, qscc
+		// - verify chaincode upgrade and new chaincode install on all peers
+		It("generates snapshot and bootstraps from snapshots", func() {
+			org1peer0 := setup.network.Peer("Org1", "peer0")
+			org2peer0 := setup.network.Peer("Org2", "peer0")
 
-		// test 1: generate snapshots on 2 peers for the same blockNum and verify they are same
-		_, snapshotDir2 := generateAndCompareSnapshots(setup.network, org1peer0, org2peer0, blockNum)
+			By("invoking marbles chaincode")
+			testKey := "marble-0"
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "initMarble", "marble-0", "blue", "35", "tom")
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "initMarble", "marble-1", "red", "100", "tom")
 
-		// test 2: bootstrap a peer in an existing org from snapshot and verify
-		By("starting new peer org2peer1 in existing org2 (couchdb)")
-		org2peer1, couchProc := startPeer(setup, "Org2", "peer1", testchannelID, true)
-		couchProcess = append(couchProcess, couchProc)
+			By("getting an txid from a block before snapshot is generated")
+			txidBeforeSnapshot := getTxIDFromLastBlock(setup.network, org1peer0)
 
-		By("installing legacy chaincode on new peer org2peer1")
-		nwo.InstallChaincodeLegacy(setup.network, legacyChaincode, org2peer1)
+			// verify snapshot commands with different parameters")
+			blockNum := nwo.GetLedgerHeight(setup.network, org1peer0, testchannelID) - 1
+			verifySnapshotRequestCmds(setup.network, org1peer0, testchannelID, blockNum)
 
-		By("joining new peer org2peer1 to the channel")
-		joinBySnapshot(setup.network, setup.orderer, org2peer1, testchannelID, snapshotDir2, blockNum)
+			// test 1: generate snapshots on 2 peers for the same blockNum and verify they are same
+			_, snapshotDir := generateAndCompareSnapshots(setup.network, org1peer0, org2peer0, blockNum)
 
-		By("verifying index created on org2peer1")
-		verifySizeIndexExists(setup.network, testchannelID, setup.orderer, org2peer1, "marbles")
+			// test 2: bootstrap a peer in an existing org from snapshot and verify
+			By("starting new peer org2peer1 in existing org2 (couchdb)")
+			org2peer1, couchProc := startPeer(setup, "Org2", "peer1", testchannelID, true)
+			couchProcess = append(couchProcess, couchProc)
 
-		By("invoking marbles chaincode on bootstrapped peer org2peer1")
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org2peer1, "transferMarble", testKey, "newowner2")
+			By("installing legacy chaincode on new peer org2peer1")
+			nwo.InstallChaincodeLegacy(setup.network, legacyChaincode, org2peer1)
 
-		By("verifying history on peer org2peer1")
-		expectedHistory := []*marbleHistoryResult{
-			{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner2")},
-		}
-		helper.assertGetHistoryForMarble(legacyChaincode.Name, org2peer1, expectedHistory, testKey)
+			By("joining new peer org2peer1 to the channel")
+			joinBySnapshot(setup.network, setup.orderer, org2peer1, testchannelID, snapshotDir, blockNum)
 
-		verifyQSCC(setup.network, org2peer1, testchannelID, blockNum, txidBeforeSnapshot)
+			By("verifying index created on org2peer1")
+			verifySizeIndexExists(setup.network, testchannelID, setup.orderer, org2peer1, "marbles")
 
-		// test 3: bootstrap a peer in a new org from snapshot and verify
-		By("starting a peer Org3.peer0 in new org3 (stateleveldb)")
-		org3peer0, _ := startPeer(setup, "Org3", "peer0", testchannelID, false)
+			By("invoking marbles chaincode on bootstrapped peer org2peer1")
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org2peer1, "transferMarble", testKey, "newowner2")
 
-		By("installing legacy chaincode on new peer org3peer0")
-		nwo.InstallChaincodeLegacy(setup.network, legacyChaincode, org3peer0)
+			By("verifying history on peer org2peer1")
+			expectedHistory := []*marbleHistoryResult{
+				{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner2")},
+			}
+			helper.assertGetHistoryForMarble(legacyChaincode.Name, org2peer1, expectedHistory, testKey)
 
-		By("joining new peer org3peer0 to the channel")
-		joinBySnapshot(setup.network, setup.orderer, org3peer0, testchannelID, snapshotDir2, blockNum)
+			verifyQSCC(setup.network, org2peer1, testchannelID, blockNum, txidBeforeSnapshot)
 
-		By("invoking marbles chaincode on bootstrapped peer org3peer0")
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org3peer0, "transferMarble", testKey, "newowner3")
+			// test 3: bootstrap a peer in a new org from snapshot and verify
+			By("starting a peer Org3.peer0 in new org3 (stateleveldb)")
+			org3peer0, _ := startPeer(setup, "Org3", "peer0", testchannelID, false)
 
-		By("verifying history on peer org3peer0")
-		expectedHistory = []*marbleHistoryResult{
-			{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner3")},
-			{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner2")},
-		}
-		helper.assertGetHistoryForMarble(legacyChaincode.Name, org3peer0, expectedHistory, testKey)
+			By("installing legacy chaincode on new peer org3peer0")
+			nwo.InstallChaincodeLegacy(setup.network, legacyChaincode, org3peer0)
 
-		verifyQSCC(setup.network, org3peer0, testchannelID, blockNum, txidBeforeSnapshot)
+			By("joining new peer org3peer0 to the channel")
+			joinBySnapshot(setup.network, setup.orderer, org3peer0, testchannelID, snapshotDir, blockNum)
 
-		// test 4: upgrade legacy chaincode to new lifecycle
-		By("enabling V2_0 capabilities")
-		channelPeers := setup.network.PeersWithChannel(testchannelID)
-		nwo.EnableCapabilities(setup.network, testchannelID, "Application", "V2_0", setup.orderer, channelPeers...)
+			By("invoking marbles chaincode on bootstrapped peer org3peer0")
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org3peer0, "transferMarble", testKey, "newowner3")
 
-		By("upgrading legacy chaincode to new lifecycle chaincode")
-		nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, newlifecycleChaincode, channelPeers...)
+			By("verifying history on peer org3peer0")
+			expectedHistory = []*marbleHistoryResult{
+				{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner3")},
+				{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner2")},
+			}
+			helper.assertGetHistoryForMarble(legacyChaincode.Name, org3peer0, expectedHistory, testKey)
 
-		By("invoking chaincode after upgraded to new lifecycle chaincode")
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "initMarble", "marble-upgrade", "blue", "35", "tom")
+			verifyQSCC(setup.network, org3peer0, testchannelID, blockNum, txidBeforeSnapshot)
 
-		// test 5: generate snapshot again on a peer bootstrapped from a snapshot and upgraded to new lifecycle chaincode
-		blockNumForNextSnapshot := nwo.GetLedgerHeight(setup.network, org2peer1, testchannelID)
-		By(fmt.Sprintf("generating a snapshot at blockNum %d on org2peer1 that was bootstrapped by a snapshot", blockNumForNextSnapshot))
-		submitSnapshotRequest(setup.network, testchannelID, blockNumForNextSnapshot, org2peer1, false, "Snapshot request submitted successfully")
+			// test 4: upgrade legacy chaincode to new lifecycle
+			By("enabling V2_0 capabilities")
+			channelPeers := setup.network.PeersWithChannel(testchannelID)
+			nwo.EnableCapabilities(setup.network, testchannelID, "Application", "V2_0", setup.orderer, channelPeers...)
 
-		// invoke chaincode to trigger snapshot generation
-		// 1st call should be committed before snapshot generation, 2nd call should be committed after snapshot generation
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "transferMarble", testKey, "newowner_beforesnapshot")
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "transferMarble", testKey, "newowner_aftersnapshot")
+			By("upgrading legacy chaincode to new lifecycle chaincode")
+			nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, newlifecycleChaincode, channelPeers...)
 
-		By("verifying snapshot completed on org2peer1")
-		verifyNoPendingSnapshotRequest(setup.network, org2peer1, testchannelID)
-		snapshotDir := filepath.Join(setup.network.PeerDir(org2peer1), "filesystem", "snapshots", "completed", testchannelID, strconv.Itoa(blockNumForNextSnapshot))
+			By("invoking chaincode after upgraded to new lifecycle chaincode")
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "initMarble", "marble-upgrade", "blue", "35", "tom")
 
-		// test 6: bootstrap a peer in a different org from the new snapshot
-		By("starting a peer (org1peer1) in existing org1 (couchdb)")
-		org1peer1, couchProc := startPeer(setup, "Org1", "peer1", testchannelID, true)
-		couchProcess = append(couchProcess, couchProc)
+			// test 5: generate snapshot again on a peer bootstrapped from a snapshot and upgraded to new lifecycle chaincode
+			blockNumForNextSnapshot := nwo.GetLedgerHeight(setup.network, org2peer1, testchannelID)
+			By(fmt.Sprintf("generating a snapshot at blockNum %d on org2peer1 that was bootstrapped by a snapshot", blockNumForNextSnapshot))
+			submitSnapshotRequest(setup.network, testchannelID, blockNumForNextSnapshot, org2peer1, false, "Snapshot request submitted successfully")
 
-		By("installing new lifecycle chaincode on peer org1peer1")
-		nwo.InstallChaincode(setup.network, newlifecycleChaincode, org1peer1)
+			// invoke chaincode to trigger snapshot generation
+			// 1st call should be committed before snapshot generation, 2nd call should be committed after snapshot generation
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "transferMarble", testKey, "newowner_beforesnapshot")
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org1peer0, "transferMarble", testKey, "newowner_aftersnapshot")
 
-		By("joining new peer org1peer1 to the channel")
-		joinBySnapshot(setup.network, setup.orderer, org1peer1, testchannelID, snapshotDir, blockNumForNextSnapshot)
+			By("verifying snapshot completed on org2peer1")
+			verifyNoPendingSnapshotRequest(setup.network, org2peer1, testchannelID)
+			nextSnapshotDir := filepath.Join(setup.network.PeerDir(org2peer1), "filesystem", "snapshots", "completed", testchannelID, strconv.Itoa(blockNumForNextSnapshot))
 
-		By("verifying index created on org1peer1")
-		verifySizeIndexExists(setup.network, testchannelID, setup.orderer, org1peer1, "marbles")
+			// test 6: bootstrap a peer in a different org from the new snapshot
+			By("starting a peer (org1peer1) in existing org1 (couchdb)")
+			org1peer1, couchProc := startPeer(setup, "Org1", "peer1", testchannelID, true)
+			couchProcess = append(couchProcess, couchProc)
 
-		By("verifying history on peer org1peer1")
-		expectedHistory = []*marbleHistoryResult{
-			{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner_aftersnapshot")},
-		}
-		helper.assertGetHistoryForMarble(legacyChaincode.Name, org1peer1, expectedHistory, testKey)
+			By("installing new lifecycle chaincode on peer org1peer1")
+			nwo.InstallChaincode(setup.network, newlifecycleChaincode, org1peer1)
 
-		verifyQSCC(setup.network, org1peer1, testchannelID, blockNumForNextSnapshot, txidBeforeSnapshot)
+			By("joining new peer org1peer1 to the channel")
+			joinBySnapshot(setup.network, setup.orderer, org1peer1, testchannelID, nextSnapshotDir, blockNumForNextSnapshot)
 
-		// test 7: bootstrap a peer in a new org from the new snapshot
-		By("starting a peer (org4peer0) in new org4 (couchdb)")
-		org4peer0, couchProc := startPeer(setup, "Org4", "peer0", testchannelID, true)
-		couchProcess = append(couchProcess, couchProc)
+			By("verifying index created on org1peer1")
+			verifySizeIndexExists(setup.network, testchannelID, setup.orderer, org1peer1, "marbles")
 
-		By("joining new peer org4peer0 to the channel")
-		joinBySnapshot(setup.network, setup.orderer, org4peer0, testchannelID, snapshotDir, blockNumForNextSnapshot)
+			By("verifying history on peer org1peer1")
+			expectedHistory = []*marbleHistoryResult{
+				{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner_aftersnapshot")},
+			}
+			helper.assertGetHistoryForMarble(legacyChaincode.Name, org1peer1, expectedHistory, testKey)
 
-		By("installing and approving chaincode on new peer org4peer0")
-		installAndApproveChaincode(setup.network, setup.orderer, org4peer0, testchannelID, newlifecycleChaincode, []string{"Org1", "Org2", "Org3", "Org4"})
+			verifyQSCC(setup.network, org1peer1, testchannelID, blockNumForNextSnapshot, txidBeforeSnapshot)
 
-		By("verifying index created on org4peer0")
-		verifySizeIndexExists(setup.network, testchannelID, setup.orderer, org2peer1, "marbles")
+			// test 7: bootstrap a peer in a new org from the new snapshot
+			By("starting a peer (org4peer0) in new org4 (couchdb)")
+			org4peer0, couchProc := startPeer(setup, "Org4", "peer0", testchannelID, true)
+			couchProcess = append(couchProcess, couchProc)
 
-		By("invoking chaincode on bootstrapped peer org4peer0")
-		helper.invokeMarblesChaincode(legacyChaincode.Name, org4peer0, "delete", testKey)
+			By("joining new peer org4peer0 to the channel")
+			joinBySnapshot(setup.network, setup.orderer, org4peer0, testchannelID, nextSnapshotDir, blockNumForNextSnapshot)
 
-		By("verifying history on peer org4peer0")
-		expectedHistory = []*marbleHistoryResult{
-			{IsDelete: "true"},
-			{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner_aftersnapshot")},
-		}
-		helper.assertGetHistoryForMarble(legacyChaincode.Name, org4peer0, expectedHistory, testKey)
+			By("installing and approving chaincode on new peer org4peer0")
+			installAndApproveChaincode(setup.network, setup.orderer, org4peer0, testchannelID, newlifecycleChaincode, []string{"Org1", "Org2", "Org3", "Org4"})
 
-		verifyQSCC(setup.network, org4peer0, testchannelID, blockNumForNextSnapshot, txidBeforeSnapshot)
+			By("verifying index created on org4peer0")
+			verifySizeIndexExists(setup.network, testchannelID, setup.orderer, org2peer1, "marbles")
 
-		// test 8: verify chaincode upgrade and install after bootstrapping
-		By("upgrading chaincode to version 2.0 on all peers after bootstrapping from snapshot")
-		newlifecycleChaincode.Version = "2.0"
-		newlifecycleChaincode.Sequence = "2"
-		nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, newlifecycleChaincode)
+			By("invoking chaincode on bootstrapped peer org4peer0")
+			helper.invokeMarblesChaincode(legacyChaincode.Name, org4peer0, "delete", testKey)
 
-		By("deploying a new chaincode on all the peers after bootstrapping from snapshot")
-		cc2 := nwo.Chaincode{
-			Name:            "kvexecutor",
-			Version:         "1.0",
-			Path:            components.Build("github.com/hyperledger/fabric/integration/chaincode/kvexecutor/cmd"),
-			Lang:            "binary",
-			SignaturePolicy: `OR ('Org1MSP.member','Org2MSP.member', 'Org3MSP.member', 'Org4MSP.member')`,
-			PackageFile:     filepath.Join(setup.testDir, "kvexcutor20.tar.gz"),
-			Label:           "kvexecutor-20",
-			Sequence:        "1",
-		}
-		nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, cc2)
+			By("verifying history on peer org4peer0")
+			expectedHistory = []*marbleHistoryResult{
+				{IsDelete: "true"},
+				{IsDelete: "false", Value: newMarble(testKey, "blue", 35, "newowner_aftersnapshot")},
+			}
+			helper.assertGetHistoryForMarble(legacyChaincode.Name, org4peer0, expectedHistory, testKey)
 
-		By("invoking the new chaincode")
-		kvdata := []kvexecutor.KVData{
-			{Key: "key1", Value: "value1"},
-			{Key: "key2", Value: "value2"},
-		}
-		invokeAndQueryKVExecutorChaincode(setup.network, setup.orderer, testchannelID, cc2, kvdata, setup.network.PeersWithChannel(testchannelID)...)
+			verifyQSCC(setup.network, org4peer0, testchannelID, blockNumForNextSnapshot, txidBeforeSnapshot)
+
+			// test 8: verify chaincode upgrade and install after bootstrapping
+			By("upgrading chaincode to version 2.0 on all peers after bootstrapping from snapshot")
+			newlifecycleChaincode.Version = "2.0"
+			newlifecycleChaincode.Sequence = "2"
+			nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, newlifecycleChaincode)
+
+			By("deploying a new chaincode on all the peers after bootstrapping from snapshot")
+			cc2 := nwo.Chaincode{
+				Name:            "kvexecutor",
+				Version:         "1.0",
+				Path:            components.Build("github.com/hyperledger/fabric/integration/chaincode/kvexecutor/cmd"),
+				Lang:            "binary",
+				SignaturePolicy: `OR ('Org1MSP.member','Org2MSP.member', 'Org3MSP.member', 'Org4MSP.member')`,
+				PackageFile:     filepath.Join(setup.testDir, "kvexcutor20.tar.gz"),
+				Label:           "kvexecutor-20",
+				Sequence:        "1",
+			}
+			nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, cc2)
+
+			By("invoking the new chaincode")
+			kvdata := []kvexecutor.KVData{
+				{Key: "key1", Value: "value1"},
+				{Key: "key2", Value: "value2"},
+			}
+			invokeAndQueryKVExecutorChaincode(setup.network, setup.orderer, testchannelID, cc2, kvdata, setup.network.PeersWithChannel(testchannelID)...)
+		})
+	})
+
+	When("chaincode has private data collections", func() {
+		BeforeEach(func() {
+			newlifecycleChaincode = nwo.Chaincode{
+				Name:              "marblesp",
+				Version:           "1.0",
+				Path:              components.Build("github.com/hyperledger/fabric/integration/chaincode/marbles_private/cmd"),
+				Lang:              "binary",
+				PackageFile:       filepath.Join(setup.testDir, "marbles-pvtdata.tar.gz"),
+				Label:             "marbles-private-20",
+				SignaturePolicy:   `OR ('Org1MSP.member','Org2MSP.member')`,
+				CollectionsConfig: filepath.Join("testdata", "collection_configs", "collections_config1.json"),
+				Sequence:          "1",
+			}
+
+			// start org3peer0 so that we have majority number of orgs (3 out of 4) to satify the channel config update policy
+			org3peer0, _ := startPeer(setup, "Org3", "peer0", testchannelID, false)
+			setup.network.JoinChannel(testchannelID, setup.orderer, org3peer0)
+
+			By("enabling V2_0 capabilities")
+			channelPeers := setup.network.PeersWithChannel(testchannelID)
+			nwo.EnableCapabilities(setup.network, testchannelID, "Application", "V2_0", setup.orderer, channelPeers...)
+
+			By("deploying newlifecycle chaincode on initial peers (leveldb)")
+			nwo.DeployChaincode(setup.network, testchannelID, setup.orderer, newlifecycleChaincode)
+		})
+
+		// This test verifies the following:
+		// bootstrapped peer can pull private data
+		// bootstrapped peer can supply private data to other bootstrapped peer
+		It("generates snapshot and bootstraps from snapshots", func() {
+			org1peer0 := setup.network.Peer("Org1", "peer0")
+			org2peer0 := setup.network.Peer("Org2", "peer0")
+			channelPeers := setup.network.PeersWithChannel(testchannelID)
+
+			// prepare test data: add and delete marble1, add and transfer marble1
+			By("adding marble1")
+			marblechaincodeutil.AddMarble(setup.network, setup.orderer, testchannelID, newlifecycleChaincode.Name,
+				`{"name":"marble1", "color":"blue", "size":35, "owner":"tom", "price":99}`, org2peer0)
+			By("deleting marble1")
+			marblechaincodeutil.DeleteMarble(setup.network, setup.orderer, testchannelID, newlifecycleChaincode.Name,
+				`{"name":"marble1"}`, org2peer0)
+
+			By("verifying the deletion of marble1")
+			marblechaincodeutil.AssertDoesNotExistInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", channelPeers...)
+			marblechaincodeutil.AssertDoesNotExistInCollectionMPD(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", channelPeers...)
+
+			By("adding marble2")
+			marblechaincodeutil.AddMarble(setup.network, setup.orderer, testchannelID, newlifecycleChaincode.Name,
+				`{"name":"marble2", "color":"blue", "size":35, "owner":"tom", "price":99}`, org2peer0)
+			By("transferring marble2")
+			marblechaincodeutil.TransferMarble(setup.network, setup.orderer, testchannelID, newlifecycleChaincode.Name,
+				`{"name":"marble2", "owner":"jerry"}`, org2peer0)
+
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble2")
+
+			By("verifying the new ownership of marble2")
+			marblechaincodeutil.AssertOwnershipInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble2", "jerry", org1peer0, org2peer0)
+
+			// test 1: generate snapshots on 2 peers for the same blockNum and verify they are same
+			blockNum := nwo.GetLedgerHeight(setup.network, org2peer0, testchannelID) - 1
+			_, snapshotDir := generateAndCompareSnapshots(setup.network, org1peer0, org2peer0, blockNum)
+
+			// test 2: bootstrap a new peer org2peer1 from snapshot and verify pvtdata
+			By("starting new peer org2peer1 (couchdb)")
+			org2peer1, couchProc := startPeer(setup, "Org2", "peer1", testchannelID, true)
+			couchProcess = append(couchProcess, couchProc)
+
+			By("installing chaincode on peer org2peer1")
+			nwo.InstallChaincode(setup.network, newlifecycleChaincode, org2peer1)
+
+			By("joining peer org2peer1 to the channel by snapshot")
+			joinBySnapshot(setup.network, setup.orderer, org2peer1, testchannelID, snapshotDir, blockNum)
+
+			By("waiting for pvtdata to be reconciled on org2peer1")
+			waitForMarblePvtdataReconciliation(setup.network, org2peer1, testchannelID, newlifecycleChaincode.Name, []string{"marble2"})
+
+			// verify pvtdata reconciliation after joinbysnapshot
+			By("verifying marble2 pvtdata reconciliation on org2peer1")
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble2", org2peer1)
+			By("verifying the new ownership of marble2")
+			marblechaincodeutil.AssertOwnershipInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble2", "jerry", org2peer1)
+
+			By("verifying marble1 does not exist")
+			marblechaincodeutil.AssertDoesNotExistInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", org2peer1)
+			marblechaincodeutil.AssertDoesNotExistInCollectionMPD(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", org2peer1)
+
+			// test 3: submit a request to generate snapshot again on a peer (org2peer1) bootstrapped from a snapshot
+			blockNumForNextSnapshot := nwo.GetLedgerHeight(setup.network, org2peer1, testchannelID)
+			By(fmt.Sprintf("generating a snapshot at blockNum %d on org2peer1 that was bootstrapped by a snapshot", blockNumForNextSnapshot))
+			submitSnapshotRequest(setup.network, testchannelID, blockNumForNextSnapshot, org2peer1, false, "Snapshot request submitted successfully")
+
+			// block for marble3 tx is in snapshot, but block for marble4 tx is post snapshot
+			By("adding marble3")
+			marblechaincodeutil.AddMarble(setup.network, setup.orderer, testchannelID, newlifecycleChaincode.Name,
+				`{"name":"marble3", "color":"blue", "size":35, "owner":"tom", "price":99}`, org2peer1)
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble3")
+
+			By("adding marble4")
+			marblechaincodeutil.AddMarble(setup.network, setup.orderer, testchannelID, newlifecycleChaincode.Name,
+				`{"name":"marble4", "color":"blue", "size":35, "owner":"tom", "price":99}`, org2peer1)
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble4")
+
+			By("verifying snapshot completed on org2peer1")
+			verifyNoPendingSnapshotRequest(setup.network, org2peer1, testchannelID)
+			nextSnapshotDir := filepath.Join(setup.network.PeerDir(org2peer1), "filesystem", "snapshots", "completed", testchannelID, strconv.Itoa(blockNumForNextSnapshot))
+
+			// stop all the peers and only restart org2peer1
+			setup.stopPeers()
+			setup.startPeer(org2peer1)
+			setup.peers = []*nwo.Peer{org2peer1}
+			setup.network.Peers = setup.peers
+
+			// test 4: bootstrap a new peer org2peer2 by snapshot and verify pvtdata reconciliation
+			By("starting a peer (org2peer2) in existing org (leveldb)")
+			org2peer2, _ := startPeer(setup, "Org2", "peer2", testchannelID, false)
+
+			By("installing new lifecycle chaincode2 on peer org2peer2")
+			nwo.InstallChaincode(setup.network, newlifecycleChaincode, org2peer2)
+
+			By("joining peer org2peer2 to the channel by snapshot")
+			joinBySnapshot(setup.network, setup.orderer, org2peer2, testchannelID, nextSnapshotDir, blockNumForNextSnapshot)
+
+			By("waiting for pvtdata to be reconciled on org2peer2")
+			waitForMarblePvtdataReconciliation(setup.network, org2peer2, testchannelID, newlifecycleChaincode.Name, []string{"marble2", "marble3", "marble4"})
+
+			By("verifying marble4 pvtdata reconciliation on org2peer2")
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble4", org2peer2)
+			By("verifying marble3 pvtdata reconciliation on org2peer2")
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble3", org2peer2)
+			By("verifying marble2 pvtdata reconciliation on org2peer2")
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble2", org2peer2)
+			By("verifying the new ownership of marble2")
+			marblechaincodeutil.AssertOwnershipInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble2", "jerry", org2peer2)
+			By("verifying marble1 does not exist")
+			marblechaincodeutil.AssertDoesNotExistInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", org2peer2)
+			marblechaincodeutil.AssertDoesNotExistInCollectionMPD(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", org2peer2)
+
+			// test 5: bootstrap a new peer Org2peer3 from genesis block to verify pvtdata reconciliation
+			By("startinging a peer Org2peer3 in an new org (leveldb)")
+			org2peer3, _ := startPeer(setup, "Org2", "peer3", testchannelID, false)
+
+			By("installing newlifecycleChaincode on new peer Org2peer3")
+			nwo.InstallChaincode(setup.network, newlifecycleChaincode, org2peer3)
+
+			By("joining peer Org2peer3 to the channel by genesis block")
+			setup.network.JoinChannel(testchannelID, setup.orderer, org2peer3)
+
+			By("waiting for the new peer to have the same ledger height")
+			channelHeight := nwo.GetMaxLedgerHeight(setup.network, testchannelID, org2peer1)
+			nwo.WaitUntilEqualLedgerHeight(setup.network, testchannelID, channelHeight, org2peer3)
+
+			By("waiting for pvtdata to be reconciled on org2peer3")
+			waitForMarblePvtdataReconciliation(setup.network, org2peer3, testchannelID, newlifecycleChaincode.Name, []string{"marble2", "marble3", "marble4"})
+
+			By("verifying marble4 pvtdata reconciliation on org2peer3")
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble4", org2peer3)
+			By("verifying marble3 pvtdata reconciliation on org2peer3")
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble3", org2peer3)
+			By("verifying marble2 pvtdata reconciliation on org2peer3")
+			assertPvtdataPresencePerCollectionConfig1(setup.network, newlifecycleChaincode.Name, "marble2", org2peer3)
+			By("verifying the new ownership of marble2")
+			marblechaincodeutil.AssertOwnershipInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble2", "jerry", org2peer3)
+			By("verifying marble1 does not exist")
+			marblechaincodeutil.AssertDoesNotExistInCollectionM(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", org2peer3)
+			marblechaincodeutil.AssertDoesNotExistInCollectionMPD(setup.network, testchannelID, newlifecycleChaincode.Name, "marble1", org2peer3)
+
+			// verify pvtdata hash on bootstrapped peers
+			peers := []*nwo.Peer{org2peer1, org2peer2, org2peer3}
+			for i := 2; i <= 4; i++ {
+				name := fmt.Sprintf("marble%d", i)
+				owner := "tom"
+				if name == "marble2" {
+					owner = "jerry"
+				}
+
+				By(fmt.Sprintf("verifying getMarbleHash for %s from all peers that has the chaincode instantiated", name))
+				expectedBytes := util.ComputeStringHash(fmt.Sprintf(`{"docType":"marble","name":"%s","color":"blue","size":35,"owner":"%s"}`, name, owner))
+				marblechaincodeutil.AssertMarblesPrivateHashM(setup.network, testchannelID, newlifecycleChaincode.Name, name, expectedBytes, peers)
+
+				By(fmt.Sprintf("verifying getMarblePrivateDetailsHash for %s from all peers that has the chaincode instantiated", name))
+				expectedBytes = util.ComputeStringHash(fmt.Sprintf(`{"docType":"marblePrivateDetails","name":"%s","price":99}`, name))
+				marblechaincodeutil.AssertMarblesPrivateDetailsHashMPD(setup.network, testchannelID, newlifecycleChaincode.Name, name, expectedBytes, peers)
+			}
+		})
 	})
 })
 
@@ -290,11 +482,11 @@ func configPeerWithCouchDB(s *setup, peer *nwo.Peer) ifrit.Process {
 	return couchProc
 }
 
-// initAndStartMultiOrgsNetwork creates a network with multiple orgs.
+// initAndStartFourOrgsNetwork creates a network with multiple orgs.
 // Initially only start Org1.peer0 and Org2.peer0 are started and join the channel.
-func initAndStartMultiOrgsNetwork() *setup {
+func initAndStartFourOrgsNetwork() *setup {
 	var err error
-	testDir, err := ioutil.TempDir("", "reset-rollback")
+	testDir, err := ioutil.TempDir("", "snapshot")
 	Expect(err).NotTo(HaveOccurred())
 
 	client, err := docker.NewClientFromEnv()
@@ -325,6 +517,16 @@ func initAndStartMultiOrgsNetwork() *setup {
 			Organization: "Org2",
 			Channels:     []*nwo.PeerChannel{},
 		},
+		&nwo.Peer{
+			Name:         "peer2",
+			Organization: "Org2",
+			Channels:     []*nwo.PeerChannel{},
+		},
+		&nwo.Peer{
+			Name:         "peer3",
+			Organization: "Org2",
+			Channels:     []*nwo.PeerChannel{},
+		},
 	)
 
 	// add org3 with one peer
@@ -341,7 +543,9 @@ func initAndStartMultiOrgsNetwork() *setup {
 	config.Peers = append(config.Peers, &nwo.Peer{
 		Name:         "peer0",
 		Organization: "Org3",
-		Channels:     []*nwo.PeerChannel{},
+		Channels: []*nwo.PeerChannel{
+			{Name: testchannelID, Anchor: true},
+		},
 	})
 
 	// add org4 with one peer
@@ -358,12 +562,28 @@ func initAndStartMultiOrgsNetwork() *setup {
 	config.Peers = append(config.Peers, &nwo.Peer{
 		Name:         "peer0",
 		Organization: "Org4",
-		Channels:     []*nwo.PeerChannel{},
-	})
+		Channels: []*nwo.PeerChannel{
+			{Name: testchannelID, Anchor: true},
+		}})
 
 	n := nwo.New(config, testDir, client, StartPort(), components)
 	n.GenerateConfigTree()
 	n.Bootstrap()
+
+	// set ReconcileSleepInterval to 1 second to reconcile pvtdata faster
+	for _, p := range n.Peers {
+		core := n.ReadPeerConfig(p)
+		core.Peer.Gossip.PvtData.ReconcileSleepInterval = 1 * time.Second
+		n.WritePeerConfig(p, core)
+	}
+
+	// set org2peer2 and org2peer3's gossip bootstrap endpoints pointing to org2peer1
+	org2peer1 := n.Peer("Org2", "peer1")
+	for _, p := range []*nwo.Peer{n.Peer("Org2", "peer2"), n.Peer("Org2", "peer3")} {
+		core := n.ReadPeerConfig(p)
+		core.Peer.Gossip.Bootstrap = n.PeerAddress(org2peer1, nwo.ListenPort)
+		n.WritePeerConfig(p, core)
+	}
 
 	// only keep Org1.peer0 and Org2.peer0 so we can add other peers back later to test join channel by snapshot
 	peers := []*nwo.Peer{}
@@ -713,4 +933,51 @@ func toCLIChaincodeArgs(args ...string) string {
 	cArgsJSON, err := json.Marshal(cArgs)
 	Expect(err).NotTo(HaveOccurred())
 	return string(cArgsJSON)
+}
+
+// waitForMarblePvtdataReconciliation queries the chaincode until it returns a success exit code, which means the data is available.
+func waitForMarblePvtdataReconciliation(n *nwo.Network, peer *nwo.Peer, channelID, chaincodeName string, marbleNames []string) {
+	for _, marbleName := range marbleNames {
+		for _, funcName := range []string{"readMarble", "readMarblePrivateDetails"} {
+			query := fmt.Sprintf(`{"Args":["%s","%s"]}`, funcName, marbleName)
+			command := commands.ChaincodeQuery{
+				ChannelID: channelID,
+				Name:      chaincodeName,
+				Ctor:      query,
+			}
+			queryData := func() int {
+				sess, err := n.PeerUserSession(peer, "User1", command)
+				Expect(err).NotTo(HaveOccurred())
+				return sess.Wait(n.EventuallyTimeout).ExitCode()
+			}
+			Eventually(queryData, n.EventuallyTimeout).Should(Equal(0))
+		}
+	}
+}
+
+func assertPvtdataPresencePerCollectionConfig1(n *nwo.Network, chaincodeName, marbleName string, peers ...*nwo.Peer) {
+	if len(peers) == 0 {
+		peers = n.Peers
+	}
+	for _, peer := range peers {
+		switch peer.Organization {
+		case "Org1":
+			By("asserting collection data M in org1 peer " + peer.ID() + " for " + marbleName)
+			marblechaincodeutil.AssertPresentInCollectionM(n, testchannelID, chaincodeName, marbleName, peer)
+			By("asserting no collection data MPD in org1 peer " + peer.ID() + " for " + marbleName)
+			marblechaincodeutil.AssertNotPresentInCollectionMPD(n, testchannelID, chaincodeName, marbleName, peer)
+
+		case "Org2":
+			By("asserting collection data M in org2 peer " + peer.ID() + " for " + marbleName)
+			marblechaincodeutil.AssertPresentInCollectionM(n, testchannelID, chaincodeName, marbleName, peer)
+			By("asserting collection data MPD in org2 peer " + peer.ID() + " for " + marbleName)
+			marblechaincodeutil.AssertPresentInCollectionMPD(n, testchannelID, chaincodeName, marbleName, peer)
+
+		case "Org3":
+			By("asserting no collection data M in org3 peer " + peer.ID() + " for " + marbleName)
+			marblechaincodeutil.AssertNotPresentInCollectionM(n, testchannelID, chaincodeName, marbleName, peer)
+			By("asserting collection data MPD in org3 peer " + peer.ID() + " for " + marbleName)
+			marblechaincodeutil.AssertPresentInCollectionMPD(n, testchannelID, chaincodeName, marbleName, peer)
+		}
+	}
 }


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- New feature

#### Description
Add IT tests to verify the following:
- bootstrapped peer can pull private data
- bootstrapped peer can supply private data to other bootstrapped peer

#### Related issues
https://jira.hyperledger.org/browse/FAB-17953
