### PR TITLE
Remove dead code, gossip/state.go

### DIFF
--- a/gossip/state/state.go
+++ b/gossip/state/state.go
@@ -42,8 +42,6 @@ type GossipStateProvider interface {
 
 const (
 	stragglerWarningThreshold = 100
-	defAntiEntropyBatchSize   = 10
-	defMaxBlockDistance       = 20
 
 	blocking    = true
 	nonBlocking = false


### PR DESCRIPTION
There is no longer use for 

```go
	defAntiEntropyBatchSize   = 10
	defMaxBlockDistance       = 20
```

constants, hence removing them. 

Signed-off-by: Artem Barger <bartem@il.ibm.com>
