### PR TITLE
Prevent race that occurs after test timeout

### DIFF
--- a/core/container/externalbuilder/instance_test.go
+++ b/core/container/externalbuilder/instance_test.go
@@ -284,7 +284,7 @@ var _ = Describe("Instance", func() {
 			Expect(instance.Session).NotTo(BeNil())
 
 			errCh := make(chan error)
-			go func() { errCh <- instance.Session.Wait() }()
+			go func(sess *externalbuilder.Session) { errCh <- sess.Wait() }(instance.Session)
 			Eventually(errCh).Should(Receive(BeNil()))
 		})
 	})
@@ -298,7 +298,7 @@ var _ = Describe("Instance", func() {
 			instance.TermTimeout = time.Minute
 
 			errCh := make(chan error)
-			go func() { errCh <- instance.Session.Wait() }()
+			go func() { errCh <- sess.Wait() }()
 			Consistently(errCh).ShouldNot(Receive())
 
 			err = instance.Stop()
@@ -316,7 +316,7 @@ var _ = Describe("Instance", func() {
 				instance.TermTimeout = time.Second
 
 				errCh := make(chan error)
-				go func() { errCh <- instance.Session.Wait() }()
+				go func() { errCh <- sess.Wait() }()
 				Consistently(errCh).ShouldNot(Receive())
 
 				err = instance.Stop()


### PR DESCRIPTION
The `instance` variable used in the suite was referenced by a transient go routine used in the test after the test failed due to a
timeout.

Instead of dereferencing the instance to acquire the session, pass the session directly to the go routine.