### PR TITLE
Use -c instead of -C for channelID in snapshot cli cmds

### DIFF
--- a/docs/source/commands/peersnapshot.md
+++ b/docs/source/commands/peersnapshot.md
@@ -23,7 +23,7 @@ Usage:
 
 Flags:
   -b, --blockNumber uint         The block number for which a snapshot will be generated
-  -C, --channelID string         The channel on which this command should be executed
+  -c, --channelID string         The channel on which this command should be executed
   -h, --help                     help for cancelrequest
       --peerAddress string       The address of the peer to connect to
       --tlsRootCertFile string   The path to the TLS root cert file of the peer to connect to, required if TLS is enabled and ignored if TLS is disabled.
@@ -38,7 +38,7 @@ Usage:
   peer snapshot listpending [flags]
 
 Flags:
-  -C, --channelID string         The channel on which this command should be executed
+  -c, --channelID string         The channel on which this command should be executed
   -h, --help                     help for listpending
       --peerAddress string       The address of the peer to connect to
       --tlsRootCertFile string   The path to the TLS root cert file of the peer to connect to, required if TLS is enabled and ignored if TLS is disabled.
@@ -54,7 +54,7 @@ Usage:
 
 Flags:
   -b, --blockNumber uint         The block number for which a snapshot will be generated
-  -C, --channelID string         The channel on which this command should be executed
+  -c, --channelID string         The channel on which this command should be executed
   -h, --help                     help for submitrequest
       --peerAddress string       The address of the peer to connect to
       --tlsRootCertFile string   The path to the TLS root cert file of the peer to connect to, required if TLS is enabled and ignored if TLS is disabled.
@@ -70,7 +70,7 @@ Here is an example of the `peer snapshot cancelrequest` command.
     for `peer0.org1.example.com:7051`:
 
     ```
-    peer snapshot cancelrequest -C mychannel -b 1000 --peerAddress peer0.org1.example.com:7051
+    peer snapshot cancelrequest -c mychannel -b 1000 --peerAddress peer0.org1.example.com:7051
 
     Snapshot request cancelled successfully
 
@@ -90,7 +90,7 @@ If a snapshot is already generated, the corresponding block number will be remov
     for `peer0.org1.example.com:7051`:
 
     ```
-    peer snapshot listpending -C mychannel --peerAddress peer0.org1.example.com:7051
+    peer snapshot listpending -c mychannel --peerAddress peer0.org1.example.com:7051
 
     Successfully got pending snapshot requests: [1000 5000]
 
@@ -108,7 +108,7 @@ Here is an example of the `peer snapshot submitrequest` command.
     for `peer0.org1.example.com:7051`:
 
     ```
-    peer snapshot submitrequest -C mychannel -b 1000 --peerAddress peer0.org1.example.com:7051
+    peer snapshot submitrequest -c mychannel -b 1000 --peerAddress peer0.org1.example.com:7051
 
     Snapshot request submitted successfully
 

--- a/docs/source/peer_ledger_snapshot.md
+++ b/docs/source/peer_ledger_snapshot.md
@@ -63,13 +63,13 @@ In this example, the ledger height is `970`.
 A snapshot request can be submitted by issuing a command similar to:
 
 ```
-peer snapshot submitrequest -C <name of channel> -b <ledger height where snapshot will be taken> --peerAddress <address of peer> --tlsRootCertFile <path to root certificate of the TLS CA>
+peer snapshot submitrequest -c <name of channel> -b <ledger height where snapshot will be taken> --peerAddress <address of peer> --tlsRootCertFile <path to root certificate of the TLS CA>
 ```
 
 For example:
 
 ```
-peer snapshot submitrequest -C testchannel -b 1000 --peerAddress 127.0.0.1:22509 --tlsRootCertFile tls/cert.pem
+peer snapshot submitrequest -c testchannel -b 1000 --peerAddress 127.0.0.1:22509 --tlsRootCertFile tls/cert.pem
 ```
 
 **If you give a ledger height of `0`, the snapshot is taken immediately. This is useful for cases when an organization is interested in generating a snapshot that will be used by one of its own peers and does not intend to share the data with another organization. Do not take these "immediate" snapshots in cases when snapshots will be evaluated from multiple peers, as it increases the likelihood that the snapshots will be taken at different ledger heights.**
@@ -79,7 +79,7 @@ If the request is successful, you will see a `Snapshot request submitted success
 You can list the pending snapshots by issuing a command similar to:
 
 ```
-peer snapshot listpending -C testchannel --peerAddress 127.0.0.1:22509 --tlsRootCertFile tls/cert.pem
+peer snapshot listpending -c testchannel --peerAddress 127.0.0.1:22509 --tlsRootCertFile tls/cert.pem
 ```
 
 You will see a response similar to:
