### PR TITLE
Test network works with Docker Desktop version 2.5.0.1

### DIFF
--- a/docs/source/prereqs.rst
+++ b/docs/source/prereqs.rst
@@ -34,14 +34,8 @@ operating, or developing on (or for), Hyperledger Fabric:
     Toolbox <https://docs.docker.com/toolbox/toolbox_install_windows/>`__ -
     again, Docker version Docker 17.06.2-ce or greater is required.
 
-The Fabric sample test network has been successfully 
-verified with Docker 2.5.0.1. Higher versions may not work at this time.
-You can check the version of Docker you have installed with the following
-command from a terminal prompt:
-
-.. code:: bash
-
-  docker --version
+The Fabric sample test network has been successfully
+verified with Docker Desktop version 2.5.0.1. Higher versions may not work at this time.
 
 .. note:: The following applies to linux systems running systemd.
 

--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -26,7 +26,7 @@ Before you can run the test network, you need to clone the `fabric-samples`
 repository and download the Fabric images. Make sure that you have installed
 the [Prerequisites](prereqs.html) and [Installed the Samples, Binaries and Docker Images](install.html).
 
-**Note:** The test network has been successfully verified with Docker version 2.5.0.1 and is the recommended version at this time. Higher versions of Docker may not work.
+**Note:** The test network has been successfully verified with Docker Desktop version 2.5.0.1 and is the recommended version at this time. Higher versions may not work.
 
 ## Bring up the test network
 
@@ -625,7 +625,7 @@ If you have any problems with the tutorial, review the following:
    After 5 attempts, peer0.org1 has failed to join channel 'mychannel'
    ```
 
-   You need to uninstall Docker and reinstall the recommended version 2.5.0.1. Then, reclone the `fabric-samples`
+   You need to uninstall Docker Desktop and reinstall the recommended version 2.5.0.1. Then, reclone the `fabric-samples`
    repository before reattempting the commands.
 
 -  If you see an error similar to the following:


### PR DESCRIPTION
Signed-off-by: pama-ibm <pama@ibm.com>

The issue with the test network and Docker is actually with Docker Desktop. 
- I've updated the instructions to refer to Docker Desktop version 2.5.0.1 instead of Docker version 2.5.0.1
- Removed the line to check their docker version using docker --version.

#### Type of change

- Documentation update

#### Description

