### PR TITLE
Pass GO_TAGS to tools container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,7 @@ $(BUILD_DIR)/images/ccenv/$(DUMMY):   BUILD_CONTEXT=images/ccenv
 $(BUILD_DIR)/images/baseos/$(DUMMY):  BUILD_CONTEXT=images/baseos
 $(BUILD_DIR)/images/peer/$(DUMMY):    BUILD_ARGS=--build-arg GO_TAGS=${GO_TAGS}
 $(BUILD_DIR)/images/orderer/$(DUMMY): BUILD_ARGS=--build-arg GO_TAGS=${GO_TAGS}
+$(BUILD_DIR)/images/tools/$(DUMMY): BUILD_ARGS=--build-arg GO_TAGS=${GO_TAGS}
 
 $(BUILD_DIR)/images/%/$(DUMMY):
 	@echo "Building Docker image $(DOCKER_NS)/fabric-$*"

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -17,7 +17,8 @@ ADD . $GOPATH/src/github.com/hyperledger/fabric
 WORKDIR $GOPATH/src/github.com/hyperledger/fabric
 
 FROM golang as tools
-RUN make configtxgen configtxlator cryptogen peer discover idemixgen
+ARG GO_TAGS
+RUN make configtxgen configtxlator cryptogen peer discover idemixgen GO_TAGS=${GO_TAGS}
 
 FROM golang:${GO_VER}-alpine
 # git is required to support `go list -m`


### PR DESCRIPTION
#### Type of change

New feature

#### Description

With this change, you can now build
the tools container with pkcs11.