### PR TITLE
[FAB-18315] Ch.Part.API: Add remove failure metric for chain status

### DIFF
--- a/docs/source/metrics_reference.rst
+++ b/docs/source/metrics_reference.rst
@@ -198,7 +198,7 @@ The following orderer metrics are exported for consumption by Prometheus.
 |                                              |           | config-tracker.                                            |           |                                                                    |
 +----------------------------------------------+-----------+------------------------------------------------------------+-----------+--------------------------------------------------------------------+
 | participation_status                         | gauge     | The channel participation status of the node: 0 if         | channel   |                                                                    |
-|                                              |           | inactive, 1 if active, 2 if onboarding.                    |           |                                                                    |
+|                                              |           | inactive, 1 if active, 2 if onboarding, 3 if failed.       |           |                                                                    |
 +----------------------------------------------+-----------+------------------------------------------------------------+-----------+--------------------------------------------------------------------+
 
 StatsD
@@ -338,7 +338,7 @@ associated with the metric.
 |                                                                           |           | config-tracker.                                            |
 +---------------------------------------------------------------------------+-----------+------------------------------------------------------------+
 | participation.status.%{channel}                                           | gauge     | The channel participation status of the node: 0 if         |
-|                                                                           |           | inactive, 1 if active, 2 if onboarding.                    |
+|                                                                           |           | inactive, 1 if active, 2 if onboarding, 3 if failed.       |
 +---------------------------------------------------------------------------+-----------+------------------------------------------------------------+
 
 Peer Metrics

--- a/orderer/common/multichannel/metrics.go
+++ b/orderer/common/multichannel/metrics.go
@@ -16,7 +16,7 @@ var (
 		Namespace:    "participation",
 		Subsystem:    "",
 		Name:         "status",
-		Help:         "The channel participation status of the node: 0 if inactive, 1 if active, 2 if onboarding.",
+		Help:         "The channel participation status of the node: 0 if inactive, 1 if active, 2 if onboarding, 3 if failed.",
 		LabelNames:   []string{"channel"},
 		StatsdFormat: "%{#fqname}.%{channel}",
 	}
@@ -67,6 +67,8 @@ func (m *Metrics) reportStatus(channel string, status types.Status) {
 		s = 1
 	case types.StatusOnBoarding:
 		s = 2
+	case types.StatusFailed:
+		s = 3
 	default:
 		logger.Panicf("Programming error: unexpected status %s", status)
 	}

--- a/orderer/common/multichannel/metrics_test.go
+++ b/orderer/common/multichannel/metrics_test.go
@@ -80,6 +80,14 @@ var _ = Describe("Metrics", func() {
 			Expect(fakeGauge.SetArgsForCall(0)).To(Equal(float64(2)))
 		})
 
+		It("reports status failure as a gauge", func() {
+			metrics.reportStatus("fake-channel", types.StatusFailed)
+			Expect(fakeGauge.WithCallCount()).To(Equal(1))
+			Expect(fakeGauge.WithArgsForCall(0)).To(Equal([]string{"channel", "fake-channel"}))
+			Expect(fakeGauge.SetCallCount()).To(Equal(1))
+			Expect(fakeGauge.SetArgsForCall(0)).To(Equal(float64(3)))
+		})
+
 		It("panics when reporting an unknown cluster status", func() {
 			Expect(func() { metrics.reportStatus("fake-channel", "unknown") }).To(Panic())
 		})

--- a/orderer/common/types/channelinfo.go
+++ b/orderer/common/types/channelinfo.go
@@ -59,6 +59,8 @@ const (
 	StatusOnBoarding Status = "onboarding"
 	// The orderer is not storing any blocks for this channel.
 	StatusInactive Status = "inactive"
+	// The last orderer operation against the channel failed.
+	StatusFailed Status = "failed"
 )
 
 // ChannelInfo carries the response to an HTTP request to List a single channel.


### PR DESCRIPTION
#### Type of change

- New feature

#### Description
Adds StatusFailure metric for channel removal failures. Ensure GET List/:channelID returns correct ChannelInfo for pending channel removals. 


#### Related issues
[FAB-18315](https://jira.hyperledger.org/browse/FAB-18315)

