### PR TITLE
Revert "Allow BCCSP config to be set using env var (#1900)"

### DIFF
--- a/bccsp/factory/nopkcs11.go
+++ b/bccsp/factory/nopkcs11.go
@@ -15,6 +15,12 @@ import (
 
 const pkcs11Enabled = false
 
+// FactoryOpts holds configuration information used to initialize factory implementations
+type FactoryOpts struct {
+	ProviderName string  `mapstructure:"default" json:"default" yaml:"Default"`
+	SwOpts       *SwOpts `mapstructure:"SW,omitempty" json:"SW,omitempty" yaml:"SW,omitempty"`
+}
+
 // InitFactories must be called before using factory interfaces
 // It is acceptable to call with config = nil, in which case
 // some defaults will get used

--- a/bccsp/factory/opts.go
+++ b/bccsp/factory/opts.go
@@ -1,19 +1,20 @@
 /*
-Copyright IBM Corp. All Rights Reserved.
+Copyright IBM Corp. 2016 All Rights Reserved.
 
-SPDX-License-Identifier: Apache-2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package factory
-
-import "github.com/hyperledger/fabric/bccsp/pkcs11"
-
-// FactoryOpts holds configuration information used to initialize factory implementations
-type FactoryOpts struct {
-	ProviderName string             `mapstructure:"default" json:"default" yaml:"Default"`
-	SwOpts       *SwOpts            `mapstructure:"SW,omitempty" json:"SW,omitempty" yaml:"SW,omitempty"`
-	Pkcs11Opts   *pkcs11.PKCS11Opts `mapstructure:"PKCS11,omitempty" json:"PKCS11,omitempty" yaml:"PKCS11"`
-}
 
 // GetDefaultOpts offers a default implementation for Opts
 // returns a new instance every time
@@ -24,10 +25,6 @@ func GetDefaultOpts() *FactoryOpts {
 			HashFamily: "SHA2",
 			SecLevel:   256,
 			Ephemeral:  true,
-		},
-		Pkcs11Opts: &pkcs11.PKCS11Opts{
-			HashFamily: "SHA2",
-			SecLevel:   256,
 		},
 	}
 }

--- a/bccsp/factory/pkcs11.go
+++ b/bccsp/factory/pkcs11.go
@@ -10,10 +10,18 @@ package factory
 
 import (
 	"github.com/hyperledger/fabric/bccsp"
+	"github.com/hyperledger/fabric/bccsp/pkcs11"
 	"github.com/pkg/errors"
 )
 
 const pkcs11Enabled = false
+
+// FactoryOpts holds configuration information used to initialize factory implementations
+type FactoryOpts struct {
+	ProviderName string             `mapstructure:"default" json:"default" yaml:"Default"`
+	SwOpts       *SwOpts            `mapstructure:"SW,omitempty" json:"SW,omitempty" yaml:"SW,omitempty"`
+	Pkcs11Opts   *pkcs11.PKCS11Opts `mapstructure:"PKCS11,omitempty" json:"PKCS11,omitempty" yaml:"PKCS11"`
+}
 
 // InitFactories must be called before using factory interfaces
 // It is acceptable to call with config = nil, in which case

--- a/common/viperutil/config_util.go
+++ b/common/viperutil/config_util.go
@@ -306,7 +306,7 @@ func bccspHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, e
 
 	err := mapstructure.WeakDecode(data, config)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not decode bccsp type")
+		return nil, errors.Wrap(err, "could not decode bcssp type")
 	}
 
 	return config, nil

--- a/integration/nwo/core_template.go
+++ b/integration/nwo/core_template.go
@@ -110,12 +110,6 @@ peer:
       Security: 256
       FileKeyStore:
         KeyStore:
-    PKCS11:
-      Hash: SHA2
-      Security: 256
-      Library:
-      Label:
-      Pin:
   mspConfigPath: {{ .PeerLocalMSPDir Peer }}
   localMspId: {{ (.Organization Peer.Organization).MSPID }}
   deliveryclient:

--- a/integration/nwo/orderer_template.go
+++ b/integration/nwo/orderer_template.go
@@ -49,12 +49,6 @@ General:
       Security: 256
       FileKeyStore:
         KeyStore:
-    PKCS11:
-      Hash: SHA2
-      Security: 256
-      Library:
-      Label:
-      Pin:
   Authentication:
     TimeWindow: 15m
 FileLedger:

--- a/internal/peer/common/common.go
+++ b/internal/peer/common/common.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -134,7 +133,6 @@ func InitCrypto(mspMgrConfigDir, localMSPID, localMSPType string) error {
 
 	// Init the BCCSP
 	SetBCCSPKeystorePath()
-
 	bccspConfig := factory.GetDefaultOpts()
 	if config := viper.Get("peer.BCCSP"); config != nil {
 		err = mapstructure.WeakDecode(config, bccspConfig)
@@ -143,48 +141,9 @@ func InitCrypto(mspMgrConfigDir, localMSPID, localMSPType string) error {
 		}
 	}
 
-	if err := SetBCCSPConfigOverrides(bccspConfig); err != nil {
-		return err
-	}
-
 	err = mspmgmt.LoadLocalMspWithType(mspMgrConfigDir, bccspConfig, localMSPID, localMSPType)
 	if err != nil {
 		return errors.WithMessagef(err, "error when setting up MSP of type %s from directory %s", localMSPType, mspMgrConfigDir)
-	}
-
-	return nil
-}
-
-// Overrides BCCSP config values when corresponding environment variables
-// are set.
-func SetBCCSPConfigOverrides(bccspConfig *factory.FactoryOpts) error {
-	if pkcs11Default, exist := os.LookupEnv("CORE_PEER_BCCSP_DEFAULT"); exist {
-		bccspConfig.ProviderName = pkcs11Default
-	}
-
-	// PKCS11 Overrides
-	if pkcs11Hash, exist := os.LookupEnv("CORE_PEER_BCCSP_PKCS11_HASH"); exist {
-		bccspConfig.Pkcs11Opts.HashFamily = pkcs11Hash
-	}
-
-	if pkcs11Security, exist := os.LookupEnv("CORE_PEER_BCCSP_PKCS11_SECURITY"); exist {
-		pkcs11Sec, err := strconv.Atoi(pkcs11Security)
-		if err != nil {
-			return errors.Errorf("CORE_PEER_BCCSP_PKCS11_SECURITY set to non-integer value: %s", pkcs11Security)
-		}
-		bccspConfig.Pkcs11Opts.SecLevel = pkcs11Sec
-	}
-
-	if pkcs11Library, exist := os.LookupEnv("CORE_PEER_BCCSP_PKCS11_LIBRARY"); exist {
-		bccspConfig.Pkcs11Opts.Library = pkcs11Library
-	}
-
-	if pkcs11Label, exist := os.LookupEnv("CORE_PEER_BCCSP_PKCS11_LABEL"); exist {
-		bccspConfig.Pkcs11Opts.Label = pkcs11Label
-	}
-
-	if pkcs11Pin, exist := os.LookupEnv("CORE_PEER_BCCSP_PKCS11_PIN"); exist {
-		bccspConfig.Pkcs11Opts.Pin = pkcs11Pin
 	}
 
 	return nil

--- a/internal/peer/common/common_test.go
+++ b/internal/peer/common/common_test.go
@@ -12,12 +12,9 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 
-	"github.com/hyperledger/fabric/bccsp/factory"
-	"github.com/hyperledger/fabric/bccsp/pkcs11"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/common/util"
 	"github.com/hyperledger/fabric/core/config/configtest"
@@ -249,58 +246,4 @@ func TestInitCmdWithoutInitCrypto(t *testing.T) {
 	os.Setenv("CORE_PEER_MSPCONFIGPATH", dir)
 
 	common.InitCmd(packageCmd, nil)
-}
-
-func TestSetBCCSPConfigOverrides(t *testing.T) {
-	bccspConfig := factory.GetDefaultOpts()
-	envConfig := &factory.FactoryOpts{
-		ProviderName: "test-default",
-		SwOpts: &factory.SwOpts{
-			HashFamily: "SHA2",
-			SecLevel:   256,
-			Ephemeral:  true,
-		},
-		Pkcs11Opts: &pkcs11.PKCS11Opts{
-			HashFamily: "test-pkcs11-hash",
-			SecLevel:   12345,
-			Library:    "test-pkcs11-library",
-			Label:      "test-pkcs11-label",
-			Pin:        "test-pkcs11-pin",
-		},
-	}
-
-	t.Run("success", func(t *testing.T) {
-		cleanup := setBCCSPEnvVariables(envConfig)
-		defer cleanup()
-		err := common.SetBCCSPConfigOverrides(bccspConfig)
-		assert.NoError(t, err)
-		assert.Equal(t, envConfig, bccspConfig)
-	})
-
-	t.Run("PKCS11 security set to string value", func(t *testing.T) {
-		cleanup := setBCCSPEnvVariables(envConfig)
-		defer cleanup()
-		os.Setenv("CORE_PEER_BCCSP_PKCS11_SECURITY", "INSECURITY")
-
-		err := common.SetBCCSPConfigOverrides(bccspConfig)
-		assert.EqualError(t, err, "CORE_PEER_BCCSP_PKCS11_SECURITY set to non-integer value: INSECURITY")
-	})
-}
-
-func setBCCSPEnvVariables(bccspConfig *factory.FactoryOpts) (cleanup func()) {
-	os.Setenv("CORE_PEER_BCCSP_DEFAULT", bccspConfig.ProviderName)
-	os.Setenv("CORE_PEER_BCCSP_PKCS11_SECURITY", strconv.Itoa(bccspConfig.Pkcs11Opts.SecLevel))
-	os.Setenv("CORE_PEER_BCCSP_PKCS11_HASH", bccspConfig.Pkcs11Opts.HashFamily)
-	os.Setenv("CORE_PEER_BCCSP_PKCS11_PIN", bccspConfig.Pkcs11Opts.Pin)
-	os.Setenv("CORE_PEER_BCCSP_PKCS11_LABEL", bccspConfig.Pkcs11Opts.Label)
-	os.Setenv("CORE_PEER_BCCSP_PKCS11_LIBRARY", bccspConfig.Pkcs11Opts.Library)
-
-	return func() {
-		os.Unsetenv("CORE_PEER_BCCSP_DEFAULT")
-		os.Unsetenv("CORE_PEER_BCCSP_PKCS11_SECURITY")
-		os.Unsetenv("CORE_PEER_BCCSP_PKCS11_HASH")
-		os.Unsetenv("CORE_PEER_BCCSP_PKCS11_PIN")
-		os.Unsetenv("CORE_PEER_BCCSP_PKCS11_LABEL")
-		os.Unsetenv("CORE_PEER_BCCSP_PKCS11_LIBRARY")
-	}
 }


### PR DESCRIPTION
This reverts commit f2e9e6e7b307a25dc4738e97a1ffb08daea4f6dc.
which pushed the pkcs11 code outside of the pkcs11 build tag.
This prevents cross-compilation of Fabric due to the fact the
miekg/pkcs11 package contains CGO which requires a cross-compiler
for each platform you are cross compiling for.

We need to find a better approach to solving this problem
that doesn't pull the code out of the build tag.