### PR TITLE
Fix link to security bug reporting process

### DIFF
--- a/docs/source/CONTRIBUTING.rst
+++ b/docs/source/CONTRIBUTING.rst
@@ -237,7 +237,7 @@ reported, then you might add a comment that you also are interested in seeing
 the defect fixed.
 
 .. note:: If the defect is security-related, please follow the Hyperledger
-          `security bug reporting process <https://wiki.hyperledger.org/display/HYP/Defect+Response>`__.
+          `security bug reporting process <https://wiki.hyperledger.org/display/SEC/Defect+Response>`__.
 
 If it has not been previously reported, you may either submit a PR with a
 well documented commit message describing the defect and the fix, or you


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

The wiki changed and the link is now dangling. This change
fixes the link in the CONTRIBUTING page.

https://hyperledger-fabric.readthedocs.io/en/latest/CONTRIBUTING.html 

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>

