### PR TITLE
Rename cluster relation member to consenter

### DIFF
--- a/integration/raft/channel_participation_test.go
+++ b/integration/raft/channel_participation_test.go
@@ -122,7 +122,7 @@ var _ = Describe("ChannelParticipation", func() {
 			orderer2 := network.Orderer("orderer2")
 			orderer3 := network.Orderer("orderer3")
 			orderers := []*nwo.Orderer{orderer1, orderer2, orderer3}
-			members := []*nwo.Orderer{orderer1, orderer2}
+			consenters := []*nwo.Orderer{orderer1, orderer2}
 			peer := network.Peer("Org1", "peer0")
 
 			By("starting all three orderers")
@@ -131,35 +131,35 @@ var _ = Describe("ChannelParticipation", func() {
 				channelparticipation.List(network, o, nil)
 			}
 
-			genesisBlock := applicationChannelGenesisBlock(network, members, peer, "participation-trophy")
+			genesisBlock := applicationChannelGenesisBlock(network, consenters, peer, "participation-trophy")
 			expectedChannelInfoPT := channelparticipation.ChannelInfo{
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          1,
 			}
 
-			for _, o := range members {
-				By("joining " + o.Name + " to channel as a member")
+			for _, o := range consenters {
+				By("joining " + o.Name + " to channel as a consenter")
 				channelparticipation.Join(network, o, "participation-trophy", genesisBlock, expectedChannelInfoPT)
 				channelInfo := channelparticipation.ListOne(network, o, "participation-trophy")
 				Expect(channelInfo).To(Equal(expectedChannelInfoPT))
 			}
 
-			submitPeerTxn(orderer1, peer, network, members, 1, channelparticipation.ChannelInfo{
+			submitPeerTxn(orderer1, peer, network, consenters, 1, channelparticipation.ChannelInfo{
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          2,
 			})
 
-			submitPeerTxn(orderer2, peer, network, members, 2, channelparticipation.ChannelInfo{
+			submitPeerTxn(orderer2, peer, network, consenters, 2, channelparticipation.ChannelInfo{
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          3,
 			})
 
@@ -189,7 +189,7 @@ var _ = Describe("ChannelParticipation", func() {
 			Expect(err).NotTo(HaveOccurred())
 			computeSignSubmitConfigUpdate(network, orderer1, peer, c, "participation-trophy")
 
-			By("ensuring orderer3 transitions from follower to member")
+			By("ensuring orderer3 transitions from follower to consenter")
 			// config update above added a block
 			expectedChannelInfoPT.Height = 4
 			Eventually(func() channelparticipation.ChannelInfo {
@@ -201,17 +201,17 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          5,
 			})
 
-			By("joining orderer1 to another channel as a member")
+			By("joining orderer1 to another channel as a consenter")
 			genesisBlockAPT := applicationChannelGenesisBlock(network, []*nwo.Orderer{orderer1}, peer, "another-participation-trophy")
 			expectedChannelInfoAPT := channelparticipation.ChannelInfo{
 				Name:            "another-participation-trophy",
 				URL:             "/participation/v1/channels/another-participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          1,
 			}
 			channelparticipation.Join(network, orderer1, "another-participation-trophy", genesisBlockAPT, expectedChannelInfoAPT)
@@ -239,12 +239,12 @@ var _ = Describe("ChannelParticipation", func() {
 				Height:          6,
 			}))
 
-			members = []*nwo.Orderer{orderer2, orderer3}
-			submitPeerTxn(orderer2, peer, network, members, 6, channelparticipation.ChannelInfo{
+			consenters = []*nwo.Orderer{orderer2, orderer3}
+			submitPeerTxn(orderer2, peer, network, consenters, 6, channelparticipation.ChannelInfo{
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          7,
 			})
 
@@ -266,19 +266,19 @@ var _ = Describe("ChannelParticipation", func() {
 			channelparticipation.List(network, orderer1, []string{"another-participation-trophy"})
 
 			By("ensuring the channel is still usable by submitting a transaction to each remaining consenter for the channel")
-			submitPeerTxn(orderer2, peer, network, members, 7, channelparticipation.ChannelInfo{
+			submitPeerTxn(orderer2, peer, network, consenters, 7, channelparticipation.ChannelInfo{
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          8,
 			})
 
-			submitPeerTxn(orderer3, peer, network, members, 8, channelparticipation.ChannelInfo{
+			submitPeerTxn(orderer3, peer, network, consenters, 8, channelparticipation.ChannelInfo{
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          9,
 			})
 
@@ -297,7 +297,7 @@ var _ = Describe("ChannelParticipation", func() {
 			channelparticipationJoinFailure(network, orderer3, "systemchannel", systemChannelBlock, http.StatusForbidden, "cannot join: application channels already exist")
 		})
 
-		It("joins application channels with join-block as member via channel participation api", func() {
+		It("joins application channels with join-block as consenter via channel participation api", func() {
 			orderer1 := network.Orderer("orderer1")
 			orderer2 := network.Orderer("orderer2")
 			orderer3 := network.Orderer("orderer3")
@@ -315,12 +315,12 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          1,
 			}
 
 			for _, o := range orderers {
-				By("joining " + o.Name + " to channel as a member")
+				By("joining " + o.Name + " to channel as a consenter")
 				channelparticipation.Join(network, o, "participation-trophy", genesisBlock, expectedChannelInfoPT)
 				channelInfo := channelparticipation.ListOne(network, o, "participation-trophy")
 				Expect(channelInfo).To(Equal(expectedChannelInfoPT))
@@ -330,7 +330,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          2,
 			})
 
@@ -338,7 +338,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          3,
 			})
 
@@ -363,30 +363,30 @@ var _ = Describe("ChannelParticipation", func() {
 			Expect(err).NotTo(HaveOccurred())
 			computeSignSubmitConfigUpdate(network, orderer2, peer, c, "participation-trophy")
 
-			By("joining orderer3 to the channel as a member")
+			By("joining orderer3 to the channel as a consenter")
 			// make sure we can join using a config block from one of the other orderers
 			configBlockPT := nwo.GetConfigBlock(network, peer, orderer2, "participation-trophy")
-			expectedChannelInfoMember := channelparticipation.ChannelInfo{
+			expectedChannelInfoConsenter := channelparticipation.ChannelInfo{
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "onboarding",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          0,
 			}
-			channelparticipation.Join(network, orderer3, "participation-trophy", configBlockPT, expectedChannelInfoMember)
+			channelparticipation.Join(network, orderer3, "participation-trophy", configBlockPT, expectedChannelInfoConsenter)
 
 			By("ensuring orderer3 completes onboarding successfully")
-			expectedChannelInfoMember.Status = "active"
-			expectedChannelInfoMember.Height = 5
+			expectedChannelInfoConsenter.Status = "active"
+			expectedChannelInfoConsenter.Height = 5
 			Eventually(func() channelparticipation.ChannelInfo {
 				return channelparticipation.ListOne(network, orderer3, "participation-trophy")
-			}, network.EventuallyTimeout).Should(Equal(expectedChannelInfoMember))
+			}, network.EventuallyTimeout).Should(Equal(expectedChannelInfoConsenter))
 
 			submitPeerTxn(orderer3, peer, network, orderers, 5, channelparticipation.ChannelInfo{
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          6,
 			})
 		})
@@ -409,12 +409,12 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          1,
 			}
 
 			for _, o := range orderers {
-				By("joining " + o.Name + " to channel as a member")
+				By("joining " + o.Name + " to channel as a consenter")
 				channelparticipation.Join(network, o, "participation-trophy", genesisBlock, expectedChannelInfoPT)
 				channelInfo := channelparticipation.ListOne(network, o, "participation-trophy")
 				Expect(channelInfo).To(Equal(expectedChannelInfoPT))
@@ -424,7 +424,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          2,
 			})
 
@@ -432,7 +432,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          3,
 			})
 
@@ -476,7 +476,7 @@ var _ = Describe("ChannelParticipation", func() {
 			Expect(err).NotTo(HaveOccurred())
 			computeSignSubmitConfigUpdate(network, orderer1, peer, c, "participation-trophy")
 
-			By("ensuring orderer3 transitions from follower to member")
+			By("ensuring orderer3 transitions from follower to consenter")
 			// config update above added a block
 			expectedChannelInfoPT.Height = 5
 			Eventually(func() channelparticipation.ChannelInfo {
@@ -487,7 +487,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          6,
 			})
 		})
@@ -512,7 +512,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "systemchannel",
 				URL:             "/participation/v1/channels/systemchannel",
 				Status:          "inactive",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          1,
 			}
 
@@ -543,7 +543,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "testchannel",
 				URL:             "/participation/v1/channels/testchannel",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          1,
 			}
 			for _, o := range orderers {
@@ -562,7 +562,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "systemchannel",
 				URL:             "/participation/v1/channels/systemchannel",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          2,
 			}
 			for _, o := range orderers {
@@ -635,7 +635,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "testchannel",
 				URL:             "/participation/v1/channels/testchannel",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          4,
 			}
 			for _, o := range orderers {
@@ -652,7 +652,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "systemchannel",
 				URL:             "/participation/v1/channels/systemchannel",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          3,
 			})
 
@@ -661,7 +661,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "testchannel",
 				URL:             "/participation/v1/channels/testchannel",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          5,
 			})
 
@@ -692,7 +692,7 @@ var _ = Describe("ChannelParticipation", func() {
 					Name:            "testchannel",
 					URL:             "/participation/v1/channels/testchannel",
 					Status:          "active",
-					ClusterRelation: "member",
+					ClusterRelation: "consenter",
 					Height:          6,
 				}))
 			}
@@ -702,7 +702,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "testchannel",
 				URL:             "/participation/v1/channels/testchannel",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          7,
 			})
 
@@ -710,7 +710,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "testchannel",
 				URL:             "/participation/v1/channels/testchannel",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          8,
 			})
 
@@ -738,7 +738,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "systemchannel",
 				URL:             "/participation/v1/channels/systemchannel",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          4,
 			})
 