@@ -93,7 +93,7 @@ When a snapshot has been generated for a particular block height, the pending re
 To delete a snapshot request, simply exchange `submitrequest` with `cancelrequest`. For example:
 
 ```
-peer snapshot cancelrequest -C testchannel -b 1000 --peerAddress 127.0.0.1:22509 --tlsRootCertFile tls/cert.pem
+peer snapshot cancelrequest -c testchannel -b 1000 --peerAddress 127.0.0.1:22509 --tlsRootCertFile tls/cert.pem
 ```
 
 If you submit the `listpending` command again, the snapshot should no longer appear.

--- a/docs/wrappers/peer_snapshot_postscript.md
+++ b/docs/wrappers/peer_snapshot_postscript.md
@@ -8,7 +8,7 @@ Here is an example of the `peer snapshot cancelrequest` command.
     for `peer0.org1.example.com:7051`:
 
     ```
-    peer snapshot cancelrequest -C mychannel -b 1000 --peerAddress peer0.org1.example.com:7051
+    peer snapshot cancelrequest -c mychannel -b 1000 --peerAddress peer0.org1.example.com:7051
 
     Snapshot request cancelled successfully
 
@@ -28,7 +28,7 @@ If a snapshot is already generated, the corresponding block number will be remov
     for `peer0.org1.example.com:7051`:
 
     ```
-    peer snapshot listpending -C mychannel --peerAddress peer0.org1.example.com:7051
+    peer snapshot listpending -c mychannel --peerAddress peer0.org1.example.com:7051
 
     Successfully got pending snapshot requests: [1000 5000]
 
