### PR TITLE
Reproduce name constraint verification from standard library in the MSP

### DIFF
--- a/msp/msp_test.go
+++ b/msp/msp_test.go
@@ -9,7 +9,11 @@ package msp
 
 import (
 	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/hex"
 	"encoding/pem"
@@ -29,6 +33,7 @@ import (
 	"github.com/hyperledger/fabric/bccsp/sw"
 	"github.com/hyperledger/fabric/bccsp/utils"
 	"github.com/hyperledger/fabric/core/config/configtest"
+	"github.com/hyperledger/fabric/protoutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -278,6 +283,90 @@ func TestSerializeIdentities(t *testing.T) {
 		t.Fatalf("Identities should be equal (%s) (%s)", id, idBack)
 		return
 	}
+}
+
+func computeSKI(key *ecdsa.PublicKey) []byte {
+	raw := elliptic.Marshal(key.Curve, key.X, key.Y)
+	hash := sha256.Sum256(raw)
+	return hash[:]
+}
+
+func TestValidateCANameConstraintsMitigation(t *testing.T) {
+	// Prior to Go 1.15, if a signing certificate contains a name constraint, the
+	// leaf certificate does not include a SAN, and the leaf common name looks
+	// like a valid hostname, the certificate chain would fail to validate.
+	// (This behavior may have been introduced with Go 1.10.)
+	//
+	// In Go 1.15, the behavior has changed and, by default, the same structure
+	// will validate. This test asserts on the old behavior.
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caKeyUsage := x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+	caTemplate := x509.Certificate{
+		Subject:                     pkix.Name{CommonName: "TestCA"},
+		SerialNumber:                big.NewInt(1),
+		NotBefore:                   time.Now().Add(-1 * time.Hour),
+		NotAfter:                    time.Now().Add(2 * time.Hour),
+		ExcludedDNSDomains:          []string{"example.com"},
+		PermittedDNSDomainsCritical: true,
+		IsCA:                        true,
+		BasicConstraintsValid:       true,
+		KeyUsage:                    caKeyUsage,
+		SubjectKeyId:                computeSKI(caKey.Public().(*ecdsa.PublicKey)),
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, caKey.Public(), caKey)
+	require.NoError(t, err)
+	ca, err := x509.ParseCertificate(certBytes)
+	require.NoError(t, err)
+
+	leafTemplate := x509.Certificate{
+		Subject:      pkix.Name{CommonName: "localhost"},
+		SerialNumber: big.NewInt(2),
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(2 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		SubjectKeyId: computeSKI(leafKey.Public().(*ecdsa.PublicKey)),
+	}
+	leafCertBytes, err := x509.CreateCertificate(rand.Reader, &leafTemplate, ca, leafKey.Public(), caKey)
+	require.NoError(t, err)
+
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(leafKey)
+	require.NoError(t, err)
+
+	caCertPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+	leafCertPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafCertBytes})
+	leafKeyPem := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+	fabricMSPConfig := &msp.FabricMSPConfig{
+		Name:      "ConstraintsMSP",
+		RootCerts: [][]byte{caCertPem},
+		SigningIdentity: &msp.SigningIdentityInfo{
+			PublicSigner: leafCertPem,
+			PrivateSigner: &msp.KeyInfo{
+				KeyIdentifier: "Certificate Without SAN",
+				KeyMaterial:   leafKeyPem,
+			},
+		},
+	}
+	mspConfig := &msp.MSPConfig{
+		Config: protoutil.MarshalOrPanic(fabricMSPConfig),
+	}
+
+	ks, err := sw.NewFileBasedKeyStore(nil, filepath.Join(configtest.GetDevMspDir(), "keystore"), true)
+	require.NoError(t, err)
+	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(ks)
+	require.NoError(t, err)
+
+	testMSP, err := NewBccspMspWithKeyStore(MSPv1_0, ks, cryptoProvider)
+	require.NoError(t, err)
+
+	err = testMSP.Setup(mspConfig)
+	require.Error(t, err)
+	var cie x509.CertificateInvalidError
+	require.True(t, errors.As(err, &cie))
+	require.Equal(t, x509.NameConstraintsWithoutSANs, cie.Reason)
 }
 
 func TestIsWellFormed(t *testing.T) {

--- a/msp/msp_test.go
+++ b/msp/msp_test.go
@@ -291,6 +291,33 @@ func computeSKI(key *ecdsa.PublicKey) []byte {
 	return hash[:]
 }
 
+func TestValidHostname(t *testing.T) {
+	tests := []struct {
+		name  string
+		valid bool
+	}{
+		{"", false},
+		{".", false},
+		{"example.com", true},
+		{"example.com.", true},
+		{"*.example.com", true},
+		{".example.com", false},
+		{"host.*.example.com", false},
+		{"localhost", true},
+		{"-localhost", false},
+		{"Not_Quite.example.com", true},
+		{"weird:colon.example.com", true},
+		{"1-2-3.example.com", true},
+	}
+	for _, tt := range tests {
+		if tt.valid {
+			require.True(t, validHostname(tt.name), "expected %s to be a valid hostname", tt.name)
+		} else {
+			require.False(t, validHostname(tt.name), "expected %s to be an invalid hostname", tt.name)
+		}
+	}
+}
+
 func TestValidateCANameConstraintsMitigation(t *testing.T) {
 	// Prior to Go 1.15, if a signing certificate contains a name constraint, the
 	// leaf certificate does not include a SAN, and the leaf common name looks
@@ -317,9 +344,9 @@ func TestValidateCANameConstraintsMitigation(t *testing.T) {
 		KeyUsage:                    caKeyUsage,
 		SubjectKeyId:                computeSKI(caKey.Public().(*ecdsa.PublicKey)),
 	}
-	certBytes, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, caKey.Public(), caKey)
+	caCertBytes, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, caKey.Public(), caKey)
 	require.NoError(t, err)
