### PR TITLE
Expose a SigningIdentity type on the integration test network model

### DIFF
--- a/integration/ledger/snapshot_test.go
+++ b/integration/ledger/snapshot_test.go
@@ -23,7 +23,6 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
-	"github.com/hyperledger/fabric/cmd/common/signer"
 	"github.com/hyperledger/fabric/core/ledger/util"
 	"github.com/hyperledger/fabric/integration/chaincode/kvexecutor"
 	"github.com/hyperledger/fabric/integration/nwo"
@@ -1045,13 +1044,7 @@ func commitTx(n *nwo.Network, orderer *nwo.Orderer, peer *nwo.Peer, channelID st
 
 	// get signing identity
 	By("getting the signer for user1 on peer " + peer.ID())
-	conf := signer.Config{
-		MSPID:        n.Organization(peer.Organization).MSPID,
-		IdentityPath: n.PeerUserCert(peer, "User1"),
-		KeyPath:      n.PeerUserKey(peer, "User1"),
-	}
-	signer, err := signer.NewSigner(conf)
-	Expect(err).NotTo(HaveOccurred())
+	signer := n.PeerUserSigner(peer, "User1")
 
 	// create deliver client and delivergroup
 	peerClient := &common.PeerClient{

--- a/integration/lifecycle/interop_test.go
+++ b/integration/lifecycle/interop_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hyperledger/fabric/integration/nwo"
 	"github.com/hyperledger/fabric/integration/nwo/commands"
 	"github.com/hyperledger/fabric/internal/peer/common"
-	"github.com/hyperledger/fabric/msp"
 	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -136,15 +135,14 @@ var _ = Describe("Release interoperability", func() {
 
 	Describe("Interoperability scenarios", func() {
 		var (
-			userSigner           msp.SigningIdentity
-			serialisedUserSigner []byte
-			endorserClient       pb.EndorserClient
-			deliveryClient       pb.DeliverClient
-			ordererClient        common.BroadcastClient
+			userSigner     *nwo.SigningIdentity
+			endorserClient pb.EndorserClient
+			deliveryClient pb.DeliverClient
+			ordererClient  common.BroadcastClient
 		)
 
 		BeforeEach(func() {
-			userSigner, serialisedUserSigner = Signer(network.PeerUserMSPDir(endorsers[0], "User1"))
+			userSigner = network.PeerUserSigner(endorsers[0], "User1")
 			endorserClient = EndorserClient(
 				network.PeerAddress(endorsers[0], nwo.ListenPort),
 				filepath.Join(network.PeerLocalTLSDir(endorsers[0]), "ca.crt"),
@@ -178,7 +176,6 @@ var _ = Describe("Release interoperability", func() {
 				"testchannel",
 				"mycc",
 				userSigner,
-				serialisedUserSigner,
 				"invoke",
 				"a",
 				"b",
@@ -241,7 +238,6 @@ var _ = Describe("Release interoperability", func() {
 				"testchannel",
 				"mycc",
 				userSigner,
-				serialisedUserSigner,
 				"invoke",
 				"a",
 				"b",
@@ -333,7 +329,6 @@ var _ = Describe("Release interoperability", func() {
 					"testchannel",
 					"caller",
 					userSigner,
-					serialisedUserSigner,
 					"INVOKE",
 					"callee",
 				)
@@ -436,7 +431,6 @@ var _ = Describe("Release interoperability", func() {
 						"testchannel",
 						"caller",
 						userSigner,
-						serialisedUserSigner,
 						"INVOKE",
 						"callee",
 					)
@@ -479,7 +473,6 @@ var _ = Describe("Release interoperability", func() {
 						"testchannel",
 						"caller",
 						userSigner,
-						serialisedUserSigner,
 						"INVOKE",
 						"callee",
 					)
@@ -527,7 +520,6 @@ var _ = Describe("Release interoperability", func() {
 						"testchannel",
 						"caller",
 						userSigner,
-						serialisedUserSigner,
 						"INVOKE",
 						"callee",
 					)
@@ -591,7 +583,6 @@ var _ = Describe("Release interoperability", func() {
 						"testchannel",
 						"caller",
 						userSigner,
-						serialisedUserSigner,
 						"INVOKE",
 						"callee",
 					)
@@ -637,7 +628,6 @@ var _ = Describe("Release interoperability", func() {
 						"testchannel",
 						"caller",
 						userSigner,
-						serialisedUserSigner,
 						"INVOKE",
 						"callee",
 					)
@@ -680,7 +670,6 @@ var _ = Describe("Release interoperability", func() {
 						"testchannel",
 						"caller",
 						userSigner,
-						serialisedUserSigner,
 						"INVOKE",
 						"callee",
 					)
@@ -726,7 +715,6 @@ var _ = Describe("Release interoperability", func() {
 						"testchannel",
 						"caller",
 						userSigner,
-						serialisedUserSigner,
 						"INVOKE",
 						"callee",
 					)

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -553,6 +553,26 @@ func (n *Network) OrdererUserKey(o *Orderer, user string) string {
 	return filepath.Join(keystore, keys[0].Name())
 }
 
+// PeerUserSigner returns a SigningIdentity representing the specified user in
+// the peer organization.
+func (n *Network) PeerUserSigner(p *Peer, user string) *SigningIdentity {
+	return &SigningIdentity{
+		CertPath: n.PeerUserCert(p, user),
+		KeyPath:  n.PeerUserKey(p, user),
+		MSPID:    n.Organization(p.Organization).MSPID,
+	}
+}
+
+// OrdererUserSigner returns a SigningIdentity representing the specified user in
+// the orderer organization.
+func (n *Network) OrdererUserSigner(o *Orderer, user string) *SigningIdentity {
+	return &SigningIdentity{
+		CertPath: n.OrdererUserCert(o, user),
+		KeyPath:  n.OrdererUserKey(o, user),
+		MSPID:    n.Organization(o.Organization).MSPID,
+	}
+}
+
 // peerLocalCryptoDir returns the path to the local crypto directory for the peer.
 func (n *Network) peerLocalCryptoDir(p *Peer, cryptoType string) string {
 	org := n.Organization(p.Organization)

--- a/integration/nwo/signingid.go
+++ b/integration/nwo/signingid.go
@@ -1,0 +1,71 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package nwo
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-protos-go/msp"
+	"github.com/hyperledger/fabric/bccsp/utils"
+)
+
+// A SigningIdentity represents an MSP signing identity.
+type SigningIdentity struct {
+	CertPath string
+	KeyPath  string
+	MSPID    string
+}
+
+// Serialize returns the probobuf encoding of an msp.SerializedIdenity.
+func (s *SigningIdentity) Serialize() ([]byte, error) {
+	cert, err := ioutil.ReadFile(s.CertPath)
+	if err != nil {
+		return nil, err
+	}
+	return proto.Marshal(&msp.SerializedIdentity{
+		Mspid:   s.MSPID,
+		IdBytes: cert,
+	})
+}
+
+// Sign computes a SHA256 message digest, signs it with the associated private
+// key, and returns the signature after low-S normlization.
+func (s *SigningIdentity) Sign(msg []byte) ([]byte, error) {
+	digest := sha256.Sum256(msg)
+	pemKey, err := ioutil.ReadFile(s.KeyPath)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(pemKey)
+	if block.Type != "EC PRIVATE KEY" && block.Type != "PRIVATE KEY" {
+		return nil, fmt.Errorf("file %s does not contain a private key", s.KeyPath)
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	eckey, ok := key.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("unexpected key type: %T", key)
+	}
+	r, _s, err := ecdsa.Sign(rand.Reader, eckey, digest[:])
+	if err != nil {
+		return nil, err
+	}
+	sig, err := utils.MarshalECDSASignature(r, _s)
+	if err != nil {
+		return nil, err
+	}
+	return utils.SignatureToLowS(&eckey.PublicKey, sig)
+}

--- a/integration/pvtdata/pvtdata_test.go
+++ b/integration/pvtdata/pvtdata_test.go
@@ -34,7 +34,6 @@ import (
 	mspp "github.com/hyperledger/fabric-protos-go/msp"
 	ab "github.com/hyperledger/fabric-protos-go/orderer"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
-	"github.com/hyperledger/fabric/bccsp/sw"
 	"github.com/hyperledger/fabric/common/crypto"
 	"github.com/hyperledger/fabric/core/ledger/util"
 	"github.com/hyperledger/fabric/integration/nwo"
@@ -853,7 +852,7 @@ var _ bool = Describe("PrivateData", func() {
 		// before and after upgrade.
 		assertDeliverWithPrivateDataACLBehavior := func() {
 			By("getting signing identity for a user in org1")
-			signingIdentity := getSigningIdentity(network, "Org1", "User1", "Org1MSP", "bccsp")
+			signingIdentity := network.PeerUserSigner(network.Peer("Org1", "peer0"), "User1")
 
 			By("adding a marble")
 			peer := network.Peer("Org2", "peer0")
@@ -1187,7 +1186,7 @@ type deliverEvent struct {
 
 // getEventFromDeliverService send a request to DeliverWithPrivateData grpc service
 // and receive the response
-func getEventFromDeliverService(network *nwo.Network, peer *nwo.Peer, channelID string, signingIdentity msp.SigningIdentity, blockNum uint64) *deliverEvent {
+func getEventFromDeliverService(network *nwo.Network, peer *nwo.Peer, channelID string, signingIdentity *nwo.SigningIdentity, blockNum uint64) *deliverEvent {
 	ctx, cancelFunc1 := context.WithTimeout(context.Background(), network.EventuallyTimeout)
 	defer cancelFunc1()
 	eventCh, conn := registerForDeliverEvent(ctx, network, peer, channelID, signingIdentity, blockNum)
@@ -1203,7 +1202,7 @@ func registerForDeliverEvent(
 	network *nwo.Network,
 	peer *nwo.Peer,
 	channelID string,
-	signingIdentity msp.SigningIdentity,
+	signingIdentity *nwo.SigningIdentity,
 	blockNum uint64,
 ) (<-chan deliverEvent, *grpc.ClientConn) {
 	// create a comm.GRPCClient
@@ -1237,46 +1236,6 @@ func registerForDeliverEvent(
 	return eventCh, conn
 }
 
-func getSigningIdentity(network *nwo.Network, org, user, mspID, mspType string) msp.SigningIdentity {
-	peerForOrg := network.Peer(org, "peer0")
-	mspConfigPath := network.PeerUserMSPDir(peerForOrg, user)
-	mspInstance, err := loadLocalMSPAt(mspConfigPath, mspID, mspType)
-	Expect(err).NotTo(HaveOccurred())
-
-	signingIdentity, err := mspInstance.GetDefaultSigningIdentity()
-	Expect(err).NotTo(HaveOccurred())
-	return signingIdentity
-}
-
-// loadLocalMSPAt loads an MSP whose configuration is stored at 'dir', and whose
-// id and type are the passed as arguments.
-func loadLocalMSPAt(dir, id, mspType string) (msp.MSP, error) {
-	if mspType != "bccsp" {
-		return nil, errors.Errorf("invalid msp type, expected 'bccsp', got %s", mspType)
-	}
-	conf, err := msp.GetLocalMspConfig(dir, nil, id)
-	if err != nil {
-		return nil, err
-	}
-	ks, err := sw.NewFileBasedKeyStore(nil, filepath.Join(dir, "keystore"), true)
-	if err != nil {
-		return nil, err
-	}
-	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
-	if err != nil {
-		return nil, err
-	}
-	thisMSP, err := msp.NewBccspMspWithKeyStore(msp.MSPv1_0, ks, cryptoProvider)
-	if err != nil {
-		return nil, err
-	}
-	err = thisMSP.Setup(conf)
-	if err != nil {
-		return nil, err
-	}
-	return thisMSP, nil
-}
-
 // receiveDeliverResponse expects to receive the BlockAndPrivateData response for the requested block.
 func receiveDeliverResponse(dp pb.Deliver_DeliverWithPrivateDataClient, address string, eventCh chan<- deliverEvent) error {
 	event := deliverEvent{}
@@ -1304,7 +1263,7 @@ func receiveDeliverResponse(dp pb.Deliver_DeliverWithPrivateDataClient, address 
 
 // createDeliverEnvelope creates a deliver request based on the block number.
 // blockNum=0 means newest block
-func createDeliverEnvelope(channelID string, signingIdentity msp.SigningIdentity, blockNum uint64) (*cb.Envelope, error) {
+func createDeliverEnvelope(channelID string, signingIdentity *nwo.SigningIdentity, blockNum uint64) (*cb.Envelope, error) {
 	creator, err := signingIdentity.Serialize()
 	if err != nil {
 		return nil, err

--- a/integration/raft/client.go
+++ b/integration/raft/client.go
@@ -9,7 +9,6 @@ package raft
 import (
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/orderer"
-	"github.com/hyperledger/fabric/cmd/common/signer"
 	"github.com/hyperledger/fabric/integration/nwo"
 	"github.com/hyperledger/fabric/integration/ordererclient"
 	"github.com/hyperledger/fabric/protoutil"
@@ -30,22 +29,31 @@ func FetchBlock(n *nwo.Network, o *nwo.Orderer, seq uint64, channel string) *com
 	return blk
 }
 
-func CreateBroadcastEnvelope(n *nwo.Network, signer interface{}, channel string, data []byte) *common.Envelope {
+func CreateBroadcastEnvelope(n *nwo.Network, entity interface{}, channel string, data []byte) *common.Envelope {
+	var signer *nwo.SigningIdentity
+	switch creator := entity.(type) {
+	case *nwo.Peer:
+		signer = n.PeerUserSigner(creator, "Admin")
+	case *nwo.Orderer:
+		signer = n.OrdererUserSigner(creator, "Admin")
+	}
+	Expect(signer).NotTo(BeNil())
+
 	env, err := protoutil.CreateSignedEnvelope(
 		common.HeaderType_MESSAGE,
 		channel,
-		nil,
+		signer,
 		&common.Envelope{Payload: data},
 		0,
 		0,
 	)
 	Expect(err).NotTo(HaveOccurred())
 
-	return signAsAdmin(n, signer, env)
+	return env
 }
 
 // CreateDeliverEnvelope creates a deliver env to seek for specified block.
-func CreateDeliverEnvelope(n *nwo.Network, entity interface{}, blkNum uint64, channel string) *common.Envelope {
+func CreateDeliverEnvelope(n *nwo.Network, o *nwo.Orderer, blkNum uint64, channel string) *common.Envelope {
 	specified := &orderer.SeekPosition{
 		Type: &orderer.SeekPosition_Specified{
 			Specified: &orderer.SeekSpecified{Number: blkNum},
@@ -54,7 +62,7 @@ func CreateDeliverEnvelope(n *nwo.Network, entity interface{}, blkNum uint64, ch
 	env, err := protoutil.CreateSignedEnvelope(
 		common.HeaderType_DELIVER_SEEK_INFO,
 		channel,
-		nil,
+		n.OrdererUserSigner(o, "Admin"),
 		&orderer.SeekInfo{
 			Start:    specified,
 			Stop:     specified,
@@ -65,47 +73,5 @@ func CreateDeliverEnvelope(n *nwo.Network, entity interface{}, blkNum uint64, ch
 	)
 	Expect(err).NotTo(HaveOccurred())
 
-	return signAsAdmin(n, entity, env)
-}
-
-func signAsAdmin(n *nwo.Network, entity interface{}, env *common.Envelope) *common.Envelope {
-	var conf signer.Config
-	switch t := entity.(type) {
-	case *nwo.Peer:
-		conf = signer.Config{
-			MSPID:        n.Organization(t.Organization).MSPID,
-			IdentityPath: n.PeerUserCert(t, "Admin"),
-			KeyPath:      n.PeerUserKey(t, "Admin"),
-		}
-	case *nwo.Orderer:
-		conf = signer.Config{
-			MSPID:        n.Organization(t.Organization).MSPID,
-			IdentityPath: n.OrdererUserCert(t, "Admin"),
-			KeyPath:      n.OrdererUserKey(t, "Admin"),
-		}
-	default:
-		panic("unsupported signing entity type")
-	}
-
-	signer, err := signer.NewSigner(conf)
-	Expect(err).NotTo(HaveOccurred())
-
-	payload, err := protoutil.UnmarshalPayload(env.Payload)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(payload.Header).NotTo(BeNil())
-	Expect(payload.Header.ChannelHeader).NotTo(BeNil())
-
-	nonce, err := protoutil.CreateNonce()
-	Expect(err).NotTo(HaveOccurred())
-	sighdr := &common.SignatureHeader{
-		Creator: signer.Creator,
-		Nonce:   nonce,
-	}
-	payload.Header.SignatureHeader = protoutil.MarshalOrPanic(sighdr)
-	payloadBytes := protoutil.MarshalOrPanic(payload)
-
-	sig, err := signer.Sign(payloadBytes)
-	Expect(err).NotTo(HaveOccurred())
-
-	return &common.Envelope{Payload: payloadBytes, Signature: sig}
+	return env
 }


### PR DESCRIPTION
Test suites that exercise gRPC services instead of the command line tools were instantiating an MSP to obtain a signing identity. In order to enable reuse of code and reduce the coupling of tests to the MSP and BCCSP, this introduces a Signer that satisfies the `Sign` and `Serialize` operations used when assembling protocol buffer messages.

With the introduction of `nwo.SigningIdentity`, additional commits update the existing suites to use the new object.