### PR TITLE
Minor updates related to documentation for commands and more osnadmin updates

### DIFF
--- a/cmd/osnadmin/main.go
+++ b/cmd/osnadmin/main.go
@@ -52,7 +52,7 @@ func executeForArgs(args []string) (output string, exit int, err error) {
 	joinChannelID := join.Flag("channelID", "Channel ID").Short('c').Required().String()
 	configBlockPath := join.Flag("config-block", "Path to the file containing an up-to-date config block for the channel").Short('b').Required().String()
 
-	list := channel.Command("list", "List channel information for an Ordering Service Node (OSN). If the channel-id flag is set, more detailed information will be provided for that channel.")
+	list := channel.Command("list", "List channel information for an Ordering Service Node (OSN). If the channelID flag is set, more detailed information will be provided for that channel.")
 	listChannelID := list.Flag("channelID", "Channel ID").Short('c').String()
 
 	remove := channel.Command("remove", "Remove an Ordering Service Node (OSN) from a channel.")

--- a/cmd/osnadmin/main.go
+++ b/cmd/osnadmin/main.go
@@ -58,7 +58,10 @@ func executeForArgs(args []string) (output string, exit int, err error) {
 	remove := channel.Command("remove", "Remove an Ordering Service Node (OSN) from a channel.")
 	removeChannelID := remove.Flag("channelID", "Channel ID").Short('c').Required().String()
 
-	command := kingpin.MustParse(app.Parse(args))
+	command, err := app.Parse(args)
+	if err != nil {
+		return "", 1, err
+	}
 
 	//
 	// flag validation

--- a/cmd/osnadmin/main_test.go
+++ b/cmd/osnadmin/main_test.go
@@ -534,6 +534,18 @@ var _ = Describe("osnadmin", func() {
 			checkOutput(output, exit, err, 201, expectedOutput)
 		})
 
+		Context("when an unknown flag is used", func() {
+			It("returns an error for long flags", func() {
+				_, _, err := executeForArgs([]string{"channel", "list", "--bad-flag"})
+				Expect(err).To(MatchError("unknown long flag '--bad-flag'"))
+			})
+
+			It("returns an error for short flags", func() {
+				_, _, err := executeForArgs([]string{"channel", "list", "-z"})
+				Expect(err).To(MatchError("unknown short flag '-z'"))
+			})
+		})
+
 		Context("when the ca cert cannot be read", func() {
 			BeforeEach(func() {
 				ordererCACert = "not-the-ca-cert-youre-looking-for"

--- a/docs/source/commands/osnadminchannel.md
+++ b/docs/source/commands/osnadminchannel.md
@@ -27,7 +27,7 @@ Channel actions
 Flags:
       --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-  -o, --orderer-address=ORDERER-ADDRESS  
+  -o, --orderer-address=ORDERER-ADDRESS
                                  Admin endpoint of the OSN
       --ca-file=CA-FILE          Path to file containing PEM-encoded TLS CA
                                  certificate(s) for the OSN
@@ -39,7 +39,7 @@ Flags:
                                  OSN
 
 Subcommands:
-  channel join --channelID=CHANNEL-ID --config-block=CONFIG-BLOCK
+  channel join --channelID=CHANNELID --config-block=CONFIG-BLOCK
     Join an Ordering Service Node (OSN) to a channel. If the channel does not
     yet exist, it will be created.
 
@@ -48,14 +48,14 @@ Subcommands:
     channel-id flag is set, more detailed information will be provided for that
     channel.
 
-  channel remove --channelID=CHANNEL-ID
+  channel remove --channelID=CHANNELID
     Remove an Ordering Service Node (OSN) from a channel.
 ```
 
 
 ## osnadmin channel join
 ```
-usage: osnadmin channel join --channelID=CHANNEL-ID --config-block=CONFIG-BLOCK
+usage: osnadmin channel join --channelID=CHANNELID --config-block=CONFIG-BLOCK
 
 Join an Ordering Service Node (OSN) to a channel. If the channel does not yet
 exist, it will be created.
@@ -63,7 +63,7 @@ exist, it will be created.
 Flags:
       --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-  -o, --orderer-address=ORDERER-ADDRESS  
+  -o, --orderer-address=ORDERER-ADDRESS
                                  Admin endpoint of the OSN
       --ca-file=CA-FILE          Path to file containing PEM-encoded TLS CA
                                  certificate(s) for the OSN
@@ -73,8 +73,8 @@ Flags:
       --client-key=CLIENT-KEY    Path to file containing PEM-encoded private key
                                  to use for mutual TLS communication with the
                                  OSN
-  -c, --channelID=CHANNEL-ID    Channel ID
-  -b, --config-block=CONFIG-BLOCK  
+  -c, --channelID=CHANNELID      Channel ID
+  -b, --config-block=CONFIG-BLOCK
                                  Path to the file containing an up-to-date
                                  config block for the channel
 ```
@@ -90,7 +90,7 @@ flag is set, more detailed information will be provided for that channel.
 Flags:
       --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-  -o, --orderer-address=ORDERER-ADDRESS  
+  -o, --orderer-address=ORDERER-ADDRESS
                                  Admin endpoint of the OSN
       --ca-file=CA-FILE          Path to file containing PEM-encoded TLS CA
                                  certificate(s) for the OSN
@@ -100,20 +100,20 @@ Flags:
       --client-key=CLIENT-KEY    Path to file containing PEM-encoded private key
                                  to use for mutual TLS communication with the
                                  OSN
-  -c, --channelID=CHANNEL-ID    Channel ID
+  -c, --channelID=CHANNELID      Channel ID
 ```
 
 
 ## osnadmin channel remove
 ```
-usage: osnadmin channel remove --channelID=CHANNEL-ID
+usage: osnadmin channel remove --channelID=CHANNELID
 
 Remove an Ordering Service Node (OSN) from a channel.
 
 Flags:
       --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
-  -o, --orderer-address=ORDERER-ADDRESS  
+  -o, --orderer-address=ORDERER-ADDRESS
                                  Admin endpoint of the OSN
       --ca-file=CA-FILE          Path to file containing PEM-encoded TLS CA
                                  certificate(s) for the OSN
@@ -123,7 +123,7 @@ Flags:
       --client-key=CLIENT-KEY    Path to file containing PEM-encoded private key
                                  to use for mutual TLS communication with the
                                  OSN
-  -c, --channelID=CHANNEL-ID    Channel ID
+  -c, --channelID=CHANNELID      Channel ID
 ```
 
 ## Example Usage
@@ -132,7 +132,7 @@ Flags:
 
 Here's an example of the `osnadmin channel join` command.
 
-* Create and join a sample channel `mychannel` defined by the application channel genesis 
+* Create and join a sample channel `mychannel` defined by the application channel genesis
   block contained in file `mychannel-genesis-block.pb`. Use the orderer admin endpoint
   at `orderer.example.com:9443`.
 
@@ -162,7 +162,7 @@ Here are some examples of the `osnadmin channel list` command.
   system channel (if one exists) and all of the application channels.
 
   ```
-  osnadmin channel list -o orderer.example.com:9443 --ca-file $CA_FILE --client-cert $CLIENT_CERT --client-key $CLIENT_KEY 
+  osnadmin channel list -o orderer.example.com:9443 --ca-file $CA_FILE --client-cert $CLIENT_CERT --client-key $CLIENT_KEY
 
   Status: 200
   {
@@ -177,7 +177,7 @@ Here are some examples of the `osnadmin channel list` command.
 
   ```
 
-  Status 200 and the list of channels are returned. 
+  Status 200 and the list of channels are returned.
 
 * Using the `--channelID` flag to list more details for `mychannel`.
 
@@ -195,7 +195,7 @@ Here are some examples of the `osnadmin channel list` command.
 
   ```
 
-  Status 200 and the details of the channels are returned. 
+  Status 200 and the details of the channels are returned.
 
 ### osnadmin channel remove example
 
@@ -209,6 +209,6 @@ Here's an example of the `osnadmin channel remove` command.
   Status: 204
   ```
 
-  Status 204 is returned upon successful removal of a channel. 
+  Status 204 is returned upon successful removal of a channel.
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/docs/source/commands/osnadminchannel.md
+++ b/docs/source/commands/osnadminchannel.md
@@ -45,7 +45,7 @@ Subcommands:
 
   channel list [<flags>]
     List channel information for an Ordering Service Node (OSN). If the
-    channel-id flag is set, more detailed information will be provided for that
+    channelID flag is set, more detailed information will be provided for that
     channel.
 
   channel remove --channelID=CHANNELID
@@ -84,7 +84,7 @@ Flags:
 ```
 usage: osnadmin channel list [<flags>]
 
-List channel information for an Ordering Service Node (OSN). If the channel-id
+List channel information for an Ordering Service Node (OSN). If the channelID
 flag is set, more detailed information will be provided for that channel.
 
 Flags:

--- a/docs/wrappers/osnadmin_channel_postscript.md
+++ b/docs/wrappers/osnadmin_channel_postscript.md
@@ -4,7 +4,7 @@
 
 Here's an example of the `osnadmin channel join` command.
 
-* Create and join a sample channel `mychannel` defined by the application channel genesis 
+* Create and join a sample channel `mychannel` defined by the application channel genesis
   block contained in file `mychannel-genesis-block.pb`. Use the orderer admin endpoint
   at `orderer.example.com:9443`.
 
@@ -34,7 +34,7 @@ Here are some examples of the `osnadmin channel list` command.
   system channel (if one exists) and all of the application channels.
 
   ```
-  osnadmin channel list -o orderer.example.com:9443 --ca-file $CA_FILE --client-cert $CLIENT_CERT --client-key $CLIENT_KEY 
+  osnadmin channel list -o orderer.example.com:9443 --ca-file $CA_FILE --client-cert $CLIENT_CERT --client-key $CLIENT_KEY
 
   Status: 200
   {
@@ -49,7 +49,7 @@ Here are some examples of the `osnadmin channel list` command.
 
   ```
 
-  Status 200 and the list of channels are returned. 
+  Status 200 and the list of channels are returned.
 
 * Using the `--channelID` flag to list more details for `mychannel`.
 
@@ -67,7 +67,7 @@ Here are some examples of the `osnadmin channel list` command.
 
   ```
 
-  Status 200 and the details of the channels are returned. 
+  Status 200 and the details of the channels are returned.
 
 ### osnadmin channel remove example
 
@@ -81,6 +81,6 @@ Here's an example of the `osnadmin channel remove` command.
   Status: 204
   ```
 
-  Status 204 is returned upon successful removal of a channel. 
+  Status 204 is returned upon successful removal of a channel.
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/docs/wrappers/peer_lifecycle_chaincode_postscript.md
+++ b/docs/wrappers/peer_lifecycle_chaincode_postscript.md
@@ -228,7 +228,7 @@ also outputs which organizations have approved the chaincode definition. If an
 organization has approved the chaincode definition specified in the command, the
 command will return a value of true. You can use this command to learn whether enough
 channel members have approved a chaincode definition to meet the
-`Application/Channel/Endorsement` policy (a majority by default) before the
+`/Channel/Application/Endorsement` policy (a majority by default) before the
 definition can be committed to a channel.
 
   * Here is an example of the `peer lifecycle chaincode checkcommitreadiness` command,

--- a/scripts/generateHelpDocs.sh
+++ b/scripts/generateHelpDocs.sh
@@ -29,7 +29,7 @@ generateHelpText(){
 
 ## $x
 \`\`\`
-$($x --help 2>&1)
+$($x --help 2>&1 | sed -E 's/[[:space:]]+$//g')
 \`\`\`
 
 EOF


### PR DESCRIPTION
- Prevent osnadmin tests from exiting the test execution process when a bad flag is provided
- Update the help doc generation script to filter trailing spaces from command help
- Update the reference to the old `channel-id` that was included in the osnadmin command help