### PR TITLE
Fix bug in snapshot request submission

### DIFF
--- a/integration/discovery/discovery_test.go
+++ b/integration/discovery/discovery_test.go
@@ -153,12 +153,13 @@ var _ = Describe("DiscoveryService", func() {
 
 	It("discovers network configuration, endorsers, and peer membership", func() {
 		By("Updating anchor peers")
+		initialHeight := nwo.GetLedgerHeight(network, org1Peer0, "testchannel")
 		network.UpdateChannelAnchors(orderer, "testchannel")
-
+		// wait for anchor peer config updates to be committed
+		nwo.WaitUntilEqualLedgerHeight(network, "testchannel", initialHeight+2, org1Peer0)
 		//
 		// bootstrapping a peer from snapshot
 		//
-
 		By("generating a snapshot at current block number on org1Peer0")
 		blockNum := nwo.GetLedgerHeight(network, org1Peer0, "testchannel") - 1
 		submitSnapshotRequest(network, "testchannel", 0, org1Peer0, "Snapshot request submitted successfully")

--- a/release_notes/v2.4.0.md
+++ b/release_notes/v2.4.0.md
@@ -13,6 +13,13 @@ These changes keep the fixed-width columns together at the left
 and add a visual break between the logging module name and log message text.
 
 
+Fixes
+------------
+**FAB-18424: peer - Ledger snapshot request submission with special value "blockNumber 0"**
+
+If a ledger snapshot request is submitted with the special value "blockNumber 0", peer is expected to translate the request to last committed block. This patch fixes the issue where, it may happen sometimes that the request is transtlated to block number 1 instead of last committed block. This leads to the situation where no snapshot gets generated, including any future snapshot requests. If you have ever used this special value, we encourage you to check the list of pending snapshots requests. If you notice one or more pending requests that are for the the block numbers lower than the latest committed block, cancel such requests to enable the further snapshot requests to be processed.
+
+
 Dependencies
 ------------
 Fabric v2.4.0 has been tested with the following dependencies:


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- Bug fix

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details
- When the snapshot request is sent with the special value "blockNumber 0", if a block commit is in progress, the derived value should be one higher than the last committed block (i.e., equal to the currently processing block). Instead in the code, it was a typo that made it always set to 1.

- Add a wait in the discovery integration test for channel config updates to be committed

#### Related issues
[FAB-18424](https://jira.hyperledger.org/browse/FAB-18424)