### PR TITLE
Restore ability to use RSA CA with Fabric MSP

### DIFF
--- a/bccsp/sw/keyimport_test.go
+++ b/bccsp/sw/keyimport_test.go
@@ -192,5 +192,17 @@ func TestX509PublicKeyImportOptsKeyImporter(t *testing.T) {
 	cert.PublicKey = "Hello world"
 	_, err = ki.KeyImport(cert, &mocks2.KeyImportOpts{})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Certificate's public key type not recognized. Supported keys: [ECDSA]")
+	require.Contains(t, err.Error(), "Certificate's public key type not recognized. Supported keys: [ECDSA, RSA]")
+}
+
+func TestX509RSAKeyImport(t *testing.T) {
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "key generation failed")
+
+	cert := &x509.Certificate{PublicKey: pk.Public()}
+	ki := x509PublicKeyImportOptsKeyImporter{}
+	key, err := ki.KeyImport(cert, nil)
+	require.NoError(t, err, "key import failed")
+	require.NotNil(t, key, "key must not be nil")
+	require.Equal(t, &rsaPublicKey{pubKey: &pk.PublicKey}, key)
 }

--- a/bccsp/sw/rsa.go
+++ b/bccsp/sw/rsa.go
@@ -1,0 +1,52 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sw
+
+import (
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/fabric/bccsp"
+)
+
+// An rsaPublicKey wraps the standard library implementation of an RSA public
+// key with functions that satisfy the bccsp.Key interface.
+//
+// NOTE: Fabric does not support RSA signing or verification. This code simply
+// allows MSPs to include RSA CAs in their certificate chains.
+type rsaPublicKey struct{ pubKey *rsa.PublicKey }
+
+func (k *rsaPublicKey) Symmetric() bool               { return false }
+func (k *rsaPublicKey) Private() bool                 { return false }
+func (k *rsaPublicKey) PublicKey() (bccsp.Key, error) { return k, nil }
+
+// Bytes converts this key to its serialized representation.
+func (k *rsaPublicKey) Bytes() (raw []byte, err error) {
+	if k.pubKey == nil {
+		return nil, errors.New("Failed marshalling key. Key is nil.")
+	}
+	raw, err = x509.MarshalPKIXPublicKey(k.pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("Failed marshalling key [%s]", err)
+	}
+	return
+}
+
+// SKI returns the subject key identifier of this key.
+func (k *rsaPublicKey) SKI() []byte {
+	if k.pubKey == nil {
+		return nil
+	}
+
+	// Marshal the public key and hash it
+	raw := x509.MarshalPKCS1PublicKey(k.pubKey)
+	hash := sha256.Sum256(raw)
+	return hash[:]
+}

--- a/bccsp/sw/rsa_test.go
+++ b/bccsp/sw/rsa_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sw
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type rsaPublicKeyASN struct {
+	N *big.Int
+	E int
+}
+
+func TestRSAPublicKey(t *testing.T) {
+	lowLevelKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	k := &rsaPublicKey{&lowLevelKey.PublicKey}
+
+	require.False(t, k.Symmetric())
+	require.False(t, k.Private())
+
+	k.pubKey = nil
+	ski := k.SKI()
+	require.Nil(t, ski)
+
+	k.pubKey = &lowLevelKey.PublicKey
+	ski = k.SKI()
+	raw, err := asn1.Marshal(rsaPublicKeyASN{N: k.pubKey.N, E: k.pubKey.E})
+	require.NoError(t, err, "asn1 marshal failed")
+	hash := sha256.New()
+	hash.Write(raw)
+	ski2 := hash.Sum(nil)
+	require.Equal(t, ski, ski2, "SKI is not computed in the right way.")
+
+	pk, err := k.PublicKey()
+	require.NoError(t, err)
+	require.Equal(t, k, pk)
+
+	bytes, err := k.Bytes()
+	require.NoError(t, err)
+	bytes2, err := x509.MarshalPKIXPublicKey(k.pubKey)
+	require.Equal(t, bytes2, bytes, "bytes are not computed in the right way.")
+
+	_, err = (&rsaPublicKey{}).Bytes()
+	require.EqualError(t, err, "Failed marshalling key. Key is nil.")
+}

