### PR TITLE
Add methods to obtain grpc.ClientConn instances configured to connect to an orderer or peer

### DIFF
--- a/integration/lifecycle/interop_test.go
+++ b/integration/lifecycle/interop_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Release interoperability", func() {
 		RunQueryInvokeQuery(network, orderer, "mycc", 90, endorsers...)
 
 		By("restarting the network from persistence")
-		RestartNetwork(&process, network)
+		process = RestartNetwork(process, network)
 
 		By("ensuring that the chaincode is still operational after the upgrade and restart")
 		RunQueryInvokeQuery(network, orderer, "mycc", 80, endorsers...)
@@ -127,7 +127,7 @@ var _ = Describe("Release interoperability", func() {
 		RunQueryInvokeQuery(network, orderer, "mycc", 70, endorsers[0])
 
 		By("restarting the network from persistence")
-		RestartNetwork(&process, network)
+		process = RestartNetwork(process, network)
 
 		By("querying/invoking/querying the chaincode with the new definition again")
 		RunQueryInvokeQuery(network, orderer, "mycc", 60, endorsers[1])

--- a/integration/lifecycle/lifecycle_suite_test.go
+++ b/integration/lifecycle/lifecycle_suite_test.go
@@ -113,12 +113,13 @@ func RunQueryInvokeQuery(n *nwo.Network, orderer *nwo.Orderer, chaincodeName str
 	ExpectWithOffset(1, sess).To(gbytes.Say(fmt.Sprint(initialQueryResult - 10)))
 }
 
-func RestartNetwork(process *ifrit.Process, network *nwo.Network) {
-	(*process).Signal(syscall.SIGTERM)
-	Eventually((*process).Wait(), network.EventuallyTimeout).Should(Receive())
+func RestartNetwork(process ifrit.Process, network *nwo.Network) ifrit.Process {
+	process.Signal(syscall.SIGTERM)
+	Eventually(process.Wait(), network.EventuallyTimeout).Should(Receive())
 	networkRunner := network.NetworkGroupRunner()
-	*process = ifrit.Invoke(networkRunner)
-	Eventually((*process).Ready(), network.EventuallyTimeout).Should(BeClosed())
+	process = ifrit.Invoke(networkRunner)
+	Eventually(process.Ready(), network.EventuallyTimeout).Should(BeClosed())
+	return process
 }
 
 func SignedProposal(channel, chaincode string, signer *nwo.SigningIdentity, args ...string) (*pb.SignedProposal, *pb.Proposal, string) {


### PR DESCRIPTION
Add methods to the network to create gRPC client connections to the orderer and peer processes that do no rely on internal packages. This also moves common functionality to the network.