### PR TITLE
Added support to specify CA, Identity and TLS cert expiry times in cryptogen

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -47,12 +47,12 @@ the binaries and images.
 
 .. note:: If you want a specific release, pass a version identifier for Fabric and Fabric-CA docker images.
           The command below demonstrates how to download the latest production releases -
-          **Fabric v2.2.1** and **Fabric CA v1.4.9**
+          **Fabric v2.3.0** and **Fabric CA v1.4.9**
 
 .. code:: bash
 
   curl -sSL https://bit.ly/2ysbOFE | bash -s -- <fabric_version> <fabric-ca_version>
-  curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.2.1 1.4.9
+  curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.3.0 1.4.9
 
 .. note:: If you get an error running the above curl command, you may
           have too old a version of curl that does not handle

--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -6,8 +6,8 @@ can deploy a test network by using scripts that are provided in the
 by running nodes on your local machine. More experienced developers can use the
 network to test their smart contracts and applications. The network is meant to
 be used only as a tool for education and testing. It should not be used as a
-template for deploying a production network. The test network is being introduced
-in Fabric v2.0 as the long term replacement for the `first-network` sample.
+template for deploying a production network. To learn about using Fabric in
+production, see [Deploying a production network](deployment_guide_overview.html).
 
 The sample network deploys a Fabric network with Docker Compose. Because the
 nodes are isolated within a Docker Compose network, the test network is not

--- a/internal/cryptogen/msp/msp_test.go
+++ b/internal/cryptogen/msp/msp_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/hyperledger/fabric/internal/cryptogen/ca"
 	"github.com/hyperledger/fabric/internal/cryptogen/msp"
@@ -28,6 +29,8 @@ const (
 	testOrganizationalUnit = "Hyperledger Fabric"
 	testStreetAddress      = "testStreetAddress"
 	testPostalCode         = "123456"
+	caCertExpiry           = 3650 * 24 * time.Hour
+	signedCertExpiry       = 365 * 24 * time.Hour
 )
 
 var testDir = filepath.Join(os.TempDir(), "msp-test")
@@ -44,10 +47,10 @@ func testGenerateLocalMSP(t *testing.T, nodeOUs bool) {
 	tlsDir := filepath.Join(testDir, "tls")
 
 	// generate signing CA
-	signCA, err := ca.NewCA(caDir, testCAOrg, testCAName, testCountry, testProvince, testLocality, testOrganizationalUnit, testStreetAddress, testPostalCode)
+	signCA, err := ca.NewCA(caDir, testCAOrg, testCAName, testCountry, testProvince, testLocality, testOrganizationalUnit, testStreetAddress, testPostalCode, caCertExpiry, signedCertExpiry)
 	require.NoError(t, err, "Error generating CA")
 	// generate TLS CA
-	tlsCA, err := ca.NewCA(tlsCADir, testCAOrg, testCAName, testCountry, testProvince, testLocality, testOrganizationalUnit, testStreetAddress, testPostalCode)
+	tlsCA, err := ca.NewCA(tlsCADir, testCAOrg, testCAName, testCountry, testProvince, testLocality, testOrganizationalUnit, testStreetAddress, testPostalCode, caCertExpiry, signedCertExpiry)
 	require.NoError(t, err, "Error generating CA")
 
 	require.NotEmpty(t, signCA.SignCert.Subject.Country, "country cannot be empty.")
@@ -132,10 +135,10 @@ func testGenerateVerifyingMSP(t *testing.T, nodeOUs bool) {
 	tlsCADir := filepath.Join(testDir, "tlsca")
 	mspDir := filepath.Join(testDir, "msp")
 	// generate signing CA
-	signCA, err := ca.NewCA(caDir, testCAOrg, testCAName, testCountry, testProvince, testLocality, testOrganizationalUnit, testStreetAddress, testPostalCode)
+	signCA, err := ca.NewCA(caDir, testCAOrg, testCAName, testCountry, testProvince, testLocality, testOrganizationalUnit, testStreetAddress, testPostalCode, caCertExpiry, signedCertExpiry)
 	require.NoError(t, err, "Error generating CA")
 	// generate TLS CA
-	tlsCA, err := ca.NewCA(tlsCADir, testCAOrg, testCAName, testCountry, testProvince, testLocality, testOrganizationalUnit, testStreetAddress, testPostalCode)
+	tlsCA, err := ca.NewCA(tlsCADir, testCAOrg, testCAName, testCountry, testProvince, testLocality, testOrganizationalUnit, testStreetAddress, testPostalCode, caCertExpiry, signedCertExpiry)
 	require.NoError(t, err, "Error generating CA")
 
 	err = msp.GenerateVerifyingMSP(mspDir, signCA, tlsCA, nodeOUs)

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -6,7 +6,7 @@
 #
 
 # if version not passed in, default to latest released version
-VERSION=2.2.1
+VERSION=2.3.0
 # if ca version not passed in, default to latest released version
 CA_VERSION=1.4.9
 ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m | sed 's/x86_64/amd64/g')")
@@ -21,8 +21,8 @@ printHelp() {
     echo "-s : bypass fabric-samples repo clone"
     echo "-b : bypass download of platform-specific binaries"
     echo
-    echo "e.g. bootstrap.sh 2.2.1 1.4.9 -s"
-    echo "will download docker images and binaries for Fabric v2.2.1 and Fabric CA v1.4.9"
+    echo "e.g. bootstrap.sh 2.3.0 1.4.9 -s"
+    echo "will download docker images and binaries for Fabric v2.3.0 and Fabric CA v1.4.9"
 }
 
 # dockerPull() pulls docker images from fabric and chaincode repositories


### PR DESCRIPTION
#### Type of change
- Improvement to cryptogen tool

#### Description
This is an improvement on cryptogen tool to allow for custom expiry times for CA, Identity and TLS certificates for each organization. The expiration times can be customized using following configuration for each organization:
    CACertExpiry: 87600h
    IdentityCertExpiry: 87600h
    TLSCertExpiry: 87600h

The default expiry time remains 10 years

