### PR TITLE
JoinBySnapshotStatus returns a string

### DIFF
--- a/integration/discovery/discovery_test.go
+++ b/integration/discovery/discovery_test.go
@@ -767,11 +767,11 @@ func verifyNoPendingSnapshotRequest(n *nwo.Network, peer *nwo.Peer, channelID st
 		ClientAuth:  n.ClientAuthRequired,
 		PeerAddress: n.PeerAddress(peer, nwo.ListenPort),
 	}
-	checkPending := func() []byte {
+	checkPending := func() string {
 		sess, err := n.PeerAdminSession(peer, cmd)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
-		return sess.Buffer().Contents()
+		return string(sess.Buffer().Contents())
 	}
 	Eventually(checkPending, n.EventuallyTimeout, 10*time.Second).Should(ContainSubstring("Successfully got pending snapshot requests: []\n"))
 }
@@ -780,7 +780,7 @@ func joinBySnapshot(n *nwo.Network, orderer *nwo.Orderer, peer *nwo.Peer, channe
 	n.JoinChannelBySnapshot(snapshotDir, peer)
 
 	By("calling JoinBySnapshotStatus until joinbysnapshot is completed")
-	checkStatus := func() []byte { return n.JoinBySnapshotStatus(peer) }
+	checkStatus := func() string { return n.JoinBySnapshotStatus(peer) }
 	Eventually(checkStatus, n.EventuallyTimeout, 10*time.Second).Should(ContainSubstring("No joinbysnapshot operation is in progress"))
 
 	By("waiting for the peer to have the same ledger height")

--- a/integration/ledger/snapshot_test.go
+++ b/integration/ledger/snapshot_test.go
@@ -41,9 +41,7 @@ import (
 	"github.com/tedsuo/ifrit"
 )
 
-const (
-	testchannelID = "testchannel"
-)
+const testchannelID = "testchannel"
 
 var _ bool = Describe("Snapshot Generation and Bootstrap", func() {
 	var (
@@ -810,7 +808,7 @@ func joinBySnapshot(n *nwo.Network, orderer *nwo.Orderer, peer *nwo.Peer, channe
 	n.JoinChannelBySnapshot(snapshotDir, peer)
 
 	By("calling JoinBySnapshotStatus")
-	checkStatus := func() []byte { return n.JoinBySnapshotStatus(peer) }
+	checkStatus := func() string { return n.JoinBySnapshotStatus(peer) }
 	Eventually(checkStatus, n.EventuallyTimeout, 10*time.Second).Should(ContainSubstring("No joinbysnapshot operation is in progress"))
 
 	By("waiting for the new peer to have the same ledger height")

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -1130,13 +1130,13 @@ func (n *Network) JoinChannelBySnapshot(snapshotDir string, peers ...*Peer) {
 	}
 }
 
-func (n *Network) JoinBySnapshotStatus(p *Peer) []byte {
+func (n *Network) JoinBySnapshotStatus(p *Peer) string {
 	sess, err := n.PeerAdminSession(p, commands.ChannelJoinBySnapshotStatus{
 		ClientAuth: n.ClientAuthRequired,
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
-	return sess.Out.Contents()
+	return string(sess.Out.Contents())
 }
 
 // Cryptogen starts a gexec.Session for the provided cryptogen command.


### PR DESCRIPTION
The tests and assertions against the output from JoinBySnapshotStatus are done with strings so have the function return a string.