### PR TITLE
[FAB-18382] Fix staticcheck issues in gossip/privdata

### DIFF
--- a/gossip/privdata/reconcile.go
+++ b/gossip/privdata/reconcile.go
@@ -120,7 +120,6 @@ func (r *Reconciler) run() {
 			r.logger.Debug("Start reconcile missing private info")
 			if err := r.reconcile(); err != nil {
 				r.logger.Error("Failed to reconcile missing private info, error: ", err.Error())
-				break
 			}
 		}
 	}


### PR DESCRIPTION
ignore staticcheck ST1019 because it is used intentionally.
break statement is ineffective and is not mean to break out of the outer loop, just delete it

FAB-18382 #done

Signed-off-by: Taction <zchao9100@gmail.com>
