### PR TITLE
Move all fixed width log entry fields to the left

### DIFF
--- a/common/flogging/global.go
+++ b/common/flogging/global.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultFormat = "%{color}%{time:2006-01-02 15:04:05.000 MST} [%{module}] %{shortfunc} -> %{level:.4s} %{id:03x}%{color:reset} %{message}"
+	defaultFormat = "%{color}%{time:2006-01-02 15:04:05.000 MST} %{id:04x} %{level:.4s}%{color:reset} [%{module}] %{color:bold}%{shortfunc}%{color:reset} -> %{message}"
 	defaultLevel  = zapcore.InfoLevel
 )
 


### PR DESCRIPTION
This would change the default log format string to keep the fixed width columns on the left.

- Move the sequence number and level before the module
- Colorize the function

Before:
```
2021-02-02 20:02:49.099 EST [nodeCmd] serve -> INFO 001 Starting peer:
 Version: latest
 Commit SHA: development build
 Go version: go1.14.14
 OS/Arch: darwin/amd64
 Chaincode:
  Base Docker Label: org.hyperledger.fabric
  Docker Namespace: hyperledger
2021-02-02 20:02:49.099 EST [peer] getLocalAddress -> INFO 002 Auto-detected peer address: 169.254.49.29:21505
2021-02-02 20:02:49.099 EST [peer] getLocalAddress -> INFO 003 Auto-detect flag is set, returning 169.254.49.29:21505
2021-02-02 20:02:49.102 EST [nodeCmd] initGrpcSemaphores -> INFO 004 concurrency limit for endorser service is 100
2021-02-02 20:02:49.102 EST [nodeCmd] initGrpcSemaphores -> INFO 005 concurrency limit for deliver service is 100
2021-02-02 20:02:49.103 EST [nodeCmd] serve -> INFO 006 Starting peer with TLS enabled
2021-02-02 20:02:49.145 EST [certmonitor] trackCertExpiration -> INFO 007 The enrollment certificate will expire on 2031-02-01 00:58:00 +0000 UTC
2021-02-02 20:02:49.145 EST [certmonitor] trackCertExpiration -> INFO 008 The server TLS certificate will expire on 2031-02-01 00:58:00 +0000 UTC
2021-02-02 20:02:49.146 EST [ledgermgmt] NewLedgerMgr -> INFO 009 Initializing LedgerMgr
2021-02-02 20:02:49.281 EST [leveldbhelper] openDBAndCheckFormat -> INFO 00a DB is empty Setting db format as 2.0
2021-02-02 20:02:49.292 EST [blkstorage] NewProvider -> INFO 00b Creating new file ledger directory at /var/folders/tw/dsbwtnf50w7dhvhh0tkg7fwr0000gn/T/acl-e2e424095865/peers/Org1.peer0/filesystem/ledgersData/chains/chains
2021-02-02 20:02:49.377 EST [leveldbhelper] openDBAndCheckFormat -> INFO 00c DB is empty Setting db format as 2.0
2021-02-02 20:02:49.515 EST [leveldbhelper] openDBAndCheckFormat -> INFO 00d DB is empty Setting db format as 2.0
2021-02-02 20:02:49.533 EST [ledgermgmt] NewLedgerMgr -> INFO 00e Initialized LedgerMgr
2021-02-02 20:02:49.534 EST [gossip.service] New -> INFO 00f Initialize gossip with endpoint 127.0.0.1:21505
2021-02-02 20:02:49.535 EST [gossip.gossip] New -> INFO 010 Creating gossip service with self membership of Endpoint: 127.0.0.1:21505, InternalEndpoint: 127.0.0.1:21505, PKI-ID: 76da153a51aa3e351a513a7bbfcbc4f74497fe02371e08bddc2182483106394b, Metadata:
2021-02-02 20:02:49.536 EST [gossip.gossip] start -> INFO 011 Gossip instance 127.0.0.1:21505 started
2021-02-02 20:02:49.536 EST [lifecycle] InitializeLocalChaincodes -> INFO 012 Initialized lifecycle cache with 0 already installed chaincodes
2021-02-02 20:02:49.537 EST [nodeCmd] computeChaincodeEndpoint -> INFO 013 Entering computeChaincodeEndpoint with peerHostname: 169.254.49.29
2021-02-02 20:02:49.537 EST [nodeCmd] computeChaincodeEndpoint -> INFO 014 Exit with ccEndpoint: 169.254.49.29:21506
2021-02-02 20:02:49.540 EST [sccapi] DeploySysCC -> INFO 015 deploying system chaincode 'lscc'
2021-02-02 20:02:49.540 EST [sccapi] DeploySysCC -> INFO 016 deploying system chaincode 'cscc'
2021-02-02 20:02:49.540 EST [sccapi] DeploySysCC -> INFO 017 deploying system chaincode 'qscc'
2021-02-02 20:02:49.540 EST [sccapi] DeploySysCC -> INFO 018 deploying system chaincode '_lifecycle'
```

