### PR TITLE
Chan.Part.API: Rename cluster relation to consensus relation

### DIFF
--- a/cmd/osnadmin/main_test.go
+++ b/cmd/osnadmin/main_test.go
@@ -117,10 +117,10 @@ var _ = Describe("osnadmin", func() {
 			})
 
 			mockChannelManagement.ChannelInfoReturns(types.ChannelInfo{
-				Name:            "asparagus",
-				ClusterRelation: "broccoli",
-				Status:          "carrot",
-				Height:          987,
+				Name:              "asparagus",
+				ConsensusRelation: "broccoli",
+				Status:            "carrot",
+				Height:            987,
 			}, nil)
 		})
 
@@ -165,11 +165,11 @@ var _ = Describe("osnadmin", func() {
 			}
 			output, exit, err := executeForArgs(args)
 			expectedOutput := types.ChannelInfo{
-				Name:            "asparagus",
-				URL:             "/participation/v1/channels/asparagus",
-				ClusterRelation: "broccoli",
-				Status:          "carrot",
-				Height:          987,
+				Name:              "asparagus",
+				URL:               "/participation/v1/channels/asparagus",
+				ConsensusRelation: "broccoli",
+				Status:            "carrot",
+				Height:            987,
 			}
 			checkOutput(output, exit, err, 200, expectedOutput)
 		})
@@ -252,10 +252,10 @@ var _ = Describe("osnadmin", func() {
 			blockPath = createBlockFile(tempDir, configBlock)
 
 			mockChannelManagement.JoinChannelReturns(types.ChannelInfo{
-				Name:            "apple",
-				ClusterRelation: "banana",
-				Status:          "orange",
-				Height:          123,
+				Name:              "apple",
+				ConsensusRelation: "banana",
+				Status:            "orange",
+				Height:            123,
 			}, nil)
 		})
 
@@ -272,11 +272,11 @@ var _ = Describe("osnadmin", func() {
 			}
 			output, exit, err := executeForArgs(args)
 			expectedOutput := types.ChannelInfo{
-				Name:            "apple",
-				URL:             "/participation/v1/channels/apple",
-				ClusterRelation: "banana",
-				Status:          "orange",
-				Height:          123,
+				Name:              "apple",
+				URL:               "/participation/v1/channels/apple",
+				ConsensusRelation: "banana",
+				Status:            "orange",
+				Height:            123,
 			}
 			checkOutput(output, exit, err, 201, expectedOutput)
 		})
@@ -403,10 +403,10 @@ var _ = Describe("osnadmin", func() {
 			)
 			blockPath := createBlockFile(tempDir, configBlock)
 			mockChannelManagement.JoinChannelReturns(types.ChannelInfo{
-				Name:            "apple",
-				ClusterRelation: "banana",
-				Status:          "orange",
-				Height:          123,
+				Name:              "apple",
+				ConsensusRelation: "banana",
+				Status:            "orange",
+				Height:            123,
 			}, nil)
 
 			args := []string{
@@ -421,11 +421,11 @@ var _ = Describe("osnadmin", func() {
 			}
 			output, exit, err := executeForArgs(args)
 			expectedOutput := types.ChannelInfo{
-				Name:            "apple",
-				URL:             "/participation/v1/channels/apple",
-				ClusterRelation: "banana",
-				Status:          "orange",
-				Height:          123,
+				Name:              "apple",
+				URL:               "/participation/v1/channels/apple",
+				ConsensusRelation: "banana",
+				Status:            "orange",
+				Height:            123,
 			}
 			checkOutput(output, exit, err, 201, expectedOutput)
 		})

--- a/docs/source/metrics_reference.rst
+++ b/docs/source/metrics_reference.rst
@@ -193,8 +193,8 @@ The following orderer metrics are exported for consumption by Prometheus.
 +----------------------------------------------+-----------+------------------------------------------------------------+-----------+--------------------------------------------------------------------+
 | logging_entries_written                      | counter   | Number of log entries that are written                     | level     |                                                                    |
 +----------------------------------------------+-----------+------------------------------------------------------------+-----------+--------------------------------------------------------------------+
-| participation_cluster_relation               | gauge     | The channel participation cluster relation of the node: 0  | channel   |                                                                    |
-|                                              |           | if none, 1 if consenter, 2 if follower, 3 if               |           |                                                                    |
+| participation_consensus_relation             | gauge     | The channel participation consensus relation of the node:  | channel   |                                                                    |
+|                                              |           | 0 if other, 1 if consenter, 2 if follower, 3 if            |           |                                                                    |
 |                                              |           | config-tracker.                                            |           |                                                                    |
 +----------------------------------------------+-----------+------------------------------------------------------------+-----------+--------------------------------------------------------------------+
 | participation_status                         | gauge     | The channel participation status of the node: 0 if         | channel   |                                                                    |
@@ -333,8 +333,8 @@ associated with the metric.
 +---------------------------------------------------------------------------+-----------+------------------------------------------------------------+
 | logging.entries_written.%{level}                                          | counter   | Number of log entries that are written                     |
 +---------------------------------------------------------------------------+-----------+------------------------------------------------------------+
-| participation.cluster_relation.%{channel}                                 | gauge     | The channel participation cluster relation of the node: 0  |
-|                                                                           |           | if none, 1 if consenter, 2 if follower, 3 if               |
+| participation.consensus_relation.%{channel}                               | gauge     | The channel participation consensus relation of the node:  |
+|                                                                           |           | 0 if other, 1 if consenter, 2 if follower, 3 if            |
 |                                                                           |           | config-tracker.                                            |
 +---------------------------------------------------------------------------+-----------+------------------------------------------------------------+
 | participation.status.%{channel}                                           | gauge     | The channel participation status of the node: 0 if         |

--- a/integration/channelparticipation/channel_participation.go
+++ b/integration/channelparticipation/channel_participation.go
@@ -102,11 +102,11 @@ func getBody(client *http.Client, url string) func() string {
 }
 
 type ChannelInfo struct {
-	Name            string `json:"name"`
-	URL             string `json:"url"`
-	Status          string `json:"status"`
-	ClusterRelation string `json:"clusterRelation"`
-	Height          uint64 `json:"height"`
+	Name              string `json:"name"`
+	URL               string `json:"url"`
+	Status            string `json:"status"`
+	ConsensusRelation string `json:"consensusRelation"`
+	Height            uint64 `json:"height"`
 }
 
 func ListOne(n *nwo.Network, o *nwo.Orderer, channel string) ChannelInfo {

--- a/integration/raft/channel_participation_test.go
+++ b/integration/raft/channel_participation_test.go
@@ -135,11 +135,11 @@ var _ = Describe("ChannelParticipation", func() {
 
 			genesisBlock := applicationChannelGenesisBlock(network, consenters, peer, "participation-trophy")
 			expectedChannelInfoPT := channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          1,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            1,
 			}
 
 			for _, o := range consenters {
@@ -150,30 +150,30 @@ var _ = Describe("ChannelParticipation", func() {
 			}
 
 			submitPeerTxn(orderer1, peer, network, consenters, 1, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          2,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            2,
 			})
 
 			submitPeerTxn(orderer2, peer, network, consenters, 2, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          3,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            3,
 			})
 
 			By("joining orderer3 to the channel as a follower")
 			// make sure we can join using a config block from one of the other orderers
 			configBlockPT := nwo.GetConfigBlock(network, peer, orderer2, "participation-trophy")
 			expectedChannelInfoPTFollower := channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "onboarding",
-				ClusterRelation: "follower",
-				Height:          0,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "onboarding",
+				ConsensusRelation: "follower",
+				Height:            0,
 			}
 			channelparticipation.Join(network, orderer3, "participation-trophy", configBlockPT, expectedChannelInfoPTFollower)
 
@@ -200,21 +200,21 @@ var _ = Describe("ChannelParticipation", func() {
 
 			By("submitting transaction to orderer3 to ensure it is active")
 			submitPeerTxn(orderer3, peer, network, orderers, 4, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          5,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            5,
 			})
 
 			By("joining orderer1 to another channel as a consenter")
 			genesisBlockAPT := applicationChannelGenesisBlock(network, []*nwo.Orderer{orderer1}, peer, "another-participation-trophy")
 			expectedChannelInfoAPT := channelparticipation.ChannelInfo{
-				Name:            "another-participation-trophy",
-				URL:             "/participation/v1/channels/another-participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          1,
+				Name:              "another-participation-trophy",
+				URL:               "/participation/v1/channels/another-participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            1,
 			}
 			channelparticipation.Join(network, orderer1, "another-participation-trophy", genesisBlockAPT, expectedChannelInfoAPT)
 			channelInfo := channelparticipation.ListOne(network, orderer1, "another-participation-trophy")
@@ -235,31 +235,31 @@ var _ = Describe("ChannelParticipation", func() {
 			Eventually(func() channelparticipation.ChannelInfo {
 				return channelparticipation.ListOne(network, orderer1, "participation-trophy")
 			}, network.EventuallyTimeout).Should(Equal(channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "follower",
-				Height:          6,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "follower",
+				Height:            6,
 			}))
 
 			consenters = []*nwo.Orderer{orderer2, orderer3}
 			submitPeerTxn(orderer2, peer, network, consenters, 6, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          7,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            7,
 			})
 
 			By("ensuring orderer1 pulls the latest block as a follower")
 			Eventually(func() channelparticipation.ChannelInfo {
 				return channelparticipation.ListOne(network, orderer1, "participation-trophy")
 			}, network.EventuallyTimeout).Should(Equal(channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "follower",
-				Height:          7,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "follower",
+				Height:            7,
 			}))
 
 			By("removing orderer1 from a channel")
@@ -288,19 +288,19 @@ var _ = Describe("ChannelParticipation", func() {
 
 			By("ensuring the channel is still usable by submitting a transaction to each remaining consenter for the channel")
 			submitPeerTxn(orderer2, peer, network, consenters, 7, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          8,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            8,
 			})
 
 			submitPeerTxn(orderer3, peer, network, consenters, 8, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          9,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            9,
 			})
 
 			By("attempting to join with an invalid block")
@@ -334,11 +334,11 @@ var _ = Describe("ChannelParticipation", func() {
 
 			genesisBlock := applicationChannelGenesisBlock(network, orderers, peer, "participation-trophy")
 			expectedChannelInfoPT := channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          1,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            1,
 			}
 
 			for _, o := range orderers {
@@ -349,19 +349,19 @@ var _ = Describe("ChannelParticipation", func() {
 			}
 
 			submitPeerTxn(orderer1, peer, network, orderers, 1, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          2,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            2,
 			})
 
 			submitPeerTxn(orderer2, peer, network, orderers, 2, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          3,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            3,
 			})
 
 			By("submitting a channel config update")
@@ -390,11 +390,11 @@ var _ = Describe("ChannelParticipation", func() {
 			// make sure we can join using a config block from one of the other orderers
 			configBlockPT := nwo.GetConfigBlock(network, peer, orderer2, "participation-trophy")
 			expectedChannelInfoConsenter := channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "onboarding",
-				ClusterRelation: "consenter",
-				Height:          0,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "onboarding",
+				ConsensusRelation: "consenter",
+				Height:            0,
 			}
 			channelparticipation.Join(network, orderer3, "participation-trophy", configBlockPT, expectedChannelInfoConsenter)
 
@@ -406,11 +406,11 @@ var _ = Describe("ChannelParticipation", func() {
 			}, network.EventuallyTimeout).Should(Equal(expectedChannelInfoConsenter))
 
 			submitPeerTxn(orderer3, peer, network, orderers, 5, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          6,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            6,
 			})
 		})
 
@@ -430,11 +430,11 @@ var _ = Describe("ChannelParticipation", func() {
 
 			genesisBlock := applicationChannelGenesisBlock(network, orderers, peer, "participation-trophy")
 			expectedChannelInfoPT := channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          1,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            1,
 			}
 
 			for _, o := range orderers {
@@ -445,19 +445,19 @@ var _ = Describe("ChannelParticipation", func() {
 			}
 
 			submitPeerTxn(orderer1, peer, network, orderers, 1, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          2,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            2,
 			})
 
 			submitPeerTxn(orderer2, peer, network, orderers, 2, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          3,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            3,
 			})
 
 			By("submitting a channel config update")
@@ -479,11 +479,11 @@ var _ = Describe("ChannelParticipation", func() {
 			// make sure we can join using a config block from one of the other orderers
 			configBlockPT := nwo.GetConfigBlock(network, peer, orderer2, "participation-trophy")
 			expectedChannelInfoPTFollower := channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "onboarding",
-				ClusterRelation: "follower",
-				Height:          0,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "onboarding",
+				ConsensusRelation: "follower",
+				Height:            0,
 			}
 			channelparticipation.Join(network, orderer3, "participation-trophy", configBlockPT, expectedChannelInfoPTFollower)
 
@@ -509,11 +509,11 @@ var _ = Describe("ChannelParticipation", func() {
 			}, network.EventuallyTimeout).Should(Equal(expectedChannelInfoPT))
 
 			submitPeerTxn(orderer3, peer, network, orderers, 5, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          6,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            6,
 			})
 		})
 