@@ -765,7 +765,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "testchannel",
 				URL:             "/participation/v1/channels/testchannel",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          9,
 			})
 
@@ -773,7 +773,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "testchannel",
 				URL:             "/participation/v1/channels/testchannel",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          10,
 			})
 
@@ -782,12 +782,12 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          1,
 			}
 
 			for _, o := range orderers {
-				By("joining " + o.Name + " to channel as a member")
+				By("joining " + o.Name + " to channel as a consenter")
 				channelparticipation.Join(network, o, "participation-trophy", genesisBlock, expectedChannelInfoPT)
 				channelInfo := channelparticipation.ListOne(network, o, "participation-trophy")
 				Expect(channelInfo).To(Equal(expectedChannelInfoPT))
@@ -797,7 +797,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          2,
 			})
 
@@ -805,7 +805,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          3,
 			})
 
@@ -813,7 +813,7 @@ var _ = Describe("ChannelParticipation", func() {
 				Name:            "participation-trophy",
 				URL:             "/participation/v1/channels/participation-trophy",
 				Status:          "active",
-				ClusterRelation: "member",
+				ClusterRelation: "consenter",
 				Height:          4,
 			})
 		})

--- a/orderer/common/channelparticipation/restapi_test.go
+++ b/orderer/common/channelparticipation/restapi_test.go
@@ -207,7 +207,7 @@ func TestHTTPHandler_ServeHTTP_ListSingle(t *testing.T) {
 	t.Run("channel exists", func(t *testing.T) {
 		fakeManager.ChannelInfoReturns(types.ChannelInfo{
 			Name:            "app-channel",
-			ClusterRelation: "member",
+			ClusterRelation: "consenter",
 			Status:          "active",
 			Height:          3,
 		}, nil)
@@ -224,7 +224,7 @@ func TestHTTPHandler_ServeHTTP_ListSingle(t *testing.T) {
 		require.Equal(t, types.ChannelInfo{
 			Name:            "app-channel",
 			URL:             channelparticipation.URLBaseV1Channels + "/app-channel",
-			ClusterRelation: "member",
+			ClusterRelation: "consenter",
 			Status:          "active",
 			Height:          3,
 		}, infoResp)
@@ -250,7 +250,7 @@ func TestHTTPHandler_ServeHTTP_Join(t *testing.T) {
 		fakeManager, h := setup(config, t)
 		fakeManager.JoinChannelReturns(types.ChannelInfo{
 			Name:            "app-channel",
-			ClusterRelation: "member",
+			ClusterRelation: "consenter",
 			Status:          "active",
 			Height:          1,
 		}, nil)
@@ -267,7 +267,7 @@ func TestHTTPHandler_ServeHTTP_Join(t *testing.T) {
 		require.Equal(t, types.ChannelInfo{
 			Name:            "app-channel",
 			URL:             channelparticipation.URLBaseV1Channels + "/app-channel",
-			ClusterRelation: "member",
+			ClusterRelation: "consenter",
 			Status:          "active",
 			Height:          1,
 		}, infoResp)

--- a/orderer/common/follower/follower_chain.go
+++ b/orderer/common/follower/follower_chain.go
@@ -158,7 +158,7 @@ func NewChain(
 	if joinBlock == nil {
 		chain.status = types.StatusActive
 		if isMem, _ := chain.clusterConsenter.IsChannelMember(chain.lastConfig); isMem {
-			chain.cRel = types.ClusterRelationMember
+			chain.cRel = types.ClusterRelationConsenter
 		}
 
 		chain.logger.Infof("Created with a nil join-block, ledger height: %d", chain.firstHeight)
@@ -182,7 +182,7 @@ func NewChain(
 			chain.status = types.StatusActive
 		}
 		if isMem, _ := chain.clusterConsenter.IsChannelMember(chain.joinBlock); isMem {
-			chain.cRel = types.ClusterRelationMember
+			chain.cRel = types.ClusterRelationConsenter
 		}
 
 		chain.logger.Infof("Created with join-block number: %d, ledger height: %d", joinBlock.Header.Number, chain.firstHeight)
@@ -400,7 +400,7 @@ func (c *Chain) pullAfterJoin() error {
 			return errors.WithMessage(err, "failed to determine channel membership from last config")
 		}
 		if isMember {
-			c.setClusterRelation(types.ClusterRelationMember)
+			c.setClusterRelation(types.ClusterRelationConsenter)
 			return nil
 		}
 

--- a/orderer/common/follower/follower_chain_test.go
+++ b/orderer/common/follower/follower_chain_test.go
@@ -125,7 +125,7 @@ func TestFollowerNewChain(t *testing.T) {
 		require.NoError(t, err)
 
 		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationMember, cRel)
+		require.Equal(t, types.ClusterRelationConsenter, cRel)
 		require.Equal(t, types.StatusOnBoarding, status)
 
 		require.NotPanics(t, chain.Start)
@@ -191,7 +191,7 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		require.NoError(t, err)
 
 		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationMember, cRel)
+		require.Equal(t, types.ClusterRelationConsenter, cRel)
 		require.Equal(t, types.StatusOnBoarding, status)
 
 		require.NotPanics(t, chain.Start)
@@ -200,7 +200,7 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		require.False(t, chain.IsRunning())
 
 		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationMember, cRel)
+		require.Equal(t, types.ClusterRelationConsenter, cRel)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 3, pullerFactory.BlockPullerCallCount())
@@ -221,7 +221,7 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		require.NoError(t, err)
 
 		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationMember, cRel)
+		require.Equal(t, types.ClusterRelationConsenter, cRel)
 		require.Equal(t, types.StatusOnBoarding, status)
 
 		require.NotPanics(t, chain.Start)
@@ -230,7 +230,7 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		require.False(t, chain.IsRunning())
 
 		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationMember, cRel)
+		require.Equal(t, types.ClusterRelationConsenter, cRel)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 3, pullerFactory.BlockPullerCallCount())
@@ -251,7 +251,7 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		require.NoError(t, err)
 
 		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationMember, cRel)
+		require.Equal(t, types.ClusterRelationConsenter, cRel)
 		require.Equal(t, types.StatusActive, status)
 
 		require.NotPanics(t, chain.Start)
@@ -260,7 +260,7 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		require.False(t, chain.IsRunning())
 
 		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationMember, cRel)
