### PR TITLE
Enable RepoLinter Tooling

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,5 +8,5 @@ There are two ways to report a security bug. The easiest is to email a descripti
 
 The other way is to file a confidential security bug in our [JIRA bug tracking system](https://jira.hyperledger.org). Be sure to set the “Security Level” to “Security issue”.
 
-The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://wiki.hyperledger.org/display/HYP/Defect+Response) on our [wiki](https://wiki.hyperledger.org).
+The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://wiki.hyperledger.org/display/SEC/Defect+Response) on our [wiki](https://wiki.hyperledger.org).
 

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -30,6 +30,17 @@ stages:
           - script: ./ci/scripts/evaluate_commits.sh
             name: SetJobTriggers
 
+      - job: LintRepo
+        pool:
+          vmImage: ubuntu-18.04
+        container: hyperledger-tools.jfrog.io/repolinter:0.10.0
+        steps:
+          - checkout: self
+            path: 'fabric'
+            displayName: Checkout Fabric Code
+          - script: bundle exec /app/bin/repolinter.js
+            displayName: Lint
+
   - stage: UnitTests
     dependsOn: VerifyBuild
     jobs:

--- a/repolint.json
+++ b/repolint.json
@@ -1,0 +1,122 @@
+{
+  "axioms": {
+    "linguist": "language",
+    "licensee": "license",
+    "packagers": "packager"
+  },
+  "rules": {
+    "all": {
+      "apache-license-file:file-contents": [
+        "error",
+        {
+          "files": [
+            "LICENSE*"
+          ],
+          "content": "Apache License.*Version 2.0",
+          "fail-on-non-existent": true
+        }
+      ],
+      "code-of-conduct-file:file-contents": [
+        "error",
+        {
+          "files": [
+            "CODE_OF_CONDUCT*"
+          ],
+          "content": "https://wiki.hyperledger.org/community/hyperledger-project-code-of-conduct",
+          "fail-on-non-existent": true
+        }
+      ],
+      "security-file-matches:file-contents": [
+        "error",
+        {
+          "files": [
+            "SECURITY.md"
+          ],
+          "content": "https://wiki.hyperledger.org/display/SEC/Defect\\+Response",
+          "fail-on-non-existent": true
+        }
+      ],
+      "readme-file-exists:file-existence": [
+        "error",
+        {
+          "files": [
+            "README.md"
+          ]
+        }
+      ],
+      "readme-references-license:file-contents": [
+        "error",
+        {
+          "files": [
+            "README.md"
+          ],
+          "content": "license",
+          "flags": "i"
+        }
+      ],
+      "maintainers-file-exists:file-existence": [
+        "error",
+        {
+          "files": [
+            "MAINTAINERS.md"
+          ]
+        }
+      ],
+      "contributing-file-exists:file-existence": [
+        "error",
+        {
+          "files": [
+            "CONTRIBUTING.md"
+          ]
+        }
+      ],
+      "changelog-file-exists:file-existence": [
+        "error",
+        {
+          "files": [
+            "CHANGELOG.md"
+          ]
+        }
+      ],
+      "integrates-with-ci:file-existence": [
+        "error",
+        {
+          "files": [
+            "ci/azure-pipelines.yml"
+          ]
+        }
+      ],
+      "notice-file-exists:file-existence": [
+        "error",
+        {
+          "files": [
+            "NOTICE"
+          ]
+        }
+      ],
+      "source-license-headers-exist:file-starts-with": [
+        "error",
+        {
+          "files": [
+            "**/*.go",
+            "**/*.sh"
+          ],
+          "skip-paths-matching": {
+            "patterns": [
+              ".pb.go$",
+              "fake[s]?/",
+              "/mock[s]?/",
+              "^vendor"
+            ]
+          },
+          "lineCount": 10,
+          "patterns": [
+            "Copyright",
+            "License"
+          ],
+          "flags": "i"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/check_go_version.sh
+++ b/scripts/check_go_version.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
I trimmed this down to exclude unnecessary checks and introduce it into PR checks.

Honestly, I'm not sure how I feel about it. Introducing node.js tooling into the repo simply to do this seems unnecessary. The repolinter is also making use of many out-of-date packages that are expected to break in upcoming node.js releases.

I would like to hear others thoughts on doing this, as I don't really like the idea of it, but thats just my opinion.