@@ -534,11 +534,11 @@ var _ = Describe("ChannelParticipation", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			expectedChannelInfo := channelparticipation.ChannelInfo{
-				Name:            "systemchannel",
-				URL:             "/participation/v1/channels/systemchannel",
-				Status:          "inactive",
-				ClusterRelation: "consenter",
-				Height:          1,
+				Name:              "systemchannel",
+				URL:               "/participation/v1/channels/systemchannel",
+				Status:            "inactive",
+				ConsensusRelation: "consenter",
+				Height:            1,
 			}
 
 			By("joining orderers to systemchannel")
@@ -565,11 +565,11 @@ var _ = Describe("ChannelParticipation", func() {
 			network.CreateChannel("testchannel", orderer1, peer)
 
 			expectedChannelInfo = channelparticipation.ChannelInfo{
-				Name:            "testchannel",
-				URL:             "/participation/v1/channels/testchannel",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          1,
+				Name:              "testchannel",
+				URL:               "/participation/v1/channels/testchannel",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            1,
 			}
 			for _, o := range orderers {
 				By("listing single channel for " + o.Name)
@@ -585,11 +585,11 @@ var _ = Describe("ChannelParticipation", func() {
 			}
 
 			expectedChannelInfo = channelparticipation.ChannelInfo{
-				Name:            "systemchannel",
-				URL:             "/participation/v1/channels/systemchannel",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          2,
+				Name:              "systemchannel",
+				URL:               "/participation/v1/channels/systemchannel",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            2,
 			}
 			for _, o := range orderers {
 				By("listing single channel for " + o.Name)
@@ -658,11 +658,11 @@ var _ = Describe("ChannelParticipation", func() {
 
 			By("listing the channels")
 			expectedChannelInfo := channelparticipation.ChannelInfo{
-				Name:            "testchannel",
-				URL:             "/participation/v1/channels/testchannel",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          4,
+				Name:              "testchannel",
+				URL:               "/participation/v1/channels/testchannel",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            4,
 			}
 			for _, o := range orderers {
 				By("listing single channel")
@@ -676,20 +676,20 @@ var _ = Describe("ChannelParticipation", func() {
 
 			By("submitting a transaction to ensure the system channel is active after restart")
 			submitOrdererTxn(orderer2, peer, network, orderers, 2, channelparticipation.ChannelInfo{
-				Name:            "systemchannel",
-				URL:             "/participation/v1/channels/systemchannel",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          3,
+				Name:              "systemchannel",
+				URL:               "/participation/v1/channels/systemchannel",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            3,
 			})
 
 			By("submitting a transaction to ensure the application channel is active after restart")
 			submitPeerTxn(orderer2, peer, network, orderers, 4, channelparticipation.ChannelInfo{
-				Name:            "testchannel",
-				URL:             "/participation/v1/channels/testchannel",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          5,
+				Name:              "testchannel",
+				URL:               "/participation/v1/channels/testchannel",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            5,
 			})
 
 			By("removing orderer3 from the consenters set")
@@ -703,11 +703,11 @@ var _ = Describe("ChannelParticipation", func() {
 			Eventually(func() channelparticipation.ChannelInfo {
 				return channelparticipation.ListOne(network, orderer3, "testchannel")
 			}, network.EventuallyTimeout).Should(Equal(channelparticipation.ChannelInfo{
-				Name:            "testchannel",
-				URL:             "/participation/v1/channels/testchannel",
-				Status:          "inactive",
-				ClusterRelation: "config-tracker",
-				Height:          6,
+				Name:              "testchannel",
+				URL:               "/participation/v1/channels/testchannel",
+				Status:            "inactive",
+				ConsensusRelation: "config-tracker",
+				Height:            6,
 			}))
 
 			By("ensuring orderers 1 and 2 receive the block")
@@ -716,29 +716,29 @@ var _ = Describe("ChannelParticipation", func() {
 				Eventually(func() channelparticipation.ChannelInfo {
 					return channelparticipation.ListOne(network, o, "testchannel")
 				}, network.EventuallyTimeout).Should(Equal(channelparticipation.ChannelInfo{
-					Name:            "testchannel",
-					URL:             "/participation/v1/channels/testchannel",
-					Status:          "active",
-					ClusterRelation: "consenter",
-					Height:          6,
+					Name:              "testchannel",
+					URL:               "/participation/v1/channels/testchannel",
+					Status:            "active",
+					ConsensusRelation: "consenter",
+					Height:            6,
 				}))
 			}
 
 			By("submitting a transaction to each active orderer")
 			submitPeerTxn(orderer1, peer, network, orderers1and2, 6, channelparticipation.ChannelInfo{
-				Name:            "testchannel",
-				URL:             "/participation/v1/channels/testchannel",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          7,
+				Name:              "testchannel",
+				URL:               "/participation/v1/channels/testchannel",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            7,
 			})
 
 			submitPeerTxn(orderer2, peer, network, orderers1and2, 7, channelparticipation.ChannelInfo{
-				Name:            "testchannel",
-				URL:             "/participation/v1/channels/testchannel",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          8,
+				Name:              "testchannel",
+				URL:               "/participation/v1/channels/testchannel",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            8,
 			})
 
 			By("restarting orderer3 to ensure it still reports inactive/config-tracker")
@@ -746,11 +746,11 @@ var _ = Describe("ChannelParticipation", func() {
 			Eventually(func() channelparticipation.ChannelInfo {
 				return channelparticipation.ListOne(network, orderer3, "testchannel")
 			}, network.EventuallyTimeout).Should(Equal(channelparticipation.ChannelInfo{
-				Name:            "testchannel",
-				URL:             "/participation/v1/channels/testchannel",
-				Status:          "inactive",
-				ClusterRelation: "config-tracker",
-				Height:          6,
+				Name:              "testchannel",
+				URL:               "/participation/v1/channels/testchannel",
+				Status:            "inactive",
+				ConsensusRelation: "config-tracker",
+				Height:            6,
 			}))
 
 			By("attempting to join a channel when the system channel is present")
@@ -762,11 +762,11 @@ var _ = Describe("ChannelParticipation", func() {
 
 			By("submitting a transaction to ensure the system channel is active after restart")
 			submitOrdererTxn(orderer3, peer, network, orderers, 3, channelparticipation.ChannelInfo{
-				Name:            "systemchannel",
-				URL:             "/participation/v1/channels/systemchannel",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          4,
+				Name:              "systemchannel",
+				URL:               "/participation/v1/channels/systemchannel",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            4,
 			})
 
 			By("putting the system channel into maintenance mode")
@@ -789,28 +789,28 @@ var _ = Describe("ChannelParticipation", func() {
 
 			By("submitting a transaction to each active orderer after restart")
 			submitPeerTxn(orderer1, peer, network, orderers1and2, 8, channelparticipation.ChannelInfo{
-				Name:            "testchannel",
-				URL:             "/participation/v1/channels/testchannel",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          9,
+				Name:              "testchannel",
+				URL:               "/participation/v1/channels/testchannel",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            9,
 			})
 
 			submitPeerTxn(orderer2, peer, network, orderers1and2, 9, channelparticipation.ChannelInfo{
-				Name:            "testchannel",
-				URL:             "/participation/v1/channels/testchannel",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          10,
+				Name:              "testchannel",
+				URL:               "/participation/v1/channels/testchannel",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            10,
 			})
 
 			By("using the channel participation API to join a new channel")
 			expectedChannelInfoPT := channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          1,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            1,
 			}
 
 			for _, o := range orderers {
@@ -821,27 +821,27 @@ var _ = Describe("ChannelParticipation", func() {
 			}
 
 			submitPeerTxn(orderer1, peer, network, orderers, 1, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          2,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            2,
 			})
 
 			submitPeerTxn(orderer2, peer, network, orderers, 2, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          3,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            3,
 			})
 
 			submitPeerTxn(orderer3, peer, network, orderers, 3, channelparticipation.ChannelInfo{
-				Name:            "participation-trophy",
-				URL:             "/participation/v1/channels/participation-trophy",
-				Status:          "active",
-				ClusterRelation: "consenter",
-				Height:          4,
+				Name:              "participation-trophy",
+				URL:               "/participation/v1/channels/participation-trophy",
+				Status:            "active",
+				ConsensusRelation: "consenter",
+				Height:            4,
 			})
 		})
 	})

--- a/orderer/common/channelparticipation/restapi_test.go
+++ b/orderer/common/channelparticipation/restapi_test.go
@@ -206,10 +206,10 @@ func TestHTTPHandler_ServeHTTP_ListSingle(t *testing.T) {
 
 	t.Run("channel exists", func(t *testing.T) {
 		fakeManager.ChannelInfoReturns(types.ChannelInfo{
-			Name:            "app-channel",
-			ClusterRelation: "consenter",
-			Status:          "active",
-			Height:          3,
+			Name:              "app-channel",
+			ConsensusRelation: "consenter",
+			Status:            "active",
+			Height:            3,
 		}, nil)
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, channelparticipation.URLBaseV1Channels+"/app-channel", nil)
@@ -222,11 +222,11 @@ func TestHTTPHandler_ServeHTTP_ListSingle(t *testing.T) {
 		err := json.Unmarshal(resp.Body.Bytes(), &infoResp)
 		require.NoError(t, err, "cannot be unmarshaled")
 		require.Equal(t, types.ChannelInfo{
-			Name:            "app-channel",
-			URL:             channelparticipation.URLBaseV1Channels + "/app-channel",
-			ClusterRelation: "consenter",
-			Status:          "active",
-			Height:          3,
+			Name:              "app-channel",
+			URL:               channelparticipation.URLBaseV1Channels + "/app-channel",
+			ConsensusRelation: "consenter",
+			Status:            "active",
+			Height:            3,
 		}, infoResp)
 
 	})
@@ -249,10 +249,10 @@ func TestHTTPHandler_ServeHTTP_Join(t *testing.T) {
 	t.Run("created ok", func(t *testing.T) {
 		fakeManager, h := setup(config, t)
 		fakeManager.JoinChannelReturns(types.ChannelInfo{
-			Name:            "app-channel",
-			ClusterRelation: "consenter",
-			Status:          "active",
-			Height:          1,
+			Name:              "app-channel",
+			ConsensusRelation: "consenter",
+			Status:            "active",
+			Height:            1,
 		}, nil)
 
 		resp := httptest.NewRecorder()
@@ -265,11 +265,11 @@ func TestHTTPHandler_ServeHTTP_Join(t *testing.T) {
 		err := json.Unmarshal(resp.Body.Bytes(), &infoResp)
 		require.NoError(t, err, "cannot be unmarshaled")
 		require.Equal(t, types.ChannelInfo{
-			Name:            "app-channel",
-			URL:             channelparticipation.URLBaseV1Channels + "/app-channel",
-			ClusterRelation: "consenter",
-			Status:          "active",
-			Height:          1,
+			Name:              "app-channel",
+			URL:               channelparticipation.URLBaseV1Channels + "/app-channel",
+			ConsensusRelation: "consenter",
+			Status:            "active",
+			Height:            1,
 		}, infoResp)
 	})
 

--- a/orderer/common/follower/follower_chain_test.go
+++ b/orderer/common/follower/follower_chain_test.go
@@ -115,8 +115,8 @@ func TestFollowerNewChain(t *testing.T) {
 		chain, err := follower.NewChain(ledgerResources, mockClusterConsenter, joinBlockAppRaft, options, pullerFactory, mockChainCreator, nil, mockChannelParticipationMetricsReporter)
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusOnBoarding, status)
 	})
 
@@ -127,8 +127,8 @@ func TestFollowerNewChain(t *testing.T) {
 		chain, err := follower.NewChain(ledgerResources, mockClusterConsenter, joinBlockAppRaft, options, pullerFactory, mockChainCreator, nil, mockChannelParticipationMetricsReporter)
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationConsenter, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationConsenter, consensusRelation)
 		require.Equal(t, types.StatusOnBoarding, status)
 
 		require.NotPanics(t, chain.Start)
@@ -155,8 +155,8 @@ func TestFollowerNewChain(t *testing.T) {
 		chain, err := follower.NewChain(ledgerResources, mockClusterConsenter, nil, options, pullerFactory, mockChainCreator, nil, mockChannelParticipationMetricsReporter)
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.True(t, status == types.StatusActive)
 	})
 }
@@ -193,8 +193,8 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		chain, err := follower.NewChain(ledgerResources, mockClusterConsenter, joinBlockAppRaft, options, pullerFactory, mockChainCreator, cryptoProvider, mockChannelParticipationMetricsReporter)
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationConsenter, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationConsenter, consensusRelation)
 		require.Equal(t, types.StatusOnBoarding, status)
 
 		require.NotPanics(t, chain.Start)
@@ -202,8 +202,8 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		require.NotPanics(t, chain.Halt)
 		require.False(t, chain.IsRunning())
 
-		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationConsenter, cRel)
+		consensusRelation, status = chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationConsenter, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 3, pullerFactory.BlockPullerCallCount())
@@ -223,14 +223,14 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		chain, err := follower.NewChain(ledgerResources, mockClusterConsenter, joinBlockAppRaft, options, pullerFactory, mockChainCreator, cryptoProvider, mockChannelParticipationMetricsReporter)
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationConsenter, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationConsenter, consensusRelation)
 		require.Equal(t, types.StatusOnBoarding, status)
 
-		require.Equal(t, 1, mockChannelParticipationMetricsReporter.ReportRelationAndStatusMetricsCallCount())
-		channel, relation, status := mockChannelParticipationMetricsReporter.ReportRelationAndStatusMetricsArgsForCall(0)
+		require.Equal(t, 1, mockChannelParticipationMetricsReporter.ReportConsensusRelationAndStatusMetricsCallCount())
+		channel, relation, status := mockChannelParticipationMetricsReporter.ReportConsensusRelationAndStatusMetricsArgsForCall(0)
 		require.Equal(t, "my-channel", channel)
-		require.Equal(t, types.ClusterRelationConsenter, relation)
+		require.Equal(t, types.ConsensusRelationConsenter, relation)
 		require.Equal(t, types.StatusOnBoarding, status)
 
 		require.NotPanics(t, chain.Start)
@@ -238,8 +238,8 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		require.NotPanics(t, chain.Halt)
 		require.False(t, chain.IsRunning())
 
-		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationConsenter, cRel)
+		consensusRelation, status = chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationConsenter, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 3, pullerFactory.BlockPullerCallCount())
@@ -249,10 +249,10 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		}
 		require.Equal(t, 1, mockChainCreator.SwitchFollowerToChainCallCount())
 
-		require.Equal(t, 3, mockChannelParticipationMetricsReporter.ReportRelationAndStatusMetricsCallCount())
-		channel, relation, status = mockChannelParticipationMetricsReporter.ReportRelationAndStatusMetricsArgsForCall(2)
+		require.Equal(t, 3, mockChannelParticipationMetricsReporter.ReportConsensusRelationAndStatusMetricsCallCount())
+		channel, relation, status = mockChannelParticipationMetricsReporter.ReportConsensusRelationAndStatusMetricsArgsForCall(2)
 		require.Equal(t, "my-channel", channel)
-		require.Equal(t, types.ClusterRelationConsenter, relation)
+		require.Equal(t, types.ConsensusRelationConsenter, relation)
 		require.Equal(t, types.StatusActive, status)
 
 	})
@@ -266,8 +266,8 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		chain, err := follower.NewChain(ledgerResources, mockClusterConsenter, joinBlockAppRaft, options, pullerFactory, mockChainCreator, cryptoProvider, mockChannelParticipationMetricsReporter)
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationConsenter, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationConsenter, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.NotPanics(t, chain.Start)
@@ -275,8 +275,8 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		require.NotPanics(t, chain.Halt)
 		require.False(t, chain.IsRunning())
 
-		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationConsenter, cRel)
+		consensusRelation, status = chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationConsenter, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 2, pullerFactory.BlockPullerCallCount())
@@ -305,8 +305,8 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		chain, err := follower.NewChain(ledgerResources, mockClusterConsenter, joinBlockAppRaft, options, pullerFactory, mockChainCreator, cryptoProvider, mockChannelParticipationMetricsReporter)
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationConsenter, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationConsenter, consensusRelation)
 		require.Equal(t, types.StatusOnBoarding, status)
 
 		require.NotPanics(t, chain.Start)
@@ -314,8 +314,8 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 		require.NotPanics(t, chain.Halt)
 		require.False(t, chain.IsRunning())
 
-		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationConsenter, cRel)
+		consensusRelation, status = chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationConsenter, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 3, pullerFactory.BlockPullerCallCount())
@@ -370,8 +370,8 @@ func TestFollowerPullAfterJoin(t *testing.T) {
 		chain, err := follower.NewChain(ledgerResources, mockClusterConsenter, nil, options, pullerFactory, mockChainCreator, cryptoProvider, mockChannelParticipationMetricsReporter)
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.NotPanics(t, chain.Start)
@@ -379,8 +379,8 @@ func TestFollowerPullAfterJoin(t *testing.T) {
 		require.NotPanics(t, chain.Halt)
 		require.False(t, chain.IsRunning())
 
-		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status = chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 1, pullerFactory.BlockPullerCallCount())
@@ -411,8 +411,8 @@ func TestFollowerPullAfterJoin(t *testing.T) {
 
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.NotPanics(t, chain.Start)
@@ -420,8 +420,8 @@ func TestFollowerPullAfterJoin(t *testing.T) {
 		require.NotPanics(t, chain.Halt)
 		require.False(t, chain.IsRunning())
 
-		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status = chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 1, pullerFactory.BlockPullerCallCount())
@@ -469,8 +469,8 @@ func TestFollowerPullAfterJoin(t *testing.T) {
 
 		require.Equal(t, 0, timeAfterCount.AfterCallCount())
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.NotPanics(t, chain.Start)
@@ -478,8 +478,8 @@ func TestFollowerPullAfterJoin(t *testing.T) {
 		require.NotPanics(t, chain.Halt)
 		require.False(t, chain.IsRunning())
 
-		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status = chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 1, pullerFactory.BlockPullerCallCount())
@@ -516,8 +516,8 @@ func TestFollowerPullAfterJoin(t *testing.T) {
 		chain, err := follower.NewChain(ledgerResources, mockClusterConsenter, nil, options, pullerFactory, mockChainCreator, cryptoProvider, mockChannelParticipationMetricsReporter)
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.NotPanics(t, chain.Start)
@@ -525,8 +525,8 @@ func TestFollowerPullAfterJoin(t *testing.T) {
 		require.NotPanics(t, chain.Halt)
 		require.False(t, chain.IsRunning())
 
-		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationConsenter, cRel)
+		consensusRelation, status = chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationConsenter, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 1, pullerFactory.BlockPullerCallCount(), "after finding a config, block puller is created")
@@ -590,8 +590,8 @@ func TestFollowerPullAfterJoin(t *testing.T) {
 
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.NotPanics(t, chain.Start)
@@ -599,8 +599,8 @@ func TestFollowerPullAfterJoin(t *testing.T) {
 		require.NotPanics(t, chain.Halt)
 		require.False(t, chain.IsRunning())
 
-		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationConsenter, cRel)
+		consensusRelation, status = chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationConsenter, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 1, pullerFactory.BlockPullerCallCount(), "after finding a config, or error, block puller is created")
@@ -661,8 +661,8 @@ func TestFollowerPullPastJoin(t *testing.T) {
 		chain, err := follower.NewChain(ledgerResources, mockClusterConsenter, joinBlockAppRaft, options, pullerFactory, mockChainCreator, cryptoProvider, mockChannelParticipationMetricsReporter)
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusOnBoarding, status)
 
 		require.NotPanics(t, chain.Start)
@@ -670,8 +670,8 @@ func TestFollowerPullPastJoin(t *testing.T) {
 		require.NotPanics(t, chain.Halt)
 		require.False(t, chain.IsRunning())
 
-		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status = chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 3, pullerFactory.BlockPullerCallCount())
@@ -702,8 +702,8 @@ func TestFollowerPullPastJoin(t *testing.T) {
 
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusOnBoarding, status)
 
 		require.NotPanics(t, chain.Start)
@@ -711,8 +711,8 @@ func TestFollowerPullPastJoin(t *testing.T) {
 		require.NotPanics(t, chain.Halt)
 		require.False(t, chain.IsRunning())
 
-		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status = chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 3, pullerFactory.BlockPullerCallCount())
@@ -749,8 +749,8 @@ func TestFollowerPullPastJoin(t *testing.T) {
 		chain, err := follower.NewChain(ledgerResources, mockClusterConsenter, joinBlockAppRaft, options, pullerFactory, mockChainCreator, cryptoProvider, mockChannelParticipationMetricsReporter)
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusOnBoarding, status)
 
 		require.NotPanics(t, chain.Start)
@@ -758,8 +758,8 @@ func TestFollowerPullPastJoin(t *testing.T) {
 		require.NotPanics(t, chain.Halt)
 		require.False(t, chain.IsRunning())
 
-		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationConsenter, cRel)
+		consensusRelation, status = chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationConsenter, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 3, pullerFactory.BlockPullerCallCount(), "after finding a config, block puller is created")
@@ -823,8 +823,8 @@ func TestFollowerPullPastJoin(t *testing.T) {
 
 		require.NoError(t, err)
 
-		cRel, status := chain.StatusReport()
-		require.Equal(t, types.ClusterRelationFollower, cRel)
+		consensusRelation, status := chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationFollower, consensusRelation)
 		require.Equal(t, types.StatusOnBoarding, status)
 
 		require.NotPanics(t, chain.Start)
@@ -832,8 +832,8 @@ func TestFollowerPullPastJoin(t *testing.T) {
 		require.NotPanics(t, chain.Halt)
 		require.False(t, chain.IsRunning())
 
-		cRel, status = chain.StatusReport()
-		require.Equal(t, types.ClusterRelationConsenter, cRel)
+		consensusRelation, status = chain.StatusReport()
+		require.Equal(t, types.ConsensusRelationConsenter, consensusRelation)
 		require.Equal(t, types.StatusActive, status)
 
 		require.Equal(t, 3, pullerFactory.BlockPullerCallCount(), "after finding a config, or error, block puller is created")

--- a/orderer/common/follower/mocks/channel_participation_metrics_reporter.go
+++ b/orderer/common/follower/mocks/channel_participation_metrics_reporter.go
@@ -9,55 +9,55 @@ import (
 )
 
 type ChannelParticipationMetricsReporter struct {
-	ReportRelationAndStatusMetricsStub        func(string, types.ClusterRelation, types.Status)
-	reportRelationAndStatusMetricsMutex       sync.RWMutex
-	reportRelationAndStatusMetricsArgsForCall []struct {
+	ReportConsensusRelationAndStatusMetricsStub        func(string, types.ConsensusRelation, types.Status)
+	reportConsensusRelationAndStatusMetricsMutex       sync.RWMutex
+	reportConsensusRelationAndStatusMetricsArgsForCall []struct {
 		arg1 string
-		arg2 types.ClusterRelation
+		arg2 types.ConsensusRelation
 		arg3 types.Status
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ChannelParticipationMetricsReporter) ReportRelationAndStatusMetrics(arg1 string, arg2 types.ClusterRelation, arg3 types.Status) {
-	fake.reportRelationAndStatusMetricsMutex.Lock()
-	fake.reportRelationAndStatusMetricsArgsForCall = append(fake.reportRelationAndStatusMetricsArgsForCall, struct {
+func (fake *ChannelParticipationMetricsReporter) ReportConsensusRelationAndStatusMetrics(arg1 string, arg2 types.ConsensusRelation, arg3 types.Status) {
+	fake.reportConsensusRelationAndStatusMetricsMutex.Lock()
+	fake.reportConsensusRelationAndStatusMetricsArgsForCall = append(fake.reportConsensusRelationAndStatusMetricsArgsForCall, struct {
 		arg1 string
-		arg2 types.ClusterRelation
+		arg2 types.ConsensusRelation
 		arg3 types.Status
 	}{arg1, arg2, arg3})
-	fake.recordInvocation("ReportRelationAndStatusMetrics", []interface{}{arg1, arg2, arg3})
-	fake.reportRelationAndStatusMetricsMutex.Unlock()
-	if fake.ReportRelationAndStatusMetricsStub != nil {
-		fake.ReportRelationAndStatusMetricsStub(arg1, arg2, arg3)
+	fake.recordInvocation("ReportConsensusRelationAndStatusMetrics", []interface{}{arg1, arg2, arg3})
+	fake.reportConsensusRelationAndStatusMetricsMutex.Unlock()
+	if fake.ReportConsensusRelationAndStatusMetricsStub != nil {
+		fake.ReportConsensusRelationAndStatusMetricsStub(arg1, arg2, arg3)
 	}
 }
 
-func (fake *ChannelParticipationMetricsReporter) ReportRelationAndStatusMetricsCallCount() int {
-	fake.reportRelationAndStatusMetricsMutex.RLock()
-	defer fake.reportRelationAndStatusMetricsMutex.RUnlock()
-	return len(fake.reportRelationAndStatusMetricsArgsForCall)
+func (fake *ChannelParticipationMetricsReporter) ReportConsensusRelationAndStatusMetricsCallCount() int {
+	fake.reportConsensusRelationAndStatusMetricsMutex.RLock()
+	defer fake.reportConsensusRelationAndStatusMetricsMutex.RUnlock()
+	return len(fake.reportConsensusRelationAndStatusMetricsArgsForCall)
 }
 
-func (fake *ChannelParticipationMetricsReporter) ReportRelationAndStatusMetricsCalls(stub func(string, types.ClusterRelation, types.Status)) {
-	fake.reportRelationAndStatusMetricsMutex.Lock()
-	defer fake.reportRelationAndStatusMetricsMutex.Unlock()
-	fake.ReportRelationAndStatusMetricsStub = stub
+func (fake *ChannelParticipationMetricsReporter) ReportConsensusRelationAndStatusMetricsCalls(stub func(string, types.ConsensusRelation, types.Status)) {
+	fake.reportConsensusRelationAndStatusMetricsMutex.Lock()
+	defer fake.reportConsensusRelationAndStatusMetricsMutex.Unlock()
+	fake.ReportConsensusRelationAndStatusMetricsStub = stub
 }
 
-func (fake *ChannelParticipationMetricsReporter) ReportRelationAndStatusMetricsArgsForCall(i int) (string, types.ClusterRelation, types.Status) {
-	fake.reportRelationAndStatusMetricsMutex.RLock()
-	defer fake.reportRelationAndStatusMetricsMutex.RUnlock()
-	argsForCall := fake.reportRelationAndStatusMetricsArgsForCall[i]
+func (fake *ChannelParticipationMetricsReporter) ReportConsensusRelationAndStatusMetricsArgsForCall(i int) (string, types.ConsensusRelation, types.Status) {
+	fake.reportConsensusRelationAndStatusMetricsMutex.RLock()
+	defer fake.reportConsensusRelationAndStatusMetricsMutex.RUnlock()
+	argsForCall := fake.reportConsensusRelationAndStatusMetricsArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *ChannelParticipationMetricsReporter) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.reportRelationAndStatusMetricsMutex.RLock()
-	defer fake.reportRelationAndStatusMetricsMutex.RUnlock()
+	fake.reportConsensusRelationAndStatusMetricsMutex.RLock()
+	defer fake.reportConsensusRelationAndStatusMetricsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/orderer/common/multichannel/chainsupport.go
+++ b/orderer/common/multichannel/chainsupport.go
@@ -96,11 +96,11 @@ func newChainSupport(
 
 	cs.StatusReporter, ok = cs.Chain.(consensus.StatusReporter)
 	if !ok { // Non-cluster types: solo, kafka
-		cs.StatusReporter = consensus.StaticStatusReporter{ClusterRelation: types.ClusterRelationNone, Status: types.StatusActive}
+		cs.StatusReporter = consensus.StaticStatusReporter{ConsensusRelation: types.ConsensusRelationOther, Status: types.StatusActive}
 	}
 
 	clusterRelation, status := cs.StatusReporter.StatusReport()
-	registrar.ReportRelationAndStatusMetrics(cs.ChannelID(), clusterRelation, status)
+	registrar.ReportConsensusRelationAndStatusMetrics(cs.ChannelID(), clusterRelation, status)
 
 	logger.Debugf("[channel: %s] Done creating channel support resources", cs.ChannelID())
 
@@ -192,7 +192,7 @@ func newOnBoardingChainSupport(
 	cs := &ChainSupport{ledgerResources: ledgerResources}
 	cs.Processor = msgprocessor.NewStandardChannel(cs, msgprocessor.CreateStandardChannelFilters(cs, config), bccsp)
 	cs.Chain = &inactive.Chain{Err: errors.New("system channel creation pending: server requires restart")}
-	cs.StatusReporter = consensus.StaticStatusReporter{ClusterRelation: types.ClusterRelationConsenter, Status: types.StatusInactive}
+	cs.StatusReporter = consensus.StaticStatusReporter{ConsensusRelation: types.ConsensusRelationConsenter, Status: types.StatusInactive}
 
 	logger.Debugf("[channel: %s] Done creating onboarding channel support resources", cs.ChannelID())
 

--- a/orderer/common/multichannel/chainsupport_test.go
+++ b/orderer/common/multichannel/chainsupport_test.go
@@ -104,7 +104,7 @@ func TestNewOnboardingChainSupport(t *testing.T) {
 	require.False(t, open)
 
 	cRel, status := cs.StatusReport()
-	require.Equal(t, types.ClusterRelationConsenter, cRel)
+	require.Equal(t, types.ConsensusRelationConsenter, cRel)
 	require.Equal(t, types.StatusInactive, status)
 
 	require.Equal(t, uint64(7), cs.Height(), "ledger ReadWriter is initialized")

--- a/orderer/common/multichannel/metrics_test.go
+++ b/orderer/common/multichannel/metrics_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Metrics", func() {
 			Expect(metrics).NotTo(BeNil())
 			Expect(fakeProvider.NewGaugeCallCount()).To(Equal(2))
 
-			Expect(metrics.Relation).To(Equal(fakeGauge))
+			Expect(metrics.ConsensusRelation).To(Equal(fakeGauge))
 			Expect(metrics.Status).To(Equal(fakeGauge))
 		})
 	})
@@ -85,7 +85,7 @@ var _ = Describe("Metrics", func() {
 		})
 	})
 
-	Context("reportRelation", func() {
+	Context("reportConsensusRelation", func() {
 		var (
 			fakeProvider *metricsfakes.Provider
 			fakeGauge    *metricsfakes.Gauge
@@ -100,63 +100,63 @@ var _ = Describe("Metrics", func() {
 			fakeGauge.WithReturns(fakeGauge)
 
 			metrics = NewMetrics(fakeProvider)
-			Expect(metrics.Relation).To(Equal(fakeGauge))
+			Expect(metrics.ConsensusRelation).To(Equal(fakeGauge))
 		})
 
-		It("reports relation none as a gauge", func() {
-			metrics.reportRelation("fake-channel", types.ClusterRelationNone)
+		It("reports consensus relation other as a gauge", func() {
+			metrics.reportConsensusRelation("fake-channel", types.ConsensusRelationOther)
 			Expect(fakeGauge.WithCallCount()).To(Equal(1))
 			Expect(fakeGauge.WithArgsForCall(0)).To(Equal([]string{"channel", "fake-channel"}))
 			Expect(fakeGauge.SetCallCount()).To(Equal(1))
 			Expect(fakeGauge.SetArgsForCall(0)).To(Equal(float64(0)))
 		})
 
-		It("reports relation consenter as a gauge", func() {
-			metrics.reportRelation("fake-channel", types.ClusterRelationConsenter)
+		It("reports consensus relation consenter as a gauge", func() {
+			metrics.reportConsensusRelation("fake-channel", types.ConsensusRelationConsenter)
 			Expect(fakeGauge.WithCallCount()).To(Equal(1))
 			Expect(fakeGauge.WithArgsForCall(0)).To(Equal([]string{"channel", "fake-channel"}))
 			Expect(fakeGauge.SetCallCount()).To(Equal(1))
 			Expect(fakeGauge.SetArgsForCall(0)).To(Equal(float64(1)))
 		})
 
-		It("reports relation follower as a gauge", func() {
-			metrics.reportRelation("fake-channel", types.ClusterRelationFollower)
+		It("reports consensus relation follower as a gauge", func() {
+			metrics.reportConsensusRelation("fake-channel", types.ConsensusRelationFollower)
 			Expect(fakeGauge.WithCallCount()).To(Equal(1))
 			Expect(fakeGauge.WithArgsForCall(0)).To(Equal([]string{"channel", "fake-channel"}))
 			Expect(fakeGauge.SetCallCount()).To(Equal(1))
 			Expect(fakeGauge.SetArgsForCall(0)).To(Equal(float64(2)))
 		})
 
-		It("reports relation config-tracker as a gauge", func() {
-			metrics.reportRelation("fake-channel", types.ClusterRelationConfigTracker)
+		It("reports consensus relation config-tracker as a gauge", func() {
+			metrics.reportConsensusRelation("fake-channel", types.ConsensusRelationConfigTracker)
 			Expect(fakeGauge.WithCallCount()).To(Equal(1))
 			Expect(fakeGauge.WithArgsForCall(0)).To(Equal([]string{"channel", "fake-channel"}))
 			Expect(fakeGauge.SetCallCount()).To(Equal(1))
 			Expect(fakeGauge.SetArgsForCall(0)).To(Equal(float64(3)))
 		})
 
-		It("panics when reporting an unknown relation", func() {
-			Expect(func() { metrics.reportRelation("fake-channel", "unknown") }).To(Panic())
+		It("panics when reporting an unknown consensus relation", func() {
+			Expect(func() { metrics.reportConsensusRelation("fake-channel", "unknown") }).To(Panic())
 		})
 	})
 })
 
 func newFakeMetrics(fakeFields *fakeMetricsFields) *Metrics {
 	return &Metrics{
-		Relation: fakeFields.fakeRelation,
-		Status:   fakeFields.fakeStatus,
+		ConsensusRelation: fakeFields.fakeConsensusRelation,
+		Status:            fakeFields.fakeStatus,
 	}
 }
 
 type fakeMetricsFields struct {
-	fakeRelation *metricsfakes.Gauge
-	fakeStatus   *metricsfakes.Gauge
+	fakeConsensusRelation *metricsfakes.Gauge
+	fakeStatus            *metricsfakes.Gauge
 }
 
 func newFakeMetricsFields() *fakeMetricsFields {
 	return &fakeMetricsFields{
-		fakeRelation: newFakeGauge(),
-		fakeStatus:   newFakeGauge(),
+		fakeConsensusRelation: newFakeGauge(),
+		fakeStatus:            newFakeGauge(),
 	}
 }
 

--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -691,22 +691,22 @@ func (r *Registrar) ChannelInfo(channelID string) (types.ChannelInfo, error) {
 
 	if c, ok := r.chains[channelID]; ok {
 		info.Height = c.Height()
-		info.ClusterRelation, info.Status = c.StatusReport()
+		info.ConsensusRelation, info.Status = c.StatusReport()
 		return info, nil
 	}
 
 	if f, ok := r.followers[channelID]; ok {
 		info.Height = f.Height()
-		info.ClusterRelation, info.Status = f.StatusReport()
+		info.ConsensusRelation, info.Status = f.StatusReport()
 		return info, nil
 	}
 
 	_, ok := r.pendingRemoval[channelID]
 	if ok {
 		return types.ChannelInfo{
-			Name:            channelID,
-			ClusterRelation: types.ClusterRelationFollower,
-			Status:          types.StatusInactive,
+			Name:              channelID,
+			ConsensusRelation: types.ConsensusRelationFollower,
+			Status:            types.StatusInactive,
 		}, nil
 	}
 
@@ -825,7 +825,7 @@ func (r *Registrar) createAsMember(ledgerRes *ledgerResources, configBlock *cb.B
 		URL:    "",
 		Height: ledgerRes.Height(),
 	}
-	info.ClusterRelation, info.Status = chain.StatusReport()
+	info.ConsensusRelation, info.Status = chain.StatusReport()
 	r.chains[channelID] = chain
 
 	logger.Infof("Joining channel: %v", info)
@@ -865,11 +865,11 @@ func (r *Registrar) createFollower(
 
 	clusterRelation, status := fChain.StatusReport()
 	info := types.ChannelInfo{
-		Name:            channelID,
-		URL:             "",
-		Height:          ledgerRes.Height(),
-		ClusterRelation: clusterRelation,
-		Status:          status,
+		Name:              channelID,
+		URL:               "",
+		Height:            ledgerRes.Height(),
+		ConsensusRelation: clusterRelation,
+		Status:            status,
 	}
 
 	r.followers[channelID] = fChain
@@ -909,7 +909,7 @@ func (r *Registrar) joinSystemChannel(
 		URL:    "",
 		Height: ledgerRes.Height(),
 	}
-	info.ClusterRelation, info.Status = r.systemChannel.StatusReport()
+	info.ConsensusRelation, info.Status = r.systemChannel.StatusReport()
 
 	logger.Infof("System channel creation pending: server requires restart! ChannelInfo: %v", info)
 
@@ -1100,7 +1100,7 @@ func (r *Registrar) removeLedgerAsync(channelID string) {
 	}()
 }
 
-func (r *Registrar) ReportRelationAndStatusMetrics(channelID string, relation types.ClusterRelation, status types.Status) {
-	r.channelParticipationMetrics.reportRelation(channelID, relation)
+func (r *Registrar) ReportConsensusRelationAndStatusMetrics(channelID string, relation types.ConsensusRelation, status types.Status) {
+	r.channelParticipationMetrics.reportConsensusRelation(channelID, relation)
 	r.channelParticipationMetrics.reportStatus(channelID, status)
 }

--- a/orderer/common/multichannel/registrar_test.go
+++ b/orderer/common/multichannel/registrar_test.go
@@ -262,7 +262,7 @@ func TestNewRegistrar(t *testing.T) {
 		info, err := manager.ChannelInfo("testchannelid")
 		require.NoError(t, err)
 		require.Equal(t,
-			types.ChannelInfo{Name: "testchannelid", URL: "", ClusterRelation: "none", Status: "active", Height: 1},
+			types.ChannelInfo{Name: "testchannelid", URL: "", ConsensusRelation: "other", Status: "active", Height: 1},
 			info,
 		)
 
@@ -354,7 +354,7 @@ func TestRegistrar_Initialize(t *testing.T) {
 		info, err := manager.ChannelInfo("my-sys-channel")
 		require.NoError(t, err)
 		require.Equal(t,
-			types.ChannelInfo{Name: "my-sys-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 1},
+			types.ChannelInfo{Name: "my-sys-channel", URL: "", ConsensusRelation: "consenter", Status: "active", Height: 1},
 			info,
 		)
 	})
@@ -393,7 +393,7 @@ func TestRegistrar_Initialize(t *testing.T) {
 		info, err := manager.ChannelInfo("my-raft-channel")
 		require.NoError(t, err)
 		require.Equal(t,
-			types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 1},
+			types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "active", Height: 1},
 			info,
 		)
 	})
@@ -429,7 +429,7 @@ func TestRegistrar_Initialize(t *testing.T) {
 		info, err := manager.ChannelInfo("my-raft-channel")
 		require.NoError(t, err)
 		require.Equal(t,
-			types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "follower", Status: "active", Height: 1},
+			types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "follower", Status: "active", Height: 1},
 			info,
 		)
 
@@ -476,7 +476,7 @@ func TestRegistrar_Initialize(t *testing.T) {
 		info, err := manager.ChannelInfo("my-raft-channel")
 		require.NoError(t, err)
 		require.Equal(t,
-			types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "follower", Status: "onboarding", Height: 1},
+			types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "follower", Status: "onboarding", Height: 1},
 			info,
 		)
 
@@ -632,14 +632,14 @@ func TestCreateChain(t *testing.T) {
 		info, err := manager.ChannelInfo("testchannelid")
 		require.NoError(t, err)
 		require.Equal(t,
-			types.ChannelInfo{Name: "testchannelid", URL: "", ClusterRelation: types.ClusterRelationConsenter, Status: types.StatusActive, Height: 1},
+			types.ChannelInfo{Name: "testchannelid", URL: "", ConsensusRelation: types.ConsensusRelationConsenter, Status: types.StatusActive, Height: 1},
 			info,
 		)
 
 		info, err = manager.ChannelInfo("mychannel")
 		require.NoError(t, err)
 		require.Equal(t,
-			types.ChannelInfo{Name: "mychannel", URL: "", ClusterRelation: types.ClusterRelationConsenter, Status: types.StatusActive, Height: 1},
+			types.ChannelInfo{Name: "mychannel", URL: "", ConsensusRelation: types.ConsensusRelationConsenter, Status: types.StatusActive, Height: 1},
 			info,
 		)
 
@@ -1100,14 +1100,14 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 			require.Nil(t, registrar.GetChain("my-raft-channel"))
 			info, err := registrar.JoinChannel("my-raft-channel", genesisBlockAppRaft, true)
 			require.NoError(t, err)
-			require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 0x1}, info)
+			require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "active", Height: 0x1}, info)
 			// After creating the channel, it exists
 			require.NotNil(t, registrar.GetChain("my-raft-channel"))
 
 			// ChannelInfo() and ChannelList() are working fine
 			info, err = registrar.ChannelInfo("my-raft-channel")
 			require.NoError(t, err)
-			require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 0x1}, info)
+			require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "active", Height: 0x1}, info)
 			channelList := registrar.ChannelList()
 			require.Equal(t, 1, len(channelList.Channels))
 			require.Equal(t, "my-raft-channel", channelList.Channels[0].Name)
@@ -1134,14 +1134,14 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 
 		info, err := registrar.JoinChannel("my-raft-channel", genesisBlockAppRaft, true)
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "onboarding", Height: 0x0}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "onboarding", Height: 0x0}, info)
 		// After creating the follower.Chain, it not in the chains map.
 		require.Nil(t, registrar.GetChain("my-raft-channel"))
 
 		// ChannelInfo() and ChannelList() are working fine
 		info, err = registrar.ChannelInfo("my-raft-channel")
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "onboarding", Height: 0x0}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "onboarding", Height: 0x0}, info)
 		channelList := registrar.ChannelList()
 		require.Equal(t, 1, len(channelList.Channels))
 		require.Equal(t, "my-raft-channel", channelList.Channels[0].Name)
@@ -1169,13 +1169,13 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 
 		info, err := registrar.JoinChannel("my-raft-channel", genesisBlockAppRaft, true)
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "follower", Status: "onboarding", Height: 0x0}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "follower", Status: "onboarding", Height: 0x0}, info)
 		// After creating the follower.Chain, it not in the chains map.
 		require.Nil(t, registrar.GetChain("my-raft-channel"))
 		// ChannelInfo() and ChannelList() are working fine
 		info, err = registrar.ChannelInfo("my-raft-channel")
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "follower", Status: "onboarding", Height: 0x0}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "follower", Status: "onboarding", Height: 0x0}, info)
 		channelList := registrar.ChannelList()
 		require.Equal(t, 1, len(channelList.Channels))
 		require.Equal(t, "my-raft-channel", channelList.Channels[0].Name)
