### PR TITLE
Update image filter used by integration tests

### DIFF
--- a/integration/helpers/images.go
+++ b/integration/helpers/images.go
@@ -23,7 +23,7 @@ func AssertImagesExist(imageNames ...string) {
 
 	for _, imageName := range imageNames {
 		images, err := dockerClient.ListImages(docker.ListImagesOptions{
-			Filter: imageName,
+			Filters: map[string][]string{"reference": {imageName}},
 		})
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Integration tests are failing on macOS with Docker for Mac v3. Looks like this may be related to some changes in v20 of the docker engine. Explicitly adding a reference filter seems to resolve the issue on macOS without impacting Linux.

```
[BeforeSuite] BeforeSuite
/Users/sykesm/workspace/fabric/src/github.com/hyperledger/fabric/integration/e2e/e2e_suite_test.go:34

  missing required image: hyperledger/fabric-ccenv:latest

  /Users/sykesm/workspace/fabric/src/github.com/hyperledger/fabric/integration/nwo/buildserver.go:56
```