### PR TITLE
Fix bug in snapshot request submission

### DIFF
--- a/core/ledger/kvledger/snapshot_mgmt.go
+++ b/core/ledger/kvledger/snapshot_mgmt.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package kvledger
 
 import (
+	"fmt"
 	"math"
 	"os"
 	"sync"
@@ -48,6 +49,11 @@ type event struct {
 	typ         eventType
 	blockNumber uint64
 }
+
+func (e *event) String() string {
+	return fmt.Sprintf("{type=%s, blockNumber=%d}", e.typ, e.blockNumber)
+}
+
 type requestResponse struct {
 	err error
 }
@@ -105,7 +111,11 @@ func (l *kvLedger) processSnapshotMgmtEvents(lastCommittedBlockNumber uint64) {
 
 	for {
 		e := <-events
-		logger.Debugw("Event received", "channelID", l.ledgerID, "type", e.typ, "blockNumber", e.blockNumber, "snapshotInProgress=", snapshotInProgress)
+		logger.Debugw("Event received",
+			"channelID", l.ledgerID, "event", e, "snapshotInProgress", snapshotInProgress,
+			"lastCommittedBlockNumber", lastCommittedBlockNumber, "committerStatus", committerStatus,
+		)
+
 		switch e.typ {
 		case commitStart:
 			committerStatus = blocked
@@ -149,7 +159,7 @@ func (l *kvLedger) processSnapshotMgmtEvents(lastCommittedBlockNumber uint64) {
 		case requestAdd:
 			leastAcceptableBlockNum := lastCommittedBlockNumber
 			if committerStatus != idle {
-				leastAcceptableBlockNum = +1
+				leastAcceptableBlockNum++
 			}
 
 			requestedBlockNum := e.blockNumber

--- a/integration/discovery/discovery_test.go
+++ b/integration/discovery/discovery_test.go
@@ -153,12 +153,13 @@ var _ = Describe("DiscoveryService", func() {
 
 	It("discovers network configuration, endorsers, and peer membership", func() {
 		By("Updating anchor peers")
+		initialHeight := nwo.GetLedgerHeight(network, org1Peer0, "testchannel")
 		network.UpdateChannelAnchors(orderer, "testchannel")
-
+		// wait for anchor peer config updates to be committed
+		nwo.WaitUntilEqualLedgerHeight(network, "testchannel", initialHeight+2, org1Peer0)
 		//
 		// bootstrapping a peer from snapshot
 		//
-
 		By("generating a snapshot at current block number on org1Peer0")
 		blockNum := nwo.GetLedgerHeight(network, org1Peer0, "testchannel") - 1
 		submitSnapshotRequest(network, "testchannel", 0, org1Peer0, "Snapshot request submitted successfully")

--- a/release_notes/v2.3.1.md
+++ b/release_notes/v2.3.1.md
@@ -25,6 +25,12 @@ these cases the peer will need to be replaced with a new peer that re-joins from
 If using regular channel data only and not private data, the empty byte array will not
 have been committed, and therefore no action is required on the peer beyond applying the fix.
 
+
+**FAB-18424: peer - Ledger snapshot request submission with special value "blockNumber 0"**
+
+If a ledger snapshot request is submitted with the special value "blockNumber 0", peer is expected to translate the request to last committed block. This patch fixes the issue where, it may happen sometimes that the request is transtlated to block number 1 instead of last committed block. This leads to the situation where no snapshot gets generated, including any future snapshot requests. If you have ever used this special value, we encourage you to check the list of pending snapshots requests. If you notice one or more pending requests that are for the the block numbers lower than the latest committed block, cancel such requests to enable the further snapshot requests to be processed.
+
+
 **orderer - incorrect osnadmin flag --channel-id**
 
 The osnadmin CLI introduced in v2.3.0 used an incorrect flag --channel-id.


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- Bug fix

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details
- cherry-picked commit 44abc6b26d964eab9adf83d17a58e4ceb96ed39c
- When the snapshot request is sent with the special value "blockNumber 0", if a block commit is in progress, the derived value should be one higher than the last committed block (i.e., equal to the currently processing block). Instead in the code, it was a typo that made it always set to 1.

- Add a wait in the discovery integration test for channel config updates to be committed

#### Related issues
[FAB-18424](https://jira.hyperledger.org/browse/FAB-18424)