+		require.Equal(t, types.ClusterRelationConsenter, cRel)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 2, pullerFactory.BlockPullerCallCount())
@@ -290,7 +290,7 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		require.NoError(t, err)
 
 		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationMember, cRel)
+		require.Equal(t, types.ClusterRelationConsenter, cRel)
 		require.Equal(t, types.StatusOnBoarding, status)
 
 		require.NotPanics(t, chain.Start)
@@ -299,7 +299,7 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		require.False(t, chain.IsRunning())
 
 		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationMember, cRel)
+		require.Equal(t, types.ClusterRelationConsenter, cRel)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 3, pullerFactory.BlockPullerCallCount())
@@ -510,7 +510,7 @@ func TestFollowerPullAfterJoin(t *testing.T) {
 		require.False(t, chain.IsRunning())
 
 		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationMember, cRel)
+		require.Equal(t, types.ClusterRelationConsenter, cRel)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 1, pullerFactory.BlockPullerCallCount(), "after finding a config, block puller is created")
@@ -584,7 +584,7 @@ func TestFollowerPullAfterJoin(t *testing.T) {
 		require.False(t, chain.IsRunning())
 
 		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationMember, cRel)
+		require.Equal(t, types.ClusterRelationConsenter, cRel)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 1, pullerFactory.BlockPullerCallCount(), "after finding a config, or error, block puller is created")
@@ -743,7 +743,7 @@ func TestFollowerPullPastJoin(t *testing.T) {
 		require.False(t, chain.IsRunning())
 
 		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationMember, cRel)
