### PR TITLE
[FAB-18252] Documentation should reference Java chaincode support

### DIFF
--- a/docs/source/blockchain.rst
+++ b/docs/source/blockchain.rst
@@ -181,8 +181,7 @@ interact with the ledger. In most cases, chaincode interacts only with the
 database component of the ledger, the world state (querying it, for example), and
 not the transaction log.
 
-Chaincode can be implemented in several programming languages. Currently, Go and
-Node are supported.
+Chaincode can be implemented in several programming languages. Currently, Go, Node.js, and Java chaincode are supported.
 
 **Privacy**
 


### PR DESCRIPTION
Signed-off-by: pama-ibm <pama@ibm.com>

Key concept Blockchain topic still says that only Go and Node.js chaincode is supported.

#### Type of change

- Documentation update

#### Description

Changed text to say "Currently, Go, Node.js, and Java chaincode are supported."


#### Related issues

FAB-18252