--- a/integration/msp/rsaca_test.go
+++ b/integration/msp/rsaca_test.go
@@ -1,0 +1,467 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package msp
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/hyperledger/fabric/integration/nwo"
+	"github.com/hyperledger/fabric/integration/nwo/commands"
+	fabricmsp "github.com/hyperledger/fabric/msp"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+	"github.com/tedsuo/ifrit"
+	"gopkg.in/yaml.v2"
+)
+
+var _ = Describe("MSPs with RSA Certificate Authorities", func() {
+	var (
+		client  *docker.Client
+		testDir string
+		network *nwo.Network
+		process ifrit.Process
+	)
+
+	BeforeEach(func() {
+		var err error
+		testDir, err = ioutil.TempDir("", "msp")
+		Expect(err).NotTo(HaveOccurred())
+
+		client, err = docker.NewClientFromEnv()
+		Expect(err).NotTo(HaveOccurred())
+
+		network = nwo.New(nwo.BasicEtcdRaft(), testDir, client, StartPort(), components)
+		network.GenerateConfigTree()
+
+		By("manually bootstrapping MSPs with RSA CAs")
+		generateRSACACrypto(network)
+		network.CreateDockerNetwork()
+		sess, err := network.ConfigTxGen(commands.OutputBlock{
+			ChannelID:   network.SystemChannel.Name,
+			Profile:     network.SystemChannel.Profile,
+			ConfigPath:  network.RootDir,
+			OutputBlock: network.OutputBlockPath(network.SystemChannel.Name),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(0))
+
+		for _, c := range network.Channels {
+			sess, err := network.ConfigTxGen(commands.CreateChannelTx{
+				ChannelID:             c.Name,
+				Profile:               c.Profile,
+				BaseProfile:           c.BaseProfile,
+				ConfigPath:            network.RootDir,
+				OutputCreateChannelTx: network.CreateChannelTxPath(c.Name),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(0))
+		}
+		network.ConcatenateTLSCACertificates()
+
+		By("starting all processes for fabric")
+		networkRunner := network.NetworkGroupRunner()
+		process = ifrit.Invoke(networkRunner)
+		Eventually(process.Ready(), network.EventuallyTimeout).Should(BeClosed())
+	})
+
+	AfterEach(func() {
+		if process != nil {
+			process.Signal(syscall.SIGTERM)
+			Eventually(process.Wait(), network.EventuallyTimeout).Should(Receive())
+		}
+		if network != nil {
+			network.Cleanup()
+		}
+		os.RemoveAll(testDir)
+	})
+
+	It("executes transactions endorsed with ECDSA signing certs", func() {
+		org1Peer0 := network.Peer("Org1", "peer0")
+		orderer := network.Orderer("orderer")
+
+		chaincode := nwo.Chaincode{
+			Name:            "mycc",
+			Version:         "0.0",
+			Path:            components.Build("github.com/hyperledger/fabric/integration/chaincode/simple/cmd"),
+			Lang:            "binary",
+			PackageFile:     filepath.Join(testDir, "simplecc.tar.gz"),
+			Ctor:            `{"Args":["init","a","100","b","200"]}`,
+			SignaturePolicy: `AND ('Org1MSP.member','Org2MSP.member')`,
+			Sequence:        "1",
+			InitRequired:    true,
+			Label:           "my_prebuilt_chaincode",
+		}
+
+		network.CreateAndJoinChannels(orderer)
+		nwo.EnableCapabilities(
+			network,
+			"testchannel",
+			"Application", "V2_0",
+			orderer,
+			network.Peer("Org1", "peer0"),
+			network.Peer("Org2", "peer0"),
+		)
+		nwo.DeployChaincode(network, "testchannel", orderer, chaincode)
+		RunQueryInvokeQuery(network, orderer, org1Peer0, 100)
+	})
+})
+
+// What follows is a bunch of code to build a hand-crafted set of MSPs where
+// everything except signing certificates use RSA keys. It's not pretty but it
+// gets the job done for testing.
+
+func generateRSACACrypto(n *nwo.Network) {
+	cryptoDir := n.CryptoPath()
+	for _, o := range n.OrdererOrgs() {
+		orgDir := filepath.Join(cryptoDir, "ordererOrganizations", o.Domain)
+		signCA, tlsCA, adminCert := createMSP(orgDir, o.Domain, o.EnableNodeOUs)
+		for i := 1; i <= o.Users; i++ {
+			name := fmt.Sprintf("User%d@%s", i, o.Domain)
+			dir := filepath.Join(orgDir, "users", name)
+			var ous []string
+			if o.EnableNodeOUs {
+				ous = append(ous, "client")
+			}
+			writeLocalMSP(dir, name, ous, nil, signCA, tlsCA, adminCert, o.EnableNodeOUs, true)
+		}
+		for _, orderer := range n.OrderersInOrg(o.Name) {
+			name := orderer.Name + "." + o.Domain
+			dir := filepath.Join(orgDir, "orderers", name)
+			sans := []string{"127.0.0.1", "::1", "localhost"}
+			var ous []string
+			if o.EnableNodeOUs {
+				ous = append(ous, "orderer")
+			}
+			writeLocalMSP(dir, name, ous, sans, signCA, tlsCA, adminCert, o.EnableNodeOUs, false)
+		}
+	}
+
+	for _, o := range n.PeerOrgs() {
+		orgDir := filepath.Join(cryptoDir, "peerOrganizations", o.Domain)
+		signCA, tlsCA, adminCert := createMSP(orgDir, o.Domain, o.EnableNodeOUs)
+		for i := 1; i <= o.Users; i++ {
+			name := fmt.Sprintf("User%d@%s", i, o.Domain)
+			dir := filepath.Join(orgDir, "users", name)
+			var ous []string
+			if o.EnableNodeOUs {
+				ous = append(ous, "client")
+			}
+			writeLocalMSP(dir, name, ous, nil, signCA, tlsCA, adminCert, o.EnableNodeOUs, true)
+		}
+		for _, peer := range n.PeersInOrg(o.Name) {
+			name := peer.Name + "." + o.Domain
+			dir := filepath.Join(orgDir, "peers", name)
+			sans := []string{"127.0.0.1", "::1", "localhost"}
+			var ous []string
+			if o.EnableNodeOUs {
+				ous = append(ous, "peer")
+			}
+			writeLocalMSP(dir, name, ous, sans, signCA, tlsCA, adminCert, o.EnableNodeOUs, false)
+		}
+	}
+}
+
+func createMSP(baseDir, domain string, nodeOUs bool) (signCA *CA, tlsCA *CA, adminPemCert []byte) {
+	caDir := filepath.Join(baseDir, "ca")
+	signCA = newCA(domain, "ca")
+	writeCA(signCA, caDir)
+
+	tlsCADir := filepath.Join(baseDir, "tlsca")
+	tlsCA = newCA(domain, "tlsca")
+	writeCA(tlsCA, tlsCADir)
+
+	mspDir := filepath.Join(baseDir, "msp")
+	writeVerifyingMSP(mspDir, signCA, tlsCA, nodeOUs)
+
+	adminUsername := "Admin@" + domain
+	adminDir := filepath.Join(baseDir, "users", adminUsername)
+	err := os.MkdirAll(adminDir, 0755)
+	Expect(err).NotTo(HaveOccurred())
+
+	var ous []string
+	if nodeOUs {
+		ous = append(ous, "admin")
+	}
+
+	writeLocalMSP(adminDir, adminUsername, ous, nil, signCA, tlsCA, nil, nodeOUs, true)
+	adminPemCert, err = ioutil.ReadFile(filepath.Join(adminDir, "msp", "signcerts", certFilename(adminUsername)))
+	Expect(err).NotTo(HaveOccurred())
+	err = ioutil.WriteFile(filepath.Join(adminDir, "msp", "admincerts", certFilename(adminUsername)), adminPemCert, 0644)
+	Expect(err).NotTo(HaveOccurred())
+
+	if !nodeOUs {
+		err := ioutil.WriteFile(filepath.Join(mspDir, "admincerts", certFilename(adminUsername)), adminPemCert, 0644)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	return signCA, tlsCA, adminPemCert
+}
+
+func writeCA(ca *CA, dir string) {
+	var err error
+	err = os.MkdirAll(dir, 0755)
+	Expect(err).NotTo(HaveOccurred())
+
+	certFilename := filepath.Join(dir, ca.certFilename())
+	writeCertificate(certFilename, ca.certBytes)
+
+	keyFilename := filepath.Join(dir, fmt.Sprintf("%x_sk", ca.cert.SubjectKeyId))
+	writeKey(keyFilename, ca.signer)
+}
+
+func writeCertificate(filename string, der []byte) {
+	certFile, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE, 0644)
+	Expect(err).NotTo(HaveOccurred())
+	defer certFile.Close()
+	err = pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func writeKey(filename string, signer crypto.Signer) {
+	keyFile, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE, 0600)
+	Expect(err).NotTo(HaveOccurred())
+	defer keyFile.Close()
+	derKey, err := x509.MarshalPKCS8PrivateKey(signer)
+	Expect(err).NotTo(HaveOccurred())
+	err = pem.Encode(keyFile, &pem.Block{Type: "PRIVATE KEY", Bytes: derKey})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func writeVerifyingMSP(mspDir string, signCA, tlsCA *CA, nodeOUs bool) {
+	for _, dir := range []string{"admincerts", "cacerts", "tlscacerts"} {
+		err := os.MkdirAll(filepath.Join(mspDir, dir), 0755)
+		Expect(err).NotTo(HaveOccurred())
+	}
+	if nodeOUs {
+		configFilename := filepath.Join(mspDir, "config.yaml")
+		writeConfigYaml(configFilename, filepath.Join("cacerts", signCA.certFilename()), nodeOUs)
+	}
+	writeCertificate(filepath.Join(mspDir, "cacerts", signCA.certFilename()), signCA.certBytes)
+	writeCertificate(filepath.Join(mspDir, "tlscacerts", tlsCA.certFilename()), tlsCA.certBytes)
+}
+
+func writeLocalMSP(baseDir, name string, signOUs, sans []string, signCA, tlsCA *CA, adminCertPem []byte, nodeOUs, client bool) {
+	mspDir := filepath.Join(baseDir, "msp")
+	err := os.MkdirAll(mspDir, 0755)
+	Expect(err).NotTo(HaveOccurred())
+	writeVerifyingMSP(mspDir, signCA, tlsCA, nodeOUs)
+
+	for _, dir := range []string{"admincerts", "keystore", "signcerts"} {
+		err := os.MkdirAll(filepath.Join(mspDir, dir), 0755)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	if !nodeOUs && len(adminCertPem) != 0 {
+		block, _ := pem.Decode(adminCertPem)
+		adminCert, err := x509.ParseCertificate(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		err = ioutil.WriteFile(filepath.Join(mspDir, "admincerts", certFilename(adminCert.Subject.CommonName)), adminCertPem, 0644)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	// create signcert
+	priv := generateECKey()
+	signcertBytes, signcert := signCA.issueSignCertificate(name, signOUs, priv.Public())
+	signcertFilename := filepath.Join(mspDir, "signcerts", certFilename(name))
+	writeCertificate(signcertFilename, signcertBytes)
+	signcertKeyFilename := filepath.Join(mspDir, "keystore", fmt.Sprintf("%x_sk", signcert.SubjectKeyId))
+	writeKey(signcertKeyFilename, priv)
+
+	// populate tls
+	tlsDir := filepath.Join(baseDir, "tls")
+	err = os.MkdirAll(tlsDir, 0755)
+	Expect(err).NotTo(HaveOccurred())
+	writeCertificate(filepath.Join(tlsDir, "ca.crt"), tlsCA.certBytes)
+
+	tlsKey := generateRSAKey()
+	tlsCertBytes, _ := tlsCA.issueTLSCertificate(name, sans, tlsKey.Public())
+	if client {
+		writeCertificate(filepath.Join(tlsDir, "client.crt"), tlsCertBytes)
+		writeKey(filepath.Join(tlsDir, "client.key"), tlsKey)
+	} else {
+		writeCertificate(filepath.Join(tlsDir, "server.crt"), tlsCertBytes)
+		writeKey(filepath.Join(tlsDir, "server.key"), tlsKey)
+	}
+}
+
+func writeConfigYaml(configFilename, caFile string, enable bool) {
+	var config = &fabricmsp.Configuration{
+		NodeOUs: &fabricmsp.NodeOUs{
+			Enable: enable,
+			ClientOUIdentifier: &fabricmsp.OrganizationalUnitIdentifiersConfiguration{
+				Certificate:                  caFile,
+				OrganizationalUnitIdentifier: "client",
+			},
+			PeerOUIdentifier: &fabricmsp.OrganizationalUnitIdentifiersConfiguration{
+				Certificate:                  caFile,
+				OrganizationalUnitIdentifier: "peer",
+			},
+			AdminOUIdentifier: &fabricmsp.OrganizationalUnitIdentifiersConfiguration{
+				Certificate:                  caFile,
+				OrganizationalUnitIdentifier: "admin",
+			},
+			OrdererOUIdentifier: &fabricmsp.OrganizationalUnitIdentifiersConfiguration{
+				Certificate:                  caFile,
+				OrganizationalUnitIdentifier: "orderer",
+			},
+		},
+	}
+
+	configFile, err := os.Create(configFilename)
+	Expect(err).NotTo(HaveOccurred())
+	defer configFile.Close()
+
+	err = yaml.NewEncoder(configFile).Encode(config)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+type CA struct {
+	signer    crypto.Signer
+	cert      *x509.Certificate
+	certBytes []byte
+}
+
+func newCA(orgName, caName string) *CA {
+	signer := generateRSAKey()
+
+	template := x509Template()
+	template.IsCA = true
+	template.KeyUsage |= x509.KeyUsageDigitalSignature
+	template.KeyUsage |= x509.KeyUsageKeyEncipherment
+	template.KeyUsage |= x509.KeyUsageCertSign
+	template.KeyUsage |= x509.KeyUsageCRLSign
+	template.ExtKeyUsage = []x509.ExtKeyUsage{
+		x509.ExtKeyUsageClientAuth,
+		x509.ExtKeyUsageServerAuth,
+	}
+	template.Subject = pkix.Name{
+		CommonName:   caName + "." + orgName,
+		Organization: []string{orgName},
+	}
+	template.SubjectKeyId = computeSKI(signer.Public())
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, signer.Public(), signer)
+	Expect(err).NotTo(HaveOccurred())
+	cert, err := x509.ParseCertificate(certBytes)
+	Expect(err).NotTo(HaveOccurred())
+
+	return &CA{
+		signer:    signer,
+		cert:      cert,
+		certBytes: certBytes,
+	}
+}
+
+func (ca *CA) issueSignCertificate(name string, ous []string, pub crypto.PublicKey) ([]byte, *x509.Certificate) {
+	template := x509Template()
+	template.KeyUsage = x509.KeyUsageDigitalSignature
+	template.ExtKeyUsage = nil
+	template.Subject = pkix.Name{
+		CommonName:         name,
+		Organization:       ca.cert.Subject.Organization,
+		OrganizationalUnit: ous,
+	}
+	template.SubjectKeyId = computeSKI(pub)
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, ca.cert, pub, ca.signer)
+	Expect(err).NotTo(HaveOccurred())
+	cert, err := x509.ParseCertificate(certBytes)
+	Expect(err).NotTo(HaveOccurred())
+	return certBytes, cert
+}
+
+func (ca *CA) issueTLSCertificate(name string, sans []string, pub crypto.PublicKey) ([]byte, *x509.Certificate) {
+	template := x509Template()
+	template.KeyUsage = x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+	template.ExtKeyUsage = []x509.ExtKeyUsage{
+		x509.ExtKeyUsageServerAuth,
+		x509.ExtKeyUsageClientAuth,
+	}
+	template.Subject = pkix.Name{
+		CommonName:   name,
+		Organization: ca.cert.Subject.Organization,
+	}
+	template.SubjectKeyId = computeSKI(pub)
+
+	for _, san := range sans {
+		if ip := net.ParseIP(san); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, san)
+		}
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, ca.cert, pub, ca.signer)
+	Expect(err).NotTo(HaveOccurred())
+	cert, err := x509.ParseCertificate(certBytes)
+	Expect(err).NotTo(HaveOccurred())
+	return certBytes, cert
+}
+
+func (ca *CA) certFilename() string {
+	return certFilename(ca.cert.Subject.CommonName)
+}
+
+func certFilename(stem string) string {
+	return stem + "-cert.pem"
+}
+
+func generateRSAKey() crypto.Signer {
+	signer, err := rsa.GenerateKey(rand.Reader, 4096)
+	Expect(err).NotTo(HaveOccurred())
+	return signer
+}
+
+func generateECKey() crypto.Signer {
+	signer, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	Expect(err).NotTo(HaveOccurred())
+	return signer
+}
+
+func x509Template() x509.Certificate {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, _ := rand.Int(rand.Reader, serialNumberLimit)
+	notBefore := time.Now().Round(time.Minute).Add(-5 * time.Minute).UTC()
+
+	return x509.Certificate{
+		SerialNumber:          serialNumber,
+		NotBefore:             notBefore,
+		NotAfter:              notBefore.Add(3650 * 24 * time.Hour).UTC(),
+		BasicConstraintsValid: true,
+	}
+}
+
+func computeSKI(key crypto.PublicKey) []byte {
+	var raw []byte
+	switch key := key.(type) {
+	case *rsa.PublicKey:
+		raw = x509.MarshalPKCS1PublicKey(key)
+	case *ecdsa.PublicKey:
+		raw = elliptic.Marshal(key.Curve, key.X, key.Y)
+	default:
+		panic(fmt.Sprintf("unexpected type: %T", key))
+	}
+	hash := sha256.Sum256(raw)
+	return hash[:]
+}

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -717,7 +717,7 @@ func (n *Network) GenerateConfigTree() {
 // written to ${rootDir}/${Channel.Name}_tx.pb.
 func (n *Network) Bootstrap() {
 	if n.DockerClient != nil {
-		n.createDockerNetwork()
+		n.CreateDockerNetwork()
 	}
 
 	sess, err := n.Cryptogen(commands.Generate{
@@ -753,7 +753,7 @@ func (n *Network) Bootstrap() {
 	n.ConcatenateTLSCACertificates()
 }
 
-func (n *Network) createDockerNetwork() {
+func (n *Network) CreateDockerNetwork() {
 	_, err := n.DockerClient.CreateNetwork(
 		docker.CreateNetworkOptions{
 			Name:   n.NetworkID,

--- a/release_notes/v2.3.0.md
+++ b/release_notes/v2.3.0.md
@@ -23,6 +23,15 @@ If adding an organization MSP and a Raft consenter in the same configuration upd
 with error "consensus metadata update for channel config update is invalid" "certificate signed by unknown authority".
 This fix adds logic to verify consenters based on the updated set of organization MSP root CAs.
 
+**FAB-18308: Restore support for MSPs that contain RSA certificate authorities**
+
+While Fabric has never supported RSA for transaction signatures or validation,
+certificate authorities included in MSP definitions could be associated with
+RSA keys. This ability was inadvertently removed during the development of
+release 2.0 and prevented migration of some networks to a 2.x version. With
+these changes, version 2.x components will no longer panic when attempting to
+initialize MSPs that include CA certificates associated with RSA keys.
+
 **peer and orderer PKCS#11 - Always Finalize the PKCS#11 FindObject Operation**
 
 In certain error paths, a PKCS#11 session was not finalized, leaving the session


### PR DESCRIPTION
While RSA has never been supported by Fabric for transaction signing and verification, prior to version 2.x, MSPs could include CA certificates that included RSA public keys. This was broken with the removal of the unsupported RSA code.

This change modifies the key import function used by the MSP to convert an RSA public key to a bccsp.Key that can then be used as part of an MSP identity.

This code does *not* add support for RSA on transaction paths.