+		require.Equal(t, types.ClusterRelationConsenter, cRel)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 3, pullerFactory.BlockPullerCallCount(), "after finding a config, block puller is created")
@@ -817,7 +817,7 @@ func TestFollowerPullPastJoin(t *testing.T) {
 		require.False(t, chain.IsRunning())
 
 		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationMember, cRel)
+		require.Equal(t, types.ClusterRelationConsenter, cRel)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 3, pullerFactory.BlockPullerCallCount(), "after finding a config, or error, block puller is created")

--- a/orderer/common/multichannel/chainsupport.go
+++ b/orderer/common/multichannel/chainsupport.go
@@ -189,7 +189,7 @@ func newOnBoardingChainSupport(
 	cs := &ChainSupport{ledgerResources: ledgerResources}
 	cs.Processor = msgprocessor.NewStandardChannel(cs, msgprocessor.CreateStandardChannelFilters(cs, config), bccsp)
 	cs.Chain = &inactive.Chain{Err: errors.New("system channel creation pending: server requires restart")}
-	cs.StatusReporter = consensus.StaticStatusReporter{ClusterRelation: types.ClusterRelationMember, Status: types.StatusInactive}
+	cs.StatusReporter = consensus.StaticStatusReporter{ClusterRelation: types.ClusterRelationConsenter, Status: types.StatusInactive}
 
 	logger.Debugf("[channel: %s] Done creating onboarding channel support resources", cs.ChannelID())
 

--- a/orderer/common/multichannel/chainsupport_test.go
+++ b/orderer/common/multichannel/chainsupport_test.go
@@ -7,10 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package multichannel
 
 import (
+	"testing"
+
 	"github.com/hyperledger/fabric/orderer/common/localconfig"
 	"github.com/hyperledger/fabric/orderer/common/msgprocessor"
 	"github.com/hyperledger/fabric/orderer/common/types"
-	"testing"
 
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/bccsp/sw"
@@ -103,7 +104,7 @@ func TestNewOnboardingChainSupport(t *testing.T) {
 	require.False(t, open)
 
 	cRel, status := cs.StatusReport()
-	require.Equal(t, types.ClusterRelationMember, cRel)
+	require.Equal(t, types.ClusterRelationConsenter, cRel)
 	require.Equal(t, types.StatusInactive, status)
 
 	require.Equal(t, uint64(7), cs.Height(), "ledger ReadWriter is initialized")

--- a/orderer/common/multichannel/registrar_test.go
+++ b/orderer/common/multichannel/registrar_test.go
@@ -354,7 +354,7 @@ func TestRegistrar_Initialize(t *testing.T) {
 		info, err := manager.ChannelInfo("my-sys-channel")
 		require.NoError(t, err)
 		require.Equal(t,
-			types.ChannelInfo{Name: "my-sys-channel", URL: "", ClusterRelation: "member", Status: "active", Height: 1},
+			types.ChannelInfo{Name: "my-sys-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 1},
 			info,
 		)
 	})
@@ -393,7 +393,7 @@ func TestRegistrar_Initialize(t *testing.T) {
 		info, err := manager.ChannelInfo("my-raft-channel")
 		require.NoError(t, err)
 		require.Equal(t,
-			types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "member", Status: "active", Height: 1},
+			types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 1},
 			info,
 		)
 	})
