### PR TITLE
[FAB-18427] Report correct reason of stream abort in orderer cluster

### DIFF
--- a/orderer/common/cluster/comm.go
+++ b/orderer/common/cluster/comm.go
@@ -555,7 +555,13 @@ func (stream *Stream) sendMessage(request *orderer.StepRequest) {
 }
 
 func (stream *Stream) serviceStream() {
-	defer stream.Cancel(errAborted)
+	streamStartTime := time.Now()
+	defer func() {
+		stream.Logger.Debugf("Stream %d to (%s) terminating at total lifetime of %s",
+			stream.ID, stream.Endpoint, time.Since(streamStartTime))
+
+		stream.Cancel(errAborted)
+	}()
 
 	for {
 		select {

--- a/orderer/common/cluster/comm_test.go
+++ b/orderer/common/cluster/comm_test.go
@@ -522,6 +522,55 @@ func TestUnavailableHosts(t *testing.T) {
 	require.Contains(t, err.Error(), "connection")
 }
 
+func TestStreamAbortReportCorrectError(t *testing.T) {
+	// Scenario: node 1 acquires a stream to node 2 and then the stream
+	// encounters an error and as a result, the stream is aborted.
+	// We ensure the error reported is the first error, even after
+	// multiple attempts of using it.
+
+	node1 := newTestNode(t)
+	defer node1.stop()
+
+	node2 := newTestNode(t)
+	defer node2.stop()
+
+	node1.c.Configure(testChannel, []cluster.RemoteNode{node2.nodeInfo})
+	node2.c.Configure(testChannel, []cluster.RemoteNode{node1.nodeInfo})
+
+	node2.handler.On("OnSubmit", testChannel, node1.nodeInfo.ID, mock.Anything).Return(errors.Errorf("whoops")).Once()
+
+	rm1, err := node1.c.Remote(testChannel, node2.nodeInfo.ID)
+	require.NoError(t, err)
+	var streamTerminated sync.WaitGroup
+	streamTerminated.Add(1)
+
+	stream := assertEventualEstablishStream(t, rm1)
+
+	l, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	stream.Logger = flogging.NewFabricLogger(l, zap.Hooks(func(entry zapcore.Entry) error {
+		if strings.Contains(entry.Message, "Stream 1 to") && strings.Contains(entry.Message, "terminated") {
+			streamTerminated.Done()
+		}
+		return nil
+	}))
+
+	// Probe the stream for the first time
+	err = stream.Send(wrapSubmitReq(testReq))
+	require.NoError(t, err)
+
+	// We should receive back the crafted error
+	_, err = stream.Recv()
+	require.Contains(t, err.Error(), "whoops")
+
+	// Wait for the stream to be terminated from within the communication infrastructure
+	streamTerminated.Wait()
+
+	// We should still receive the original crafted error despite the stream being terminated
+	err = stream.Send(wrapSubmitReq(testReq))
+	require.Contains(t, err.Error(), "whoops")
+}
+
 func TestStreamAbort(t *testing.T) {
 	// Scenarios: node 1 is connected to node 2 in 2 channels,
 	// and the consumer of the communication calls receive.


### PR DESCRIPTION
This PR fixes a bug that makes the cluster communication infrastructure
always report an "aborted" reason after a stream terminates.

The reason for the bug is that the serviceStream() method was always
overriding the real reason the stream was terminated, with the same "aborted" reason.

Moving the stream termination reason to reside inside the sync.Once block along with
the rest of the termination logic solved this bug.

This PR also contains a commit that adds a log for the stream termination and its lifetime duration, that is useful on its own, but is also used in the test of the second commit.