-	ca, err := x509.ParseCertificate(certBytes)
+	ca, err := x509.ParseCertificate(caCertBytes)
 	require.NoError(t, err)
 
 	leafTemplate := x509.Certificate{
@@ -336,37 +363,82 @@ func TestValidateCANameConstraintsMitigation(t *testing.T) {
 	keyBytes, err := x509.MarshalPKCS8PrivateKey(leafKey)
 	require.NoError(t, err)
 
-	caCertPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+	caCertPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertBytes})
 	leafCertPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafCertBytes})
 	leafKeyPem := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
-	fabricMSPConfig := &msp.FabricMSPConfig{
-		Name:      "ConstraintsMSP",
-		RootCerts: [][]byte{caCertPem},
-		SigningIdentity: &msp.SigningIdentityInfo{
-			PublicSigner: leafCertPem,
-			PrivateSigner: &msp.KeyInfo{
-				KeyIdentifier: "Certificate Without SAN",
-				KeyMaterial:   leafKeyPem,
+
+	t.Run("VerifyNameConstraintsSingleCert", func(t *testing.T) {
+		for _, der := range [][]byte{caCertBytes, leafCertBytes} {
+			cert, err := x509.ParseCertificate(der)
+			require.NoError(t, err, "failed to parse certificate")
+
+			err = verifyLegacyNameConstraints([]*x509.Certificate{cert})
+			require.NoError(t, err, "single certificate should not trigger legacy constraints")
+		}
+	})
+
+	t.Run("VerifyNameConstraints", func(t *testing.T) {
+		var certs []*x509.Certificate
+		for _, der := range [][]byte{leafCertBytes, caCertBytes} {
+			cert, err := x509.ParseCertificate(der)
+			require.NoError(t, err, "failed to parse certificate")
+			certs = append(certs, cert)
+		}
+
+		err = verifyLegacyNameConstraints(certs)
+		require.Error(t, err, "certificate chain should trigger legacy constraints")
+		var cie x509.CertificateInvalidError
+		require.True(t, errors.As(err, &cie))
+		require.Equal(t, x509.NameConstraintsWithoutSANs, cie.Reason)
+	})
+
+	t.Run("VerifyNameConstraintsWithSAN", func(t *testing.T) {
+		caCert, err := x509.ParseCertificate(caCertBytes)
+		require.NoError(t, err)
+
+		leafTemplate := leafTemplate
+		leafTemplate.DNSNames = []string{"localhost"}
+
+		leafCertBytes, err := x509.CreateCertificate(rand.Reader, &leafTemplate, caCert, leafKey.Public(), caKey)
+		require.NoError(t, err)
+
+		leafCert, err := x509.ParseCertificate(leafCertBytes)
+		require.NoError(t, err)
+
+		err = verifyLegacyNameConstraints([]*x509.Certificate{leafCert, caCert})
+		require.NoError(t, err, "signer with name constraints and leaf with SANs should be valid")
+	})
+
+	t.Run("ValidationAtSetup", func(t *testing.T) {
+		fabricMSPConfig := &msp.FabricMSPConfig{
+			Name:      "ConstraintsMSP",
+			RootCerts: [][]byte{caCertPem},
+			SigningIdentity: &msp.SigningIdentityInfo{
+				PublicSigner: leafCertPem,
+				PrivateSigner: &msp.KeyInfo{
+					KeyIdentifier: "Certificate Without SAN",
+					KeyMaterial:   leafKeyPem,
+				},
 			},
-		},
-	}
-	mspConfig := &msp.MSPConfig{
-		Config: protoutil.MarshalOrPanic(fabricMSPConfig),
-	}
+		}
+		mspConfig := &msp.MSPConfig{
+			Config: protoutil.MarshalOrPanic(fabricMSPConfig),
+		}
 
-	ks, err := sw.NewFileBasedKeyStore(nil, filepath.Join(configtest.GetDevMspDir(), "keystore"), true)
-	require.NoError(t, err)
-	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(ks)
-	require.NoError(t, err)
+		ks, err := sw.NewFileBasedKeyStore(nil, filepath.Join(configtest.GetDevMspDir(), "keystore"), true)
+		require.NoError(t, err)
+		cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(ks)
+		require.NoError(t, err)
 
-	testMSP, err := NewBccspMspWithKeyStore(MSPv1_0, ks, cryptoProvider)
-	require.NoError(t, err)
+		testMSP, err := NewBccspMspWithKeyStore(MSPv1_0, ks, cryptoProvider)
+		require.NoError(t, err)
 
-	err = testMSP.Setup(mspConfig)
-	require.Error(t, err)
-	var cie x509.CertificateInvalidError
-	require.True(t, errors.As(err, &cie))
-	require.Equal(t, x509.NameConstraintsWithoutSANs, cie.Reason)
+		err = testMSP.Setup(mspConfig)
+		require.Error(t, err)
+		var cie x509.CertificateInvalidError
+		require.True(t, errors.As(err, &cie))
+		require.Equal(t, x509.NameConstraintsWithoutSANs, cie.Reason)
+	})
 }
 
 func TestIsWellFormed(t *testing.T) {

--- a/msp/mspimpl.go
+++ b/msp/mspimpl.go
@@ -10,8 +10,10 @@ import (
 	"bytes"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/hex"
 	"encoding/pem"
+	"strings"
 
 	"github.com/golang/protobuf/proto"
 	m "github.com/hyperledger/fabric-protos-go/msp"
@@ -728,7 +730,105 @@ func (msp *bccspmsp) getUniqueValidationChain(cert *x509.Certificate, opts x509.
 		return nil, errors.Errorf("this MSP only supports a single validation chain, got %d", len(validationChains))
 	}
 
+	// Make the additional verification checks that were done in Go 1.14.
+	err = verifyLegacyNameConstraints(validationChains[0])
+	if err != nil {
+		return nil, errors.WithMessage(err, "the supplied identity is not valid")
+	}
+
 	return validationChains[0], nil
+}
+
+var (
+	oidExtensionSubjectAltName  = asn1.ObjectIdentifier{2, 5, 29, 17}
+	oidExtensionNameConstraints = asn1.ObjectIdentifier{2, 5, 29, 30}
+)
+
+// verifyLegacyNameConstraints exercises the name constraint validation rules
+// that were part of the certificate verification process in Go 1.14.
+//
+// If a signing certificate contains a name constratint, the leaf certificate
+// does not include SAN extensions, and the leaf's common name looks like a
+// host name, the validation would fail with an x509.CertificateInvalidError
+// and a rason of x509.NameConstraintsWithoutSANs.
+func verifyLegacyNameConstraints(chain []*x509.Certificate) error {
+	if len(chain) < 2 {
+		return nil
+	}
+
+	// Leaf certificates with SANs are fine.
+	if oidInExtensions(oidExtensionSubjectAltName, chain[0].Extensions) {
+		return nil
+	}
+	// Leaf certificates without a hostname in CN are fine.
+	if !validHostname(chain[0].Subject.CommonName) {
+		return nil
+	}
+	// If an intermediate or root have a name constraint, validation
+	// would fail in Go 1.14.
+	for _, c := range chain[1:] {
+		if oidInExtensions(oidExtensionNameConstraints, c.Extensions) {
+			return x509.CertificateInvalidError{Cert: chain[0], Reason: x509.NameConstraintsWithoutSANs}
+		}
+	}
+	return nil
+}
+
+func oidInExtensions(oid asn1.ObjectIdentifier, exts []pkix.Extension) bool {
+	for _, ext := range exts {
+		if ext.Id.Equal(oid) {
+			return true
+		}
+	}
+	return false
+}
+
+// validHostname reports whether host is a valid hostname that can be matched or
+// matched against according to RFC 6125 2.2, with some leniency to accommodate
+// legacy values.
+//
+// This implementation is sourced from the standaard library.
+func validHostname(host string) bool {
+	host = strings.TrimSuffix(host, ".")
+
+	if len(host) == 0 {
+		return false
+	}
+
+	for i, part := range strings.Split(host, ".") {
+		if part == "" {
+			// Empty label.
+			return false
+		}
+		if i == 0 && part == "*" {
+			// Only allow full left-most wildcards, as those are the only ones
+			// we match, and matching literal '*' characters is probably never
+			// the expected behavior.
+			continue
+		}
+		for j, c := range part {
+			if 'a' <= c && c <= 'z' {
+				continue
+			}
+			if '0' <= c && c <= '9' {
+				continue
+			}
+			if 'A' <= c && c <= 'Z' {
+				continue
+			}
+			if c == '-' && j != 0 {
+				continue
+			}
+			if c == '_' || c == ':' {
+				// Not valid characters in hostnames, but commonly
+				// found in deployments outside the WebPKI.
+				continue
+			}
+			return false
+		}
+	}
+
+	return true
 }
 
 func (msp *bccspmsp) getValidationChain(cert *x509.Certificate, isIntermediateChain bool) ([]*x509.Certificate, error) {


### PR DESCRIPTION
Implemented @yacovm's suggestion from  https://github.com/hyperledger/fabric/pull/1716#issuecomment-673583502.