@@ -1206,7 +1206,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		genesisBlockAppRaft.Header.Number = 1
 		info, err := registrar.JoinChannel("my-raft-channel", genesisBlockAppRaft, true)
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "follower", Status: "onboarding", Height: 0x0}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "follower", Status: "onboarding", Height: 0x0}, info)
 
 		// After creating the follower.Chain, it not in the chains map, it is in the followers map.
 		require.Nil(t, registrar.GetChain("my-raft-channel"))
@@ -1232,7 +1232,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		// ChannelInfo() and ChannelList() are still working fine
 		info, err = registrar.ChannelInfo("my-raft-channel")
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 0x1}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "active", Height: 0x1}, info)
 		channelList := registrar.ChannelList()
 		require.Equal(t, 1, len(channelList.Channels))
 		require.Equal(t, "my-raft-channel", channelList.Channels[0].Name)
@@ -1260,7 +1260,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 
 		info, err := registrar.JoinChannel("my-raft-channel", genesisBlockAppRaft, true)
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 0x1}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "active", Height: 0x1}, info)
 		// After creating the chain, it exists
 		cs := registrar.GetChain("my-raft-channel")
 		require.NotNil(t, cs)
@@ -1268,7 +1268,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		// ChannelInfo() and ChannelList() are working fine
 		info, err = registrar.ChannelInfo("my-raft-channel")
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 0x1}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "active", Height: 0x1}, info)
 		channelList := registrar.ChannelList()
 		require.Equal(t, 1, len(channelList.Channels))
 		require.Equal(t, "my-raft-channel", channelList.Channels[0].Name)
