### PR TITLE
Update README.md to include link to Fabric v2.3 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Follow the release discussion on the [#fabric-release](https://chat.hyperledger.
 Please visit our
 online documentation for
 information on getting started using and developing with the fabric, SDK and chaincode:
+- [v2.3](http://hyperledger-fabric.readthedocs.io/en/release-2.3/)
 - [v2.2](http://hyperledger-fabric.readthedocs.io/en/release-2.2/)
 - [v2.1](http://hyperledger-fabric.readthedocs.io/en/release-2.1/)
 - [v2.0](http://hyperledger-fabric.readthedocs.io/en/release-2.0/)


### PR DESCRIPTION
Signed-off-by: pama-ibm <pama@ibm.com>

I noticed the Fabric README.md was missing a link to the v2.3 documentation

#### Type of change

- Documentation update

#### Description

Added a line to doc for the latest release:
Please visit our
online documentation for
information on getting started using and developing with the fabric, SDK and chaincode:
- [v2.3](http://hyperledger-fabric.readthedocs.io/en/release-2.3/)
