### PR TITLE
Pin npm to latest-6 for compatibility with node 8

### DIFF
--- a/images/ccenv/Dockerfile.in
+++ b/images/ccenv/Dockerfile.in
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 FROM _BASE_NS_/fabric-baseimage:_BASE_TAG_
-RUN npm install -g npm@latest
+RUN npm install -g npm@latest-6
 COPY payload/chaintool payload/protoc-gen-go /usr/local/bin/
 ADD payload/goshim.tar.bz2 $GOPATH/src/
 RUN mkdir -p /chaincode/input /chaincode/output


### PR DESCRIPTION
See https://github.com/npm/cli/issues/2599

The base image is built with [node 8](https://github.com/hyperledger/fabric-baseimage/blob/23ac4cfdc5a0fdcb41d10f32842ff05a7ce5ee87/scripts/common/setup.sh#L70-L71).

FAB-18413