@@ -1292,7 +1292,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		// ChannelInfo() and ChannelList() are still working fine
 		info, err = registrar.ChannelInfo("my-raft-channel")
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "follower", Status: "active", Height: 0x2}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "follower", Status: "active", Height: 0x2}, info)
 		channelList = registrar.ChannelList()
 		require.Equal(t, 1, len(channelList.Channels))
 		require.Equal(t, "my-raft-channel", channelList.Channels[0].Name)
@@ -1315,7 +1315,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 
 		info, err := registrar.JoinChannel("sys-raft-channel", genesisBlockSysRaft, false)
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ClusterRelation: "consenter", Status: "inactive", Height: 0x1}, info)
+		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "inactive", Height: 0x1}, info)
 		// After creating the chain, it exists
 		cs := registrar.GetChain("sys-raft-channel")
 		require.NotNil(t, cs)
@@ -1328,7 +1328,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		// ChannelInfo() and ChannelList() are working fine
 		info, err = registrar.ChannelInfo("sys-raft-channel")
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ClusterRelation: "consenter", Status: "inactive", Height: 0x1}, info)
+		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "inactive", Height: 0x1}, info)
 		channelList := registrar.ChannelList()
 		require.Equal(t, 0, len(channelList.Channels))
 		require.NotNil(t, channelList.SystemChannel)
