### PR TITLE
Add to MAINTAINERS.md a link to the relevant doc

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,8 @@
 Maintainers
 ===========
 
+See [the documentation on Maintainers](https://hyperledger-fabric.readthedocs.io/en/latest/CONTRIBUTING.html#maintainers) to learn about the role of the maintainers and the process to become one.
+
 **Active Maintainers**
 
 | Name | GitHub | Chat | email


### PR DESCRIPTION
Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>

#### Type of change

- Documentation update

#### Description

This change adds to the Maintainers.md file a link to the documentation section on Maintainers so that people can easily find what the role of maintainers is and what the process to become one is.
