### PR TITLE
Revert "Allow BCCSP config to be set using env var (#1900)"

### DIFF
--- a/bccsp/factory/nopkcs11.go
+++ b/bccsp/factory/nopkcs11.go
@@ -15,6 +15,12 @@ import (
 
 const pkcs11Enabled = false
 
+// FactoryOpts holds configuration information used to initialize factory implementations
+type FactoryOpts struct {
+	Default string  `json:"default" yaml:"Default"`
+	SW      *SwOpts `json:"SW,omitempty" yaml:"SW,omitempty"`
+}
+
 // InitFactories must be called before using factory interfaces
 // It is acceptable to call with config = nil, in which case
 // some defaults will get used

--- a/bccsp/factory/opts.go
+++ b/bccsp/factory/opts.go
@@ -6,25 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 
 package factory
 
-import "github.com/hyperledger/fabric/bccsp/pkcs11"
-
-// FactoryOpts holds configuration information used to initialize factory implementations
-type FactoryOpts struct {
-	Default string             `json:"default" yaml:"Default"`
-	SW      *SwOpts            `json:"SW,omitempty" yaml:"SW,omitempty"`
-	PKCS11  *pkcs11.PKCS11Opts `json:"PKCS11,omitempty" yaml:"PKCS11"`
-}
-
 // GetDefaultOpts offers a default implementation for Opts
 // returns a new instance every time
 func GetDefaultOpts() *FactoryOpts {
 	return &FactoryOpts{
 		Default: "SW",
 		SW: &SwOpts{
-			Hash:     "SHA2",
-			Security: 256,
-		},
-		PKCS11: &pkcs11.PKCS11Opts{
 			Hash:     "SHA2",
 			Security: 256,
 		},

--- a/bccsp/factory/pkcs11.go
+++ b/bccsp/factory/pkcs11.go
@@ -10,10 +10,18 @@ package factory
 
 import (
 	"github.com/hyperledger/fabric/bccsp"
+	"github.com/hyperledger/fabric/bccsp/pkcs11"
 	"github.com/pkg/errors"
 )
 
 const pkcs11Enabled = false
+
+// FactoryOpts holds configuration information used to initialize factory implementations
+type FactoryOpts struct {
+	Default string             `json:"default" yaml:"Default"`
+	SW      *SwOpts            `json:"SW,omitempty" yaml:"SW,omitempty"`
+	PKCS11  *pkcs11.PKCS11Opts `json:"PKCS11,omitempty" yaml:"PKCS11"`
+}
 
 // InitFactories must be called before using factory interfaces
 // It is acceptable to call with config = nil, in which case

--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -110,12 +110,6 @@ peer:
       Security: 256
       FileKeyStore:
         KeyStore:
-    PKCS11:
-      Hash: SHA2
-      Security: 256
-      Library:
-      Label:
-      Pin:
   mspConfigPath: {{ .PeerLocalMSPDir Peer }}
   localMspId: {{ (.Organization Peer.Organization).MSPID }}
   deliveryclient:

--- a/integration/nwo/orderer_template.go
+++ b/integration/nwo/orderer_template.go
@@ -49,12 +49,6 @@ General:
       Security: 256
       FileKeyStore:
         KeyStore:
-    PKCS11:
-      Hash: SHA2
-      Security: 256
-      Library:
-      Label:
-      Pin:
   Authentication:
     TimeWindow: 15m
 FileLedger:

--- a/internal/peer/common/common.go
+++ b/internal/peer/common/common.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -133,54 +132,14 @@ func InitCrypto(mspMgrConfigDir, localMSPID, localMSPType string) error {
 
 	// Init the BCCSP
 	SetBCCSPKeystorePath()
-
 	bccspConfig := factory.GetDefaultOpts()
 	if err := viper.UnmarshalKey("peer.BCCSP", &bccspConfig); err != nil {
 		return errors.WithMessage(err, "could not decode peer BCCSP configuration")
 	}
 
-	if err := SetBCCSPConfigOverrides(bccspConfig); err != nil {
-		return err
-	}
-
 	err = mspmgmt.LoadLocalMspWithType(mspMgrConfigDir, bccspConfig, localMSPID, localMSPType)
 	if err != nil {
 		return errors.WithMessagef(err, "error when setting up MSP of type %s from directory %s", localMSPType, mspMgrConfigDir)
-	}
-
-	return nil
-}
-
-// Overrides BCCSP config values when corresponding environment variables
-// are set.
-func SetBCCSPConfigOverrides(bccspConfig *factory.FactoryOpts) error {
-	if pkcs11Default, exist := os.LookupEnv("CORE_PEER_BCCSP_DEFAULT"); exist {
-		bccspConfig.Default = pkcs11Default
-	}
-
-	// PKCS11 Overrides
-	if pkcs11Hash, exist := os.LookupEnv("CORE_PEER_BCCSP_PKCS11_HASH"); exist {
-		bccspConfig.PKCS11.Hash = pkcs11Hash
-	}
-
-	if pkcs11Security, exist := os.LookupEnv("CORE_PEER_BCCSP_PKCS11_SECURITY"); exist {
-		pkcs11Sec, err := strconv.Atoi(pkcs11Security)
-		if err != nil {
-			return errors.Errorf("CORE_PEER_BCCSP_PKCS11_SECURITY set to non-integer value: %s", pkcs11Security)
-		}
-		bccspConfig.PKCS11.Security = pkcs11Sec
-	}
-
-	if pkcs11Library, exist := os.LookupEnv("CORE_PEER_BCCSP_PKCS11_LIBRARY"); exist {
-		bccspConfig.PKCS11.Library = pkcs11Library
-	}
-
-	if pkcs11Label, exist := os.LookupEnv("CORE_PEER_BCCSP_PKCS11_LABEL"); exist {
-		bccspConfig.PKCS11.Label = pkcs11Label
-	}
-
-	if pkcs11Pin, exist := os.LookupEnv("CORE_PEER_BCCSP_PKCS11_PIN"); exist {
-		bccspConfig.PKCS11.Pin = pkcs11Pin
 	}
 
 	return nil


### PR DESCRIPTION
This reverts commit 0a9f7663a3a548385f3e4fa55e147b6dbce055d4 which pushed the pkcs11 code outside of the pkcs11 build tag. This prevents cross-compilation of Fabric due to the fact the miekg/pkcs11 package contains CGO which requires a cross-compiler for each platform you are cross compiling for.

We need to find a better approach to solving this problem that doesn't pull the code out of the build tag.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