@@ -1352,7 +1352,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		genesisBlockSysRaft.Header.Number = 7
 		info, err := registrar.JoinChannel("sys-raft-channel", genesisBlockSysRaft, false)
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ClusterRelation: "consenter", Status: "inactive", Height: 0x0}, info)
+		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "inactive", Height: 0x0}, info)
 		// After creating the chain, it exists
 		cs := registrar.GetChain("sys-raft-channel")
 		require.NotNil(t, cs)
@@ -1365,7 +1365,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 		// ChannelInfo() and ChannelList() are working fine
 		info, err = registrar.ChannelInfo("sys-raft-channel")
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ClusterRelation: "consenter", Status: "inactive", Height: 0x0}, info)
+		require.Equal(t, types.ChannelInfo{Name: "sys-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "inactive", Height: 0x0}, info)
 		channelList := registrar.ChannelList()
 		require.Equal(t, 0, len(channelList.Channels))
 		require.NotNil(t, channelList.SystemChannel)
@@ -1377,10 +1377,10 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 }
 
 func checkMetrics(t *testing.T, fakeFields *fakeMetricsFields, expectedLabels []string, expectedRelation, expectedStatus, expectedCallCount int) {
-	require.Equal(t, expectedCallCount, fakeFields.fakeRelation.SetCallCount())
-	require.Equal(t, float64(expectedRelation), fakeFields.fakeRelation.SetArgsForCall(expectedCallCount-1))
-	require.Equal(t, expectedCallCount, fakeFields.fakeRelation.WithCallCount())
-	require.Equal(t, expectedLabels, fakeFields.fakeRelation.WithArgsForCall(expectedCallCount-1))
+	require.Equal(t, expectedCallCount, fakeFields.fakeConsensusRelation.SetCallCount())
+	require.Equal(t, float64(expectedRelation), fakeFields.fakeConsensusRelation.SetArgsForCall(expectedCallCount-1))
+	require.Equal(t, expectedCallCount, fakeFields.fakeConsensusRelation.WithCallCount())
+	require.Equal(t, expectedLabels, fakeFields.fakeConsensusRelation.WithArgsForCall(expectedCallCount-1))
 	require.Equal(t, expectedCallCount, fakeFields.fakeStatus.SetCallCount())
 	require.Equal(t, float64(expectedStatus), fakeFields.fakeStatus.SetArgsForCall(expectedCallCount-1))
 	require.Equal(t, expectedCallCount, fakeFields.fakeStatus.WithCallCount())
@@ -1525,7 +1525,7 @@ func TestRegistrar_RemoveChannel(t *testing.T) {
 			require.NotContains(t, ledgerFactory.ChannelIDs(), "my-raft-channel")
 			info, err := registrar.JoinChannel("my-raft-channel", genesisBlockAppRaft, true)
 			require.NoError(t, err)
-			require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 1}, info)
+			require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "active", Height: 1}, info)
 			require.NotNil(t, registrar.GetChain("my-raft-channel"))
 			require.Contains(t, ledgerFactory.ChannelIDs(), "my-raft-channel")
 
