### PR TITLE
Redirect integration test logs to GinkgoWriter

### DIFF
--- a/integration/ledger/ledger_suite_test.go
+++ b/integration/ledger/ledger_suite_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/integration"
 	"github.com/hyperledger/fabric/integration/nwo"
 	. "github.com/onsi/ginkgo"
@@ -38,6 +39,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 }, func(payload []byte) {
 	err := json.Unmarshal(payload, &components)
 	Expect(err).NotTo(HaveOccurred())
+
+	flogging.SetWriter(GinkgoWriter)
 })
 
 var _ = SynchronizedAfterSuite(func() {


### PR DESCRIPTION
Avoid printing the numerous log messages issued by client code running in the integration tests suites by redirecting them to the log stream associated with the test. Not only does this quiet down the tests, it ensures that when an error occurs, the messages appear in time-order.