### PR TITLE
[FAB-18298] Default cluster cert and key

### DIFF
--- a/integration/raft/cft_test.go
+++ b/integration/raft/cft_test.go
@@ -471,6 +471,8 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 				ordererConfig.General.Cluster.ListenAddress = ""
 				ordererConfig.General.Cluster.ServerCertificate = ""
 				ordererConfig.General.Cluster.ServerPrivateKey = ""
+				ordererConfig.General.Cluster.ClientCertificate = ""
+				ordererConfig.General.Cluster.ClientPrivateKey = ""
 				network.WriteOrdererConfig(orderer, ordererConfig)
 			}
 

--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -463,17 +463,23 @@ func initializeClusterClientConfig(conf *localconfig.TopLevel) comm.ClientConfig
 		SecOpts:      comm.SecureOptions{},
 	}
 
-	if conf.General.Cluster.ClientCertificate == "" {
-		return cc
-	}
+	reuseGrpcListener := reuseListener(conf)
 
 	certFile := conf.General.Cluster.ClientCertificate
+	keyFile := conf.General.Cluster.ClientPrivateKey
+	if certFile == "" && keyFile == "" {
+		if !reuseGrpcListener {
+			return cc
+		}
+		certFile = conf.General.TLS.Certificate
+		keyFile = conf.General.TLS.PrivateKey
+	}
+
 	certBytes, err := ioutil.ReadFile(certFile)
 	if err != nil {
 		logger.Fatalf("Failed to load client TLS certificate file '%s' (%s)", certFile, err)
 	}
 
-	keyFile := conf.General.Cluster.ClientPrivateKey
 	keyBytes, err := ioutil.ReadFile(keyFile)
 	if err != nil {
 		logger.Fatalf("Failed to load client TLS key file '%s' (%s)", keyFile, err)
@@ -489,7 +495,7 @@ func initializeClusterClientConfig(conf *localconfig.TopLevel) comm.ClientConfig
 	}
 
 	timeShift := conf.General.TLS.TLSHandshakeTimeShift
-	if reuseGrpcListener := reuseListener(conf); !reuseGrpcListener {
+	if !reuseGrpcListener {
 		timeShift = conf.General.Cluster.TLSHandshakeTimeShift
 	}
 

--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -194,14 +194,102 @@ func TestInitializeServerConfig(t *testing.T) {
 		clusterCert    string
 		clusterKey     string
 		clusterCA      string
+		isCluster      bool
 	}{
-		{"BadCertificate", badFile, goodFile, goodFile, goodFile, "", "", ""},
-		{"BadPrivateKey", goodFile, badFile, goodFile, goodFile, "", "", ""},
-		{"BadRootCA", goodFile, goodFile, badFile, goodFile, "", "", ""},
-		{"BadClientRootCertificate", goodFile, goodFile, goodFile, badFile, "", "", ""},
-		{"ClusterBadCertificate", goodFile, goodFile, goodFile, goodFile, badFile, goodFile, goodFile},
-		{"ClusterBadPrivateKey", goodFile, goodFile, goodFile, goodFile, goodFile, badFile, goodFile},
-		{"ClusterBadRootCA", goodFile, goodFile, goodFile, goodFile, goodFile, goodFile, badFile},
+		{
+			name:           "BadCertificate",
+			certificate:    badFile,
+			privateKey:     goodFile,
+			rootCA:         goodFile,
+			clientRootCert: goodFile,
+		},
+		{
+			name:           "BadPrivateKey",
+			certificate:    goodFile,
+			privateKey:     badFile,
+			rootCA:         goodFile,
+			clientRootCert: goodFile,
+		},
+		{
+			name:           "BadRootCA",
+			certificate:    goodFile,
+			privateKey:     goodFile,
+			rootCA:         badFile,
+			clientRootCert: goodFile,
+		},
+		{
+			name:           "BadClientRootCertificate",
+			certificate:    goodFile,
+			privateKey:     goodFile,
+			rootCA:         goodFile,
+			clientRootCert: badFile,
+		},
+		{
+			name:           "BadCertificate - cluster reuses server config",
+			certificate:    badFile,
+			privateKey:     goodFile,
+			rootCA:         goodFile,
+			clientRootCert: goodFile,
+			clusterCert:    "",
+			clusterKey:     "",
+			clusterCA:      "",
+			isCluster:      true,
+		},
+		{
+			name:           "BadPrivateKey - cluster reuses server config",
+			certificate:    goodFile,
+			privateKey:     badFile,
+			rootCA:         goodFile,
+			clientRootCert: goodFile,
+			clusterCert:    "",
+			clusterKey:     "",
+			clusterCA:      "",
+			isCluster:      true,
+		},
+		{
+			name:           "BadRootCA - cluster reuses server config",
+			certificate:    goodFile,
+			privateKey:     goodFile,
+			rootCA:         badFile,
+			clientRootCert: goodFile,
+			clusterCert:    "",
+			clusterKey:     "",
+			clusterCA:      "",
+			isCluster:      true,
+		},
+		{
+			name:           "ClusterBadCertificate",
+			certificate:    goodFile,
+			privateKey:     goodFile,
+			rootCA:         goodFile,
+			clientRootCert: goodFile,
+			clusterCert:    badFile,
+			clusterKey:     goodFile,
+			clusterCA:      goodFile,
+			isCluster:      true,
+		},
+		{
+			name:           "ClusterBadPrivateKey",
+			certificate:    goodFile,
+			privateKey:     goodFile,
+			rootCA:         goodFile,
+			clientRootCert: goodFile,
+			clusterCert:    goodFile,
+			clusterKey:     badFile,
+			clusterCA:      goodFile,
+			isCluster:      true,
+		},
+		{
+			name:           "ClusterBadRootCA",
+			certificate:    goodFile,
+			privateKey:     goodFile,
+			rootCA:         goodFile,
+			clientRootCert: goodFile,
+			clusterCert:    goodFile,
+			clusterKey:     goodFile,
+			clusterCA:      badFile,
+			isCluster:      true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -222,8 +310,8 @@ func TestInitializeServerConfig(t *testing.T) {
 					},
 				},
 			}
-			assert.Panics(t, func() {
-				if tc.clusterCert == "" {
+			require.Panics(t, func() {
+				if !tc.isCluster {
 					initializeServerConfig(conf, nil)
 				} else {
 					initializeClusterClientConfig(conf)


### PR DESCRIPTION
#### Type of change

- New feature (backport)

#### Description

When cluster listener is reused, default cluster client certificate and private key (if not set) to the TLS server certificate and key.

#### Related issues

[FAB-18298](https://jira.hyperledger.org/browse/FAB-18298)