@@ -632,14 +632,14 @@ func TestCreateChain(t *testing.T) {
 		info, err := manager.ChannelInfo("testchannelid")
 		require.NoError(t, err)
 		require.Equal(t,
-			types.ChannelInfo{Name: "testchannelid", URL: "", ClusterRelation: types.ClusterRelationMember, Status: types.StatusActive, Height: 1},
+			types.ChannelInfo{Name: "testchannelid", URL: "", ClusterRelation: types.ClusterRelationConsenter, Status: types.StatusActive, Height: 1},
 			info,
 		)
 
 		info, err = manager.ChannelInfo("mychannel")
 		require.NoError(t, err)
 		require.Equal(t,
-			types.ChannelInfo{Name: "mychannel", URL: "", ClusterRelation: types.ClusterRelationMember, Status: types.StatusActive, Height: 1},
+			types.ChannelInfo{Name: "mychannel", URL: "", ClusterRelation: types.ClusterRelationConsenter, Status: types.StatusActive, Height: 1},
 			info,
 		)
 
@@ -1063,14 +1063,14 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 			require.Nil(t, registrar.GetChain("my-raft-channel"))
 			info, err := registrar.JoinChannel("my-raft-channel", genesisBlockAppRaft, true)
 			require.NoError(t, err)
-			require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "member", Status: "active", Height: 0x1}, info)
+			require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 0x1}, info)
 			// After creating the channel, it exists
 			require.NotNil(t, registrar.GetChain("my-raft-channel"))
 
 			// ChannelInfo() and ChannelList() are working fine
 			info, err = registrar.ChannelInfo("my-raft-channel")
 			require.NoError(t, err)
