### PR TITLE
[FAB-18401] Remove unreachable and unnecessary code in gossip membership

### DIFF
--- a/gossip/discovery/discovery_impl.go
+++ b/gossip/discovery/discovery_impl.go
@@ -869,11 +869,7 @@ func (d *gossipDiscoveryImpl) learnExistingMembers(aliveArr []*protoext.SignedGo
 			alive.lastSeen = time.Now()
 			alive.seqNum = am.Timestamp.SeqNum
 
-			if am := d.aliveMembership.MsgByID(m.GetAliveMsg().Membership.PkiId); am == nil {
-				d.logger.Debug("Adding", am, "to aliveMembership")
-				msg := &protoext.SignedGossipMessage{GossipMessage: m.GossipMessage, Envelope: am.Envelope}
-				d.aliveMembership.Put(m.GetAliveMsg().Membership.PkiId, msg)
-			} else {
+			if am := d.aliveMembership.MsgByID(m.GetAliveMsg().Membership.PkiId); am != nil {
 				d.logger.Debug("Replacing", am, "in aliveMembership")
 				am.GossipMessage = m.GossipMessage
 				am.Envelope = m.Envelope


### PR DESCRIPTION
In gossip, alive messages are stored in membership stores, and they also have logical timestamps.

When a peer learns of an alive message with a higher logical timestamp of its latest alive message (for a specific peer),
it enters learnExistingMembers() and tentatively updates the latest envelope and gossip message of what is stored in the membership store.

However, for completeness, the code checks if the membership store already contains an earlier instance, and if not, populates the membership store with a new instance. 
This population is not needed, because the code only enters the function if it already knows the peer, hence the membership
store contains an earlier instance.

This commit simply removes the unneeded code path where the instance is unknown despite the fact that we know about the peer already.

Change-Id: Ia91cb35eabe18a8771ad12a30b06489892a2b49f
Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>
