### PR TITLE
Replace hostname with invalid IP address

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb_test.go
@@ -271,12 +271,12 @@ func TestIsEmpty(t *testing.T) {
 	require.True(t, isEmpty)
 
 	configCopy := *config
-	configCopy.Address = "junk"
+	configCopy.Address = "address-and-port.invalid:0"
 	configCopy.MaxRetries = 0
 	couchInstance.conf = &configCopy
 	_, err = couchInstance.isEmpty(ignore)
 	require.Error(t, err)
-	require.Regexp(t, `unable to connect to CouchDB, check the hostname and port: http error calling couchdb: Get "?http://junk/_all_dbs"?`, err.Error())
+	require.Regexp(t, `unable to connect to CouchDB, check the hostname and port: http error calling couchdb: Get "?http://address-and-port.invalid:0/_all_dbs"?`, err.Error())
 }
 
 func TestDBBadDatabaseName(t *testing.T) {


### PR DESCRIPTION



<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

- Test failed locally because 'junk' was a resolvable name on the network. By
switching to an invalid IP address, the connection will always fail.

<!--- Describe your changes in detail, including motivation. -->

