### PR TITLE
Add Alpine Version to Tools Image

### DIFF
--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -21,7 +21,7 @@ FROM golang as tools
 ARG GO_TAGS
 RUN make configtxgen configtxlator cryptogen peer discover osnadmin idemixgen GO_TAGS=${GO_TAGS}
 
-FROM golang:${GO_VER}-alpine
+FROM golang:${GO_VER}-alpine${ALPINE_VER}
 # git is required to support `go list -m`
 RUN apk add --no-cache \
 	bash \


### PR DESCRIPTION
`ALPINE_VERSION` was removed for both the intermediate layer and the final layer, a previous commit added it back to the intermediate layer but missed adding it back to the final layer.

Signed-off-by: Brett Logan <lindluni@github.com>
