### PR TITLE
Remove custom error types

### DIFF
--- a/common/ledger/blkstorage/blockfile_mgr_test.go
+++ b/common/ledger/blkstorage/blockfile_mgr_test.go
@@ -28,8 +28,8 @@ func TestBlockfileMgrBlockReadWrite(t *testing.T) {
 	defer blkfileMgrWrapper.close()
 	blocks := testutil.ConstructTestBlocks(t, 10)
 	blkfileMgrWrapper.addBlocks(blocks)
-	blkfileMgrWrapper.testGetBlockByHash(blocks, nil)
-	blkfileMgrWrapper.testGetBlockByNumber(blocks, 0, nil)
+	blkfileMgrWrapper.testGetBlockByHash(blocks)
+	blkfileMgrWrapper.testGetBlockByNumber(blocks)
 }
 
 func TestAddBlockWithWrongHash(t *testing.T) {
@@ -384,7 +384,7 @@ func TestBlockfileMgrRestart(t *testing.T) {
 	blkfileMgrWrapper = newTestBlockfileWrapper(env, ledgerid)
 	defer blkfileMgrWrapper.close()
 	require.Equal(t, 9, int(blkfileMgrWrapper.blockfileMgr.blockfilesInfo.lastPersistedBlock))
-	blkfileMgrWrapper.testGetBlockByHash(blocks, nil)
+	blkfileMgrWrapper.testGetBlockByHash(blocks)
 	require.Equal(t, expectedHeight, blkfileMgrWrapper.blockfileMgr.getBlockchainInfo().Height)
 }
 
@@ -406,14 +406,14 @@ func TestBlockfileMgrFileRolling(t *testing.T) {
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, ledgerid)
 	blkfileMgrWrapper.addBlocks(blocks[:100])
 	require.Equal(t, 1, blkfileMgrWrapper.blockfileMgr.blockfilesInfo.latestFileNumber)
-	blkfileMgrWrapper.testGetBlockByHash(blocks[:100], nil)
+	blkfileMgrWrapper.testGetBlockByHash(blocks[:100])
 	blkfileMgrWrapper.close()
 
 	blkfileMgrWrapper = newTestBlockfileWrapper(env, ledgerid)
 	defer blkfileMgrWrapper.close()
 	blkfileMgrWrapper.addBlocks(blocks[100:])
 	require.Equal(t, 2, blkfileMgrWrapper.blockfileMgr.blockfilesInfo.latestFileNumber)
-	blkfileMgrWrapper.testGetBlockByHash(blocks[100:], nil)
+	blkfileMgrWrapper.testGetBlockByHash(blocks[100:])
 }
 
 func TestBlockfileMgrGetBlockByTxID(t *testing.T) {
@@ -500,7 +500,7 @@ func testBlockfileMgrSimulateCrashAtFirstBlockInFile(t *testing.T, deleteBlkfile
 	blkfileMgrWrapper.addBlocks(blocks[5:])
 	require.True(t, testutilGetFileSize(t, lastFilePath) > 0)
 	require.Equal(t, firstBlkFileSize, testutilGetFileSize(t, firstFilePath))
-	blkfileMgrWrapper.testGetBlockByNumber(blocks, 0, nil)
+	blkfileMgrWrapper.testGetBlockByNumber(blocks)
 	testBlockfileMgrBlockIterator(t, blkfileMgrWrapper.blockfileMgr, 0, len(blocks)-1, blocks)
 }
 

--- a/common/ledger/blkstorage/blockstore_provider.go
+++ b/common/ledger/blkstorage/blockstore_provider.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hyperledger/fabric/common/ledger/dataformat"
 	"github.com/hyperledger/fabric/common/ledger/util/leveldbhelper"
 	"github.com/hyperledger/fabric/common/metrics"
-	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/internal/fileutil"
 	"github.com/pkg/errors"
 )
@@ -52,14 +51,6 @@ func (c *IndexConfig) Contains(indexableAttr IndexableAttr) bool {
 	}
 	return false
 }
