### PR TITLE
Fixed Typo in Documentation

### DIFF
--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -291,7 +291,7 @@ export CORE_PEER_ADDRESS=localhost:7051
 The `CORE_PEER_TLS_ROOTCERT_FILE` and `CORE_PEER_MSPCONFIGPATH` environment
 variables point to the Org1 crypto material in the `organizations` folder.
 
-If you used `./network.sh deployCC` to install and start the asset-transfer (basic) chaincode, you can invoke the `InitLedger` function of the (Go) chaincode to put an initial list of assets on the ledger (if using typescript or javascript `./network.sh deployCC -l javascript` for example, you will invoke the `InitLedger` function of the respective chaincodes).
+If you used `./network.sh deployCC` to install and start the asset-transfer (basic) chaincode, you can invoke the `InitLedger` function of the (Go) chaincode to put an initial list of assets on the ledger (if using typescript or javascript `./network.sh deployCC -ccl javascript` for example, you will invoke the `InitLedger` function of the respective chaincodes).
 
 Run the following command to initialize the ledger with assets:
 ```


### PR DESCRIPTION
Typo fix on the example code in documentation "docs/source/test_network.md" 

#### Type of change

- Documentation update

#### Description

Typo fix on example code.
Option "-l"  does not exist  on ./network.sh parameters. It seems to be renamed to "-ccl" not but updated on documentations.
