### PR TITLE
[FAB-18398] Added osnadmin binary to tools image

### DIFF
--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR $GOPATH/src/github.com/hyperledger/fabric
 
 FROM golang as tools
 ARG GO_TAGS
-RUN make configtxgen configtxlator cryptogen peer discover idemixgen GO_TAGS=${GO_TAGS}
+RUN make configtxgen configtxlator cryptogen peer discover osnadmin idemixgen GO_TAGS=${GO_TAGS}
 
 FROM golang:${GO_VER}-alpine
 # git is required to support `go list -m`


### PR DESCRIPTION
managing channels without system channel is the
main feature of 2.3, however the osnadmin binary
was left out from the 2.3 tools docker image.
This PR will fix that issue and also need to be
back ported to 2.3.0 tools image.

Signed-off-by: Tong Li <litong01@us.ibm.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix
- New feature
- Improvement (improvement to code, performance, etc)
- Test update
- Documentation update

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