@@ -1550,7 +1550,7 @@ func TestRegistrar_RemoveChannel(t *testing.T) {
 			require.NotContains(t, ledgerFactory.ChannelIDs(), "my-follower-raft-channel")
 			info, err := registrar.JoinChannel("my-follower-raft-channel", genesisBlockAppRaftFollower, true)
 			require.NoError(t, err)
-			require.Equal(t, types.ChannelInfo{Name: "my-follower-raft-channel", URL: "", ClusterRelation: "follower", Status: "onboarding", Height: 0}, info)
+			require.Equal(t, types.ChannelInfo{Name: "my-follower-raft-channel", URL: "", ConsensusRelation: "follower", Status: "onboarding", Height: 0}, info)
 			require.NotNil(t, registrar.GetFollower("my-follower-raft-channel"))
 			require.Contains(t, ledgerFactory.ChannelIDs(), "my-follower-raft-channel")
 
@@ -1562,9 +1562,9 @@ func TestRegistrar_RemoveChannel(t *testing.T) {
 			channelInfo, err := registrar.ChannelInfo("my-follower-raft-channel")
 			require.NoError(t, err)
 			require.Equal(t, channelInfo, types.ChannelInfo{
-				Name:            "my-follower-raft-channel",
-				ClusterRelation: types.ClusterRelationFollower,
-				Status:          types.StatusInactive,
+				Name:              "my-follower-raft-channel",
+				ConsensusRelation: types.ConsensusRelationFollower,
+				Status:            types.StatusInactive,
 			})
 			require.Eventually(t, func() bool { return len(ledgerFactory.ChannelIDs()) == 0 }, time.Minute, time.Second)
 			require.NotContains(t, ledgerFactory.ChannelIDs(), "my-follower-raft-channel")
@@ -1683,7 +1683,7 @@ func TestRegistrar_RemoveChannel(t *testing.T) {
 		require.NotContains(t, ledgerFactory.ChannelIDs(), "my-raft-channel")
 		info, err := registrar.JoinChannel("my-raft-channel", genesisBlockAppRaft, true)
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 1}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "active", Height: 1}, info)
 		require.NotNil(t, registrar.GetChain("my-raft-channel"))
 		require.Contains(t, ledgerFactory.ChannelIDs(), "my-raft-channel")
 
