### PR TITLE
Nominate Will Lahti as Fabric Maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,6 +17,7 @@ Maintainers
 | Manish Sethi | [manish-sethi][manish-sethi] | manish-sethi | <manish.sethi@gmail.com>
 | Gari Singh | [mastersingh24][mastersingh24] | mastersingh24 | <gari.r.singh@gmail.com>
 | Matthew Sykes | [sykesm][sykesm] | sykesm | <sykesmat@us.ibm.com>
+| Will Lahti | [wlahti][wlahti] | wlahti | <wtlahti@us.ibm.com>
 | Yacov Manevich | [yacovm][yacovm] | yacovm | <yacovm@il.ibm.com>
 
 **Documentation Maintainers**
@@ -82,4 +83,5 @@ Maintainers
 [srderson]: https://github.com/srderson
 [sykesm]: https://github.com/sykesm
 [tamasblummer]: https://github.com/tamasblummer
+[wlahti]: https://github.com/wlahti
 [yacovm]: https://github.com/yacovm


### PR DESCRIPTION
Will has been a core contributor to Hyperledger Fabric since 2016. His contributions have been part of the CLI, peer event hub, channel event services, operations, integration tests, metrics, lifecycle 2.0, external chaincode builder, and, more recently, the channel participation API.

Beyond his code contributions, Will works to actively support Fabric users by engaging in discussions on Rocket Chat where he has answered many questions. He also partners effectively with the documentation maintainers to ensure features can be adopted and used by users.

In support of Fabric contributors, Will frequently reviews Fabric pull requests and provides excellent feedback and support that results in improved quality and maintainability.

Will's influence has grown tremendously since his early involvement with Fabric. Given the depth and breadth of Will's contributions, I believe Will is well suited to be a Fabric Maintainer.