### PR TITLE
Remove Short Names and Replace With Full Path in Fabric

### DIFF
--- a/docs/source/channel_update_tutorial.rst
+++ b/docs/source/channel_update_tutorial.rst
@@ -571,7 +571,7 @@ use the ``test-network`` script to deploy the Basic chaincode:
 .. code:: bash
 
   cd fabric-samples/test-network
-  ./network.sh deployCC -ccn basic -ccl go
+  ./network.sh deployCC -ccn basic -ccp ../asset-transfer-basic/chaincode-go/ -ccl go
 
 The script will install the Basic chaincode on the Org1 and Org2 peers, approve
 the chaincode definition for Org1 and Org2, and then commit the chaincode

--- a/docs/source/couchdb_tutorial.rst
+++ b/docs/source/couchdb_tutorial.rst
@@ -311,7 +311,7 @@ Run the following command to deploy the smart contract to `mychannel`:
 
 .. code:: bash
 
-  ./network.sh deployCC -ccn ledger -ccep "OR('Org1MSP.peer','Org2MSP.peer')"
+  ./network.sh deployCC -ccn ledger -ccp ../asset-transfer-ledger-queries/chaincode-go/ -ccep "OR('Org1MSP.peer','Org2MSP.peer')"
 
 Note that we are using the `-ccep` flag to deploy the smart contract with an endorsement policy of
 `"OR('Org1MSP.peer','Org2MSP.peer')"`. This allows either organization to create an asset without

--- a/docs/source/create_channel/create_channel.md
+++ b/docs/source/create_channel/create_channel.md
@@ -366,7 +366,7 @@ Blockchain info: {"height":3,"currentBlockHash":"eBpwWKTNUgnXGpaY2ojF4xeP3bWdjlP
 
 We can confirm that the channel was created successfully by deploying a chaincode to the channel. We can use the `network.sh` script to deploy the Basic asset transfer chaincode to any test network channel. Deploy a chaincode to our new channel using the following command:
 ```
-./network.sh deployCC --ccn basic -c channel1 --cci InitLedger
+./network.sh deployCC -ccn basic -ccp ../asset-transfer-basic/chaincode-go/ -c channel1 --cci InitLedger
 ```
 
 After you run the command, you should see the chaincode being deployed to the channel in your logs. The chaincode is invoked to add data to the channel ledger.

--- a/docs/source/private_data_tutorial.rst
+++ b/docs/source/private_data_tutorial.rst
@@ -447,7 +447,7 @@ Run the following command from the test network directory.
 
 .. code:: bash
 
-   ./network.sh deployCC -ccn private -ccep "OR('Org1MSP.peer','Org2MSP.peer')" -cccg ../asset-transfer-private-data/chaincode-go/collections_config.json
+   ./network.sh deployCC -ccn private -ccp ../asset-transfer-private-data/chaincode-go/ -ccep "OR('Org1MSP.peer','Org2MSP.peer')" -cccg ../asset-transfer-private-data/chaincode-go/collections_config.json
 
 Note that we need to pass the path to the private data collection definition file
 to the command. As part of deploying the chaincode to the channel, both organizations

--- a/docs/source/secured_asset_transfer/secured_private_asset_transfer_tutorial.md
+++ b/docs/source/secured_asset_transfer/secured_private_asset_transfer_tutorial.md
@@ -91,7 +91,7 @@ The script will deploy the nodes of the network and create a single channel name
 
 You can use the test network script to deploy the secured asset transfer smart contract to the channel. Run the following command to deploy the smart contract to `mychannel`:
 ```
-./network.sh deployCC -ccn secured -ccep "OR('Org1MSP.peer','Org2MSP.peer')"
+./network.sh deployCC -ccn secured -ccp ../asset-transfer-secured-agreement/chaincode-go/ -ccep "OR('Org1MSP.peer','Org2MSP.peer')"
 ```
 
 Note that we are using the `-ccep` flag to deploy the smart contract with an endorsement policy of `"OR('Org1MSP.peer','Org2MSP.peer')"`. This allows either organization to create an asset without receiving an endorsement from the other organization.

--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -60,11 +60,11 @@ Usage:
 
     Used with network.sh deployCC
     -c <channel name> - Name of channel to deploy chaincode to
-    -ccn <name> - Chaincode name. This flag can be used to deploy one of the asset transfer samples to a channel. Sample options: basic (default),ledger, private, sbe, secured
+    -ccn <name> - Chaincode name.
     -ccl <language> - Programming language of the chaincode to deploy: go (default), java, javascript, typescript
     -ccv <version>  - Chaincode version. 1.0 (default), v2, version3.x, etc
     -ccs <sequence>  - Chaincode definition sequence. Must be an integer, 1 (default), 2, 3, etc
-    -ccp <path>  - (Optional) File path to the chaincode. When provided, the -ccn flag will be used only for the chaincode name.
+    -ccp <path>  - File path to the chaincode.
     -ccep <policy>  - (Optional) Chaincode endorsement policy using signature policy syntax. The default policy requires an endorsement from Org1 and Org2
     -cccg <collection-config>  - (Optional) File path to private data collections configuration file
     -cci <fcn name>  - (Optional) Name of chaincode initialization function. When a function is provided, the execution of init will be requested and the function will be invoked.
@@ -80,7 +80,7 @@ Usage:
  Examples:
    network.sh up createChannel -ca -c mychannel -s couchdb -i 2.0.0
    network.sh createChannel -c channelName
-   network.sh deployCC -ccn basic -ccl javascript
+   network.sh deployCC -ccn basic -ccp ../asset-transfer-basic/chaincode-javascript/ -ccl javascript
    network.sh deployCC -ccn mychaincode -ccp ./user/mychaincode -ccv 1 -ccl javascript
 ```
 

--- a/docs/source/write_first_app.rst
+++ b/docs/source/write_first_app.rst
@@ -138,7 +138,7 @@ Next, let's deploy the chaincode by calling the ``./network.sh`` script with the
 
 .. code:: bash
 
-  ./network.sh deployCC -ccn basic -ccl javascript
+  ./network.sh deployCC -ccn basic -ccp ../asset-transfer-basic/chaincode-javascript/ -ccl javascript
 
 .. note:: Behind the scenes, this script uses the chaincode lifecycle to package, install,
           query installed chaincode, approve chaincode for both Org1 and Org2, and finally commit the chaincode.


### PR DESCRIPTION


<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (improvement to code, performance, etc)
- Documentation update

#### Description

<!--- Describe your changes in detail, including motivation. -->
- Short names are a crutch that can prevent someone from learning how to deploy their own chaincode. Short names have been replaced with their full path name.