@@ -1707,7 +1707,7 @@ func TestRegistrar_RemoveChannel(t *testing.T) {
 		require.NotContains(t, ledgerFactory.ChannelIDs(), "my-raft-channel")
 		info, err := registrar.JoinChannel("my-raft-channel", genesisBlockAppRaft, true)
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 1}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "active", Height: 1}, info)
 		require.NotNil(t, registrar.GetChain("my-raft-channel"))
 		require.Contains(t, ledgerFactory.ChannelIDs(), "my-raft-channel")
 
@@ -1731,7 +1731,7 @@ func TestRegistrar_RemoveChannel(t *testing.T) {
 		require.NotContains(t, ledgerFactory.ChannelIDs(), "my-raft-channel")
 		info, err := registrar.JoinChannel("my-raft-channel", genesisBlockAppRaft, true)
 		require.NoError(t, err)
-		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ClusterRelation: "consenter", Status: "active", Height: 1}, info)
+		require.Equal(t, types.ChannelInfo{Name: "my-raft-channel", URL: "", ConsensusRelation: "consenter", Status: "active", Height: 1}, info)
 		require.NotNil(t, registrar.GetChain("my-raft-channel"))
 		require.Contains(t, ledgerFactory.ChannelIDs(), "my-raft-channel")
 
@@ -1749,9 +1749,9 @@ func TestRegistrar_RemoveChannel(t *testing.T) {
 		channelInfo, err := registrar.ChannelInfo("my-raft-channel")
 		require.NoError(t, err)
 		require.Equal(t, channelInfo, types.ChannelInfo{
-			Name:            "my-raft-channel",
-			ClusterRelation: types.ClusterRelationFollower,
-			Status:          types.StatusInactive})
+			Name:              "my-raft-channel",
+			ConsensusRelation: types.ConsensusRelationFollower,
+			Status:            types.StatusInactive})
 	})
 }
 

--- a/orderer/common/multichannel/util_test.go
+++ b/orderer/common/multichannel/util_test.go
@@ -27,8 +27,8 @@ type mockChainCluster struct {
 	*mockChain
 }
 
