### PR TITLE
Isolate Kafka tests to their own suite

### DIFF
--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -213,11 +213,11 @@ var _ = Describe("EndToEnd", func() {
 		})
 	})
 
-	Describe("basic kafka network with 2 orgs", func() {
+	Describe("basic etcdraft network with docker chaincode builds", func() {
 		BeforeEach(func() {
-			network = nwo.New(nwo.BasicKafka(), testDir, client, StartPort(), components)
-			network.MetricsProvider = "prometheus"
+			network = nwo.New(nwo.MultiChannelEtcdRaft(), testDir, client, StartPort(), components)
 			network.Consensus.ChannelParticipationEnabled = true
+			network.MetricsProvider = "prometheus"
 			network.GenerateConfigTree()
 			network.Bootstrap()
 
@@ -226,13 +226,13 @@ var _ = Describe("EndToEnd", func() {
 			Eventually(process.Ready(), network.EventuallyTimeout).Should(BeClosed())
 		})
 
-		It("executes a basic kafka network with 2 orgs (using docker chaincode builds)", func() {
+		It("builds and executes transactions with docker chaincode", func() {
 			chaincodePath, err := filepath.Abs("../chaincode/module")
 			Expect(err).NotTo(HaveOccurred())
 
 			// use these two variants of the same chaincode to ensure we test
 			// the golang docker build for both module and gopath chaincode
-			chaincode = nwo.Chaincode{
+			chaincode := nwo.Chaincode{
 				Name:            "mycc",
 				Version:         "0.0",
 				Path:            chaincodePath,
@@ -291,6 +291,7 @@ var _ = Describe("EndToEnd", func() {
 
 			RunQueryInvokeQuery(network, orderer, network.Peer("Org1", "peer0"), "testchannel")
 
+			By("evaluating the operations endpoint and prometheus metrics")
 			CheckPeerOperationEndpoints(network, network.Peer("Org2", "peer0"))
 			CheckOrdererOperationEndpoints(network, orderer)
 
@@ -341,7 +342,7 @@ var _ = Describe("EndToEnd", func() {
 		})
 	})
 
-	Describe("basic single node etcdraft network", func() {
+	Describe("basic single node etcdraft network with static leader", func() {
 		var (
 			peerRunners    []*ginkgomon.Runner
 			processes      map[string]ifrit.Process

--- a/integration/e2e/health_test.go
+++ b/integration/e2e/health_test.go
@@ -41,9 +41,7 @@ var _ = Describe("Health", func() {
 		client, err = docker.NewClientFromEnv()
 		Expect(err).NotTo(HaveOccurred())
 
-		config := nwo.BasicKafka()
-		config.Consensus.Brokers = 3
-
+		config := nwo.BasicEtcdRaft()
 		network = nwo.New(config, testDir, client, StartPort(), components)
 		network.GenerateConfigTree()
 		network.Bootstrap()
@@ -99,7 +97,7 @@ var _ = Describe("Health", func() {
 		When("running health checks on Couch DB", func() {
 			It("returns appropriate response codes", func() {
 				By("returning 200 when able to reach Couch DB")
-				statusCode, status := DoHealthCheck(authClient, healthURL)
+				statusCode, status := doHealthCheck(authClient, healthURL)
 				Expect(statusCode).To(Equal(http.StatusOK))
 				Expect(status.Status).To(Equal("OK"))
 
@@ -118,10 +116,10 @@ var _ = Describe("Health", func() {
 
 				By("returning 503 when unable to reach Couch DB")
 				Eventually(func() int {
-					statusCode, _ := DoHealthCheck(authClient, healthURL)
+					statusCode, _ := doHealthCheck(authClient, healthURL)
 					return statusCode
 				}, network.EventuallyTimeout).Should(Equal(http.StatusServiceUnavailable))
-				statusCode, status = DoHealthCheck(authClient, healthURL)
+				statusCode, status = doHealthCheck(authClient, healthURL)
 				Expect(statusCode).To(Equal(http.StatusServiceUnavailable))
 				Expect(status.Status).To(Equal("Service Unavailable"))
 				Expect(status.FailedChecks[0].Component).To(Equal("couchdb"))
@@ -129,103 +127,9 @@ var _ = Describe("Health", func() {
 			})
 		})
 	})
-
-	Describe("Kafka health checks", func() {
-		var (
-			oProcess ifrit.Process
-			zProcess ifrit.Process
-			kProcess []ifrit.Process
-
-			authClient *http.Client
-			healthURL  string
-		)
-
-		BeforeEach(func() {
-			// Start Zookeeper
-			zookeepers := []string{}
-			zk := network.ZooKeeperRunner(0)
-			zookeepers = append(zookeepers, fmt.Sprintf("%s:2181", zk.Name))
-			zProcess = ifrit.Invoke(zk)
-			Eventually(zProcess.Ready(), network.EventuallyTimeout).Should(BeClosed())
-
-			// Start Kafka Brokers
-			for i := 0; i < network.Consensus.Brokers; i++ {
-				kafkaRunner := network.BrokerRunner(i, zookeepers)
-				kp := ifrit.Invoke(kafkaRunner)
-				Eventually(kp.Ready(), network.EventuallyTimeout).Should(BeClosed())
-				kProcess = append(kProcess, kp)
-			}
-
-			// Start Orderer
-			ordererRunner := network.OrdererGroupRunner()
-			oProcess = ifrit.Invoke(ordererRunner)
-			Eventually(oProcess.Ready(), network.EventuallyTimeout).Should(BeClosed())
-
-			orderer := network.Orderers[0]
-			authClient, _ = nwo.OrdererOperationalClients(network, orderer)
-			healthURL = fmt.Sprintf("https://127.0.0.1:%d/healthz", network.OrdererPort(orderer, nwo.OperationsPort))
-		})
-
-		AfterEach(func() {
-			if zProcess != nil {
-				zProcess.Signal(syscall.SIGTERM)
-				Eventually(zProcess.Wait(), network.EventuallyTimeout).Should(Receive())
-			}
-			if oProcess != nil {
-				oProcess.Signal(syscall.SIGTERM)
-				Eventually(oProcess.Wait(), network.EventuallyTimeout).Should(Receive())
-			}
-			for _, k := range kProcess {
-				if k != nil {
-					k.Signal(syscall.SIGTERM)
-					Eventually(k.Wait(), network.EventuallyTimeout).Should(Receive())
-				}
-			}
-		})
-
-		Context("when running health checks on orderer the kafka health check", func() {
-			It("returns appropriate response code", func() {
-				By("returning 200 when all brokers are online", func() {
-					statusCode, status := DoHealthCheck(authClient, healthURL)
-					Expect(statusCode).To(Equal(http.StatusOK))
-					Expect(status.Status).To(Equal("OK"))
-				})
-
-				By("returning a 200 when one of the three brokers goes offline", func() {
-					k := kProcess[1]
-					k.Signal(syscall.SIGTERM)
-					Eventually(k.Wait(), network.EventuallyTimeout).Should(Receive())
-
-					var statusCode int
-					var status *healthz.HealthStatus
-					Consistently(func() int {
-						statusCode, status = DoHealthCheck(authClient, healthURL)
-						return statusCode
-					}).Should(Equal(http.StatusOK))
-					Expect(status.Status).To(Equal("OK"))
-				})
-
-				By("returning a 503 when two of the three brokers go offline", func() {
-					k := kProcess[0]
-					k.Signal(syscall.SIGTERM)
-					Eventually(k.Wait(), network.EventuallyTimeout).Should(Receive())
-
-					var statusCode int
-					var status *healthz.HealthStatus
-					Eventually(func() int {
-						statusCode, status = DoHealthCheck(authClient, healthURL)
-						return statusCode
-					}, network.EventuallyTimeout).Should(Equal(http.StatusServiceUnavailable))
-					Expect(status.Status).To(Equal("Service Unavailable"))
-					Expect(status.FailedChecks[0].Component).To(Equal("systemchannel/0"))
-					Expect(status.FailedChecks[0].Reason).To(MatchRegexp(`\[replica ids: \[\d \d \d\]\]: kafka server: Messages are rejected since there are fewer in-sync replicas than required\.`))
-				})
-			})
-		})
-	})
 })
 
-func DoHealthCheck(client *http.Client, url string) (int, *healthz.HealthStatus) {
+func doHealthCheck(client *http.Client, url string) (int, *healthz.HealthStatus) {
 	resp, err := client.Get(url)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/integration/kafka/e2e_test.go
+++ b/integration/kafka/e2e_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package kafka
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/hyperledger/fabric/integration/nwo"
+	"github.com/hyperledger/fabric/integration/nwo/commands"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/tedsuo/ifrit"
+)
+
+var _ = Describe("basic kafka network with 2 orgs", func() {
+	var (
+		testDir string
+		client  *docker.Client
+		network *nwo.Network
+		process ifrit.Process
+	)
+
+	BeforeEach(func() {
+		var err error
+		testDir, err = ioutil.TempDir("", "kafka-e2e")
+		Expect(err).NotTo(HaveOccurred())
+
+		client, err = docker.NewClientFromEnv()
+		Expect(err).NotTo(HaveOccurred())
+
+		network = nwo.New(nwo.BasicKafka(), testDir, client, StartPort(), components)
+		network.GenerateConfigTree()
+		network.Bootstrap()
+
+		networkRunner := network.NetworkGroupRunner()
+		process = ifrit.Invoke(networkRunner)
+		Eventually(process.Ready(), network.EventuallyTimeout).Should(BeClosed())
+	})
+
+	AfterEach(func() {
+		if process != nil {
+			process.Signal(syscall.SIGTERM)
+			Eventually(process.Wait(), network.EventuallyTimeout).Should(Receive())
+		}
+		if network != nil {
+			network.Cleanup()
+		}
+		os.RemoveAll(testDir)
+	})
+
+	It("executes a basic kafka network with 2 orgs", func() {
+		chaincodePath, err := filepath.Abs("../chaincode/module")
+		Expect(err).NotTo(HaveOccurred())
+
+		// use these two variants of the same chaincode to ensure we test
+		// the golang docker build for both module and gopath chaincode
+		chaincode := nwo.Chaincode{
+			Name:            "mycc",
+			Version:         "0.0",
+			Path:            chaincodePath,
+			Lang:            "golang",
+			PackageFile:     filepath.Join(testDir, "modulecc.tar.gz"),
+			Ctor:            `{"Args":["init","a","100","b","200"]}`,
+			SignaturePolicy: `AND ('Org1MSP.member','Org2MSP.member')`,
+			Sequence:        "1",
+			InitRequired:    true,
+			Label:           "my_module_chaincode",
+		}
+
+		network.CreateAndJoinChannel(network.Orderer("orderer"), "testchannel")
+		nwo.EnableCapabilities(
+			network,
+			"testchannel",
+			"Application", "V2_0",
+			network.Orderer("orderer"),
+			network.Peer("Org1", "peer0"),
+			network.Peer("Org2", "peer0"),
+		)
+		nwo.DeployChaincode(
+			network,
+			"testchannel",
+			network.Orderer("orderer"),
+			chaincode,
+			network.Peer("Org1", "peer0"),
+			network.Peer("Org2", "peer0"),
+		)
+		RunQueryInvokeQuery(
+			network,
+			"testchannel",
+			network.Orderer("orderer"),
+			network.Peer("Org1", "peer0"),
+			network.Peer("Org2", "peer0"),
+		)
+	})
+})
+
+func RunQueryInvokeQuery(n *nwo.Network, channel string, orderer *nwo.Orderer, peers ...*nwo.Peer) {
+	By("querying the chaincode")
+	sess, err := n.PeerUserSession(peers[0], "User1", commands.ChaincodeQuery{
+		ChannelID: channel,
+		Name:      "mycc",
+		Ctor:      `{"Args":["query","a"]}`,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
+	Expect(sess).To(gbytes.Say("100"))
+
+	var peerAddrs []string
+	for _, p := range peers {
+		peerAddrs = append(peerAddrs, n.PeerAddress(p, nwo.ListenPort))
+	}
+	sess, err = n.PeerUserSession(peers[0], "User1", commands.ChaincodeInvoke{
+		ChannelID:     channel,
+		Orderer:       n.OrdererAddress(orderer, nwo.ListenPort),
+		Name:          "mycc",
+		Ctor:          `{"Args":["invoke","a","b","10"]}`,
+		PeerAddresses: peerAddrs,
+		WaitForEvent:  true,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
+	Expect(sess.Err).To(gbytes.Say("Chaincode invoke successful. result: status:200"))
+
+	sess, err = n.PeerUserSession(peers[0], "User1", commands.ChaincodeQuery{
+		ChannelID: channel,
+		Name:      "mycc",
+		Ctor:      `{"Args":["query","a"]}`,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
+	Expect(sess).To(gbytes.Say("90"))
+}

--- a/integration/kafka/health_test.go
+++ b/integration/kafka/health_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package kafka
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"syscall"
+
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/hyperledger/fabric-lib-go/healthz"
+	"github.com/hyperledger/fabric/integration/nwo"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/tedsuo/ifrit"
+)
+
+var _ = Describe("Kafka Health", func() {
+	var (
+		testDir string
+		client  *docker.Client
+		network *nwo.Network
+		process ifrit.Process
+	)
+
+	BeforeEach(func() {
+		var err error
+		testDir, err = ioutil.TempDir("", "kafka-health")
+		Expect(err).NotTo(HaveOccurred())
+
+		client, err = docker.NewClientFromEnv()
+		Expect(err).NotTo(HaveOccurred())
+
+		config := nwo.BasicKafka()
+		config.Consensus.Brokers = 3
+
+		network = nwo.New(config, testDir, client, StartPort(), components)
+		network.GenerateConfigTree()
+		network.Bootstrap()
+	})
+
+	AfterEach(func() {
+		if process != nil {
+			process.Signal(syscall.SIGTERM)
+			Eventually(process.Wait(), network.EventuallyTimeout).Should(Receive())
+		}
+		if network != nil {
+			network.Cleanup()
+		}
+		os.RemoveAll(testDir)
+	})
+
+	Describe("Kafka health checks", func() {
+		var (
+			oProcess ifrit.Process
+			zProcess ifrit.Process
+			kProcess []ifrit.Process
+
+			authClient *http.Client
+			healthURL  string
+		)
+
+		BeforeEach(func() {
+			// Start Zookeeper
+			zookeepers := []string{}
+			zk := network.ZooKeeperRunner(0)
+			zookeepers = append(zookeepers, fmt.Sprintf("%s:2181", zk.Name))
+			zProcess = ifrit.Invoke(zk)
+			Eventually(zProcess.Ready(), network.EventuallyTimeout).Should(BeClosed())
+
+			// Start Kafka Brokers
+			for i := 0; i < network.Consensus.Brokers; i++ {
+				kafkaRunner := network.BrokerRunner(i, zookeepers)
+				kp := ifrit.Invoke(kafkaRunner)
+				Eventually(kp.Ready(), network.EventuallyTimeout).Should(BeClosed())
+				kProcess = append(kProcess, kp)
+			}
+
+			// Start Orderer
+			ordererRunner := network.OrdererGroupRunner()
+			oProcess = ifrit.Invoke(ordererRunner)
+			Eventually(oProcess.Ready(), network.EventuallyTimeout).Should(BeClosed())
+
+			orderer := network.Orderers[0]
+			authClient, _ = nwo.OrdererOperationalClients(network, orderer)
+			healthURL = fmt.Sprintf("https://127.0.0.1:%d/healthz", network.OrdererPort(orderer, nwo.OperationsPort))
+		})
+
+		AfterEach(func() {
+			if zProcess != nil {
+				zProcess.Signal(syscall.SIGTERM)
+				Eventually(zProcess.Wait(), network.EventuallyTimeout).Should(Receive())
+			}
+			if oProcess != nil {
+				oProcess.Signal(syscall.SIGTERM)
+				Eventually(oProcess.Wait(), network.EventuallyTimeout).Should(Receive())
+			}
+			for _, k := range kProcess {
+				if k != nil {
+					k.Signal(syscall.SIGTERM)
+					Eventually(k.Wait(), network.EventuallyTimeout).Should(Receive())
+				}
+			}
+		})
+
+		Context("when running health checks on orderer the kafka health check", func() {
+			It("returns appropriate response code", func() {
+				By("returning 200 when all brokers are online", func() {
+					statusCode, status := doHealthCheck(authClient, healthURL)
+					Expect(statusCode).To(Equal(http.StatusOK))
+					Expect(status.Status).To(Equal("OK"))
+				})
+
+				By("returning a 200 when one of the three brokers goes offline", func() {
+					k := kProcess[1]
+					k.Signal(syscall.SIGTERM)
+					Eventually(k.Wait(), network.EventuallyTimeout).Should(Receive())
+
+					var statusCode int
+					var status *healthz.HealthStatus
+					Consistently(func() int {
+						statusCode, status = doHealthCheck(authClient, healthURL)
+						return statusCode
+					}).Should(Equal(http.StatusOK))
+					Expect(status.Status).To(Equal("OK"))
+				})
+
+				By("returning a 503 when two of the three brokers go offline", func() {
+					k := kProcess[0]
+					k.Signal(syscall.SIGTERM)
+					Eventually(k.Wait(), network.EventuallyTimeout).Should(Receive())
+
+					var statusCode int
+					var status *healthz.HealthStatus
+					Eventually(func() int {
+						statusCode, status = doHealthCheck(authClient, healthURL)
+						return statusCode
+					}, network.EventuallyTimeout).Should(Equal(http.StatusServiceUnavailable))
+					Expect(status.Status).To(Equal("Service Unavailable"))
+					Expect(status.FailedChecks[0].Component).To(Equal("systemchannel/0"))
+					Expect(status.FailedChecks[0].Reason).To(MatchRegexp(`\[replica ids: \[\d \d \d\]\]: kafka server: Messages are rejected since there are fewer in-sync replicas than required\.`))
+				})
+			})
+		})
+	})
+})
+
+func doHealthCheck(client *http.Client, url string) (int, *healthz.HealthStatus) {
+	resp, err := client.Get(url)
+	Expect(err).NotTo(HaveOccurred())
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+	resp.Body.Close()
+
+	// This occurs when a request to the health check server times out, no body is
+	// returned when a timeout occurs
+	if len(bodyBytes) == 0 {
+		return resp.StatusCode, nil
+	}
+
+	healthStatus := &healthz.HealthStatus{}
+	err = json.Unmarshal(bodyBytes, &healthStatus)
+	Expect(err).NotTo(HaveOccurred())
+
+	return resp.StatusCode, healthStatus
+}

--- a/integration/kafka/kafka_suite_test.go
+++ b/integration/kafka/kafka_suite_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package kafka
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hyperledger/fabric/integration"
+	"github.com/hyperledger/fabric/integration/nwo"
+	"github.com/hyperledger/fabric/integration/runner"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestKafka(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kafka Suite")
+}
+
+var (
+	buildServer *nwo.BuildServer
+	components  *nwo.Components
+)
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	nwo.RequiredImages = append(
+		nwo.RequiredImages,
+		runner.KafkaDefaultImage,
+		runner.ZooKeeperDefaultImage,
+	)
+	buildServer = nwo.NewBuildServer()
+	buildServer.Serve()
+
+	components = buildServer.Components()
+	payload, err := json.Marshal(components)
+	Expect(err).NotTo(HaveOccurred())
+
+	return payload
+}, func(payload []byte) {
+	err := json.Unmarshal(payload, &components)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = SynchronizedAfterSuite(func() {
+}, func() {
+	buildServer.Shutdown()
+})
+
+func StartPort() int {
+	return integration.KafkaBasePort.StartPortForNode()
+}

--- a/integration/nwo/components.go
+++ b/integration/nwo/components.go
@@ -66,6 +66,4 @@ const CCEnvDefaultImage = "hyperledger/fabric-ccenv:latest"
 var RequiredImages = []string{
 	CCEnvDefaultImage,
 	runner.CouchDBDefaultImage,
-	runner.KafkaDefaultImage,
-	runner.ZooKeeperDefaultImage,
 }

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -29,6 +29,7 @@ const (
 	E2EBasePort
 	GossipBasePort
 	IdemixBasePort
+	KafkaBasePort
 	LedgerPort
 	LifecyclePort
 	MSPPort


### PR DESCRIPTION
Move Kafka e2e, health checks, and Kafka to raft migration tests to their own suite and remove Kafka and ZooKeeper from the required docker image list.