### PR TITLE
Add function GetChannelConfig in cscc and use in peer client

### DIFF
--- a/core/aclmgmt/defaultaclprovider.go
+++ b/core/aclmgmt/defaultaclprovider.go
@@ -98,6 +98,7 @@ func newDefaultACLProvider(policyChecker policy.PolicyChecker) defaultACLProvide
 
 	//c resources
 	d.cResourcePolicyMap[resources.Cscc_GetConfigBlock] = CHANNELREADERS
+	d.cResourcePolicyMap[resources.Cscc_GetChannelConfig] = CHANNELREADERS
 
 	//---------------- non-scc resources ------------
 	//Peer resources

--- a/core/aclmgmt/resources/resources.go
+++ b/core/aclmgmt/resources/resources.go
@@ -51,6 +51,7 @@ const (
 	Cscc_JoinChainBySnapshot  = "cscc/JoinChainBySnapshot"
 	Cscc_JoinBySnapshotStatus = "cscc/JoinBySnapshotStatus"
 	Cscc_GetConfigBlock       = "cscc/GetConfigBlock"
+	Cscc_GetChannelConfig     = "cscc/GetChannelConfig"
 	Cscc_GetChannels          = "cscc/GetChannels"
 
 	//Peer resources

--- a/integration/e2e/acl_test.go
+++ b/integration/e2e/acl_test.go
@@ -234,6 +234,7 @@ var _ = Describe("EndToEndACL", func() {
 		// cscc
 		//
 		ItEnforcesPolicy("cscc", "GetConfigBlock", "testchannel")
+		ItEnforcesPolicy("cscc", "GetChannelConfig", "testchannel")
 
 		//
 		// _lifecycle ACL policies

--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -194,6 +194,9 @@ Application: &ApplicationDefaults
         # ACL policy for cscc's "GetConfigBlock" function
         cscc/GetConfigBlock: /Channel/Application/Readers
 
+        # ACL policy for cscc's "GetChannelConfig" function
+        cscc/GetChannelConfig: /Channel/Application/Readers
+
         #---Miscellaneous peer function to policy mapping for access control---#
 
         # ACL policy for invoking chaincodes on peer


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Description
CSCC has a function GetConfigBlock that is used by the peer client to extract the orderer endpoints. A peer bootstrapped from a snapshot may not have the config block until next channel config update is committed. This commit introduces a function a cscc to return channel config and makes use of this in the peer client.

#### Additional details
Though, in general we do not encourage to add functions in these built-in chanincodes, but here we cannot modify the existing function GetConfigBlock as some external clients may be using this and it will break the backward compatibility. However, the intention is to encourage the users to use this new API to pave the way for the removal of the existing API.

#### Related issues
[FAB-18300](https://jira.hyperledger.org/browse/FAB-18300)
