### PR TITLE
Update AZP Service Connection Name

### DIFF
--- a/ci/azure-pipelines-release.yml
+++ b/ci/azure-pipelines-release.yml
@@ -78,7 +78,7 @@ stages:
               addChangeLog: true
               assets: $(Pipeline.Workspace)/*amd64*/*
               compareWith: lastFullRelease
-              gitHubConnection: fabric-release
+              gitHubConnection: hyperledger
               isDraft: true
               releaseNotesFile: release_notes/v$(RELEASE).md
               repositoryName: $(Build.Repository.Name)


### PR DESCRIPTION
We are retiring the use of OAuth service connections in favor of the recommended and more reliable Azure App Service Connections. This change switches over to the new service connection.

Signed-off-by: Brett Logan <lindluni@github.com>
