### PR TITLE
Change docker compose network name

### DIFF
--- a/docs/source/create_channel/create_channel_test_net.md
+++ b/docs/source/create_channel/create_channel_test_net.md
@@ -40,7 +40,7 @@ You can then use the following command to start the test network:
 ```
 This command creates a Fabric network with the two peer organizations and the single ordering node ordering organization. The peer organizations will operate one peer each, while the ordering service administrator will operate a single ordering node. When you run the command, the script prints out the nodes being created:
 ```
-Creating network "net_test" with the default driver
+Creating network "fabric_test" with the default driver
 Creating volume "net_orderer.example.com" with default driver
 Creating volume "net_peer0.org1.example.com" with default driver
 Creating volume "net_peer0.org2.example.com" with default driver

--- a/docs/source/deploy_chaincode.md
+++ b/docs/source/deploy_chaincode.md
@@ -56,7 +56,7 @@ find . -name monitordocker.sh
 
 You can then start Logspout by running the following command:
 ```
-./monitordocker.sh net_test
+./monitordocker.sh fabric_test
 ```
 You should see output similar to the following:
 ```

--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -105,7 +105,7 @@ ordering node. No channel is created when you run `./network.sh up`, though we
 will get there in a [future step](#creating-a-channel). If the command completes
 successfully, you will see the logs of the nodes being created:
 ```
-Creating network "net_test" with the default driver
+Creating network "fabric_test" with the default driver
 Creating volume "net_orderer.example.com" with default driver
 Creating volume "net_peer0.org1.example.com" with default driver
 Creating volume "net_peer0.org2.example.com" with default driver

--- a/docs/source/tutorial/commercial_paper.md
+++ b/docs/source/tutorial/commercial_paper.md
@@ -180,14 +180,14 @@ need to horizontally scroll to locate the information):
 * The Ordering Org CA, `ca_orderer`, is running in container `7b01f5454832`
 
 These containers all form a [Docker network](https://docs.docker.com/network/)
-called `net_test`. You can view the network with the `docker network` command:
+called `fabric_test`. You can view the network with the `docker network` command:
 
 ```
-$ docker network inspect net_test
+$ docker network inspect fabric_test
 
   [
       {
-          "Name": "net_test",
+          "Name": "fabric_test",
           "Id": "f4c9712139311004b8f7acc14e9f90170c5dcfd8cdd06303c7b074624b44dc9f",
           "Created": "2020-04-28T22:45:38.525016Z",
           "Containers": {
@@ -289,21 +289,21 @@ smart contracts, for example.
 
 In the MagnetoCorp directory, run the following command to run the
 `monitordocker.sh`  script and start the `logspout` tool for the containers
-associated with PaperNet running on `net_test`:
+associated with PaperNet running on `fabric_test`:
 ```
-(magnetocorp admin)$ ./configuration/cli/monitordocker.sh net_test
+(magnetocorp admin)$ ./configuration/cli/monitordocker.sh fabric_test
 ...
 latest: Pulling from gliderlabs/logspout
 4fe2ade4980c: Pull complete
 decca452f519: Pull complete
 (...)
-Starting monitoring on all containers on the network net_test
+Starting monitoring on all containers on the network fabric_test
 b7f3586e5d0233de5a454df369b8eadab0613886fc9877529587345fc01a3582
 ```
 
 Note that you can pass a port number to the above command if the default port in `monitordocker.sh` is already in use.
 ```
-(magnetocorp admin)$ ./monitordocker.sh net_test <port_number>
+(magnetocorp admin)$ ./monitordocker.sh fabric_test <port_number>
 ```
 
 This window will now show output from the Docker containers for the remainder of the


### PR DESCRIPTION
Signed-off-by: Nikhil Gupta <ngupta@symbridge.com>

We recently renamed the docker compose network in the Fabric samples. https://github.com/hyperledger/fabric-samples/pull/417

This PR updates the test network name in the docs.

#### Type of change

- Documentation update
