### PR TITLE
Ch.Part.API: Allow retry of failed removals

### DIFF
--- a/orderer/common/channelparticipation/restapi.go
+++ b/orderer/common/channelparticipation/restapi.go
@@ -296,8 +296,6 @@ func (h *HTTPHandler) serveRemove(resp http.ResponseWriter, req *http.Request) {
 		h.sendResponseJsonError(resp, http.StatusNotFound, errors.WithMessage(err, "cannot remove"))
 	case types.ErrChannelPendingRemoval:
 		h.sendResponseJsonError(resp, http.StatusConflict, errors.WithMessage(err, "cannot remove"))
-	case types.ErrChannelRemovalFailure:
-		h.sendResponseJsonError(resp, http.StatusInternalServerError, errors.WithMessage(err, "cannot remove"))
 	default:
 		h.sendResponseJsonError(resp, http.StatusBadRequest, errors.WithMessage(err, "cannot remove"))
 	}

--- a/orderer/common/channelparticipation/restapi_test.go
+++ b/orderer/common/channelparticipation/restapi_test.go
@@ -488,14 +488,6 @@ func TestHTTPHandler_ServeHTTP_Remove(t *testing.T) {
 		checkErrorResponse(t, http.StatusConflict, "cannot remove: channel pending removal", resp)
 	})
 
-	t.Run("Error: Channel Removal", func(t *testing.T) {
-		fakeManager, h := setup(config, t)
-		fakeManager.RemoveChannelReturns(types.ErrChannelRemovalFailure)
-		resp := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodDelete, path.Join(channelparticipation.URLBaseV1Channels, "my-channel"), nil)
-		h.ServeHTTP(resp, req)
-		checkErrorResponse(t, http.StatusInternalServerError, "cannot remove: channel removal failure", resp)
-	})
 }
 
 func setup(config localconfig.ChannelParticipation, t *testing.T) (*mocks.ChannelManagement, *channelparticipation.HTTPHandler) {

--- a/orderer/common/multichannel/registrar_test.go
+++ b/orderer/common/multichannel/registrar_test.go
@@ -1686,10 +1686,10 @@ func TestRegistrar_RemoveChannel(t *testing.T) {
 
 		registrar.pendingRemoval["my-raft-channel"] = false
 		err = registrar.RemoveChannel("my-raft-channel")
-		require.Error(t, err)
-		require.Equal(t, types.ErrChannelRemovalFailure, err)
+		require.NoError(t, err)
 
-		require.Contains(t, registrar.ChannelList().Channels, types.ChannelInfoShort{Name: "my-raft-channel"})
+		require.Eventually(t, func() bool { return len(ledgerFactory.ChannelIDs()) == 0 }, time.Minute, time.Second)
+		require.NotContains(t, registrar.ChannelList().Channels, types.ChannelInfoShort{Name: "my-raft-channel"})
 	})
 
 	t.Run("remove channel fails", func(t *testing.T) {


### PR DESCRIPTION
#### Type of change

- Improvement 

#### Description

Allow retrying of failed channel removals per [comment](https://github.com/hyperledger/fabric/pull/2027/files#r518875811) 

