### PR TITLE
Adjust etcdraft error assertions for go 1.15

### DIFF
--- a/orderer/consensus/etcdraft/consenter.go
+++ b/orderer/consensus/etcdraft/consenter.go
@@ -194,7 +194,7 @@ func (c *Consenter) HandleChain(support consensus.ConsenterSupport, metadata *co
 	} else {
 		tickInterval, err = time.ParseDuration(c.EtcdRaftConfig.TickIntervalOverride)
 		if err != nil {
-			return nil, errors.Errorf("failed parsing Consensus.TickIntervalOverride: %s: %v", c.EtcdRaftConfig.TickIntervalOverride, err)
+			return nil, errors.WithMessage(err, "failed parsing Consensus.TickIntervalOverride")
 		}
 		c.Logger.Infof("TickIntervalOverride is set, overriding channel configuration tick interval to %v", tickInterval)
 	}

--- a/orderer/consensus/etcdraft/consenter_test.go
+++ b/orderer/consensus/etcdraft/consenter_test.go
@@ -537,7 +537,8 @@ var _ = Describe("Consenter", func() {
 			consenter.EtcdRaftConfig.TickIntervalOverride = "seven"
 
 			_, err := consenter.HandleChain(support, nil)
-			Expect(err).To(MatchError("failed parsing Consensus.TickIntervalOverride: seven: time: invalid duration seven"))
+			Expect(err).To(MatchError(HavePrefix("failed parsing Consensus.TickIntervalOverride:")))
+			Expect(err).To(MatchError(ContainSubstring("seven")))
 		})
 	})
 


### PR DESCRIPTION
Duration parsing error messages in go 1.15 quote the input string while earlier versions do not. This change updates the assertion to look for the prefix added by the consensus layer and the original input value. The loosened assertion should work with all current versions of Go.