### PR TITLE
[FAB-18308] Add RSA support back

### DIFF
--- a/bccsp/bccsp_test.go
+++ b/bccsp/bccsp_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,6 +45,23 @@ func TestAESOpts(t *testing.T) {
 	require.True(t, opts.Ephemeral())
 	opts.Temporary = false
 	require.False(t, opts.Ephemeral())
+}
+
+func TestRSAOpts(t *testing.T) {
+	test := func(ephemeral bool) {
+		for _, opts := range []KeyGenOpts{
+			&RSA1024KeyGenOpts{ephemeral},
+			&RSA2048KeyGenOpts{ephemeral},
+			&RSA3072KeyGenOpts{ephemeral},
+			&RSA4096KeyGenOpts{ephemeral},
+		} {
+			expectedAlgorithm := reflect.TypeOf(opts).String()[7:14]
+			assert.Equal(t, expectedAlgorithm, opts.Algorithm())
+			assert.Equal(t, ephemeral, opts.Ephemeral())
+		}
+	}
+	test(true)
+	test(false)
 }
 
 func TestECDSAOpts(t *testing.T) {
@@ -116,13 +134,17 @@ func TestHMAC(t *testing.T) {
 
 func TestKeyGenOpts(t *testing.T) {
 	expectedAlgorithms := map[reflect.Type]string{
-		reflect.TypeOf(&HMACImportKeyOpts{}):       "HMAC",
-		reflect.TypeOf(&X509PublicKeyImportOpts{}): "X509Certificate",
-		reflect.TypeOf(&AES256ImportKeyOpts{}):     "AES",
+		reflect.TypeOf(&HMACImportKeyOpts{}):        "HMAC",
+		reflect.TypeOf(&RSAKeyGenOpts{}):            "RSA",
+		reflect.TypeOf(&RSAGoPublicKeyImportOpts{}): "RSA",
+		reflect.TypeOf(&X509PublicKeyImportOpts{}):  "X509Certificate",
+		reflect.TypeOf(&AES256ImportKeyOpts{}):      "AES",
 	}
 	test := func(ephemeral bool) {
 		for _, opts := range []KeyGenOpts{
 			&HMACImportKeyOpts{ephemeral},
+			&RSAKeyGenOpts{ephemeral},
+			&RSAGoPublicKeyImportOpts{ephemeral},
 			&X509PublicKeyImportOpts{ephemeral},
 			&AES256ImportKeyOpts{ephemeral},
 		} {

--- a/bccsp/opts.go
+++ b/bccsp/opts.go
@@ -22,6 +22,19 @@ const (
 	// ECDSAReRand ECDSA key re-randomization
 	ECDSAReRand = "ECDSA_RERAND"
 
+	// RSA at the default security level.
+	// Each BCCSP may or may not support default security level. If not supported than
+	// an error will be returned.
+	RSA = "RSA"
+	// RSA at 1024 bit security level.
+	RSA1024 = "RSA1024"
+	// RSA at 2048 bit security level.
+	RSA2048 = "RSA2048"
+	// RSA at 3072 bit security level.
+	RSA3072 = "RSA3072"
+	// RSA at 4096 bit security level.
+	RSA4096 = "RSA4096"
+
 	// AES Advanced Encryption Standard at the default security level.
 	// Each BCCSP may or may not support default security level. If not supported than
 	// an error will be returned.
@@ -262,5 +275,37 @@ func (opts *X509PublicKeyImportOpts) Algorithm() string {
 // Ephemeral returns true if the key to generate has to be ephemeral,
 // false otherwise.
 func (opts *X509PublicKeyImportOpts) Ephemeral() bool {
+	return opts.Temporary
+}
+
+// RSAKeyGenOpts contains options for RSA key generation.
+type RSAKeyGenOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key generation algorithm identifier (to be used).
+func (opts *RSAKeyGenOpts) Algorithm() string {
+	return RSA
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *RSAKeyGenOpts) Ephemeral() bool {
+	return opts.Temporary
+}
+
+// ECDSAGoPublicKeyImportOpts contains options for RSA key importation from rsa.PublicKey
+type RSAGoPublicKeyImportOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key importation algorithm identifier (to be used).
+func (opts *RSAGoPublicKeyImportOpts) Algorithm() string {
+	return RSA
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *RSAGoPublicKeyImportOpts) Ephemeral() bool {
 	return opts.Temporary
 }

--- a/bccsp/rsaopts.go
+++ b/bccsp/rsaopts.go
@@ -1,0 +1,81 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bccsp
+
+// RSA1024KeyGenOpts contains options for RSA key generation at 1024 security.
+type RSA1024KeyGenOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key generation algorithm identifier (to be used).
+func (opts *RSA1024KeyGenOpts) Algorithm() string {
+	return RSA1024
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *RSA1024KeyGenOpts) Ephemeral() bool {
+	return opts.Temporary
+}
+
+// RSA2048KeyGenOpts contains options for RSA key generation at 2048 security.
+type RSA2048KeyGenOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key generation algorithm identifier (to be used).
+func (opts *RSA2048KeyGenOpts) Algorithm() string {
+	return RSA2048
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *RSA2048KeyGenOpts) Ephemeral() bool {
+	return opts.Temporary
+}
+
+// RSA3072KeyGenOpts contains options for RSA key generation at 3072 security.
+type RSA3072KeyGenOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key generation algorithm identifier (to be used).
+func (opts *RSA3072KeyGenOpts) Algorithm() string {
+	return RSA3072
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *RSA3072KeyGenOpts) Ephemeral() bool {
+	return opts.Temporary
+}
+
+// RSA4096KeyGenOpts contains options for RSA key generation at 4096 security.
+type RSA4096KeyGenOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key generation algorithm identifier (to be used).
+func (opts *RSA4096KeyGenOpts) Algorithm() string {
+	return RSA4096
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *RSA4096KeyGenOpts) Ephemeral() bool {
+	return opts.Temporary
+}

--- a/bccsp/sw/conf.go
+++ b/bccsp/sw/conf.go
@@ -20,6 +20,7 @@ type config struct {
 	ellipticCurve elliptic.Curve
 	hashFunction  func() hash.Hash
 	aesBitLength  int
+	rsaBitLength  int
 }
 
 func (conf *config) setSecurityLevel(securityLevel int, hashFamily string) (err error) {
@@ -39,10 +40,12 @@ func (conf *config) setSecurityLevelSHA2(level int) (err error) {
 	case 256:
 		conf.ellipticCurve = elliptic.P256()
 		conf.hashFunction = sha256.New
+		conf.rsaBitLength = 2048
 		conf.aesBitLength = 32
 	case 384:
 		conf.ellipticCurve = elliptic.P384()
 		conf.hashFunction = sha512.New384
+		conf.rsaBitLength = 3072
 		conf.aesBitLength = 32
 	default:
 		err = fmt.Errorf("Security level not supported [%d]", level)
@@ -55,10 +58,12 @@ func (conf *config) setSecurityLevelSHA3(level int) (err error) {
 	case 256:
 		conf.ellipticCurve = elliptic.P256()
 		conf.hashFunction = sha3.New256
+		conf.rsaBitLength = 2048
 		conf.aesBitLength = 32
 	case 384:
 		conf.ellipticCurve = elliptic.P384()
 		conf.hashFunction = sha3.New384
+		conf.rsaBitLength = 3072
 		conf.aesBitLength = 32
 	default:
 		err = fmt.Errorf("Security level not supported [%d]", level)

--- a/bccsp/sw/keygen.go
+++ b/bccsp/sw/keygen.go
@@ -20,6 +20,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"fmt"
 
 	"github.com/hyperledger/fabric/bccsp"
@@ -49,4 +50,18 @@ func (kg *aesKeyGenerator) KeyGen(opts bccsp.KeyGenOpts) (bccsp.Key, error) {
 	}
 
 	return &aesPrivateKey{lowLevelKey, false}, nil
+}
+
+type rsaKeyGenerator struct {
+	length int
+}
+
+func (kg *rsaKeyGenerator) KeyGen(opts bccsp.KeyGenOpts) (bccsp.Key, error) {
+	lowLevelKey, err := rsa.GenerateKey(rand.Reader, int(kg.length))
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed generating RSA %d key [%s]", kg.length, err)
+	}
+
+	return &rsaPrivateKey{lowLevelKey}, nil
 }

--- a/bccsp/sw/keygen_test.go
+++ b/bccsp/sw/keygen_test.go
@@ -14,6 +14,7 @@ import (
 
 	mocks2 "github.com/hyperledger/fabric/bccsp/mocks"
 	"github.com/hyperledger/fabric/bccsp/sw/mocks"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -73,6 +74,20 @@ func TestAESKeyGenerator(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, aesK.privKey)
 	require.Equal(t, len(aesK.privKey), 32)
+}
+
+func TestRSAKeyGenerator(t *testing.T) {
+	t.Parallel()
+
+	kg := &rsaKeyGenerator{length: 512}
+
+	k, err := kg.KeyGen(nil)
+	assert.NoError(t, err)
+
+	rsaK, ok := k.(*rsaPrivateKey)
+	assert.True(t, ok)
+	assert.NotNil(t, rsaK.privKey)
+	assert.Equal(t, rsaK.privKey.N.BitLen(), 512)
 }
 
 func TestAESKeyGeneratorInvalidInputs(t *testing.T) {

--- a/bccsp/sw/keyimport.go
+++ b/bccsp/sw/keyimport.go
@@ -8,13 +8,17 @@ package sw
 
 import (
 	"crypto/ecdsa"
+	"crypto/rsa"
 	"crypto/x509"
 	"errors"
 	"fmt"
 	"reflect"
 
 	"github.com/hyperledger/fabric/bccsp"
+	"github.com/hyperledger/fabric/common/flogging"
 )
+
+var mspLogger = flogging.MustGetLogger("KeyImport")
 
 type aes256ImportKeyOptsKeyImporter struct{}
 
@@ -111,12 +115,26 @@ func (*ecdsaGoPublicKeyImportOptsKeyImporter) KeyImport(raw interface{}, opts bc
 	return &ecdsaPublicKey{lowLevelKey}, nil
 }
 
+type rsaGoPublicKeyImportOptsKeyImporter struct{}
+
+func (*rsaGoPublicKeyImportOptsKeyImporter) KeyImport(raw interface{}, opts bccsp.KeyImportOpts) (bccsp.Key, error) {
+
+	lowLevelKey, ok := raw.(*rsa.PublicKey)
+	if !ok {
+		return nil, errors.New("Invalid raw material. Expected *rsa.PublicKey.")
+	}
+
+	return &rsaPublicKey{lowLevelKey}, nil
+}
+
 type x509PublicKeyImportOptsKeyImporter struct {
 	bccsp *CSP
 }
 
 func (ki *x509PublicKeyImportOptsKeyImporter) KeyImport(raw interface{}, opts bccsp.KeyImportOpts) (bccsp.Key, error) {
+
 	x509Cert, ok := raw.(*x509.Certificate)
+
 	if !ok {
 		return nil, errors.New("Invalid raw material. Expected *x509.Certificate.")
 	}
@@ -128,7 +146,12 @@ func (ki *x509PublicKeyImportOptsKeyImporter) KeyImport(raw interface{}, opts bc
 		return ki.bccsp.KeyImporters[reflect.TypeOf(&bccsp.ECDSAGoPublicKeyImportOpts{})].KeyImport(
 			pk,
 			&bccsp.ECDSAGoPublicKeyImportOpts{Temporary: opts.Ephemeral()})
+	case *rsa.PublicKey:
+
+		return ki.bccsp.KeyImporters[reflect.TypeOf(&bccsp.RSAGoPublicKeyImportOpts{})].KeyImport(
+			pk,
+			&bccsp.RSAGoPublicKeyImportOpts{Temporary: opts.Ephemeral()})
 	default:
-		return nil, errors.New("Certificate's public key type not recognized. Supported keys: [ECDSA]")
+		return nil, errors.New("Certificate's public key type not recognized. Supported keys: [ECDSA, RSA]")
 	}
 }

--- a/bccsp/sw/keyimport_test.go
+++ b/bccsp/sw/keyimport_test.go
@@ -192,5 +192,5 @@ func TestX509PublicKeyImportOptsKeyImporter(t *testing.T) {
 	cert.PublicKey = "Hello world"
 	_, err = ki.KeyImport(cert, &mocks2.KeyImportOpts{})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Certificate's public key type not recognized. Supported keys: [ECDSA]")
+	require.Contains(t, err.Error(), "Certificate's public key type not recognized. Supported keys: [ECDSA, RSA]")
 }

--- a/bccsp/sw/new.go
+++ b/bccsp/sw/new.go
@@ -60,10 +60,13 @@ func NewWithParams(securityLevel int, hashFamily string, keyStore bccsp.KeyStore
 
 	// Set the Signers
 	swbccsp.AddWrapper(reflect.TypeOf(&ecdsaPrivateKey{}), &ecdsaSigner{})
+	swbccsp.AddWrapper(reflect.TypeOf(&rsaPrivateKey{}), &rsaSigner{})
 
 	// Set the Verifiers
 	swbccsp.AddWrapper(reflect.TypeOf(&ecdsaPrivateKey{}), &ecdsaPrivateKeyVerifier{})
 	swbccsp.AddWrapper(reflect.TypeOf(&ecdsaPublicKey{}), &ecdsaPublicKeyKeyVerifier{})
+	swbccsp.AddWrapper(reflect.TypeOf(&rsaPrivateKey{}), &rsaPrivateKeyVerifier{})
+	swbccsp.AddWrapper(reflect.TypeOf(&rsaPublicKey{}), &rsaPublicKeyKeyVerifier{})
 
 	// Set the Hashers
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.SHAOpts{}), &hasher{hash: conf.hashFunction})
@@ -80,6 +83,11 @@ func NewWithParams(securityLevel int, hashFamily string, keyStore bccsp.KeyStore
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.AES256KeyGenOpts{}), &aesKeyGenerator{length: 32})
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.AES192KeyGenOpts{}), &aesKeyGenerator{length: 24})
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.AES128KeyGenOpts{}), &aesKeyGenerator{length: 16})
+	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSAKeyGenOpts{}), &rsaKeyGenerator{length: conf.rsaBitLength})
+	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSA1024KeyGenOpts{}), &rsaKeyGenerator{length: 1024})
+	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSA2048KeyGenOpts{}), &rsaKeyGenerator{length: 2048})
+	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSA3072KeyGenOpts{}), &rsaKeyGenerator{length: 3072})
+	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSA4096KeyGenOpts{}), &rsaKeyGenerator{length: 4096})
 
 	// Set the key deriver
 	swbccsp.AddWrapper(reflect.TypeOf(&ecdsaPrivateKey{}), &ecdsaPrivateKeyKeyDeriver{})