After:
```
2021-02-02 19:59:22.306 EST 0001 INFO [nodeCmd] serve -> Starting peer:
 Version: latest
 Commit SHA: development build
 Go version: go1.15.6
 OS/Arch: linux/amd64
 Chaincode:
  Base Docker Label: org.hyperledger.fabric
  Docker Namespace: hyperledger
2021-02-02 19:59:22.307 EST 0002 INFO [peer] getLocalAddress -> Auto-detected peer address: 192.168.1.175:21508
2021-02-02 19:59:22.307 EST 0003 INFO [peer] getLocalAddress -> Auto-detect flag is set, returning 192.168.1.175:21508
2021-02-02 19:59:22.308 EST 0004 INFO [nodeCmd] initGrpcSemaphores -> concurrency limit for endorser service is 100
2021-02-02 19:59:22.308 EST 0005 INFO [nodeCmd] initGrpcSemaphores -> concurrency limit for deliver service is 100
2021-02-02 19:59:22.308 EST 0006 INFO [nodeCmd] serve -> Starting peer with TLS enabled
2021-02-02 19:59:22.435 EST 0007 INFO [certmonitor] trackCertExpiration -> The enrollment certificate will expire on 2031-02-01 00:54:00 +0000 UTC
2021-02-02 19:59:22.435 EST 0008 INFO [certmonitor] trackCertExpiration -> The server TLS certificate will expire on 2031-02-01 00:54:00 +0000 UTC
2021-02-02 19:59:22.436 EST 0009 INFO [ledgermgmt] NewLedgerMgr -> Initializing LedgerMgr
2021-02-02 19:59:22.574 EST 000a INFO [leveldbhelper] openDBAndCheckFormat -> DB is empty Setting db format as 2.0
2021-02-02 19:59:22.576 EST 000b INFO [blkstorage] NewProvider -> Creating new file ledger directory at /tmp/e2e785051710/peers/Org1.peer0/filesystem/ledgersData/chains/chains
2021-02-02 19:59:22.638 EST 000c INFO [leveldbhelper] openDBAndCheckFormat -> DB is empty Setting db format as 2.0
2021-02-02 19:59:22.767 EST 000d INFO [couchdb] createDatabaseIfNotExist -> Created state database _users
2021-02-02 19:59:22.809 EST 000e INFO [couchdb] createDatabaseIfNotExist -> Created state database _replicator
2021-02-02 19:59:22.947 EST 000f INFO [couchdb] createDatabaseIfNotExist -> Created state database fabric__internal
2021-02-02 19:59:23.038 EST 0010 INFO [ledgermgmt] NewLedgerMgr -> Initialized LedgerMgr
2021-02-02 19:59:23.039 EST 0011 INFO [gossip.service] New -> Initialize gossip with endpoint 127.0.0.1:21508
2021-02-02 19:59:23.040 EST 0012 INFO [gossip.gossip] New -> Creating gossip service with self membership of Endpoint: 127.0.0.1:21508, InternalEndpoint: 127.0.0.1:21508, PKI-ID: 73ed9326dc17c754b98841dfc84ff500e6b9bc715955f6c7c2acf7d8bc00f259, Metadata:
2021-02-02 19:59:23.040 EST 0013 INFO [gossip.gossip] start -> Gossip instance 127.0.0.1:21508 started
2021-02-02 19:59:23.040 EST 0014 INFO [lifecycle] InitializeLocalChaincodes -> Initialized lifecycle cache with 0 already installed chaincodes
2021-02-02 19:59:23.041 EST 0015 INFO [nodeCmd] computeChaincodeEndpoint -> Entering computeChaincodeEndpoint with peerHostname: 192.168.1.175
2021-02-02 19:59:23.041 EST 0016 INFO [nodeCmd] computeChaincodeEndpoint -> Exit with ccEndpoint: 192.168.1.175:21509
2021-02-02 19:59:23.042 EST 0017 INFO [sccapi] DeploySysCC -> deploying system chaincode 'lscc'
2021-02-02 19:59:23.042 EST 0018 INFO [sccapi] DeploySysCC -> deploying system chaincode 'cscc'
2021-02-02 19:59:23.042 EST 0019 INFO [sccapi] DeploySysCC -> deploying system chaincode 'qscc'
2021-02-02 19:59:23.042 EST 001a INFO [sccapi] DeploySysCC -> deploying system chaincode '_lifecycle'
```