### PR TITLE
Optimize importing snapshot data into pvtdatastore

### DIFF
--- a/common/ledger/blkstorage/blockindex.go
+++ b/common/ledger/blkstorage/blockindex.go
@@ -38,7 +38,7 @@ var (
 	indexSavePointKey              = []byte(indexSavePointKeyStr)
 	errIndexSavePointKeyNotPresent = errors.New("NoBlockIndexed")
 	errNilValue                    = errors.New("")
-	importTxIDsBatchSize           = uint64(1000) // txID is 64 bytes, so batch size roughly translates to 64KB
+	importTxIDsBatchSize           = uint64(10000) // txID is 64 bytes, so batch size roughly translates to 640KB
 )
 
 type blockIdxInfo struct {

--- a/core/ledger/kvledger/kv_ledger_provider.go
+++ b/core/ledger/kvledger/kv_ledger_provider.go
@@ -244,7 +244,7 @@ func (p *Provider) initSnapshotDir() error {
 		return errors.Errorf("invalid path: %s. The path for the snapshot dir is expected to be an absolute path", snapshotsRootDir)
 	}
 
-	inProgressSnapshotsPath := InProgressSnapshotsPath(snapshotsRootDir)
+	inProgressSnapshotsPath := SnapshotsTempDirPath(snapshotsRootDir)
 	completedSnapshotsPath := CompletedSnapshotsPath(snapshotsRootDir)
 
 	if err := os.RemoveAll(inProgressSnapshotsPath); err != nil {
@@ -294,7 +294,10 @@ func (p *Provider) CreateFromGenesisBlock(genesisBlock *common.Block) (ledger.Pe
 func (p *Provider) deleteUnderConstructionLedger(ledger ledger.PeerLedger, ledgerID string, creationErr error) error {
 	if creationErr == nil {
 		return nil
+	} else {
+		logger.Errorf("ledger creation error = %+v", creationErr)
 	}
+
 	if ledger != nil {
 		ledger.Close()
 	}

--- a/core/ledger/kvledger/ledger_filepath.go
+++ b/core/ledger/kvledger/ledger_filepath.go
@@ -50,9 +50,9 @@ func BookkeeperDBPath(rootFSPath string) string {
 	return filepath.Join(rootFSPath, "bookkeeper")
 }
 
-// InProgressSnapshotsPath returns the dir path that is used temporarily during the genration of the snapshots for a ledger
-func InProgressSnapshotsPath(snapshotRootDir string) string {
-	return filepath.Join(snapshotRootDir, "underConstruction")
+// SnapshotsTempDirPath returns the dir path that is used temporarily during the genration or import of the snapshots for a ledger
+func SnapshotsTempDirPath(snapshotRootDir string) string {
+	return filepath.Join(snapshotRootDir, "temp")
 }
 
 // CompletedSnapshotsPath returns the absolute path that is used for persisting the snapshots

--- a/core/ledger/kvledger/snapshot_test.go
+++ b/core/ledger/kvledger/snapshot_test.go
@@ -449,7 +449,7 @@ func TestSnapshotCouchDBIndexCreation(t *testing.T) {
 }
 
 func TestSnapshotDirPaths(t *testing.T) {
-	require.Equal(t, "/peerFSPath/snapshotRootDir/underConstruction", InProgressSnapshotsPath("/peerFSPath/snapshotRootDir"))
+	require.Equal(t, "/peerFSPath/snapshotRootDir/temp", SnapshotsTempDirPath("/peerFSPath/snapshotRootDir"))
 	require.Equal(t, "/peerFSPath/snapshotRootDir/completed", CompletedSnapshotsPath("/peerFSPath/snapshotRootDir"))
 	require.Equal(t, "/peerFSPath/snapshotRootDir/completed/myLedger", SnapshotsDirForLedger("/peerFSPath/snapshotRootDir", "myLedger"))
 	require.Equal(t, "/peerFSPath/snapshotRootDir/completed/myLedger/2000", SnapshotDirForLedgerBlockNum("/peerFSPath/snapshotRootDir", "myLedger", 2000))
@@ -463,7 +463,7 @@ func TestSnapshotDirPathsCreation(t *testing.T) {
 		provider.Close()
 	}()
 
-	inProgressSnapshotsPath := InProgressSnapshotsPath(conf.SnapshotsConfig.RootDir)
+	inProgressSnapshotsPath := SnapshotsTempDirPath(conf.SnapshotsConfig.RootDir)
 	completedSnapshotsPath := CompletedSnapshotsPath(conf.SnapshotsConfig.RootDir)
 
 	// verify that upon first time start, kvledgerProvider creates an empty temp dir and an empty final dir for the snapshots
@@ -555,7 +555,7 @@ func TestGenerateSnapshotErrors(t *testing.T) {
 	t.Run("snapshot tmp dir creation returns error", func(t *testing.T) {
 		closeAndReopenLedgerProvider()
 		require.NoError(t, os.RemoveAll( // remove the base tempdir so that the snapshot tempdir creation fails
-			InProgressSnapshotsPath(conf.SnapshotsConfig.RootDir),
+			SnapshotsTempDirPath(conf.SnapshotsConfig.RootDir),
 		))
 		err := kvlgr.generateSnapshot()
 		require.Error(t, err)
@@ -858,7 +858,7 @@ func verifySnapshotOutput(
 	t *testing.T,
 	o *expectedSnapshotOutput,
 ) {
-	inProgressSnapshotsPath := InProgressSnapshotsPath(o.snapshotRootDir)
+	inProgressSnapshotsPath := SnapshotsTempDirPath(o.snapshotRootDir)
 	f, err := ioutil.ReadDir(inProgressSnapshotsPath)
 	require.NoError(t, err)
 	require.Len(t, f, 0)

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/mock/snapshot_pvtdatahashes_consumer.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/mock/snapshot_pvtdatahashes_consumer.go
@@ -23,6 +23,16 @@ type SnapshotPvtdataHashesConsumer struct {
 	consumeSnapshotDataReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DoneStub        func() error
+	doneMutex       sync.RWMutex
+	doneArgsForCall []struct {
+	}
+	doneReturns struct {
+		result1 error
+	}
+	doneReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -101,11 +111,65 @@ func (fake *SnapshotPvtdataHashesConsumer) ConsumeSnapshotDataReturnsOnCall(i in
 	}{result1}
 }
 
+func (fake *SnapshotPvtdataHashesConsumer) Done() error {
+	fake.doneMutex.Lock()
+	ret, specificReturn := fake.doneReturnsOnCall[len(fake.doneArgsForCall)]
+	fake.doneArgsForCall = append(fake.doneArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Done", []interface{}{})
+	fake.doneMutex.Unlock()
+	if fake.DoneStub != nil {
+		return fake.DoneStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.doneReturns
+	return fakeReturns.result1
+}
+
+func (fake *SnapshotPvtdataHashesConsumer) DoneCallCount() int {
+	fake.doneMutex.RLock()
+	defer fake.doneMutex.RUnlock()
+	return len(fake.doneArgsForCall)
+}
+
+func (fake *SnapshotPvtdataHashesConsumer) DoneCalls(stub func() error) {
+	fake.doneMutex.Lock()
+	defer fake.doneMutex.Unlock()
+	fake.DoneStub = stub
+}
+
+func (fake *SnapshotPvtdataHashesConsumer) DoneReturns(result1 error) {
+	fake.doneMutex.Lock()
+	defer fake.doneMutex.Unlock()
+	fake.DoneStub = nil
+	fake.doneReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *SnapshotPvtdataHashesConsumer) DoneReturnsOnCall(i int, result1 error) {
+	fake.doneMutex.Lock()
+	defer fake.doneMutex.Unlock()
+	fake.DoneStub = nil
+	if fake.doneReturnsOnCall == nil {
+		fake.doneReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.doneReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *SnapshotPvtdataHashesConsumer) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.consumeSnapshotDataMutex.RLock()
 	defer fake.consumeSnapshotDataMutex.RUnlock()
+	fake.doneMutex.RLock()
+	defer fake.doneMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/snapshot_purge_mgr_builder.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/snapshot_purge_mgr_builder.go
@@ -65,3 +65,7 @@ func (b *PurgeMgrBuilder) ConsumeSnapshotData(
 	}
 	return nil
 }
+
+func (b *PurgeMgrBuilder) Done() error {
+	return nil
+}

--- a/core/ledger/pvtdatastorage/store.go
+++ b/core/ledger/pvtdatastorage/store.go
@@ -151,6 +151,7 @@ func (p *Provider) SnapshotDataImporterFor(
 	lastBlockInSnapshot uint64,
 	membershipProvider ledger.MembershipInfoProvider,
 	configHistoryRetriever *confighistory.Retriever,
+	tempDirRoot string,
 ) (*SnapshotDataImporter, error) {
 	db := p.dbProvider.GetDBHandle(ledgerID)
 	batch := db.NewUpdateBatch()
@@ -165,7 +166,8 @@ func (p *Provider) SnapshotDataImporterFor(
 		p.dbProvider.GetDBHandle(ledgerID),
 		membershipProvider,
 		configHistoryRetriever,
-	), nil
+		tempDirRoot,
+	)
 }
 
 // OpenStore returns a handle to a store

--- a/core/ledger/pvtdatastorage/store_created_from_snapshot_test.go
+++ b/core/ledger/pvtdatastorage/store_created_from_snapshot_test.go
@@ -61,7 +61,7 @@ func TestPvtdataStoreCreatedFromSnapshot(t *testing.T) {
 		)
 
 		snapshotDataImporter, err := p.SnapshotDataImporterFor("test-ledger", 25,
-			newMockMembershipProvider("myOrg"), configHistoryMgr.GetRetriever("test-ledger"),
+			newMockMembershipProvider("myOrg"), configHistoryMgr.GetRetriever("test-ledger"), testDir,
 		)
 		require.NoError(t, err)
 
@@ -70,6 +70,7 @@ func TestPvtdataStoreCreatedFromSnapshot(t *testing.T) {
 				snapshotDataImporter.ConsumeSnapshotData("ns", d.collection, d.keyHash, d.valueHash, d.version),
 			)
 		}
+		require.NoError(t, snapshotDataImporter.Done())
 
 		store, err := p.OpenStore("test-ledger")
 		require.NoError(t, err)
@@ -321,7 +322,22 @@ func TestStoreCreationErrorPath(t *testing.T) {
 	configHistoryMgr, err := confighistorytest.NewMgr(path.Join(testDir, "config-history"))
 	require.NoError(t, err)
 
-	p.Close()
-	_, err = p.SnapshotDataImporterFor("test-ledger", 25, newMockMembershipProvider("myOrg"), configHistoryMgr.GetRetriever("test-ledger"))
-	require.Contains(t, err.Error(), "error while writing snapshot info to db")
+	t.Run("error-while-constructing-snapshot-data-importer", func(t *testing.T) {
+		_, err = p.SnapshotDataImporterFor("test-ledger", 25,
+			newMockMembershipProvider("myOrg"),
+			configHistoryMgr.GetRetriever("test-ledger"),
+			"non-existing-dir",
+		)
+		require.Contains(t, err.Error(), "error while creating temp dir for sorting rows")
+	})
+
+	t.Run("error-while-writing-snapshot-info-into-pvtdata-store", func(t *testing.T) {
+		p.Close()
+		_, err = p.SnapshotDataImporterFor("test-ledger", 25,
+			newMockMembershipProvider("myOrg"),
+			configHistoryMgr.GetRetriever("test-ledger"),
+			testDir,
+		)
+		require.Contains(t, err.Error(), "error while writing snapshot info to db")
+	})
 }


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Description
The pvtdata hashes in the snapshot files are maintained in the sort order of key-hashes. However, the data in pvtdata store is primarily maintained as group by block number. This causes inefficiencies during importing the data in the pvtdata store primarily because without any optimization, we end up performing write for each data item independently.

This would not have been as bad as such, if we write to leveldb with async I/O, however, due to a bug previously observed in leveldb, we always perform every write to leveldb as a sync write. This makes the overall data loading into pvtdata store very poor performing because of significantly high numbers of fsyncs, as observed in the system performance tests.

In this commit, we adopt to a different algorithm where in we sort the snapshot data by block number in a temporary space and group by desired attributes for different entry types in memory and finally write the entries in pvtdata store in batches.