-
-var (
-	// ErrNotFoundInIndex is used to indicate missing entry in the index
-	ErrNotFoundInIndex = ledger.NotFoundInIndexErr("")
-
-	// ErrAttrNotIndexed is used to indicate that an attribute is not indexed
-	ErrAttrNotIndexed = errors.New("attribute not indexed")
-)
 
 // BlockStoreProvider provides handle to block storage - this is not thread-safe
 type BlockStoreProvider struct {

--- a/common/ledger/blkstorage/blockstore_provider_test.go
+++ b/common/ledger/blkstorage/blockstore_provider_test.go
@@ -140,23 +140,23 @@ func checkBlocks(t *testing.T, expectedBlocks []*common.Block, store *BlockStore
 func checkWithWrongInputs(t *testing.T, store *BlockStore, numBlocks int) {
 	block, err := store.RetrieveBlockByHash([]byte("non-existent-hash"))
 	require.Nil(t, block)
-	require.Equal(t, ErrNotFoundInIndex, err)
+	require.EqualError(t, err, fmt.Sprintf("no such block hash [%x] in index", []byte("non-existent-hash")))
 
 	block, err = store.RetrieveBlockByTxID("non-existent-txid")
 	require.Nil(t, block)
-	require.Equal(t, ErrNotFoundInIndex, err)
+	require.EqualError(t, err, "no such transaction ID [non-existent-txid] in index")
 
 	tx, err := store.RetrieveTxByID("non-existent-txid")
 	require.Nil(t, tx)
-	require.Equal(t, ErrNotFoundInIndex, err)
+	require.EqualError(t, err, "no such transaction ID [non-existent-txid] in index")
 
 	tx, err = store.RetrieveTxByBlockNumTranNum(uint64(numBlocks+1), uint64(0))
 	require.Nil(t, tx)
-	require.Equal(t, ErrNotFoundInIndex, err)
+	require.EqualError(t, err, fmt.Sprintf("no such blockNumber, transactionNumber <%d, 0> in index", numBlocks+1))
 
 	txCode, err := store.RetrieveTxValidationCodeByTxID("non-existent-txid")
 	require.Equal(t, peer.TxValidationCode(-1), txCode)
-	require.Equal(t, ErrNotFoundInIndex, err)
+	require.EqualError(t, err, "no such transaction ID [non-existent-txid] in index")
 }
 
 func TestBlockStoreProvider(t *testing.T) {

--- a/common/ledger/blkstorage/reset_test.go
+++ b/common/ledger/blkstorage/reset_test.go
@@ -232,8 +232,7 @@ func assertBlockStorePostReset(t *testing.T, store *BlockStore, originallyCommit
 	require.Equal(t, originallyCommittedBlocks[0], blk)
 
 	_, err = store.RetrieveBlockByNumber(1)
-	require.Error(t, err)
-	require.Equal(t, err, ErrNotFoundInIndex)
+	require.EqualError(t, err, "no such block number [1] in index")
 
 	err = store.AddBlock(originallyCommittedBlocks[0])
 	require.EqualError(t, err, "block number should have been 1 but was 0")

--- a/common/ledger/blkstorage/rollback_test.go
+++ b/common/ledger/blkstorage/rollback_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hyperledger/fabric/common/ledger/testutil"
 	"github.com/hyperledger/fabric/common/metrics/disabled"
 	"github.com/hyperledger/fabric/protoutil"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,9 +54,9 @@ func TestRollback(t *testing.T) {
 	require.Equal(t, actualBlkfilesInfo.latestFileNumber, 4)
 
 	// 4. Check whether all blocks are stored correctly
-	blkfileMgrWrapper.testGetBlockByNumber(blocks, 0, nil)
-	blkfileMgrWrapper.testGetBlockByHash(blocks, nil)
-	blkfileMgrWrapper.testGetBlockByTxID(blocks, nil)
+	blkfileMgrWrapper.testGetBlockByNumber(blocks)
+	blkfileMgrWrapper.testGetBlockByHash(blocks)
+	blkfileMgrWrapper.testGetBlockByTxID(blocks)
 
 	// 5. Close the blkfileMgrWrapper
 	env.provider.Close()
@@ -314,23 +313,22 @@ func assertBlockStoreRollback(t *testing.T, path, ledgerID string, blocks []*com
 
 	// 3. Check whether all blocks till the target block number are stored correctly
 	if blkfileMgrWrapper.blockfileMgr.index.isAttributeIndexed(IndexableAttrBlockNum) {
-		blkfileMgrWrapper.testGetBlockByNumber(blocks[:rollbackedToBlkNum+1], 0, nil)
+		blkfileMgrWrapper.testGetBlockByNumber(blocks[:rollbackedToBlkNum+1])
 	}
 	if blkfileMgrWrapper.blockfileMgr.index.isAttributeIndexed(IndexableAttrBlockHash) {
-		blkfileMgrWrapper.testGetBlockByHash(blocks[:rollbackedToBlkNum+1], nil)
+		blkfileMgrWrapper.testGetBlockByHash(blocks[:rollbackedToBlkNum+1])
 	}
 	if blkfileMgrWrapper.blockfileMgr.index.isAttributeIndexed(IndexableAttrTxID) {
-		blkfileMgrWrapper.testGetBlockByTxID(blocks[:rollbackedToBlkNum+1], nil)
+		blkfileMgrWrapper.testGetBlockByTxID(blocks[:rollbackedToBlkNum+1])
 	}
 
 	// 4. Check whether all blocks with number greater than target block number
 	// are removed including index entries
-	expectedErr := errors.New("Entry not found in index")
 	if blkfileMgrWrapper.blockfileMgr.index.isAttributeIndexed(IndexableAttrBlockHash) {
-		blkfileMgrWrapper.testGetBlockByHash(blocks[rollbackedToBlkNum+1:], expectedErr)
+		blkfileMgrWrapper.testGetBlockByHashNotIndexed(blocks[rollbackedToBlkNum+1:])
 	}
 	if blkfileMgrWrapper.blockfileMgr.index.isAttributeIndexed(IndexableAttrTxID) {
-		blkfileMgrWrapper.testGetBlockByTxID(blocks[rollbackedToBlkNum+1:], expectedErr)
+		blkfileMgrWrapper.testGetBlockByTxIDNotIndexed(blocks[rollbackedToBlkNum+1:])
 	}
 
 	// 5. Close the blkfileMgrWrapper

--- a/common/ledger/blkstorage/snapshot_test.go
+++ b/common/ledger/blkstorage/snapshot_test.go
@@ -285,7 +285,7 @@ func TestImportFromSnapshot(t *testing.T) {
 
 			// before, we test for index sync-up, verify that the last set of blocks not indexed in the original index
 			_, err := blkfileMgr.retrieveBlockByNumber(block.Header.Number)
-			require.Exactly(t, ErrNotFoundInIndex, err)
+			require.EqualError(t, err, fmt.Sprintf("no such block number [%d] in index", block.Header.Number))
 
 			// close and open should be able to sync-up the index
 			closeBlockStore()
@@ -473,7 +473,7 @@ func verifyQueriesOnBlocksPriorToSnapshot(
 		require.EqualError(t, err, expectedErrStr)
 
 		_, err = bootstrappedBlockStore.RetrieveBlockByHash(blockHash)
-		require.Equal(t, ErrNotFoundInIndex, err)
+		require.EqualError(t, err, fmt.Sprintf("no such block hash [%x] in index", blockHash))
 	}
 
 	bootstrappingSnapshotHeight := uint64(len(blocksDetailsBeforeSnapshot))

--- a/core/ledger/kvledger/channelinfo_provider_test.go
+++ b/core/ledger/kvledger/channelinfo_provider_test.go
@@ -202,7 +202,7 @@ func TestGetAllMSPIDs_NegativeTests(t *testing.T) {
 	configBlock = newBlock(nil, lastBlockNum, lastBlockNum+1, protoutil.BlockHeaderHash(configBlock.Header))
 	require.NoError(t, blkStore.AddBlock(configBlock))
 	_, err = channelInfoProvider.getAllMSPIDs()
-	require.EqualError(t, err, "Entry not found in index")
+	require.EqualError(t, err, "no such block number [3] in index")
 
 	// test GetLastConfigIndexFromBlock error by using invalid bytes for LastConfig metadata value
 	lastBlockNum++

--- a/core/ledger/ledger_interface.go
+++ b/core/ledger/ledger_interface.go
@@ -585,13 +585,6 @@ func (e *ErrCollectionConfigNotYetAvailable) Error() string {
 	return e.Msg
 }
 
-// NotFoundInIndexErr is used to indicate missing entry in the index
-type NotFoundInIndexErr string
-
-func (NotFoundInIndexErr) Error() string {
-	return "Entry not found in index"
-}
-
 // CollConfigNotDefinedError is returned whenever an operation
 // is requested on a collection whose config has not been defined
 type CollConfigNotDefinedError struct {


### PR DESCRIPTION
This commit removes the custom error types that are not used by the consumers

#### Type of change
- Improvement (improvement to code)

#### Additional details
Previously one of the custom error types `NotFoundInIndexErr` was used in the validation path, with this [PR](https://github.com/hyperledger/fabric/pull/2075), it's no longer the case.