@@ -92,6 +100,7 @@ func NewWithParams(securityLevel int, hashFamily string, keyStore bccsp.KeyStore
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.ECDSAPKIXPublicKeyImportOpts{}), &ecdsaPKIXPublicKeyImportOptsKeyImporter{})
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.ECDSAPrivateKeyImportOpts{}), &ecdsaPrivateKeyImportOptsKeyImporter{})
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.ECDSAGoPublicKeyImportOpts{}), &ecdsaGoPublicKeyImportOptsKeyImporter{})
+	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSAGoPublicKeyImportOpts{}), &rsaGoPublicKeyImportOptsKeyImporter{})
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.X509PublicKeyImportOpts{}), &x509PublicKeyImportOptsKeyImporter{bccsp: swbccsp})
 
 	return swbccsp, nil

--- a/bccsp/sw/rsa.go
+++ b/bccsp/sw/rsa.go
@@ -1,0 +1,73 @@
+/*
+Copyright IBM Corp. 2017 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sw
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/fabric/bccsp"
+)
+
+type rsaSigner struct{}
+
+func (s *rsaSigner) Sign(k bccsp.Key, digest []byte, opts bccsp.SignerOpts) ([]byte, error) {
+	if opts == nil {
+		return nil, errors.New("Invalid options. Must be different from nil.")
+	}
+	return k.(*rsaPrivateKey).privKey.Sign(rand.Reader, digest, opts)
+}
+
+type rsaPrivateKeyVerifier struct{}
+
+func (v *rsaPrivateKeyVerifier) Verify(k bccsp.Key, signature, digest []byte, opts bccsp.SignerOpts) (bool, error) {
+
+	if opts == nil {
+		return false, errors.New("Invalid options. Must be different from nil.")
+	}
+
+	switch opts.(type) {
+	case *rsa.PSSOptions:
+		err := rsa.VerifyPSS(&(k.(*rsaPrivateKey).privKey.PublicKey),
+			(opts.(*rsa.PSSOptions)).Hash,
+			digest, signature, opts.(*rsa.PSSOptions))
+
+		return err == nil, err
+	default:
+		return false, fmt.Errorf("Opts type not recognized [%s]", opts)
+	}
+}
+
+type rsaPublicKeyKeyVerifier struct{}
+
+func (v *rsaPublicKeyKeyVerifier) Verify(k bccsp.Key, signature, digest []byte, opts bccsp.SignerOpts) (bool, error) {
+	if opts == nil {
+		return false, errors.New("Invalid options. Must be different from nil.")
+	}
+	switch opts.(type) {
+	case *rsa.PSSOptions:
+		err := rsa.VerifyPSS(k.(*rsaPublicKey).pubKey,
+			(opts.(*rsa.PSSOptions)).Hash,
+			digest, signature, opts.(*rsa.PSSOptions))
+
+		return err == nil, err
+	default:
+		return false, fmt.Errorf("Opts type not recognized [%s]", opts)
+	}
+}

--- a/bccsp/sw/rsa_test.go
+++ b/bccsp/sw/rsa_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright IBM Corp. 2017 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sw
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
+	"strings"
+	"testing"
+
+	"github.com/hyperledger/fabric/bccsp/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRSAPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	lowLevelKey, err := rsa.GenerateKey(rand.Reader, 512)
+	assert.NoError(t, err)
+	k := &rsaPrivateKey{lowLevelKey}
+
+	assert.False(t, k.Symmetric())
+	assert.True(t, k.Private())
+
+	_, err = k.Bytes()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Not supported.")
+
+	k.privKey = nil
+	ski := k.SKI()
+	assert.Nil(t, ski)
+
+	k.privKey = lowLevelKey
+	ski = k.SKI()
+	raw, _ := asn1.Marshal(rsaPublicKeyASN{N: k.privKey.N, E: k.privKey.E})
+	hash := sha256.New()
+	hash.Write(raw)
+	ski2 := hash.Sum(nil)
+	assert.Equal(t, ski2, ski, "SKI is not computed in the right way.")
+
+	pk, err := k.PublicKey()
+	assert.NoError(t, err)
+	assert.NotNil(t, pk)
+	ecdsaPK, ok := pk.(*rsaPublicKey)
+	assert.True(t, ok)
+	assert.Equal(t, &lowLevelKey.PublicKey, ecdsaPK.pubKey)
+}
+
+func TestRSAPublicKey(t *testing.T) {
+	t.Parallel()
+
+	lowLevelKey, err := rsa.GenerateKey(rand.Reader, 512)
+	assert.NoError(t, err)
+	k := &rsaPublicKey{&lowLevelKey.PublicKey}
+
+	assert.False(t, k.Symmetric())
+	assert.False(t, k.Private())
+
+	k.pubKey = nil
+	ski := k.SKI()
+	assert.Nil(t, ski)
+
+	k.pubKey = &lowLevelKey.PublicKey
+	ski = k.SKI()
+	raw, _ := asn1.Marshal(rsaPublicKeyASN{N: k.pubKey.N, E: k.pubKey.E})
+	hash := sha256.New()
+	hash.Write(raw)
+	ski2 := hash.Sum(nil)
+	assert.Equal(t, ski, ski2, "SKI is not computed in the right way.")
+
+	pk, err := k.PublicKey()
+	assert.NoError(t, err)
+	assert.Equal(t, k, pk)
+
+	bytes, err := k.Bytes()
+	assert.NoError(t, err)
+	bytes2, err := x509.MarshalPKIXPublicKey(k.pubKey)
+	assert.Equal(t, bytes2, bytes, "bytes are not computed in the right way.")
+}
+
+func TestRSASignerSign(t *testing.T) {
+	t.Parallel()
+
+	signer := &rsaSigner{}
+	verifierPrivateKey := &rsaPrivateKeyVerifier{}
+	verifierPublicKey := &rsaPublicKeyKeyVerifier{}
+
+	// Generate a key
+	lowLevelKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	assert.NoError(t, err)
+	k := &rsaPrivateKey{lowLevelKey}
+	pk, err := k.PublicKey()
+	assert.NoError(t, err)
+
+	// Sign
+	msg := []byte("Hello World!!!")
+
+	_, err = signer.Sign(k, msg, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid options. Must be different from nil.")
+
+	_, err = signer.Sign(k, msg, &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash, Hash: crypto.SHA256})
+	assert.Error(t, err)
+
+	hf := sha256.New()
+	hf.Write(msg)
+	digest := hf.Sum(nil)
+	sigma, err := signer.Sign(k, digest, &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash, Hash: crypto.SHA256})
+	assert.NoError(t, err)
+
+	opts := &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash, Hash: crypto.SHA256}
+	// Verify against msg, must fail
+	err = rsa.VerifyPSS(&lowLevelKey.PublicKey, crypto.SHA256, msg, sigma, opts)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "crypto/rsa: verification error")
+
+	// Verify against digest, must succeed
+	err = rsa.VerifyPSS(&lowLevelKey.PublicKey, crypto.SHA256, digest, sigma, opts)
+	assert.NoError(t, err)
+
+	valid, err := verifierPrivateKey.Verify(k, sigma, msg, opts)
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "crypto/rsa: verification error"))
+
+	valid, err = verifierPrivateKey.Verify(k, sigma, digest, opts)
+	assert.NoError(t, err)
+	assert.True(t, valid)
+
+	valid, err = verifierPublicKey.Verify(pk, sigma, msg, opts)
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "crypto/rsa: verification error"))
+
+	valid, err = verifierPublicKey.Verify(pk, sigma, digest, opts)
+	assert.NoError(t, err)
+	assert.True(t, valid)
+}
+
+func TestRSAVerifiersInvalidInputs(t *testing.T) {
+	t.Parallel()
+
+	verifierPrivate := &rsaPrivateKeyVerifier{}
+	_, err := verifierPrivate.Verify(nil, nil, nil, nil)
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "Invalid options. Must be different from nil."))
+
+	_, err = verifierPrivate.Verify(nil, nil, nil, &mocks.SignerOpts{})
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "Opts type not recognized ["))
+
+	verifierPublic := &rsaPublicKeyKeyVerifier{}
+	_, err = verifierPublic.Verify(nil, nil, nil, nil)
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "Invalid options. Must be different from nil."))
+
+	_, err = verifierPublic.Verify(nil, nil, nil, &mocks.SignerOpts{})
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "Opts type not recognized ["))
+}

--- a/bccsp/sw/rsakey.go
+++ b/bccsp/sw/rsakey.go
@@ -1,0 +1,133 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package sw
+
+import (
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/hyperledger/fabric/bccsp"
+)
+
+// rsaPublicKey reflects the ASN.1 structure of a PKCS#1 public key.
+type rsaPublicKeyASN struct {
+	N *big.Int
+	E int
+}
+
+type rsaPrivateKey struct {
+	privKey *rsa.PrivateKey
+}
+
+// Bytes converts this key to its byte representation,
+// if this operation is allowed.
+func (k *rsaPrivateKey) Bytes() ([]byte, error) {
+	return nil, errors.New("Not supported.")
+}
+
+// SKI returns the subject key identifier of this key.
+func (k *rsaPrivateKey) SKI() []byte {
+	if k.privKey == nil {
+		return nil
+	}
+
+	// Marshall the public key
+	raw, _ := asn1.Marshal(rsaPublicKeyASN{
+		N: k.privKey.N,
+		E: k.privKey.E,
+	})
+
+	// Hash it
+	hash := sha256.New()
+	hash.Write(raw)
+	return hash.Sum(nil)
+}
+
+// Symmetric returns true if this key is a symmetric key,
+// false is this key is asymmetric
+func (k *rsaPrivateKey) Symmetric() bool {
+	return false
+}
+
+// Private returns true if this key is an asymmetric private key,
+// false otherwise.
+func (k *rsaPrivateKey) Private() bool {
+	return true
+}
+
+// PublicKey returns the corresponding public key part of an asymmetric public/private key pair.
+// This method returns an error in symmetric key schemes.
+func (k *rsaPrivateKey) PublicKey() (bccsp.Key, error) {
+	return &rsaPublicKey{&k.privKey.PublicKey}, nil
+}
+
+type rsaPublicKey struct {
+	pubKey *rsa.PublicKey
+}
+
+// Bytes converts this key to its byte representation,
+// if this operation is allowed.
+func (k *rsaPublicKey) Bytes() (raw []byte, err error) {
+	if k.pubKey == nil {
+		return nil, errors.New("Failed marshalling key. Key is nil.")
+	}
+	raw, err = x509.MarshalPKIXPublicKey(k.pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("Failed marshalling key [%s]", err)
+	}
+	return
+}
+
+// SKI returns the subject key identifier of this key.
+func (k *rsaPublicKey) SKI() []byte {
+	if k.pubKey == nil {
+		return nil
+	}
+
+	// Marshall the public key
+	raw, _ := asn1.Marshal(rsaPublicKeyASN{
+		N: k.pubKey.N,
+		E: k.pubKey.E,
+	})
+
+	// Hash it
+	hash := sha256.New()
+	hash.Write(raw)
+	return hash.Sum(nil)
+}
+
+// Symmetric returns true if this key is a symmetric key,
+// false is this key is asymmetric
+func (k *rsaPublicKey) Symmetric() bool {
+	return false
+}
+
+// Private returns true if this key is an asymmetric private key,
+// false otherwise.
+func (k *rsaPublicKey) Private() bool {
+	return false
+}
+
+// PublicKey returns the corresponding public key part of an asymmetric public/private key pair.
+// This method returns an error in symmetric key schemes.
+func (k *rsaPublicKey) PublicKey() (bccsp.Key, error) {
+	return k, nil
+}

--- a/bccsp/utils/keys_test.go
+++ b/bccsp/utils/keys_test.go
@@ -1,0 +1,427 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOidFromNamedCurve(t *testing.T) {
+
+	var (
+		oidNamedCurveP224 = asn1.ObjectIdentifier{1, 3, 132, 0, 33}
+		oidNamedCurveP256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7}
+		oidNamedCurveP384 = asn1.ObjectIdentifier{1, 3, 132, 0, 34}
+		oidNamedCurveP521 = asn1.ObjectIdentifier{1, 3, 132, 0, 35}
+	)
+
+	type result struct {
+		oid asn1.ObjectIdentifier
+		ok  bool
+	}
+
+	var tests = []struct {
+		name     string
+		curve    elliptic.Curve
+		expected result
+	}{
+		{
+			name:  "P224",
+			curve: elliptic.P224(),
+			expected: result{
+				oid: oidNamedCurveP224,
+				ok:  true,
+			},
+		},
+		{
+			name:  "P256",
+			curve: elliptic.P256(),
+			expected: result{
+				oid: oidNamedCurveP256,
+				ok:  true,
+			},
+		},
+		{
+			name:  "P384",
+			curve: elliptic.P384(),
+			expected: result{
+				oid: oidNamedCurveP384,
+				ok:  true,
+			},
+		},
+		{
+			name:  "P521",
+			curve: elliptic.P521(),
+			expected: result{
+				oid: oidNamedCurveP521,
+				ok:  true,
+			},
+		},
+		{
+			name:  "T-1000",
+			curve: &elliptic.CurveParams{Name: "T-1000"},
+			expected: result{
+				oid: nil,
+				ok:  false,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			oid, ok := oidFromNamedCurve(test.curve)
+			assert.Equal(t, oid, test.expected.oid)
+			assert.Equal(t, ok, test.expected.ok)
+		})
+	}
+
+}
+
+func TestECDSAKeys(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed generating ECDSA key [%s]", err)
+	}
+
+	// Private Key DER format
+	der, err := PrivateKeyToDER(key)
+	if err != nil {
+		t.Fatalf("Failed converting private key to DER [%s]", err)
+	}
+	keyFromDER, err := DERToPrivateKey(der)
+	if err != nil {
+		t.Fatalf("Failed converting DER to private key [%s]", err)
+	}
+	ecdsaKeyFromDer := keyFromDER.(*ecdsa.PrivateKey)
+	// TODO: check the curve
+	if key.D.Cmp(ecdsaKeyFromDer.D) != 0 {
+		t.Fatal("Failed converting DER to private key. Invalid D.")
+	}
+	if key.X.Cmp(ecdsaKeyFromDer.X) != 0 {
+		t.Fatal("Failed converting DER to private key. Invalid X coordinate.")
+	}
+	if key.Y.Cmp(ecdsaKeyFromDer.Y) != 0 {
+		t.Fatal("Failed converting DER to private key. Invalid Y coordinate.")
+	}
+
+	// Private Key PEM format
+	rawPEM, err := PrivateKeyToPEM(key, nil)
+	if err != nil {
+		t.Fatalf("Failed converting private key to PEM [%s]", err)
+	}
+	pemBlock, _ := pem.Decode(rawPEM)
+	if pemBlock.Type != "PRIVATE KEY" {
+		t.Fatalf("Expected type 'PRIVATE KEY' but found '%s'", pemBlock.Type)
+	}
+	_, err = x509.ParsePKCS8PrivateKey(pemBlock.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse PKCS#8 private key [%s]", err)
+	}
+	keyFromPEM, err := PEMtoPrivateKey(rawPEM, nil)
+	if err != nil {
+		t.Fatalf("Failed converting DER to private key [%s]", err)
+	}
+	ecdsaKeyFromPEM := keyFromPEM.(*ecdsa.PrivateKey)
+	// TODO: check the curve
+	if key.D.Cmp(ecdsaKeyFromPEM.D) != 0 {
+		t.Fatal("Failed converting PEM to private key. Invalid D.")
+	}
+	if key.X.Cmp(ecdsaKeyFromPEM.X) != 0 {
+		t.Fatal("Failed converting PEM to private key. Invalid X coordinate.")
+	}
+	if key.Y.Cmp(ecdsaKeyFromPEM.Y) != 0 {
+		t.Fatal("Failed converting PEM to private key. Invalid Y coordinate.")
+	}
+
+	// Nil Private Key <-> PEM
+	_, err = PrivateKeyToPEM(nil, nil)
+	if err == nil {
+		t.Fatal("PublicKeyToPEM should fail on nil")
+	}
+
+	_, err = PrivateKeyToPEM((*ecdsa.PrivateKey)(nil), nil)
+	if err == nil {
+		t.Fatal("PrivateKeyToPEM should fail on nil")
+	}
+
+	_, err = PrivateKeyToPEM((*rsa.PrivateKey)(nil), nil)
+	if err == nil {
+		t.Fatal("PrivateKeyToPEM should fail on nil")
+	}
+
+	_, err = PEMtoPrivateKey(nil, nil)
+	if err == nil {
+		t.Fatal("PEMtoPublicKey should fail on nil")
+	}
+
+	_, err = PEMtoPrivateKey([]byte{0, 1, 3, 4}, nil)
+	if err == nil {
+		t.Fatal("PEMtoPublicKey should fail invalid PEM")
+	}
+
+	_, err = DERToPrivateKey(nil)
+	if err == nil {
+		t.Fatal("DERToPrivateKey should fail on nil")
+	}
+
+	_, err = DERToPrivateKey([]byte{0, 1, 3, 4})
+	if err == nil {
+		t.Fatal("DERToPrivateKey should fail on invalid DER")
+	}
+
+	_, err = PrivateKeyToDER(nil)
+	if err == nil {
+		t.Fatal("DERToPrivateKey should fail on nil")
+	}
+
+	// Private Key Encrypted PEM format
+	encPEM, err := PrivateKeyToPEM(key, []byte("passwd"))
+	if err != nil {
+		t.Fatalf("Failed converting private key to encrypted PEM [%s]", err)
+	}
+	_, err = PEMtoPrivateKey(encPEM, nil)
+	assert.Error(t, err)
+	encKeyFromPEM, err := PEMtoPrivateKey(encPEM, []byte("passwd"))
+	if err != nil {
+		t.Fatalf("Failed converting DER to private key [%s]", err)
+	}
+	ecdsaKeyFromEncPEM := encKeyFromPEM.(*ecdsa.PrivateKey)
+	// TODO: check the curve
+	if key.D.Cmp(ecdsaKeyFromEncPEM.D) != 0 {
+		t.Fatal("Failed converting encrypted PEM to private key. Invalid D.")
+	}
+	if key.X.Cmp(ecdsaKeyFromEncPEM.X) != 0 {
+		t.Fatal("Failed converting encrypted PEM to private key. Invalid X coordinate.")
+	}
+	if key.Y.Cmp(ecdsaKeyFromEncPEM.Y) != 0 {
+		t.Fatal("Failed converting encrypted PEM to private key. Invalid Y coordinate.")
+	}
+
+	// Public Key PEM format
+	rawPEM, err = PublicKeyToPEM(&key.PublicKey, nil)
+	if err != nil {
+		t.Fatalf("Failed converting public key to PEM [%s]", err)
+	}
+	pemBlock, _ = pem.Decode(rawPEM)
+	if pemBlock.Type != "PUBLIC KEY" {
+		t.Fatalf("Expected type 'PUBLIC KEY' but found '%s'", pemBlock.Type)
+	}
+	keyFromPEM, err = PEMtoPublicKey(rawPEM, nil)
+	if err != nil {
+		t.Fatalf("Failed converting DER to public key [%s]", err)
+	}
+	ecdsaPkFromPEM := keyFromPEM.(*ecdsa.PublicKey)
+	// TODO: check the curve
+	if key.X.Cmp(ecdsaPkFromPEM.X) != 0 {
+		t.Fatal("Failed converting PEM to private key. Invalid X coordinate.")
+	}
+	if key.Y.Cmp(ecdsaPkFromPEM.Y) != 0 {
+		t.Fatal("Failed converting PEM to private key. Invalid Y coordinate.")
+	}
+
+	// Nil Public Key <-> PEM
+	_, err = PublicKeyToPEM(nil, nil)
+	if err == nil {
+		t.Fatal("PublicKeyToPEM should fail on nil")
+	}
+
+	_, err = PEMtoPublicKey(nil, nil)
+	if err == nil {
+		t.Fatal("PEMtoPublicKey should fail on nil")
+	}
+
+	_, err = PEMtoPublicKey([]byte{0, 1, 3, 4}, nil)
+	if err == nil {
+		t.Fatal("PEMtoPublicKey should fail on invalid PEM")
+	}
+
+	// Public Key Encrypted PEM format
+	encPEM, err = PublicKeyToPEM(&key.PublicKey, []byte("passwd"))
+	if err != nil {
+		t.Fatalf("Failed converting private key to encrypted PEM [%s]", err)
+	}
+	_, err = PEMtoPublicKey(encPEM, nil)
+	assert.Error(t, err)
+	pkFromEncPEM, err := PEMtoPublicKey(encPEM, []byte("passwd"))
+	if err != nil {
+		t.Fatalf("Failed converting DER to private key [%s]", err)
+	}
+	ecdsaPkFromEncPEM := pkFromEncPEM.(*ecdsa.PublicKey)
+	// TODO: check the curve
+	if key.X.Cmp(ecdsaPkFromEncPEM.X) != 0 {
+		t.Fatal("Failed converting encrypted PEM to private key. Invalid X coordinate.")
+	}
+	if key.Y.Cmp(ecdsaPkFromEncPEM.Y) != 0 {
+		t.Fatal("Failed converting encrypted PEM to private key. Invalid Y coordinate.")
+	}
+
+	_, err = PEMtoPublicKey(encPEM, []byte("passw"))
+	if err == nil {
+		t.Fatal("PEMtoPublicKey should fail on wrong password")
+	}
+
+	_, err = PEMtoPublicKey(encPEM, []byte("passw"))
+	if err == nil {
+		t.Fatal("PEMtoPublicKey should fail on nil password")
+	}
+
+	_, err = PEMtoPublicKey(nil, []byte("passwd"))
+	if err == nil {
+		t.Fatal("PEMtoPublicKey should fail on nil PEM")
+	}
+
+	_, err = PEMtoPublicKey([]byte{0, 1, 3, 4}, []byte("passwd"))
+	if err == nil {
+		t.Fatal("PEMtoPublicKey should fail on invalid PEM")
+	}
+
+	_, err = PEMtoPublicKey(nil, []byte("passw"))
+	if err == nil {
+		t.Fatal("PEMtoPublicKey should fail on nil PEM and wrong password")
+	}
+
+	// Public Key DER format
+	der, err = PublicKeyToDER(&key.PublicKey)
+	assert.NoError(t, err)
+	keyFromDER, err = DERToPublicKey(der)
+	assert.NoError(t, err)
+	ecdsaPkFromPEM = keyFromDER.(*ecdsa.PublicKey)
+	// TODO: check the curve
+	if key.X.Cmp(ecdsaPkFromPEM.X) != 0 {
+		t.Fatal("Failed converting PEM to private key. Invalid X coordinate.")
+	}
+	if key.Y.Cmp(ecdsaPkFromPEM.Y) != 0 {
+		t.Fatal("Failed converting PEM to private key. Invalid Y coordinate.")
+	}
+}
+
+func TestAESKey(t *testing.T) {
+	k := []byte{0, 1, 2, 3, 4, 5}
+	pem := AEStoPEM(k)
+
+	k2, err := PEMtoAES(pem, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, k, k2)
+
+	pem, err = AEStoEncryptedPEM(k, k)
+	assert.NoError(t, err)
+
+	k2, err = PEMtoAES(pem, k)
+	assert.NoError(t, err)
+	assert.Equal(t, k, k2)
+
+	_, err = PEMtoAES(pem, nil)
+	assert.Error(t, err)
+
+	_, err = AEStoEncryptedPEM(k, nil)
+	assert.NoError(t, err)
+
+	k2, err = PEMtoAES(pem, k)
+	assert.NoError(t, err)
+	assert.Equal(t, k, k2)
+}
+
+func TestDERToPublicKey(t *testing.T) {
+	_, err := DERToPublicKey(nil)
+	assert.Error(t, err)
+}
+
+func TestNil(t *testing.T) {
+	_, err := PrivateKeyToEncryptedPEM(nil, nil)
+	assert.Error(t, err)
+
+	_, err = PrivateKeyToEncryptedPEM((*ecdsa.PrivateKey)(nil), nil)
+	assert.Error(t, err)
+
+	_, err = PrivateKeyToEncryptedPEM("Hello World", nil)
+	assert.Error(t, err)
+
+	_, err = PEMtoAES(nil, nil)
+	assert.Error(t, err)
+
+	_, err = AEStoEncryptedPEM(nil, nil)
+	assert.Error(t, err)
+
+	_, err = PublicKeyToPEM(nil, nil)
+	assert.Error(t, err)
+	_, err = PublicKeyToPEM((*ecdsa.PublicKey)(nil), nil)
+	assert.Error(t, err)
+	_, err = PublicKeyToPEM((*rsa.PublicKey)(nil), nil)
+	assert.Error(t, err)
+	_, err = PublicKeyToPEM(nil, []byte("hello world"))
+	assert.Error(t, err)
+
+	_, err = PublicKeyToPEM("hello world", nil)
+	assert.Error(t, err)
+	_, err = PublicKeyToPEM("hello world", []byte("hello world"))
+	assert.Error(t, err)
+
+	_, err = PublicKeyToDER(nil)
+	assert.Error(t, err)
+	_, err = PublicKeyToDER((*ecdsa.PublicKey)(nil))
+	assert.Error(t, err)
+	_, err = PublicKeyToDER((*rsa.PublicKey)(nil))
+	assert.Error(t, err)
+	_, err = PublicKeyToDER("hello world")
+	assert.Error(t, err)
+
+	_, err = PublicKeyToEncryptedPEM(nil, nil)
+	assert.Error(t, err)
+	_, err = PublicKeyToEncryptedPEM((*ecdsa.PublicKey)(nil), nil)
+	assert.Error(t, err)
+	_, err = PublicKeyToEncryptedPEM("hello world", nil)
+	assert.Error(t, err)
+	_, err = PublicKeyToEncryptedPEM("hello world", []byte("Hello world"))
+	assert.Error(t, err)
+
+}
+
+func TestPrivateKeyToPEM(t *testing.T) {
+	_, err := PrivateKeyToPEM(nil, nil)
+	assert.Error(t, err)
+
+	_, err = PrivateKeyToPEM("hello world", nil)
+	assert.Error(t, err)
+
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	assert.NoError(t, err)
+	pem, err := PrivateKeyToPEM(key, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, pem)
+	key2, err := PEMtoPrivateKey(pem, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, key2)
+	assert.Equal(t, key.D, key2.(*rsa.PrivateKey).D)
+
+	pem, err = PublicKeyToPEM(&key.PublicKey, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, pem)
+	key3, err := PEMtoPublicKey(pem, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, key2)
+	assert.Equal(t, key.PublicKey.E, key3.(*rsa.PublicKey).E)
+	assert.Equal(t, key.PublicKey.N, key3.(*rsa.PublicKey).N)
+}


### PR DESCRIPTION
#### Make it possible to upgrade from a ledger with rsa certificates

- Bug fix

#### Description

It's not possible to upgrade from fabric 1.4 using an existing ledger with rsa certificates.

#### Related issues

[FAB-18308 ](https://jira.hyperledger.org/projects/FAB/issues/FAB-18308)
