### PR TITLE
[FAB-18323] CherryPick: remove the ephemeral field from the BCCSP software options (PR #1553)

### DIFF
--- a/bccsp/factory/factory_test.go
+++ b/bccsp/factory/factory_test.go
@@ -62,7 +62,7 @@ BCCSP:
 	cfgVariations := []*FactoryOpts{
 		{},
 		{ProviderName: "SW"},
-		{ProviderName: "SW", SwOpts: &SwOpts{HashFamily: "SHA2", SecLevel: 256, Ephemeral: true}},
+		{ProviderName: "SW", SwOpts: &SwOpts{HashFamily: "SHA2", SecLevel: 256}},
 		yamlBCCSP,
 	}
 

--- a/bccsp/factory/opts.go
+++ b/bccsp/factory/opts.go
@@ -24,7 +24,6 @@ func GetDefaultOpts() *FactoryOpts {
 		SwOpts: &SwOpts{
 			HashFamily: "SHA2",
 			SecLevel:   256,
-			Ephemeral:  true,
 		},
 	}
 }

--- a/bccsp/factory/pkcs11_test.go
+++ b/bccsp/factory/pkcs11_test.go
@@ -49,7 +49,6 @@ func TestInitFactoriesInvalidArgs(t *testing.T) {
 func TestGetBCCSPFromOpts(t *testing.T) {
 	opts := GetDefaultOpts()
 	opts.SwOpts.FileKeystore = &FileKeystoreOpts{KeyStorePath: os.TempDir()}
-	opts.SwOpts.Ephemeral = false
 	csp, err := GetBCCSPFromOpts(opts)
 	assert.NoError(t, err)
 	assert.NotNil(t, csp)

--- a/bccsp/factory/swfactory.go
+++ b/bccsp/factory/swfactory.go
@@ -45,8 +45,6 @@ func (f *SWFactory) Get(config *FactoryOpts) (bccsp.BCCSP, error) {
 
 	var ks bccsp.KeyStore
 	switch {
-	case swOpts.Ephemeral:
-		ks = sw.NewDummyKeyStore()
 	case swOpts.FileKeystore != nil:
 		fks, err := sw.NewFileBasedKeyStore(nil, swOpts.FileKeystore.KeyStorePath, false)
 		if err != nil {
@@ -66,11 +64,8 @@ func (f *SWFactory) Get(config *FactoryOpts) (bccsp.BCCSP, error) {
 // SwOpts contains options for the SWFactory
 type SwOpts struct {
 	// Default algorithms when not specified (Deprecated?)
-	SecLevel   int    `mapstructure:"security" json:"security" yaml:"Security"`
-	HashFamily string `mapstructure:"hash" json:"hash" yaml:"Hash"`
-
-	// Keystore Options
-	Ephemeral     bool               `mapstructure:"tempkeys,omitempty" json:"tempkeys,omitempty"`
+	SecLevel      int                `mapstructure:"security" json:"security" yaml:"Security"`
+	HashFamily    string             `mapstructure:"hash" json:"hash" yaml:"Hash"`
 	FileKeystore  *FileKeystoreOpts  `mapstructure:"filekeystore,omitempty" json:"filekeystore,omitempty" yaml:"FileKeyStore"`
 	DummyKeystore *DummyKeystoreOpts `mapstructure:"dummykeystore,omitempty" json:"dummykeystore,omitempty"`
 	InmemKeystore *InmemKeystoreOpts `mapstructure:"inmemkeystore,omitempty" json:"inmemkeystore,omitempty"`

--- a/msp/configbuilder.go
+++ b/msp/configbuilder.go
@@ -145,7 +145,6 @@ func SetupBCCSPKeystoreConfig(bccspConfig *factory.FactoryOpts, keystoreDir stri
 		// Only override the KeyStorePath if it was left empty
 		if bccspConfig.SwOpts.FileKeystore == nil ||
 			bccspConfig.SwOpts.FileKeystore.KeyStorePath == "" {
-			bccspConfig.SwOpts.Ephemeral = false
 			bccspConfig.SwOpts.FileKeystore = &factory.FileKeystoreOpts{KeyStorePath: keystoreDir}
 		}
 	}

--- a/msp/configbuilder_test.go
+++ b/msp/configbuilder_test.go
@@ -42,7 +42,6 @@ func TestSetupBCCSPKeystoreConfig(t *testing.T) {
 	bccspConfig.SwOpts = &factory.SwOpts{
 		HashFamily: "SHA2",
 		SecLevel:   256,
-		Ephemeral:  true,
 	}
 	rtnConfig = SetupBCCSPKeystoreConfig(bccspConfig, keystoreDir)
 	assert.NotNil(t, rtnConfig.SwOpts.FileKeystore)
@@ -77,7 +76,6 @@ func TestSetupBCCSPKeystoreConfig(t *testing.T) {
 	bccspConfig.SwOpts = &factory.SwOpts{
 		HashFamily: "SHA2",
 		SecLevel:   256,
-		Ephemeral:  true,
 	}
 	rtnConfig = SetupBCCSPKeystoreConfig(bccspConfig, keystoreDir)
 	assert.NotNil(t, rtnConfig.SwOpts.FileKeystore)

--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -474,7 +474,6 @@ func TestLoadLocalMSP(t *testing.T) {
 						SwOpts: &factory.SwOpts{
 							HashFamily: "SHA2",
 							SecLevel:   256,
-							Ephemeral:  true,
 						},
 					},
 				},
@@ -1031,7 +1030,6 @@ func genesisConfig(t *testing.T, genesisFile string) *localconfig.TopLevel {
 				SwOpts: &factory.SwOpts{
 					HashFamily: "SHA2",
 					SecLevel:   256,
-					Ephemeral:  true,
 				},
 			},
 		},


### PR DESCRIPTION
Signed-off-by: Matthew Sykes <matthew.sykes@gmail.com>
Signed-off-by: Wenjian Qiao <wenjianq@gmail.com>

#### Type of change
- Bug fix
- Improvement (improvement to code, performance, etc)

#### Description
Cherry pick PR #1553 to release-2.2.

#### Related issues
https://jira.hyperledger.org/browse/FAB-18323