### PR TITLE
Add persistent volume note to peer deploy guide

### DIFF
--- a/docs/source/deploypeer/peerchecklist.md
+++ b/docs/source/deploypeer/peerchecklist.md
@@ -89,7 +89,7 @@ address: 0.0.0.0:7051
 mspConfigPath: msp
 ```
 - **`mspConfigPath`**: (Default value should be overridden.) This is the path to the peer's local MSP, which must be created before the peer can be deployed. The path can be absolute or relative to `FABRIC_CFG_PATH` (by default, it is `/etc/hyperledger/fabric` in the peer image). Unless an absolute path is specified to a folder named something other than "msp", the peer defaults to looking for a folder called “msp” at the path (in other words, `FABRIC_CFG_PATH/msp`) and when using the peer image: `/etc/hyperledger/fabric/msp`. If you are using the recommended folder structure described in the [Registering and enrolling identities with a CA](https://hyperledger-fabric-ca.readthedocs.io/en/release-1.4/deployguide/use_CA.html) topic, it would be relative to the FABRIC_CFG_PATH as follows:
-`config/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp`
+`config/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp`. **The best practice is to store this data in persistent storage**. This prevents the MSP from being lost if your peer containers are destroyed for some reason.
 
 ## peer.localMspId
 ```
@@ -112,7 +112,7 @@ localMspId: SampleOrg
 # modification that might corrupt the peer operations.
 fileSystemPath: /var/hyperledger/production
 ```
-- **`fileSystemPath`**: (Default value should be overridden.) This is the path to the ledger and installed chaincodes on the local filesystem of the peer. It can be an absolute path or relative to `FABRIC_CFG_PATH`. It defaults to `/var/hyperledger/production`. The user running the peer needs to own and have write access to this directory.
+- **`fileSystemPath`**: (Default value should be overridden.) This is the path to the ledger and installed chaincodes on the local filesystem of the peer. It can be an absolute path or relative to `FABRIC_CFG_PATH`. It defaults to `/var/hyperledger/production`. The user running the peer needs to own and have write access to this directory. **The best practice is to store this data in persistent storage**. This prevents the ledger and any installed chaincodes from being lost if your peer containers are destroyed for some reason.
 
 ## peer.gossip.*
 


### PR DESCRIPTION
Change-Id: I54defff6b0d68953e3f4c3220faee01b4947a904
Signed-off-by: joe-alewine <Joe.Alewine@ibm.com>

#### Type of change

- Documentation update

#### Description

Wanted to make it more explicit that certain files should be mounted as persistent storage. 