### PR TITLE
Chan.Part.API: Onboarding and follower CFT IT

### DIFF
--- a/integration/channelparticipation/channel_participation.go
+++ b/integration/channelparticipation/channel_participation.go
@@ -89,7 +89,6 @@ func getBody(client *http.Client, url string) func() string {
 	return func() string {
 		resp, err := client.Get(url)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 		resp.Body.Close()


### PR DESCRIPTION
#### Type of change

- Test update

#### Description

Add integration tests to ensure onboarding and follower logic are crash fault tolerant.

#### Related issues

[FAB-18148](https://jira.hyperledger.org/browse/FAB-18148)
[FAB-18149](https://jira.hyperledger.org/browse/FAB-18149)