### PR TITLE
Check correct error

### DIFF
--- a/bccsp/pkcs11/pkcs11.go
+++ b/bccsp/pkcs11/pkcs11.go
@@ -556,7 +556,7 @@ func (csp *Provider) generateECKey(curve asn1.ObjectIdentifier, ephemeral bool) 
 			return nil, nil, fmt.Errorf("P11: Private Key copy failed with error [%s]. Please contact your HSM vendor", prvCopyerror)
 		}
 		prvKeyDestroyError := csp.ctx.DestroyObject(session, prv)
-		if pubKeyDestroyError != nil {
+		if prvKeyDestroyError != nil {
 			return nil, nil, fmt.Errorf("P11: Private Key destroy failed with error [%s]. Please contact your HSM vendor", prvKeyDestroyError)
 		}
 	}


### PR DESCRIPTION
The error check accidentally checks for a previous error instead of the current

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