-			require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "member", Status: "active", Height: 0x1}, info)
+			require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 0x1}, info)
 			channelList := registrar.ChannelList()
 			require.Equal(t, 1, len(channelList.Channels))
 			require.Equal(t, "my-raft-channel", channelList.Channels[0].Name)
@@ -1096,14 +1096,14 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 
 		info, err := registrar.JoinChannel("my-raft-channel", genesisBlockAppRaft, true)
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "member", Status: "onboarding", Height: 0x0}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "onboarding", Height: 0x0}, info)
 		// After creating the follower.Chain, it not in the chains map.
 		require.Nil(t, registrar.GetChain("my-raft-channel"))
 
 		// ChannelInfo() and ChannelList() are working fine
 		info, err = registrar.ChannelInfo("my-raft-channel")
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "member", Status: "onboarding", Height: 0x0}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "onboarding", Height: 0x0}, info)
 		channelList := registrar.ChannelList()
 		require.Equal(t, 1, len(channelList.Channels))
 		require.Equal(t, "my-raft-channel", channelList.Channels[0].Name)
@@ -1187,7 +1187,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		// ChannelInfo() and ChannelList() are still working fine
 		info, err = registrar.ChannelInfo("my-raft-channel")
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "member", Status: "active", Height: 0x1}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 0x1}, info)
 		channelList := registrar.ChannelList()
 		require.Equal(t, 1, len(channelList.Channels))
 		require.Equal(t, "my-raft-channel", channelList.Channels[0].Name)
