### PR TITLE
[FAB-18298] Default cluster cert and key 

### DIFF
--- a/integration/raft/cft_test.go
+++ b/integration/raft/cft_test.go
@@ -470,6 +470,8 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 				ordererConfig.General.Cluster.ListenAddress = ""
 				ordererConfig.General.Cluster.ServerCertificate = ""
 				ordererConfig.General.Cluster.ServerPrivateKey = ""
+				ordererConfig.General.Cluster.ClientCertificate = ""
+				ordererConfig.General.Cluster.ClientPrivateKey = ""
 				network.WriteOrdererConfig(orderer, ordererConfig)
 			}
 

--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -195,14 +195,102 @@ func TestInitializeServerConfig(t *testing.T) {
 		clusterCert    string
 		clusterKey     string
 		clusterCA      string
+		isCluster      bool
 	}{
-		{"BadCertificate", badFile, goodFile, goodFile, goodFile, "", "", ""},
-		{"BadPrivateKey", goodFile, badFile, goodFile, goodFile, "", "", ""},
-		{"BadRootCA", goodFile, goodFile, badFile, goodFile, "", "", ""},
-		{"BadClientRootCertificate", goodFile, goodFile, goodFile, badFile, "", "", ""},
-		{"ClusterBadCertificate", goodFile, goodFile, goodFile, goodFile, badFile, goodFile, goodFile},
-		{"ClusterBadPrivateKey", goodFile, goodFile, goodFile, goodFile, goodFile, badFile, goodFile},
-		{"ClusterBadRootCA", goodFile, goodFile, goodFile, goodFile, goodFile, goodFile, badFile},
+		{
+			name:           "BadCertificate",
+			certificate:    badFile,
+			privateKey:     goodFile,
+			rootCA:         goodFile,
+			clientRootCert: goodFile,
+		},
+		{
+			name:           "BadPrivateKey",
+			certificate:    goodFile,
+			privateKey:     badFile,
+			rootCA:         goodFile,
+			clientRootCert: goodFile,
+		},
+		{
+			name:           "BadRootCA",
+			certificate:    goodFile,
+			privateKey:     goodFile,
+			rootCA:         badFile,
+			clientRootCert: goodFile,
+		},
+		{
+			name:           "BadClientRootCertificate",
+			certificate:    goodFile,
+			privateKey:     goodFile,
+			rootCA:         goodFile,
+			clientRootCert: badFile,
+		},
+		{
+			name:           "BadCertificate - cluster reuses server config",
+			certificate:    badFile,
+			privateKey:     goodFile,
+			rootCA:         goodFile,
+			clientRootCert: goodFile,
+			clusterCert:    "",
+			clusterKey:     "",
+			clusterCA:      "",
+			isCluster:      true,
+		},
+		{
+			name:           "BadPrivateKey - cluster reuses server config",
+			certificate:    goodFile,
+			privateKey:     badFile,
+			rootCA:         goodFile,
+			clientRootCert: goodFile,
+			clusterCert:    "",
+			clusterKey:     "",
+			clusterCA:      "",
+			isCluster:      true,
+		},
+		{
+			name:           "BadRootCA - cluster reuses server config",
+			certificate:    goodFile,
+			privateKey:     goodFile,
+			rootCA:         badFile,
+			clientRootCert: goodFile,
+			clusterCert:    "",
+			clusterKey:     "",
+			clusterCA:      "",
+			isCluster:      true,
+		},
+		{
+			name:           "ClusterBadCertificate",
+			certificate:    goodFile,
+			privateKey:     goodFile,
+			rootCA:         goodFile,
+			clientRootCert: goodFile,
+			clusterCert:    badFile,
+			clusterKey:     goodFile,
+			clusterCA:      goodFile,
+			isCluster:      true,
+		},
+		{
+			name:           "ClusterBadPrivateKey",
+			certificate:    goodFile,
+			privateKey:     goodFile,
+			rootCA:         goodFile,
+			clientRootCert: goodFile,
+			clusterCert:    goodFile,
+			clusterKey:     badFile,
+			clusterCA:      goodFile,
+			isCluster:      true,
+		},
+		{
+			name:           "ClusterBadRootCA",
+			certificate:    goodFile,
+			privateKey:     goodFile,
+			rootCA:         goodFile,
+			clientRootCert: goodFile,
+			clusterCert:    goodFile,
+			clusterKey:     goodFile,
+			clusterCA:      badFile,
+			isCluster:      true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -224,7 +312,7 @@ func TestInitializeServerConfig(t *testing.T) {
 				},
 			}
 			require.Panics(t, func() {
-				if tc.clusterCert == "" {
+				if !tc.isCluster {
 					initializeServerConfig(conf, nil)
 				} else {
 					initializeClusterClientConfig(conf)


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

When cluster listener is reused, default cluster client certificate and private key (if not set) to the TLS server certificate and key.

#### Related issues

[FAB-18298](https://jira.hyperledger.org/browse/FAB-18298)
