### PR TITLE
Update documentation to include Go SDK

### DIFF
--- a/docs/source/CONTRIBUTING.rst
+++ b/docs/source/CONTRIBUTING.rst
@@ -321,7 +321,7 @@ hours (3 days), it will be flagged to the #fabric-pr-review channel daily until
 it receives a review comment(s).
 
 This policy applies to all official Fabric projects (fabric, fabric-ca,
-fabric-samples, fabric-test, fabric-sdk-node, fabric-sdk-java, fabric-gateway-java,
+fabric-samples, fabric-test, fabric-sdk-node, fabric-sdk-java, fabric-sdk-go, fabric-gateway-java,
 fabric-chaincode-node, fabric-chaincode-java, fabric-chaincode-evm,
 fabric-baseimage, and fabric-amcl).
 

--- a/docs/source/dev-setup/devenv.rst
+++ b/docs/source/dev-setup/devenv.rst
@@ -180,7 +180,7 @@ few commands.
 
 If those commands completely successfully, you're ready to Go!
 
-If you plan to use the Hyperledger Fabric application SDKs then be sure to check out their prerequisites in the Node.js SDK `README <https://github.com/hyperledger/fabric-sdk-node#build-and-test>`__ and Java SDK `README <https://github.com/hyperledger/fabric-gateway-java/blob/master/README.md>`__.
+If you plan to use the Hyperledger Fabric application SDKs then be sure to check out their prerequisites in the Node.js SDK `README <https://github.com/hyperledger/fabric-sdk-node#build-and-test>`__, Java SDK `README <https://github.com/hyperledger/fabric-gateway-java/blob/master/README.md>`__, and Go SDK `README <https://github.com/hyperledger/fabric-sdk-go/blob/main/README.md>`__.
 
 .. Licensed under Creative Commons Attribution 4.0 International License
    https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/fabric-sdks.rst
+++ b/docs/source/fabric-sdks.rst
@@ -1,12 +1,13 @@
 Hyperledger Fabric SDKs
 =======================
 
-Hyperledger Fabric intends to offer a number of SDKs for a wide variety of
-programming languages. The first two delivered are the Node.js and Java
-SDKs. We hope to provide Python, REST and Go SDKs in a subsequent release.
+Hyperledger Fabric offers a number of SDKs for a wide variety of
+programming languages. The first three delivered are the Node.js, Java, and Go
+SDKs. We hope to provide Python, and REST SDKs in a subsequent release.
 
   * `Hyperledger Fabric Node SDK documentation <https://hyperledger.github.io/fabric-sdk-node/>`__.
   * `Hyperledger Fabric Java SDK documentation <https://hyperledger.github.io/fabric-gateway-java/>`__.
+  * `Hyperledger Fabric Go SDK documentation <https://pkg.go.dev/github.com/hyperledger/fabric-sdk-go/>`__.
 
 .. Licensed under Creative Commons Attribution 4.0 International License
    https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -40,14 +40,16 @@ Hyperledger Fabric offers a number of SDKs to support developing applications in
 
   * `Node.js SDK <https://github.com/hyperledger/fabric-sdk-node>`__ and `Node.js SDK documentation <https://hyperledger.github.io/fabric-sdk-node/>`__.
   * `Java SDK <https://github.com/hyperledger/fabric-gateway-java>`__ and `Java SDK documentation <https://hyperledger.github.io/fabric-gateway-java/>`__.
+  * `Go SDK <https://github.com/hyperledger/fabric-sdk-go>`__ and `Go SDK documentation <https://pkg.go.dev/github.com/hyperledger/fabric-sdk-go/>`__.
 
-  Prerequisites for developing with the SDKs can be found in the Node.js SDK `README <https://github.com/hyperledger/fabric-sdk-node#build-and-test>`__ and Java SDK `README <https://github.com/hyperledger/fabric-gateway-java/blob/master/README.md>`__.
+  Prerequisites for developing with the SDKs can be found in the Node.js SDK `README <https://github.com/hyperledger/fabric-sdk-node#build-and-test>`__ ,
+  Java SDK `README <https://github.com/hyperledger/fabric-gateway-java/blob/master/README.md>`__, and
+  Go SDK `README <https://github.com/hyperledger/fabric-sdk-go/blob/main/README.md>`__.
 
-In addition, there are two more application SDKs that have not yet been officially released
-(for Python and Go), but they are still available for downloading and testing:
+In addition, there is one other application SDK that has not yet been officially released
+for Python, but is still available for downloading and testing:
 
   * `Python SDK <https://github.com/hyperledger/fabric-sdk-py>`__.
-  * `Go SDK <https://github.com/hyperledger/fabric-sdk-go>`__.
 
 Currently, Node.js, Java and Go support the new application programming model delivered in Hyperledger Fabric v1.4.
 

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -590,9 +590,8 @@ cryptographic algorithms for signatures, logging frameworks and state stores,
 are easily swapped in and out of the SDK. The SDK provides APIs for transaction
 processing, membership services, node traversal and event handling.
 
-Currently, the two officially supported SDKs are for Node.js and Java, while two
-more -- Python and Go -- are not yet official but can still be downloaded
-and tested.
+Currently, there are three officially supported SDKs -- for Node.js, Java, and Go. While the Python SDK
+is not yet official but can still be downloaded and tested.
 
 .. _Smart-Contract:
 


### PR DESCRIPTION
Signed-off-by: pama-ibm <pama@ibm.com>

Since the Go SDK officially release v1.0.0 recently, we need to update references to it. 

#### Type of change

- Documentation update

#### Description

Everywhere that we talk about the available SDKs, I appended the Go SDK, including a link to the GitHub repo, README, and docs. 
