### PR TITLE
[FAB-18307] IT: set DeprioritizedDataReconcilerInterval to prevent CI flake

### DIFF
--- a/integration/ledger/snapshot_test.go
+++ b/integration/ledger/snapshot_test.go
@@ -571,9 +571,12 @@ func initAndStartFourOrgsNetwork() *setup {
 	n.Bootstrap()
 
 	// set ReconcileSleepInterval to 1 second to reconcile pvtdata faster
+	// set DeprioritizedDataReconcilerInterval to 2 seconds to resume reconciliation quickly
+	// to prevent CI flake in case peer connection is temporarily lost.
 	for _, p := range n.Peers {
 		core := n.ReadPeerConfig(p)
 		core.Peer.Gossip.PvtData.ReconcileSleepInterval = 1 * time.Second
+		core.Ledger.PvtdataStore.DeprioritizedDataReconcilerInterval = 2 * time.Second
 		n.WritePeerConfig(p, core)
 	}
 

--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -217,6 +217,8 @@ ledger:
       warmIndexesAfterNBlocks: 1
   history:
     enableHistoryDatabase: true
+  pvtdataStore:
+    deprioritizedDataReconcilerInterval: 60m
 
 operations:
   listenAddress: 127.0.0.1:{{ .PeerPort Peer "Operations" }}

--- a/integration/nwo/fabricconfig/core.go
+++ b/integration/nwo/fabricconfig/core.go
@@ -294,8 +294,9 @@ type SystemFlags struct {
 
 type Ledger struct {
 	// Blockchain - not sure if it's needed
-	State   *StateConfig   `yaml:"state,omitempty"`
-	History *HistoryConfig `yaml:"history,omitempty"`
+	State        *StateConfig   `yaml:"state,omitempty"`
+	History      *HistoryConfig `yaml:"history,omitempty"`
+	PvtdataStore *PvtdataStore  `yaml:"pvtdataStore,omitempty"`
 }
 
 type StateConfig struct {
@@ -317,6 +318,10 @@ type CouchDBConfig struct {
 
 type HistoryConfig struct {
 	EnableHistoryDatabase bool `yaml:"enableHistoryDatabase"`
+}
+
+type PvtdataStore struct {
+	DeprioritizedDataReconcilerInterval time.Duration
 }
 
 type Operations struct {


### PR DESCRIPTION
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Test update

#### Description
Pvtdata reconciliation will fail in case the peer temporarily loses connection
to another peer that provides the pvtdata during IT test. This could cause CI flake
because the missing data were put to a deprioritized list. To prevent the flake,
set deprioritizedDataReconcilerInterval to a small value so that the missing data can be reconciled quickly.

#### Related issues
https://jira.hyperledger.org/browse/FAB-18307
