### PR TITLE
Update wiki link for Hyperledger Caliper

### DIFF
--- a/docs/source/whatis.md
+++ b/docs/source/whatis.md
@@ -299,7 +299,7 @@ requirements.
 Performance of a blockchain platform can be affected by many variables such as
 transaction size, block size, network size, as well as limits of the hardware,
 etc. The Hyperledger Fabric [Performance and Scale working group](https://wiki.hyperledger.org/display/PSWG/Performance+and+Scale+Working+Group)
-currently works on a benchmarking framework called [Hyperledger Caliper](https://wiki.hyperledger.org/projects/caliper).
+currently works on a benchmarking framework called [Hyperledger Caliper](https://wiki.hyperledger.org/display/caliper).
 
 Several research papers have been published studying and testing the performance
 capabilities of Hyperledger Fabric. The latest [scaled Fabric to 20,000 transactions per second](https://arxiv.org/abs/1901.00910).


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Current link does not seem to be working. This is the one I found through Hyperledger wiki main page.


Signed-off-by: Mashhood Ijaz <mashhoodijaz786@gmail.com>