### PR TITLE
FABGW-1: Allow gateway direct access to discovery service

### DIFF
--- a/internal/pkg/gateway/server/discovery.go
+++ b/internal/pkg/gateway/server/discovery.go
@@ -1,0 +1,19 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package server
+
+import (
+	protos "github.com/hyperledger/fabric-protos-go/discovery"
+	"github.com/hyperledger/fabric/gossip/common"
+	"github.com/hyperledger/fabric/gossip/discovery"
+)
+
+// DiscoveryService defines capabilities directly accessed in the embedded peer's discovery service
+type DiscoveryService interface {
+	PeersForEndorsement(channel common.ChannelID, interest *protos.ChaincodeInterest) (*protos.EndorsementDescriptor, error)
+	PeersOfChannel(common.ChannelID) discovery.Members
+}


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Allow the embedded Gateway service to access capabilities of the peer's discovery service directly without requiring a client identity. This allows the embedded Gateway service to:
1. Identify active channel peers and their ledger heights
2. Obtain endorsement plans