### PR TITLE
[doc] fix broken link

### DIFF
--- a/docs/source/developapps/connectionprofile.md
+++ b/docs/source/developapps/connectionprofile.md
@@ -209,7 +209,7 @@ about it:
   application operations relate to organizations rather than channels. For
   example, an application can request notification from one or all peers within
   its organization, or all organizations within the network -- using [connection
-  options](./connectoptions.html).  For this, there needs to be an organization
+  options](./connectionoptions.html).  For this, there needs to be an organization
   to peer mapping, and this section provides it.
 
 * Line 101: `MagnetoCorp:`


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

There was a broken link to connectionoptions.html

#### Additional details

Doc tested in dev env: link is now pointing to the correct page.
