### PR TITLE
Fix name of CHANNEL_CONFIG_BLOCK in the Channel participation API tut…

### DIFF
--- a/docs/source/create_channel/create_channel_participation.md
+++ b/docs/source/create_channel/create_channel_participation.md
@@ -358,7 +358,7 @@ An unlimited number of profiles can be listed in the `Profiles` section accordin
 After you have completed editing the `configtx.yaml`, you can use it to create a new channel for the peer organizations. Every channel configuration starts with a genesis block. Because we previously set the environment variables for the `configtxgen` tool, you can run the following command to build the genesis block for `channel1` using the `SampleAppChannelEtcdRaft` profile:
 
 ```
-configtxgen -profile SampleAppGenesisEtcdRaft -outputBlock ./channel-artifacts/channel1.tx -channelID channel1
+configtxgen -profile SampleAppGenesisEtcdRaft -outputBlock genesis_block.pb -channelID channel1
 ```
 
 Where:


### PR DESCRIPTION


Signed-off-by: pama-ibm <pama@ibm.com>

In the channel participation API tutorial I noticed a mismatch between the name of the genesis block that we generate and the name of the CHANNEL_CONFIG_BLOCK used by the osnadmin channel join command.  This PR addresses the mismatch.

#### Type of change

- Documentation update

#### Description

Existing doc generates the genesis block with this command and outputs the result to ./channel-artifacts/channel1.tx .
configtxgen -profile SampleAppGenesisEtcdRaft -outputBlock ./channel-artifacts/channel1.tx -channelID channel1

Then the subsequent step uses --config-block genesis_block.pb which won't work:

osnadmin channel join –-channel-id channel1 --config-block genesis_block.pb -o OSN1.example.com:7050 --ca-file $OSN_TLS_CA_ROOT_CERT --client-cert $ADMIN_TLS_SIGN_CERT --client-key $ADMIN_TLS_PRIVATE_KEY

After discussing with Will, we decide we should change the configtxgen command to be this instead:
configtxgen -profile SampleAppGenesisEtcdRaft -outputBlock genesis_block.pb -channelID channel1