@@ -46,7 +46,7 @@ Here is an example of the `peer snapshot submitrequest` command.
     for `peer0.org1.example.com:7051`:
 
     ```
-    peer snapshot submitrequest -C mychannel -b 1000 --peerAddress peer0.org1.example.com:7051
+    peer snapshot submitrequest -c mychannel -b 1000 --peerAddress peer0.org1.example.com:7051
 
     Snapshot request submitted successfully
 

--- a/internal/peer/snapshot/cancelrequest.go
+++ b/internal/peer/snapshot/cancelrequest.go
@@ -81,7 +81,7 @@ func cancelRequest(cmd *cobra.Command, cl *client, cryptoProvider bccsp.BCCSP) e
 
 func validateCancelRequest() error {
 	if channelID == "" {
-		return errors.New("the required parameter 'channelID' is empty. Rerun the command with -C flag")
+		return errors.New("the required parameter 'channelID' is empty. Rerun the command with -c flag")
 	}
 	if blockNumber == 0 {
 		return errors.New("the required parameter 'blockNumber' is empty or set to 0. Rerun the command with -b flag")

--- a/internal/peer/snapshot/cancelrequest_test.go
+++ b/internal/peer/snapshot/cancelrequest_test.go
@@ -26,7 +26,7 @@ func TestCancelRequestCmd(t *testing.T) {
 
 	resetFlags()
 	cmd := cancelRequestCmd(mockClient, nil)
-	cmd.SetArgs([]string{"-C", "mychannel", "-b", "100"})
+	cmd.SetArgs([]string{"-c", "mychannel", "-b", "100"})
 	err := cmd.Execute()
 	require.NoError(t, err)
 	require.Equal(t, []byte("Snapshot request cancelled successfully\n"), buffer.Contents())
@@ -43,9 +43,9 @@ func TestCancelRequestCmd(t *testing.T) {
 
 	resetFlags()
 	cmd.SetArgs([]string{"-b", "100"})
-	require.EqualError(t, cmd.Execute(), "the required parameter 'channelID' is empty. Rerun the command with -C flag")
+	require.EqualError(t, cmd.Execute(), "the required parameter 'channelID' is empty. Rerun the command with -c flag")
 
 	resetFlags()
-	cmd.SetArgs([]string{"-C", "mychannel"})
+	cmd.SetArgs([]string{"-c", "mychannel"})
 	require.EqualError(t, cmd.Execute(), "the required parameter 'blockNumber' is empty or set to 0. Rerun the command with -b flag")
 }

--- a/internal/peer/snapshot/client_test.go
+++ b/internal/peer/snapshot/client_test.go
@@ -39,7 +39,7 @@ func TestValidatePeerConnectionParameters(t *testing.T) {
 	require.NoError(t, validatePeerConnectionParameters())
 
 	// test error propagation
-	args := []string{"-C", "mychannel"}
+	args := []string{"-c", "mychannel"}
 	resetFlags()
 	cmd := listPendingCmd(nil, nil)
 	cmd.SetArgs(args)

--- a/internal/peer/snapshot/listpending.go
+++ b/internal/peer/snapshot/listpending.go
@@ -78,7 +78,7 @@ func listPending(cmd *cobra.Command, cl *client, cryptoProvider bccsp.BCCSP) err
 
 func validateListPending() error {
 	if channelID == "" {
-		return errors.New("the required parameter 'channelID' is empty. Rerun the command with -C flag")
+		return errors.New("the required parameter 'channelID' is empty. Rerun the command with -c flag")
 	}
 	return nil
 }

--- a/internal/peer/snapshot/listpending_test.go
+++ b/internal/peer/snapshot/listpending_test.go
@@ -26,7 +26,7 @@ func TestListPendingCmd(t *testing.T) {
 
 	resetFlags()
 	cmd := listPendingCmd(mockClient, nil)
-	cmd.SetArgs([]string{"-C", "mychannel"})
+	cmd.SetArgs([]string{"-c", "mychannel"})
 	err := cmd.Execute()
 	require.NoError(t, err)
 	require.Equal(t, []byte("Successfully got pending snapshot requests: [100 200]\n"), buffer.Contents())
@@ -43,5 +43,5 @@ func TestListPendingCmd(t *testing.T) {
 
 	resetFlags()
 	cmd.SetArgs([]string{})
-	require.EqualError(t, cmd.Execute(), "the required parameter 'channelID' is empty. Rerun the command with -C flag")
+	require.EqualError(t, cmd.Execute(), "the required parameter 'channelID' is empty. Rerun the command with -c flag")
 }

--- a/internal/peer/snapshot/snapshot.go
+++ b/internal/peer/snapshot/snapshot.go
@@ -56,7 +56,7 @@ func init() {
 func resetFlags() {
 	flags = &pflag.FlagSet{}
 
-	flags.StringVarP(&channelID, "channelID", "C", "", "The channel on which this command should be executed")
+	flags.StringVarP(&channelID, "channelID", "c", "", "The channel on which this command should be executed")
 	flags.Uint64VarP(&blockNumber, "blockNumber", "b", 0, "The block number for which a snapshot will be generated")
 	flags.StringVarP(&peerAddress, "peerAddress", "", "", "The address of the peer to connect to")
 	flags.StringVarP(&tlsRootCertFile, "tlsRootCertFile", "", "",

--- a/internal/peer/snapshot/submitrequest.go
+++ b/internal/peer/snapshot/submitrequest.go
@@ -81,7 +81,7 @@ func submitRequest(cmd *cobra.Command, cl *client, cryptoProvider bccsp.BCCSP) e
 
 func validateSubmitRequest() error {
 	if channelID == "" {
-		return errors.New("the required parameter 'channelID' is empty. Rerun the command with -C flag")
+		return errors.New("the required parameter 'channelID' is empty. Rerun the command with -c flag")
 	}
 	return nil
 }

--- a/internal/peer/snapshot/submitrequest_test.go
+++ b/internal/peer/snapshot/submitrequest_test.go
@@ -26,7 +26,7 @@ func TestSubmitRequestCmd(t *testing.T) {
 
 	resetFlags()
 	cmd := submitRequestCmd(mockClient, nil)
-	cmd.SetArgs([]string{"-C", "mychannel"})
+	cmd.SetArgs([]string{"-c", "mychannel"})
 	require.NoError(t, cmd.Execute())
 	require.Equal(t, []byte("Snapshot request submitted successfully\n"), buffer.Contents())
 
@@ -35,7 +35,7 @@ func TestSubmitRequestCmd(t *testing.T) {
 	mockClient.writer = buffer2
 	resetFlags()
 	cmd = submitRequestCmd(mockClient, nil)
-	cmd.SetArgs([]string{"-C", "mychannel", "-b", "100"})
+	cmd.SetArgs([]string{"-c", "mychannel", "-b", "100"})
 	require.NoError(t, cmd.Execute())
 	require.Equal(t, []byte("Snapshot request submitted successfully\n"), buffer2.Contents())
 
@@ -51,5 +51,5 @@ func TestSubmitRequestCmd(t *testing.T) {
 
 	resetFlags()
 	cmd.SetArgs([]string{})
-	require.EqualError(t, cmd.Execute(), "the required parameter 'channelID' is empty. Rerun the command with -C flag")
+	require.EqualError(t, cmd.Execute(), "the required parameter 'channelID' is empty. Rerun the command with -c flag")
 }


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
Use -c instead of -C for channelID to be consistent to other channel commands.

#### Related issues
https://jira.hyperledger.org/browse/FAB-18145