### PR TITLE
[FAB-17800] Update reset/rollback/rebuild/upgrade_dbs cmd descriptions for snapshot

### DIFF
--- a/internal/peer/node/rebuild_dbs.go
+++ b/internal/peer/node/rebuild_dbs.go
@@ -18,7 +18,9 @@ func rebuildDBsCmd() *cobra.Command {
 var nodeRebuildCmd = &cobra.Command{
 	Use:   "rebuild-dbs",
 	Short: "Rebuilds databases.",
-	Long:  "Drops the databases for all the channels and rebuilds them upon peer restart. When the command is executed, the peer must be offline.",
+	Long: "Drops the databases for all the channels and rebuilds them upon peer restart. " +
+		" When the command is executed, the peer must be offline." +
+		" The command is not supported if the peer contains any channel that was bootstrapped from a snapshot.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		config := ledgerConfig()
 		return kvledger.RebuildDBs(config)

--- a/internal/peer/node/reset.go
+++ b/internal/peer/node/reset.go
@@ -18,7 +18,9 @@ func resetCmd() *cobra.Command {
 var nodeResetCmd = &cobra.Command{
 	Use:   "reset",
 	Short: "Resets the node.",
-	Long:  `Resets all channels to the genesis block. When the command is executed, the peer must be offline. When the peer starts after the reset, it will receive blocks starting with block number one from an orderer or another peer to rebuild the block store and state database.`,
+	Long: "Resets all channels to the genesis block. When the command is executed, the peer must be offline." +
+		" When the peer starts after the reset, it will receive blocks starting with block number one from an orderer or another peer to rebuild the block store and state database." +
+		" The command is not supported if the peer contains any channel that was bootstrapped from a snapshot.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		config := ledgerConfig()
 		return kvledger.ResetAllKVLedgers(config.RootFSPath)

--- a/internal/peer/node/rollback.go
+++ b/internal/peer/node/rollback.go
@@ -30,7 +30,10 @@ func rollbackCmd() *cobra.Command {
 var nodeRollbackCmd = &cobra.Command{
 	Use:   "rollback",
 	Short: "Rolls back a channel.",
-	Long:  `Rolls back a channel to a specified block number. When the command is executed, the peer must be offline. When the peer starts after the rollback, it will receive blocks, which got removed during the rollback, from an orderer or another peer to rebuild the block store and state database.`,
+	Long: "Rolls back a channel to a specified block number. When the command is executed, the peer must be offline." +
+		" When the peer starts after the rollback, it will receive blocks, which got removed during the rollback," +
+		" from an orderer or another peer to rebuild the block store and state database." +
+		" The command is not supported if the peer contains any channel that was bootstrapped from a snapshot.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if channelID == common.UndefinedParamValue {
 			return errors.New("Must supply channel ID")

--- a/internal/peer/node/upgrade_dbs.go
+++ b/internal/peer/node/upgrade_dbs.go
@@ -18,7 +18,9 @@ func upgradeDBsCmd() *cobra.Command {
 var nodeUpgradeDBsCmd = &cobra.Command{
 	Use:   "upgrade-dbs",
 	Short: "Upgrades databases.",
-	Long:  "Upgrades databases by directly updating the database format or dropping the databases. Dropped databases will be rebuilt with new format upon peer restart. When the command is executed, the peer must be offline.",
+	Long: "Upgrades databases by directly updating the database format or dropping the databases." +
+		" Dropped databases will be rebuilt with new format upon peer restart. When the command is executed, the peer must be offline." +
+		" The command is not supported if the peer contains any channel that was bootstrapped from a snapshot.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		config := ledgerConfig()
 		return kvledger.UpgradeDBs(config)


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- New feature

#### Description
Update reset/rollback/rebuild/upgrade_dbs command descriptions to indicate
that these commands are not supported if the peer has any channel that was
bootstrapped from a snapshot.

#### Related issues
https://jira.hyperledger.org/browse/FAB-17800