-func (c *mockChainCluster) StatusReport() (types.ClusterRelation, types.Status) {
-	return types.ClusterRelationConsenter, types.StatusActive
+func (c *mockChainCluster) StatusReport() (types.ConsensusRelation, types.Status) {
+	return types.ConsensusRelationConsenter, types.StatusActive
 }
 
 type mockChain struct {

--- a/orderer/common/types/channelinfo.go
+++ b/orderer/common/types/channelinfo.go
@@ -29,21 +29,21 @@ type ChannelInfoShort struct {
 	URL string `json:"url"`
 }
 
-// ClusterRelation represents the relationship between the orderer and the channel's consensus cluster.
-type ClusterRelation string
+// ConsensusRelation represents the relationship between the orderer and the channel's consensus cluster.
+type ConsensusRelation string
 
 const (
 	// The orderer is a cluster consenter of a cluster consensus protocol (e.g. etcdraft) for a specific channel.
 	// That is, the orderer is in the consenters set of the channel.
-	ClusterRelationConsenter ClusterRelation = "consenter"
+	ConsensusRelationConsenter ConsensusRelation = "consenter"
 	// The orderer is following a cluster consensus protocol by pulling blocks from other orderers.
 	// The orderer is NOT in the consenters set of the channel.
-	ClusterRelationFollower ClusterRelation = "follower"
+	ConsensusRelationFollower ConsensusRelation = "follower"
 	// The orderer is NOT in the consenters set of the channel, and is just tracking (polling) the last config block
 	// of the channel in order to detect when it is added to the channel.
-	ClusterRelationConfigTracker ClusterRelation = "config-tracker"
+	ConsensusRelationConfigTracker ConsensusRelation = "config-tracker"
 	// The orderer runs a non-cluster consensus type, solo or kafka.
-	ClusterRelationNone ClusterRelation = "none"
+	ConsensusRelationOther ConsensusRelation = "other"
 )
 
 // Status represents the degree by which the orderer had caught up with the rest of the cluster after joining the
@@ -70,9 +70,9 @@ type ChannelInfo struct {
 	URL string `json:"url"`
 	// Whether the orderer is a “consenter”, ”follower”, or "config-tracker" of
 	// the cluster for this channel.
-	// For non cluster consensus types (solo, kafka) it is "none".
-	// Possible values:  “consenter”, ”follower”, "config-tracker", "none".
-	ClusterRelation ClusterRelation `json:"clusterRelation"`
+	// For non cluster consensus types (solo, kafka) it is "other".
+	// Possible values:  “consenter”, ”follower”, "config-tracker", "other".
+	ConsensusRelation ConsensusRelation `json:"consensusRelation"`
 	// Whether the orderer is ”onboarding”, ”active”, or "inactive", for this channel.
 	// For non cluster consensus types (solo, kafka) it is "active".
 	// Possible values:  “onboarding”, ”active”, "inactive".

--- a/orderer/common/types/channelinfo_test.go
+++ b/orderer/common/types/channelinfo_test.go
@@ -73,16 +73,16 @@ func TestChannelList(t *testing.T) {
 
 func TestChannelInfo(t *testing.T) {
 	info := types.ChannelInfo{
-		Name:            "a",
-		URL:             "/api/channels/a",
-		ClusterRelation: types.ClusterRelationFollower,
-		Status:          types.StatusActive,
-		Height:          uint64(1) << 60,
+		Name:              "a",
+		URL:               "/api/channels/a",
+		ConsensusRelation: types.ConsensusRelationFollower,
+		Status:            types.StatusActive,
+		Height:            uint64(1) << 60,
 	}
 
 	buff, err := json.Marshal(info)
 	require.NoError(t, err)
-	require.Equal(t, `{"name":"a","url":"/api/channels/a","clusterRelation":"follower","status":"active","height":1152921504606846976}`, string(buff))
+	require.Equal(t, `{"name":"a","url":"/api/channels/a","consensusRelation":"follower","status":"active","height":1152921504606846976}`, string(buff))
 
 	var info2 types.ChannelInfo
 	err = json.Unmarshal(buff, &info2)

--- a/orderer/consensus/cluster_status.go
+++ b/orderer/consensus/cluster_status.go
@@ -18,15 +18,15 @@ import "github.com/hyperledger/fabric/orderer/common/types"
 type StatusReporter interface {
 	// StatusReport provides the cluster relation and status.
 	// See:  channelparticipation.ChannelInfo for more details.
-	StatusReport() (types.ClusterRelation, types.Status)
+	StatusReport() (types.ConsensusRelation, types.Status)
 }
 
 // StaticStatusReporter is intended for chains that do not implement the StatusReporter interface.
 type StaticStatusReporter struct {
-	ClusterRelation types.ClusterRelation
-	Status          types.Status
+	ConsensusRelation types.ConsensusRelation
+	Status            types.Status
 }
 
-func (s StaticStatusReporter) StatusReport() (types.ClusterRelation, types.Status) {
-	return s.ClusterRelation, s.Status
+func (s StaticStatusReporter) StatusReport() (types.ConsensusRelation, types.Status) {
+	return s.ConsensusRelation, s.Status
 }

--- a/orderer/consensus/cluster_status_test.go
+++ b/orderer/consensus/cluster_status_test.go
@@ -16,12 +16,12 @@ import (
 
 func TestStaticStatusReporter(t *testing.T) {
 	staticSR := &consensus.StaticStatusReporter{
-		ClusterRelation: types.ClusterRelationNone,
-		Status:          types.StatusActive,
+		ConsensusRelation: types.ConsensusRelationOther,
+		Status:            types.StatusActive,
 	}
 
 	var sr consensus.StatusReporter = staticSR // make sure it implements this interface
 	cRel, status := sr.StatusReport()
-	require.Equal(t, types.ClusterRelationNone, cRel)
+	require.Equal(t, types.ConsensusRelationOther, cRel)
 	require.Equal(t, types.StatusActive, status)
 }

--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -216,7 +216,7 @@ var _ = Describe("Chain", func() {
 
 			chain.Start()
 			cRel, status := chain.StatusReport()
-			Expect(cRel).To(Equal(orderer_types.ClusterRelationConsenter))
+			Expect(cRel).To(Equal(orderer_types.ConsensusRelationConsenter))
 			Expect(status).To(Equal(orderer_types.StatusActive))
 
 			// When the Raft node bootstraps, it produces a ConfChange
@@ -1450,11 +1450,11 @@ var _ = Describe("Chain", func() {
 			Eventually(fakeHaltCallbacker.HaltCallbackCallCount).Should(Equal(1))
 			By("Asserting the StatusReport responds correctly after eviction")
 			Eventually(
-				func() orderer_types.ClusterRelation {
+				func() orderer_types.ConsensusRelation {
 					cRel, _ := c1.StatusReport()
 					return cRel
 				},
-			).Should(Equal(orderer_types.ClusterRelationConfigTracker))
+			).Should(Equal(orderer_types.ConsensusRelationConfigTracker))
 			_, status := c1.StatusReport()
 			Expect(status).To(Equal(orderer_types.StatusInactive))
 
@@ -1501,7 +1501,7 @@ var _ = Describe("Chain", func() {
 				},
 			).Should(Equal(orderer_types.StatusInactive))
 			cRel, _ := c1.StatusReport()
-			Expect(cRel).To(Equal(orderer_types.ClusterRelationConsenter))
+			Expect(cRel).To(Equal(orderer_types.ConsensusRelationConsenter))
 		})
 
 		It("can remove leader by reconfiguring cluster even if leadership transfer fails", func() {

--- a/orderer/consensus/etcdraft/consenter.go
+++ b/orderer/consensus/etcdraft/consenter.go
@@ -53,7 +53,7 @@ type ChainManager interface {
 	GetConsensusChain(channelID string) consensus.Chain
 	CreateChain(channelID string)
 	SwitchChainToFollower(channelID string)
-	ReportRelationAndStatusMetrics(channelID string, relation types.ClusterRelation, status types.Status)
+	ReportConsensusRelationAndStatusMetrics(channelID string, relation types.ConsensusRelation, status types.Status)
 }
 
 // Config contains etcdraft configurations
@@ -167,7 +167,7 @@ func (c *Consenter) HandleChain(support consensus.ConsenterSupport, metadata *co
 			c.InactiveChainRegistry.TrackChain(support.ChannelID(), support.Block(0), func() {
 				c.ChainManager.CreateChain(support.ChannelID())
 			})
-			c.ChainManager.ReportRelationAndStatusMetrics(support.ChannelID(), types.ClusterRelationConfigTracker, types.StatusInactive)
+			c.ChainManager.ReportConsensusRelationAndStatusMetrics(support.ChannelID(), types.ConsensusRelationConfigTracker, types.StatusInactive)
 			return &inactive.Chain{Err: errors.Errorf("channel %s is not serviced by me", support.ChannelID())}, nil
 		}
 
@@ -238,7 +238,7 @@ func (c *Consenter) HandleChain(support consensus.ConsenterSupport, metadata *co
 		c.Logger.Info("With system channel: after eviction InactiveChainRegistry.TrackChain will be called")
 		haltCallback = func() {
 			c.InactiveChainRegistry.TrackChain(support.ChannelID(), nil, func() { c.ChainManager.CreateChain(support.ChannelID()) })
-			c.ChainManager.ReportRelationAndStatusMetrics(support.ChannelID(), types.ClusterRelationConfigTracker, types.StatusInactive)
+			c.ChainManager.ReportConsensusRelationAndStatusMetrics(support.ChannelID(), types.ConsensusRelationConfigTracker, types.StatusInactive)
 		}
 	} else {
 		// when we do NOT have a system channel, we switch to a follower.Chain upon eviction.

--- a/orderer/consensus/etcdraft/consenter_test.go
+++ b/orderer/consensus/etcdraft/consenter_test.go
@@ -449,10 +449,10 @@ var _ = Describe("Consenter", func() {
 		Expect(err).To(Not(HaveOccurred()))
 		Expect(chain.Order(nil, 0).Error()).To(Equal("channel foo is not serviced by me"))
 		Expect(consenter.icr.TrackChainCallCount()).To(Equal(1))
-		Expect(chainManager.ReportRelationAndStatusMetricsCallCount()).To(Equal(1))
-		channel, relation, status := chainManager.ReportRelationAndStatusMetricsArgsForCall(0)
+		Expect(chainManager.ReportConsensusRelationAndStatusMetricsCallCount()).To(Equal(1))
+		channel, relation, status := chainManager.ReportConsensusRelationAndStatusMetricsArgsForCall(0)
 		Expect(channel).To(Equal("foo"))
-		Expect(relation).To(Equal(types.ClusterRelationConfigTracker))
+		Expect(relation).To(Equal(types.ConsensusRelationConfigTracker))
 		Expect(status).To(Equal(types.StatusInactive))
 	})
 

--- a/orderer/consensus/etcdraft/mocks/chain_manager.go
+++ b/orderer/consensus/etcdraft/mocks/chain_manager.go
@@ -26,11 +26,11 @@ type ChainManager struct {
 	getConsensusChainReturnsOnCall map[int]struct {
 		result1 consensus.Chain
 	}
-	ReportRelationAndStatusMetricsStub        func(string, types.ClusterRelation, types.Status)
-	reportRelationAndStatusMetricsMutex       sync.RWMutex
-	reportRelationAndStatusMetricsArgsForCall []struct {
+	ReportConsensusRelationAndStatusMetricsStub        func(string, types.ConsensusRelation, types.Status)
+	reportConsensusRelationAndStatusMetricsMutex       sync.RWMutex
+	reportConsensusRelationAndStatusMetricsArgsForCall []struct {
 		arg1 string
-		arg2 types.ClusterRelation
+		arg2 types.ConsensusRelation
 		arg3 types.Status
 	}
 	SwitchChainToFollowerStub        func(string)
@@ -133,36 +133,36 @@ func (fake *ChainManager) GetConsensusChainReturnsOnCall(i int, result1 consensu
 	}{result1}
 }
 
-func (fake *ChainManager) ReportRelationAndStatusMetrics(arg1 string, arg2 types.ClusterRelation, arg3 types.Status) {
-	fake.reportRelationAndStatusMetricsMutex.Lock()
-	fake.reportRelationAndStatusMetricsArgsForCall = append(fake.reportRelationAndStatusMetricsArgsForCall, struct {
+func (fake *ChainManager) ReportConsensusRelationAndStatusMetrics(arg1 string, arg2 types.ConsensusRelation, arg3 types.Status) {
+	fake.reportConsensusRelationAndStatusMetricsMutex.Lock()
+	fake.reportConsensusRelationAndStatusMetricsArgsForCall = append(fake.reportConsensusRelationAndStatusMetricsArgsForCall, struct {
 		arg1 string
-		arg2 types.ClusterRelation
+		arg2 types.ConsensusRelation
 		arg3 types.Status
 	}{arg1, arg2, arg3})
-	fake.recordInvocation("ReportRelationAndStatusMetrics", []interface{}{arg1, arg2, arg3})
-	fake.reportRelationAndStatusMetricsMutex.Unlock()
-	if fake.ReportRelationAndStatusMetricsStub != nil {
-		fake.ReportRelationAndStatusMetricsStub(arg1, arg2, arg3)
+	fake.recordInvocation("ReportConsensusRelationAndStatusMetrics", []interface{}{arg1, arg2, arg3})
+	fake.reportConsensusRelationAndStatusMetricsMutex.Unlock()
+	if fake.ReportConsensusRelationAndStatusMetricsStub != nil {
+		fake.ReportConsensusRelationAndStatusMetricsStub(arg1, arg2, arg3)
 	}
 }
 
-func (fake *ChainManager) ReportRelationAndStatusMetricsCallCount() int {
-	fake.reportRelationAndStatusMetricsMutex.RLock()
-	defer fake.reportRelationAndStatusMetricsMutex.RUnlock()
-	return len(fake.reportRelationAndStatusMetricsArgsForCall)
+func (fake *ChainManager) ReportConsensusRelationAndStatusMetricsCallCount() int {
+	fake.reportConsensusRelationAndStatusMetricsMutex.RLock()
+	defer fake.reportConsensusRelationAndStatusMetricsMutex.RUnlock()
+	return len(fake.reportConsensusRelationAndStatusMetricsArgsForCall)
 }
 
-func (fake *ChainManager) ReportRelationAndStatusMetricsCalls(stub func(string, types.ClusterRelation, types.Status)) {
-	fake.reportRelationAndStatusMetricsMutex.Lock()
-	defer fake.reportRelationAndStatusMetricsMutex.Unlock()
-	fake.ReportRelationAndStatusMetricsStub = stub
+func (fake *ChainManager) ReportConsensusRelationAndStatusMetricsCalls(stub func(string, types.ConsensusRelation, types.Status)) {
+	fake.reportConsensusRelationAndStatusMetricsMutex.Lock()
+	defer fake.reportConsensusRelationAndStatusMetricsMutex.Unlock()
+	fake.ReportConsensusRelationAndStatusMetricsStub = stub
 }
 
-func (fake *ChainManager) ReportRelationAndStatusMetricsArgsForCall(i int) (string, types.ClusterRelation, types.Status) {
-	fake.reportRelationAndStatusMetricsMutex.RLock()
-	defer fake.reportRelationAndStatusMetricsMutex.RUnlock()
-	argsForCall := fake.reportRelationAndStatusMetricsArgsForCall[i]
+func (fake *ChainManager) ReportConsensusRelationAndStatusMetricsArgsForCall(i int) (string, types.ConsensusRelation, types.Status) {
+	fake.reportConsensusRelationAndStatusMetricsMutex.RLock()
+	defer fake.reportConsensusRelationAndStatusMetricsMutex.RUnlock()
+	argsForCall := fake.reportConsensusRelationAndStatusMetricsArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
@@ -204,8 +204,8 @@ func (fake *ChainManager) Invocations() map[string][][]interface{} {
 	defer fake.createChainMutex.RUnlock()
 	fake.getConsensusChainMutex.RLock()
 	defer fake.getConsensusChainMutex.RUnlock()
-	fake.reportRelationAndStatusMetricsMutex.RLock()
-	defer fake.reportRelationAndStatusMetricsMutex.RUnlock()
+	fake.reportConsensusRelationAndStatusMetricsMutex.RLock()
+	defer fake.reportConsensusRelationAndStatusMetricsMutex.RUnlock()
 	fake.switchChainToFollowerMutex.RLock()
 	defer fake.switchChainToFollowerMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/orderer/consensus/inactive/inactive_chain.go
+++ b/orderer/consensus/inactive/inactive_chain.go
@@ -44,7 +44,7 @@ func (c *Chain) Halt() {
 
 }
 
-// StatusReport returns the ClusterRelation & Status
-func (c *Chain) StatusReport() (types.ClusterRelation, types.Status) {
-	return types.ClusterRelationConfigTracker, types.StatusInactive
+// StatusReport returns the ConsensusRelation & Status
+func (c *Chain) StatusReport() (types.ConsensusRelation, types.Status) {
+	return types.ConsensusRelationConfigTracker, types.StatusInactive
 }

--- a/orderer/consensus/inactive/inactive_chain_test.go
+++ b/orderer/consensus/inactive/inactive_chain_test.go
@@ -28,6 +28,6 @@ func TestInactiveChain(t *testing.T) {
 	require.False(t, open)
 
 	cRel, status := chain.StatusReport()
-	require.Equal(t, types.ClusterRelationConfigTracker, cRel)
+	require.Equal(t, types.ConsensusRelationConfigTracker, cRel)
 	require.Equal(t, types.StatusInactive, status)
 }


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Rename cluster relation to consensus relation to more accurately reflect its meaning.

#### Related issues

[FAB-18327](https://jira.hyperledger.org/browse/FAB-18327)