### PR TITLE
Fixed URL in pullBinaries in bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -87,7 +87,7 @@ download() {
 
 pullBinaries() {
     echo "===> Downloading version ${FABRIC_TAG} platform specific fabric binaries"
-    download "${BINARY_FILE}" "https://github.com/hyperledger/fabric/releases/download/v${VERSION}/${BINARY_FILE}"
+    download "${BINARY_FILE}" "https://github.com/hyperledger/fabric/releases/v${VERSION}/${BINARY_FILE}"
     if [ $? -eq 22 ]; then
         echo
         echo "------> ${FABRIC_TAG} platform specific fabric binary is not available to download <----"


### PR DESCRIPTION
Changed download URL in pullBinaries function to remove /download/ as this is no longer a valid directory in the repository.

#### Type of change

- Bug fix

#### Description

When attempting to download the binaries, using the command displayed in the docs install page, it would give an error ' platform specific fabric binary is not available to download'. After cracking open the bootstrap bash script 'https://raw.githubusercontent.com/hyperledger/fabric/master/scripts/bootstrap.sh' I edited it to remove the /download/ part of the URL in the pullBinaries function and it worked.
