### PR TITLE
Remove GetSigningIdentity from MSP interface

### DIFF
--- a/core/chaincode/lifecycle/mock/msp.go
+++ b/core/chaincode/lifecycle/mock/msp.go
@@ -46,19 +46,6 @@ type MSP struct {
 		result1 string
 		result2 error
 	}
-	GetSigningIdentityStub        func(*msp.IdentityIdentifier) (msp.SigningIdentity, error)
-	getSigningIdentityMutex       sync.RWMutex
-	getSigningIdentityArgsForCall []struct {
-		arg1 *msp.IdentityIdentifier
-	}
-	getSigningIdentityReturns struct {
-		result1 msp.SigningIdentity
-		result2 error
-	}
-	getSigningIdentityReturnsOnCall map[int]struct {
-		result1 msp.SigningIdentity
-		result2 error
-	}
 	GetTLSIntermediateCertsStub        func() [][]byte
 	getTLSIntermediateCertsMutex       sync.RWMutex
 	getTLSIntermediateCertsArgsForCall []struct {
@@ -322,69 +309,6 @@ func (fake *MSP) GetIdentifierReturnsOnCall(i int, result1 string, result2 error
 	}
 	fake.getIdentifierReturnsOnCall[i] = struct {
 		result1 string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *MSP) GetSigningIdentity(arg1 *msp.IdentityIdentifier) (msp.SigningIdentity, error) {
-	fake.getSigningIdentityMutex.Lock()
-	ret, specificReturn := fake.getSigningIdentityReturnsOnCall[len(fake.getSigningIdentityArgsForCall)]
-	fake.getSigningIdentityArgsForCall = append(fake.getSigningIdentityArgsForCall, struct {
-		arg1 *msp.IdentityIdentifier
-	}{arg1})
-	fake.recordInvocation("GetSigningIdentity", []interface{}{arg1})
-	fake.getSigningIdentityMutex.Unlock()
-	if fake.GetSigningIdentityStub != nil {
-		return fake.GetSigningIdentityStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.getSigningIdentityReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *MSP) GetSigningIdentityCallCount() int {
-	fake.getSigningIdentityMutex.RLock()
-	defer fake.getSigningIdentityMutex.RUnlock()
-	return len(fake.getSigningIdentityArgsForCall)
-}
-
-func (fake *MSP) GetSigningIdentityCalls(stub func(*msp.IdentityIdentifier) (msp.SigningIdentity, error)) {
-	fake.getSigningIdentityMutex.Lock()
-	defer fake.getSigningIdentityMutex.Unlock()
-	fake.GetSigningIdentityStub = stub
-}
-
-func (fake *MSP) GetSigningIdentityArgsForCall(i int) *msp.IdentityIdentifier {
-	fake.getSigningIdentityMutex.RLock()
-	defer fake.getSigningIdentityMutex.RUnlock()
-	argsForCall := fake.getSigningIdentityArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *MSP) GetSigningIdentityReturns(result1 msp.SigningIdentity, result2 error) {
-	fake.getSigningIdentityMutex.Lock()
-	defer fake.getSigningIdentityMutex.Unlock()
-	fake.GetSigningIdentityStub = nil
-	fake.getSigningIdentityReturns = struct {
-		result1 msp.SigningIdentity
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *MSP) GetSigningIdentityReturnsOnCall(i int, result1 msp.SigningIdentity, result2 error) {
-	fake.getSigningIdentityMutex.Lock()
-	defer fake.getSigningIdentityMutex.Unlock()
-	fake.GetSigningIdentityStub = nil
-	if fake.getSigningIdentityReturnsOnCall == nil {
-		fake.getSigningIdentityReturnsOnCall = make(map[int]struct {
-			result1 msp.SigningIdentity
-			result2 error
-		})
-	}
-	fake.getSigningIdentityReturnsOnCall[i] = struct {
-		result1 msp.SigningIdentity
 		result2 error
 	}{result1, result2}
 }
@@ -847,8 +771,6 @@ func (fake *MSP) Invocations() map[string][][]interface{} {
 	defer fake.getDefaultSigningIdentityMutex.RUnlock()
 	fake.getIdentifierMutex.RLock()
 	defer fake.getIdentifierMutex.RUnlock()
-	fake.getSigningIdentityMutex.RLock()
-	defer fake.getSigningIdentityMutex.RUnlock()
 	fake.getTLSIntermediateCertsMutex.RLock()
 	defer fake.getTLSIntermediateCertsMutex.RUnlock()
 	fake.getTLSRootCertsMutex.RLock()

--- a/core/committer/txvalidator/v14/validator_test.go
+++ b/core/committer/txvalidator/v14/validator_test.go
@@ -577,10 +577,6 @@ func (fake *mockMSP) GetIdentifier() (string, error) {
 	return fake.MspID, nil
 }
 
-func (fake *mockMSP) GetSigningIdentity(identifier *msp.IdentityIdentifier) (msp.SigningIdentity, error) {
-	return nil, nil
-}
-
 func (fake *mockMSP) GetDefaultSigningIdentity() (msp.SigningIdentity, error) {
 	return nil, nil
 }

--- a/core/committer/txvalidator/v20/validator_test.go
+++ b/core/committer/txvalidator/v20/validator_test.go
@@ -409,10 +409,6 @@ func (fake *mockMSP) GetIdentifier() (string, error) {
 	return fake.MspID, nil
 }
 
-func (fake *mockMSP) GetSigningIdentity(identifier *msp.IdentityIdentifier) (msp.SigningIdentity, error) {
-	return nil, nil
-}
-
 func (fake *mockMSP) GetDefaultSigningIdentity() (msp.SigningIdentity, error) {
 	return nil, nil
 }

--- a/core/handlers/validation/builtin/v12/validation_logic_test.go
+++ b/core/handlers/validation/builtin/v12/validation_logic_test.go
@@ -1919,7 +1919,7 @@ func TestMain(m *testing.M) {
 
 	id, err = mspmgmt.GetLocalMSP(cryptoProvider).GetDefaultSigningIdentity()
 	if err != nil {
-		fmt.Printf("GetSigningIdentity failed with err %s", err)
+		fmt.Printf("GetDefaultSigningIdentity failed with err %s", err)
 		return
 	}
 

--- a/core/handlers/validation/builtin/v13/validation_logic_test.go
+++ b/core/handlers/validation/builtin/v13/validation_logic_test.go
@@ -1985,7 +1985,7 @@ func TestMain(m *testing.M) {
 
 	id, err = mspmgmt.GetLocalMSP(cryptoProvider).GetDefaultSigningIdentity()
 	if err != nil {
-		fmt.Printf("GetSigningIdentity failed with err %s", err)
+		fmt.Printf("GetDefaultSigningIdentity failed with err %s", err)
 		return
 	}
 

--- a/core/handlers/validation/builtin/v20/validation_logic_test.go
+++ b/core/handlers/validation/builtin/v20/validation_logic_test.go
@@ -286,7 +286,7 @@ func TestMain(m *testing.M) {
 
 	id, err = mspmgmt.GetLocalMSP(cryptoProvider).GetDefaultSigningIdentity()
 	if err != nil {
-		fmt.Printf("GetSigningIdentity failed with err %s", err)
+		fmt.Printf("GetDefaultSigningIdentity failed with err %s", err)
 		return
 	}
 

--- a/core/ledger/kvledger/benchmark/mocks/msp.go
+++ b/core/ledger/kvledger/benchmark/mocks/msp.go
@@ -37,11 +37,6 @@ func (msp *noopmsp) GetIdentifier() (string, error) {
 	return "NOOP", nil
 }
 
-func (msp *noopmsp) GetSigningIdentity(identifier *msp.IdentityIdentifier) (msp.SigningIdentity, error) {
-	id, _ := newNoopSigningIdentity()
-	return id, nil
-}
-
 func (msp *noopmsp) GetDefaultSigningIdentity() (msp.SigningIdentity, error) {
 	id, _ := newNoopSigningIdentity()
 	return id, nil

--- a/core/scc/lscc/lscc_test.go
+++ b/core/scc/lscc/lscc_test.go
@@ -1525,7 +1525,7 @@ func TestMain(m *testing.M) {
 
 	id, err = mspmgmt.GetLocalMSP(cryptoProvider).GetDefaultSigningIdentity()
 	if err != nil {
-		fmt.Printf("GetSigningIdentity failed with err %s", err)
+		fmt.Printf("GetDefaultSigningIdentity failed with err %s", err)
 		os.Exit(-1)
 	}
 

--- a/msp/cache/cache_test.go
+++ b/msp/cache/cache_test.go
@@ -65,20 +65,6 @@ func TestGetIdentifier(t *testing.T) {
 	mockMSP.AssertExpectations(t)
 }
 
-func TestGetSigningIdentity(t *testing.T) {
-	mockMSP := &mocks.MockMSP{}
-	i, err := New(mockMSP)
-	require.NoError(t, err)
-
-	mockIdentity := &mocks.MockSigningIdentity{Mock: mock.Mock{}, MockIdentity: &mocks.MockIdentity{ID: "Alice"}}
-	identifier := &msp.IdentityIdentifier{Mspid: "MSP", Id: "Alice"}
-	mockMSP.On("GetSigningIdentity", identifier).Return(mockIdentity, nil)
-	id, err := i.GetSigningIdentity(identifier)
-	require.NoError(t, err)
-	require.Equal(t, mockIdentity, id)
-	mockMSP.AssertExpectations(t)
-}
-
 func TestGetDefaultSigningIdentity(t *testing.T) {
 	mockMSP := &mocks.MockMSP{}
 	i, err := New(mockMSP)

--- a/msp/idemixmsp.go
+++ b/msp/idemixmsp.go
@@ -245,10 +245,6 @@ func (msp *idemixmsp) GetIdentifier() (string, error) {
 	return msp.name, nil
 }
 
-func (msp *idemixmsp) GetSigningIdentity(identifier *IdentityIdentifier) (SigningIdentity, error) {
-	return nil, errors.Errorf("GetSigningIdentity not implemented")
-}
-
 func (msp *idemixmsp) GetDefaultSigningIdentity() (SigningIdentity, error) {
 	mspLogger.Debugf("Obtaining default idemix signing identity")
 

--- a/msp/mocks/mocks.go
+++ b/msp/mocks/mocks.go
@@ -47,11 +47,6 @@ func (m *MockMSP) GetIdentifier() (string, error) {
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockMSP) GetSigningIdentity(identifier *msp.IdentityIdentifier) (msp.SigningIdentity, error) {
-	args := m.Called(identifier)
-	return args.Get(0).(msp.SigningIdentity), args.Error(1)
-}
-
 func (m *MockMSP) GetDefaultSigningIdentity() (msp.SigningIdentity, error) {
 	args := m.Called()
 	return args.Get(0).(msp.SigningIdentity), args.Error(1)

--- a/msp/msp.go
+++ b/msp/msp.go
@@ -74,9 +74,6 @@ type MSP interface {
 	// GetIdentifier returns the provider identifier
 	GetIdentifier() (string, error)
 
-	// GetSigningIdentity returns a signing identity corresponding to the provided identifier
-	GetSigningIdentity(identifier *IdentityIdentifier) (SigningIdentity, error)
-
 	// GetDefaultSigningIdentity returns the default signing identity
 	GetDefaultSigningIdentity() (SigningIdentity, error)
 

--- a/msp/msp_test.go
+++ b/msp/msp_test.go
@@ -239,8 +239,6 @@ func TestGetSigningIdentityFromVerifyingMSP(t *testing.T) {
 
 	_, err = newmsp.GetDefaultSigningIdentity()
 	require.Error(t, err)
-	_, err = newmsp.GetSigningIdentity(nil)
-	require.Error(t, err)
 }
 
 func TestValidateDefaultSigningIdentity(t *testing.T) {
@@ -254,7 +252,7 @@ func TestValidateDefaultSigningIdentity(t *testing.T) {
 func TestSerializeIdentities(t *testing.T) {
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
-		t.Fatalf("GetSigningIdentity should have succeeded, got err %s", err)
+		t.Fatalf("GetDefaultSigningIdentity should have succeeded, got err %s", err)
 		return
 	}
 
@@ -287,7 +285,7 @@ func TestIsWellFormed(t *testing.T) {
 
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
-		t.Fatalf("GetSigningIdentity should have succeeded, got err %s", err)
+		t.Fatalf("GetDefaultSigningIdentity should have succeeded, got err %s", err)
 		return
 	}
 
@@ -420,7 +418,7 @@ func TestValidateAdminIdentity(t *testing.T) {
 func TestSerializeIdentitiesWithWrongMSP(t *testing.T) {
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
-		t.Fatalf("GetSigningIdentity should have succeeded, got err %s", err)
+		t.Fatalf("GetDefaultSigningIdentity should have succeeded, got err %s", err)
 		return
 	}
 
@@ -446,7 +444,7 @@ func TestSerializeIdentitiesWithWrongMSP(t *testing.T) {
 func TestSerializeIdentitiesWithMSPManager(t *testing.T) {
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
-		t.Fatalf("GetSigningIdentity should have succeeded, got err %s", err)
+		t.Fatalf("GetDefaultSigningIdentity should have succeeded, got err %s", err)
 		return
 	}
 
@@ -480,7 +478,7 @@ func TestSerializeIdentitiesWithMSPManager(t *testing.T) {
 func TestIdentitiesGetters(t *testing.T) {
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
-		t.Fatalf("GetSigningIdentity should have succeeded, got err %s", err)
+		t.Fatalf("GetDefaultSigningIdentity should have succeeded, got err %s", err)
 		return
 	}
 
@@ -494,7 +492,7 @@ func TestIdentitiesGetters(t *testing.T) {
 func TestSignAndVerify(t *testing.T) {
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
-		t.Fatalf("GetSigningIdentity should have succeeded")
+		t.Fatalf("GetDefaultSigningIdentity should have succeeded")
 		return
 	}
 
@@ -540,7 +538,7 @@ func TestSignAndVerifyFailures(t *testing.T) {
 
 	id, err := localMspBad.GetDefaultSigningIdentity()
 	if err != nil {
-		t.Fatalf("GetSigningIdentity should have succeeded")
+		t.Fatalf("GetDefaultSigningIdentity should have succeeded")
 		return
 	}
 
@@ -569,7 +567,7 @@ func TestSignAndVerifyFailures(t *testing.T) {
 func TestSignAndVerifyOtherHash(t *testing.T) {
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
-		t.Fatalf("GetSigningIdentity should have succeeded")
+		t.Fatalf("GetDefaultSigningIdentity should have succeeded")
 		return
 	}
 
@@ -592,7 +590,7 @@ func TestSignAndVerifyOtherHash(t *testing.T) {
 func TestSignAndVerify_longMessage(t *testing.T) {
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
-		t.Fatalf("GetSigningIdentity should have succeeded")
+		t.Fatalf("GetDefaultSigningIdentity should have succeeded")
 		return
 	}
 
@@ -631,7 +629,7 @@ func TestSignAndVerify_longMessage(t *testing.T) {
 func TestGetOU(t *testing.T) {
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
-		t.Fatalf("GetSigningIdentity should have succeeded")
+		t.Fatalf("GetDefaultSigningIdentity should have succeeded")
 		return
 	}
 
@@ -641,7 +639,7 @@ func TestGetOU(t *testing.T) {
 func TestGetOUFail(t *testing.T) {
 	id, err := localMspBad.GetDefaultSigningIdentity()
 	if err != nil {
-		t.Fatalf("GetSigningIdentity should have succeeded")
+		t.Fatalf("GetDefaultSigningIdentity should have succeeded")
 		return
 	}
 

--- a/msp/mspimpl.go
+++ b/msp/mspimpl.go
@@ -302,13 +302,6 @@ func (msp *bccspmsp) GetDefaultSigningIdentity() (SigningIdentity, error) {
 	return msp.signer, nil
 }
 
-// GetSigningIdentity returns a specific signing
-// identity identified by the supplied identifier
-func (msp *bccspmsp) GetSigningIdentity(identifier *IdentityIdentifier) (SigningIdentity, error) {
-	// TODO
-	return nil, errors.Errorf("no signing identity for %#v", identifier)
-}
-
 // Validate attempts to determine whether
 // the supplied identity is valid according
 // to this MSP's roots of trust; it returns

--- a/orderer/consensus/etcdraft/mocks/msp.go
+++ b/orderer/consensus/etcdraft/mocks/msp.go
@@ -46,19 +46,6 @@ type MSP struct {
 		result1 string
 		result2 error
 	}
-	GetSigningIdentityStub        func(*msp.IdentityIdentifier) (msp.SigningIdentity, error)
-	getSigningIdentityMutex       sync.RWMutex
-	getSigningIdentityArgsForCall []struct {
-		arg1 *msp.IdentityIdentifier
-	}
-	getSigningIdentityReturns struct {
-		result1 msp.SigningIdentity
-		result2 error
-	}
-	getSigningIdentityReturnsOnCall map[int]struct {
-		result1 msp.SigningIdentity
-		result2 error
-	}
 	GetTLSIntermediateCertsStub        func() [][]byte
 	getTLSIntermediateCertsMutex       sync.RWMutex
 	getTLSIntermediateCertsArgsForCall []struct {
@@ -322,69 +309,6 @@ func (fake *MSP) GetIdentifierReturnsOnCall(i int, result1 string, result2 error
 	}
 	fake.getIdentifierReturnsOnCall[i] = struct {
 		result1 string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *MSP) GetSigningIdentity(arg1 *msp.IdentityIdentifier) (msp.SigningIdentity, error) {
-	fake.getSigningIdentityMutex.Lock()
-	ret, specificReturn := fake.getSigningIdentityReturnsOnCall[len(fake.getSigningIdentityArgsForCall)]
-	fake.getSigningIdentityArgsForCall = append(fake.getSigningIdentityArgsForCall, struct {
-		arg1 *msp.IdentityIdentifier
-	}{arg1})
-	fake.recordInvocation("GetSigningIdentity", []interface{}{arg1})
-	fake.getSigningIdentityMutex.Unlock()
-	if fake.GetSigningIdentityStub != nil {
-		return fake.GetSigningIdentityStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.getSigningIdentityReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *MSP) GetSigningIdentityCallCount() int {
-	fake.getSigningIdentityMutex.RLock()
-	defer fake.getSigningIdentityMutex.RUnlock()
-	return len(fake.getSigningIdentityArgsForCall)
-}
-
-func (fake *MSP) GetSigningIdentityCalls(stub func(*msp.IdentityIdentifier) (msp.SigningIdentity, error)) {
-	fake.getSigningIdentityMutex.Lock()
-	defer fake.getSigningIdentityMutex.Unlock()
-	fake.GetSigningIdentityStub = stub
-}
-
-func (fake *MSP) GetSigningIdentityArgsForCall(i int) *msp.IdentityIdentifier {
-	fake.getSigningIdentityMutex.RLock()
-	defer fake.getSigningIdentityMutex.RUnlock()
-	argsForCall := fake.getSigningIdentityArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *MSP) GetSigningIdentityReturns(result1 msp.SigningIdentity, result2 error) {
-	fake.getSigningIdentityMutex.Lock()
-	defer fake.getSigningIdentityMutex.Unlock()
-	fake.GetSigningIdentityStub = nil
-	fake.getSigningIdentityReturns = struct {
-		result1 msp.SigningIdentity
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *MSP) GetSigningIdentityReturnsOnCall(i int, result1 msp.SigningIdentity, result2 error) {
-	fake.getSigningIdentityMutex.Lock()
-	defer fake.getSigningIdentityMutex.Unlock()
-	fake.GetSigningIdentityStub = nil
-	if fake.getSigningIdentityReturnsOnCall == nil {
-		fake.getSigningIdentityReturnsOnCall = make(map[int]struct {
-			result1 msp.SigningIdentity
-			result2 error
-		})
-	}
-	fake.getSigningIdentityReturnsOnCall[i] = struct {
-		result1 msp.SigningIdentity
 		result2 error
 	}{result1, result2}
 }
@@ -847,8 +771,6 @@ func (fake *MSP) Invocations() map[string][][]interface{} {
 	defer fake.getDefaultSigningIdentityMutex.RUnlock()
 	fake.getIdentifierMutex.RLock()
 	defer fake.getIdentifierMutex.RUnlock()
-	fake.getSigningIdentityMutex.RLock()
-	defer fake.getSigningIdentityMutex.RUnlock()
 	fake.getTLSIntermediateCertsMutex.RLock()
 	defer fake.getTLSIntermediateCertsMutex.RUnlock()
 	fake.getTLSRootCertsMutex.RLock()


### PR DESCRIPTION
There were no calls to the method in production code and the two production implementations in fabric (bccspmsp and idemixmsp) returned errors indicating the function was not implemented.

Messages in test assertions were also updated to reflect the name of the function that was actually being used in most cases (`GetDefaultSigningIdentity`).