### PR TITLE
Prepare for next release v2.3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@
 #   - verify - runs unit tests for only the changed package tree
 
 ALPINE_VER ?= 3.12
-BASE_VERSION = 2.3.1
+BASE_VERSION = 2.3.2
 
 # 3rd party image version
 # These versions are also set in the runners in ./integration/runners/

--- a/release_notes/v2.3.2.md
+++ b/release_notes/v2.3.2.md
@@ -1,41 +1,28 @@
-v2.3.1 Wednesday, February 3, 2021
-==================================
+v2.3.2 <RELEASE DATE TBD>
+=========================
 
 Fixes
 -----
 
-**peer - incorrect handling of values set to empty byte array in node chaincode**
+**FAB-18424: peer - Ledger snapshot request submission with special value "blockNumber 0"**
 
-Peer should handle key values set to nil or empty byte arrays as a delete of the key.
-While the behavior worked as expected when using Go chaincode and Java chaincode,
-if using node chaincode it did not work correctly when setting key values to empty byte arrays.
-This fix ensures that peer will interpret empty byte arrays as deletes even for node chaincodes.
-If using node chaincode with private data, if you had set private data values to an empty
-byte array, the private data hash would have been committed incorrectly to the state database.
-To repair the state database, after applying the fix, with the peer stopped, request that
-the state database be rebuilt by calling "peer node rebuild-dbs" or by deleting the state database.
-Upon the next start, the peer will rebuild the state database from the already processed block store.
-If subsequent transactions had referenced the existence of such a private data hash by calling
-GetPrivateDataHash, then the subsequent transactions may have been processed incorrectly and
-the peer will need to additionally reprocess blocks, which can be triggered by calling
-"peer node reset" instead of "peer node rebuild-dbs".
-If the peer joined channels from a snapshot, "peer node rebuild-dbs" and "peer node reset"
-are not available since the peer does not have all blocks since the genesis block. In
-these cases the peer will need to be replaced with a new peer that re-joins from the snapshots.
-If using regular channel data only and not private data, the empty byte array will not
-have been committed, and therefore no action is required on the peer beyond applying the fix.
+If a ledger snapshot request is submitted with the special value "blockNumber 0",
+peer is expected to translate the request to last committed block. This patch fixes
+an issue where the request may be translated to block number 1 instead of last committed block.
+This leads to the situation where no snapshot gets generated, including any future snapshot requests.
+If you have used this special value on a snapshot request to a peer, check the list of pending snapshots
+requests by using "peer snapshot listpending" command. If you notice one or more pending
+requests that are for the the block numbers lower than the latest committed block,
+cancel such requests with "peer snapshot cancelrequest" command to enable subsequent snapshot
+requests to be processed.
 
-**orderer - incorrect osnadmin flag --channel-id**
-
-The osnadmin CLI introduced in v2.3.0 used an incorrect flag --channel-id.
-The flag has been corrected to be --channelID in order to be consistent
-with other CLIs.
+<ADD OTHER FIX NOTES HERE UP UNTIL RELEASE DATE>
 
 
 Dependencies
 ------------
-Fabric v2.3.1 has been tested with the following dependencies:
-* Go 1.14.12
+Fabric v2.3.2 has been tested with the following dependencies:
+* Go 1.15.7
 * CouchDB v3.1.1
 
 


### PR DESCRIPTION
Update Makefile and release notes in preparation for future release of v2.3.2.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