@@ -1211,7 +1211,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 
 		info, err := registrar.JoinChannel("my-raft-channel", genesisBlockAppRaft, true)
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "member", Status: "active", Height: 0x1}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 0x1}, info)
 		// After creating the chain, it exists
 		cs := registrar.GetChain("my-raft-channel")
 		require.NotNil(t, cs)
@@ -1219,7 +1219,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		// ChannelInfo() and ChannelList() are working fine
 		info, err = registrar.ChannelInfo("my-raft-channel")
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "member", Status: "active", Height: 0x1}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 0x1}, info)
 		channelList := registrar.ChannelList()
 		require.Equal(t, 1, len(channelList.Channels))
 		require.Equal(t, "my-raft-channel", channelList.Channels[0].Name)
@@ -1264,7 +1264,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 
 		info, err := registrar.JoinChannel("sys-raft-channel", genesisBlockSysRaft, false)
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ClusterRelation: "member", Status: "inactive", Height: 0x1}, info)
+		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ClusterRelation: "consenter", Status: "inactive", Height: 0x1}, info)
 		// After creating the chain, it exists
 		cs := registrar.GetChain("sys-raft-channel")
 		require.NotNil(t, cs)
@@ -1277,7 +1277,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		// ChannelInfo() and ChannelList() are working fine
 		info, err = registrar.ChannelInfo("sys-raft-channel")
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ClusterRelation: "member", Status: "inactive", Height: 0x1}, info)
+		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ClusterRelation: "consenter", Status: "inactive", Height: 0x1}, info)
 		channelList := registrar.ChannelList()
 		require.Equal(t, 0, len(channelList.Channels))
 		require.NotNil(t, channelList.SystemChannel)
@@ -1301,7 +1301,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		genesisBlockSysRaft.Header.Number = 7
 		info, err := registrar.JoinChannel("sys-raft-channel", genesisBlockSysRaft, false)
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ClusterRelation: "member", Status: "inactive", Height: 0x0}, info)
+		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ClusterRelation: "consenter", Status: "inactive", Height: 0x0}, info)
 		// After creating the chain, it exists
 		cs := registrar.GetChain("sys-raft-channel")
 		require.NotNil(t, cs)
@@ -1314,7 +1314,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		// ChannelInfo() and ChannelList() are working fine
 		info, err = registrar.ChannelInfo("sys-raft-channel")
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ClusterRelation: "member", Status: "inactive", Height: 0x0}, info)
+		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ClusterRelation: "consenter", Status: "inactive", Height: 0x0}, info)
 		channelList := registrar.ChannelList()
 		require.Equal(t, 0, len(channelList.Channels))
 		require.NotNil(t, channelList.SystemChannel)
