### PR TITLE
Fix a duplicate message while orderer setting up

### DIFF
--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -825,7 +825,7 @@ func TestUpdateTrustedRoots(t *testing.T) {
 		ordererRootCAsByChain: make(map[string][][]byte),
 	}
 
-	clusterConf := initializeClusterClientConfig(conf)
+	clusterConf, _ := initializeClusterClientConfig(conf)
 	predDialer := &cluster.PredicateDialer{
 		Config: clusterConf,
 	}


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description
There is a duplicate message while orderer setting up because reuseListener() was called twice.
This patch fixes to call it only once.