### PR TITLE
Remove redundant identity unmarshaling

### DIFF
--- a/core/endorser/endorser_test.go
+++ b/core/endorser/endorser_test.go
@@ -385,11 +385,11 @@ var _ = Describe("Endorser", func() {
 
 		It("wraps and returns an error and responds to the client", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
-			Expect(err).To(MatchError("error validating proposal: access denied: channel [channel-id] creator org [msp-id]"))
+			Expect(err).To(MatchError("error validating proposal: access denied: channel [channel-id] creator org unknown, creator is malformed"))
 			Expect(proposalResponse).To(Equal(&pb.ProposalResponse{
 				Response: &pb.Response{
 					Status:  500,
-					Message: "error validating proposal: access denied: channel [channel-id] creator org [msp-id]",
+					Message: "error validating proposal: access denied: channel [channel-id] creator org unknown, creator is malformed",
 				},
 			}))
 		})
@@ -618,11 +618,11 @@ var _ = Describe("Endorser", func() {
 
 			It("wraps and returns an error and responds to the client", func() {
 				proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
-				Expect(err).To(MatchError("error validating proposal: access denied: channel [] creator org [msp-id]"))
+				Expect(err).To(MatchError("error validating proposal: access denied: channel [] creator org unknown, creator is malformed"))
 				Expect(proposalResponse).To(Equal(&pb.ProposalResponse{
 					Response: &pb.Response{
 						Status:  500,
-						Message: "error validating proposal: access denied: channel [] creator org [msp-id]",
+						Message: "error validating proposal: access denied: channel [] creator org unknown, creator is malformed",
 					},
 				}))
 			})

--- a/core/endorser/msgvalidation.go
+++ b/core/endorser/msgvalidation.go
@@ -167,20 +167,14 @@ func (up *UnpackedProposal) Validate(idDeserializer msp.IdentityDeserializer) er
 		return errors.Errorf("empty signature bytes")
 	}
 
-	sId, err := protoutil.UnmarshalSerializedIdentity(up.SignatureHeader.Creator)
-	if err != nil {
-		return errors.Errorf("access denied: channel [%s] creator org unknown, creator is malformed", up.ChannelID())
-	}
-
-	genericAuthError := errors.Errorf("access denied: channel [%s] creator org [%s]", up.ChannelID(), sId.Mspid)
-
 	// get the identity of the creator
 	creator, err := idDeserializer.DeserializeIdentity(up.SignatureHeader.Creator)
 	if err != nil {
 		logger.Warningf("access denied: channel %s", err)
-		return genericAuthError
+		return errors.Errorf("access denied: channel [%s] creator org unknown, creator is malformed", up.ChannelID())
 	}
 
+	genericAuthError := errors.Errorf("access denied: channel [%s] creator org [%s]", up.ChannelID(), creator.GetMSPIdentifier())
 	// ensure that creator is a valid certificate
 	err = creator.Validate()
 	if err != nil {

--- a/core/endorser/msgvalidation_test.go
+++ b/core/endorser/msgvalidation_test.go
@@ -446,18 +446,6 @@ var _ = Describe("Validate", func() {
 		})
 	})
 
-	Context("when the identity is actually not a validly serialized proto", func() {
-		BeforeEach(func() {
-			up.SignatureHeader.Creator = []byte("garbage")
-			up.ChannelHeader.TxId = "8f9de857052f103caee0fef35f66766562b4b4c2a14af34e9626351de52edfc4"
-		})
-
-		It("returns an auth error", func() {
-			err := up.Validate(fakeIdentityDeserializer)
-			Expect(err).To(MatchError("access denied: channel [channel-id] creator org unknown, creator is malformed"))
-		})
-	})
-
 	Context("when the identity cannot be deserialized", func() {
 		BeforeEach(func() {
 			fakeIdentityDeserializer.DeserializeIdentityReturns(nil, fmt.Errorf("fake-deserializing-error"))
@@ -465,12 +453,13 @@ var _ = Describe("Validate", func() {
 
 		It("returns a generic auth error", func() {
 			err := up.Validate(fakeIdentityDeserializer)
-			Expect(err).To(MatchError("access denied: channel [channel-id] creator org [mspid]"))
+			Expect(err).To(MatchError("access denied: channel [channel-id] creator org unknown, creator is malformed"))
 		})
 	})
 
 	Context("when the identity is not valid", func() {
 		BeforeEach(func() {
+			fakeIdentity.GetMSPIdentifierReturns("mspid")
 			fakeIdentity.ValidateReturns(fmt.Errorf("fake-validate-error"))
 		})
 
@@ -482,6 +471,7 @@ var _ = Describe("Validate", func() {
 
 	Context("when the identity signature is not valid", func() {
 		BeforeEach(func() {
+			fakeIdentity.GetMSPIdentifierReturns("mspid")
 			fakeIdentity.VerifyReturns(fmt.Errorf("fake-verify-error"))
 		})
 

--- a/integration/e2e/acl_test.go
+++ b/integration/e2e/acl_test.go
@@ -265,7 +265,7 @@ var _ = Describe("EndToEndACL", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit())
-		Expect(sess.Err).To(gbytes.Say(`access denied: channel \[\] creator org \[Org2MSP\]`))
+		Expect(sess.Err).To(gbytes.Say(`access denied: channel \[\] creator org unknown, creator is malformed`))
 
 		By("installing the chaincode to an org1 peer as a non-admin org1 identity")
 		sess, err = network.PeerUserSession(org1Peer0, "User1", commands.ChaincodeInstall{


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Within `core/endorser/msgvalidation.go:170` there is a code

```go
 sId, err := protoutil.UnmarshalSerializedIdentity(up.SignatureHeader.Creator)
 if err != nil {
    return errors.Errorf("access denied: channel
            [%s] creator org unknown, creator is malformed",
                        up.ChannelID())
}
```

which is later on repeated with

```go
creator, err := idDeserializer.DeserializeIdentity(up.SignatureHeader.Creator)

```

this commit removes the first block due to its redundancy.

Signed-off-by: Artem Barger <bartem@il.ibm.com>
