### PR TITLE
Add check for invalid key before hitting couchdb (#2133)

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
@@ -440,6 +440,9 @@ func (vdb *VersionedDB) readFromDB(namespace, key string) (*keyValue, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := validateKey(key); err != nil {
+		return nil, err
+	}
 	couchDoc, _, err := db.readDoc(key)
 	if err != nil {
 		return nil, err

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
@@ -1874,3 +1874,37 @@ func verifyFullScanIterator(
 	}
 	require.Equal(t, expectedResult, results)
 }
+
+func TestReadFromDBInvalidKey(t *testing.T) {
+	vdbEnv.init(t, sysNamespaces)
+	defer vdbEnv.cleanup()
+	channelName := "test_getstate_invalidkey"
+	db, err := vdbEnv.DBProvider.GetDBHandle(channelName, nil)
+	require.NoError(t, err)
+	vdb := db.(*VersionedDB)
+
+	testcase := []struct {
+		key              string
+		expectedErrorMsg string
+	}{
+		{
+			key:              string([]byte{0xff, 0xfe, 0xfd}),
+			expectedErrorMsg: "invalid key [fffefd], must be a UTF-8 string",
+		},
+		{
+			key:              "",
+			expectedErrorMsg: "invalid key. Empty string is not supported as a key by couchdb",
+		},
+		{
+			key:              "_key_starting_with_an_underscore",
+			expectedErrorMsg: `invalid key [_key_starting_with_an_underscore], cannot begin with "_"`,
+		},
+	}
+
+	for i, tc := range testcase {
+		t.Run(fmt.Sprintf("testcase-%d", i), func(t *testing.T) {
+			_, err = vdb.readFromDB("ns", tc.key)
+			require.EqualError(t, err, tc.expectedErrorMsg)
+		})
+	}
+}


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Add check for invalid key before querying couchdb

FAB-13897

Signed-off-by: manish <manish.sethi@gmail.com>
Signed-off-by: David Enyeart <enyeart@us.ibm.com>
