### PR TITLE
Add tools target for the tools docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,9 @@ protos: gotool.protoc-gen-go
 .PHONY: native
 native: $(RELEASE_EXES)
 
+.PHONY: tools
+tools: $(TOOLS_EXES)
+
 .PHONY: $(RELEASE_EXES)
 $(RELEASE_EXES): %: $(BUILD_DIR)/bin/%
 
@@ -227,11 +230,11 @@ docker: $(RELEASE_IMAGES:%=%-docker)
 .PHONY: $(RELEASE_IMAGES:%=%-docker)
 $(RELEASE_IMAGES:%=%-docker): %-docker: $(BUILD_DIR)/images/%/$(DUMMY)
 
-$(BUILD_DIR)/images/ccenv/$(DUMMY):   BUILD_CONTEXT=images/ccenv
 $(BUILD_DIR)/images/baseos/$(DUMMY):  BUILD_CONTEXT=images/baseos
+$(BUILD_DIR)/images/ccenv/$(DUMMY):   BUILD_CONTEXT=images/ccenv
 $(BUILD_DIR)/images/peer/$(DUMMY):    BUILD_ARGS=--build-arg GO_TAGS=${GO_TAGS}
 $(BUILD_DIR)/images/orderer/$(DUMMY): BUILD_ARGS=--build-arg GO_TAGS=${GO_TAGS}
-$(BUILD_DIR)/images/tools/$(DUMMY): BUILD_ARGS=--build-arg GO_TAGS=${GO_TAGS}
+$(BUILD_DIR)/images/tools/$(DUMMY):   BUILD_ARGS=--build-arg GO_TAGS=${GO_TAGS}
 
 $(BUILD_DIR)/images/%/$(DUMMY):
 	@echo "Building Docker image $(DOCKER_NS)/fabric-$*"

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR $GOPATH/src/github.com/hyperledger/fabric
 
 FROM golang as tools
 ARG GO_TAGS
-RUN make configtxgen configtxlator cryptogen peer discover osnadmin idemixgen GO_TAGS=${GO_TAGS}
+RUN make tools GO_TAGS=${GO_TAGS}
 
 FROM golang:${GO_VER}-alpine${ALPINE_VER}
 # git is required to support `go list -m`


### PR DESCRIPTION
FAB-16348:

Today the fabric tools Dockerfile calls `RUN make configtxgen configtxlator cryptogen peer discover idemixgen`. This should be changed to point to a make target that encapsulates all of these items so we don't have to make changes in multiple places in the future.