### PR TITLE
FAB-18301 Registrar.JoinChannel takes the wrong lock type

### DIFF
--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -693,8 +693,8 @@ func (r *Registrar) ChannelInfo(channelID string) (types.ChannelInfo, error) {
 // JoinChannel instructs the orderer to create a channel and join it with the provided config block.
 // The URL field is empty, and is to be completed by the caller.
 func (r *Registrar) JoinChannel(channelID string, configBlock *cb.Block, isAppChannel bool) (info types.ChannelInfo, err error) {
-	r.lock.RLock()
-	defer r.lock.RUnlock()
+	r.lock.Lock()
+	defer r.lock.Unlock()
 
 	if r.systemChannelID != "" {
 		return types.ChannelInfo{}, types.ErrSystemChannelExists


### PR DESCRIPTION
Replace RLock() with Lock() since Registrar.JoinChannel writes
to the internal data structure.

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: Ic78a35ad6167e4ccbb3d1613ce1085bfdcb5aba1


#### Type of change
- Bug fix
#### Related issues

Issue: FAB-18301
Epic: FAB-17712