### PR TITLE
Add note to AnchorPeers in sampleconfig/configtx.yaml

### DIFF
--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -66,8 +66,12 @@ Organizations:
             - "127.0.0.1:7050"
 
         # AnchorPeers defines the location of peers which can be used for
-        # cross-org gossip communication. Note, this value is only encoded in
-        # the genesis block in the Application section context.
+        # cross-org gossip communication. 
+        #
+        # NOTE: this value should only be set when using the deprecated 
+        # `configtxgen --outputAnchorPeersUpdate` command. It is recommended
+        # to instead use the channel configuration update process to set the
+        # anchor peers for each organization.
         AnchorPeers:
             - Host: 127.0.0.1
               Port: 7051


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

This section was only used by the deprecated `configtxgen --outputAnchorsPeerUpdate` command. As we move to the channel participation flow without a system channel, we should stop recommending this value be set in configtx.yaml as it doesn't make sense to include anchor peers in the genesis block for a channel. The anchor peers should be set per org using the channel config update process.

#### Related issues

[FAB-18381](https://jira.hyperledger.org/browse/FAB-18381)