### PR TITLE
Split command in "add an org to network" tutorial

### DIFF
--- a/docs/source/channel_update_tutorial.rst
+++ b/docs/source/channel_update_tutorial.rst
@@ -284,7 +284,8 @@ means of the ``jq`` tool:
 
 .. code:: bash
 
-  configtxlator proto_decode --input config_block.pb --type common.Block | jq .data.data[0].payload.data.config > config.json
+  configtxlator proto_decode --input config_block.pb --type common.Block --output config_block.json
+  jq .data.data[0].payload.data.config config_block.json > config.json
 
 This command leaves us with a trimmed down JSON object -- ``config.json`` -- which
 will serve as the baseline for our config update.
@@ -743,7 +744,8 @@ channel configuration.
 
 .. code:: bash
 
-    configtxlator proto_decode --input config_block.pb --type common.Block | jq .data.data[0].payload.data.config > config.json
+  configtxlator proto_decode --input config_block.pb --type common.Block --output config_block.json
+  jq .data.data[0].payload.data.config config_block.json > config.json
 
 The ``config.json`` is the now trimmed JSON representing the latest channel configuration
 that we will update.


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

The config block output from configtxlator is too large to pipe on Mac, leading to "configtxlator: error: open /dev/stdout: permission denied, try --help". Update the tutorial to split the command in two, using a config_block.json for the configtxlator output instead.

#### Related issues

[FAB-17815](https://jira.hyperledger.org/browse/FAB-17815)