@@ -1454,7 +1454,7 @@ func TestRegistrar_RemoveChannel(t *testing.T) {
 		setup(t)
 		defer cleanup()
 
-		t.Run("member", func(t *testing.T) {
+		t.Run("consenter", func(t *testing.T) {
 			consenter.IsChannelMemberReturns(true, nil)
 			registrar := NewRegistrar(config, ledgerFactory, mockCrypto(), &disabled.Provider{}, cryptoProvider, dialer)
 			registrar.Initialize(mockConsenters)
@@ -1463,7 +1463,7 @@ func TestRegistrar_RemoveChannel(t *testing.T) {
 			require.NotContains(t, ledgerFactory.ChannelIDs(), "my-raft-channel")
 			info, err := registrar.JoinChannel("my-raft-channel", genesisBlockAppRaft, true)
 			require.NoError(t, err)
-			require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "member", Status: "active", Height: 1}, info)
+			require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 1}, info)
 			require.NotNil(t, registrar.GetChain("my-raft-channel"))
 			require.Contains(t, ledgerFactory.ChannelIDs(), "my-raft-channel")
 

--- a/orderer/common/multichannel/util_test.go
+++ b/orderer/common/multichannel/util_test.go
@@ -28,7 +28,7 @@ type mockChainCluster struct {
 }
 
 func (c *mockChainCluster) StatusReport() (types.ClusterRelation, types.Status) {
-	return types.ClusterRelationMember, types.StatusActive
+	return types.ClusterRelationConsenter, types.StatusActive
 }
 
 type mockChain struct {

--- a/orderer/common/types/channelinfo.go
+++ b/orderer/common/types/channelinfo.go
@@ -33,9 +33,9 @@ type ChannelInfoShort struct {
 type ClusterRelation string
 
 const (
-	// The orderer is a cluster member of a cluster consensus protocol (e.g. etcdraft) for a specific channel.
+	// The orderer is a cluster consenter of a cluster consensus protocol (e.g. etcdraft) for a specific channel.
 	// That is, the orderer is in the consenters set of the channel.
-	ClusterRelationMember ClusterRelation = "member"
+	ClusterRelationConsenter ClusterRelation = "consenter"
 	// The orderer is following a cluster consensus protocol by pulling blocks from other orderers.
 	// The orderer is NOT in the consenters set of the channel.
 	ClusterRelationFollower ClusterRelation = "follower"
@@ -47,7 +47,7 @@ const (
 )
 
 // Status represents the degree by which the orderer had caught up with the rest of the cluster after joining the
-// channel (either as a member or a follower).
+// channel (either as a consenter or a follower).
 type Status string
 
 const (
@@ -68,9 +68,10 @@ type ChannelInfo struct {
 	Name string `json:"name"`
 	// The channel relative URL (no Host:Port, only path), e.g.: "/participation/v1/channels/my-channel".
 	URL string `json:"url"`
-	// Whether the orderer is a “member” or ”follower” of the cluster, or "config-tracker" of the cluster, for this channel.
+	// Whether the orderer is a “consenter”, ”follower”, or "config-tracker" of
+	// the cluster for this channel.
 	// For non cluster consensus types (solo, kafka) it is "none".
-	// Possible values:  “member”, ”follower”, "config-tracker", "none".
+	// Possible values:  “consenter”, ”follower”, "config-tracker", "none".
 	ClusterRelation ClusterRelation `json:"clusterRelation"`
 	// Whether the orderer is ”onboarding”, ”active”, or "inactive", for this channel.
 	// For non cluster consensus types (solo, kafka) it is "active".

--- a/orderer/consensus/etcdraft/chain.go
+++ b/orderer/consensus/etcdraft/chain.go
@@ -274,7 +274,7 @@ func NewChain(
 		createPuller:     f,
 		clock:            opts.Clock,
 		haltCallback:     haltCallback,
-		clusterRelation:  types.ClusterRelationMember,
+		clusterRelation:  types.ClusterRelationConsenter,
 		status:           types.StatusActive,
 		Metrics: &Metrics{
 			ClusterSize:             opts.Metrics.ClusterSize.With("channel", support.ChannelID()),

--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -216,7 +216,7 @@ var _ = Describe("Chain", func() {
 
 			chain.Start()
 			cRel, status := chain.StatusReport()
-			Expect(cRel).To(Equal(orderer_types.ClusterRelationMember))
+			Expect(cRel).To(Equal(orderer_types.ClusterRelationConsenter))
 			Expect(status).To(Equal(orderer_types.StatusActive))
 
 			// When the Raft node bootstraps, it produces a ConfChange
@@ -1501,7 +1501,7 @@ var _ = Describe("Chain", func() {
 				},
 			).Should(Equal(orderer_types.StatusInactive))
 			cRel, _ := c1.StatusReport()
-			Expect(cRel).To(Equal(orderer_types.ClusterRelationMember))
+			Expect(cRel).To(Equal(orderer_types.ClusterRelationConsenter))
 		})
 
 		It("can remove leader by reconfiguring cluster even if leadership transfer fails", func() {


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

For clarity/consistency, change the cluster relation "member" to "consenter".

#### Related issues

[FAB-18320](https://jira.hyperledger.org/browse/FAB-18320)