### PR TITLE
Disable connection pool in operational clients

### DIFF
--- a/integration/nwo/operational_client.go
+++ b/integration/nwo/operational_client.go
@@ -38,6 +38,7 @@ func operationalClients(tlsDir string) (authClient, unauthClient *http.Client) {
 
 	authenticatedClient := &http.Client{
 		Transport: &http.Transport{
+			MaxIdleConnsPerHost: -1,
 			TLSClientConfig: &tls.Config{
 				Certificates: []tls.Certificate{clientCert},
 				RootCAs:      clientCertPool,
@@ -46,7 +47,8 @@ func operationalClients(tlsDir string) (authClient, unauthClient *http.Client) {
 	}
 	unauthenticatedClient := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{RootCAs: clientCertPool},
+			MaxIdleConnsPerHost: -1,
+			TLSClientConfig:     &tls.Config{RootCAs: clientCertPool},
 		},
 	}
 


### PR DESCRIPTION
No need to maintain a connection pool in a client we're simply throwing away to the garbage collector.