### PR TITLE
Remove gossipSupport from the peer package

### DIFF
--- a/discovery/support/gossip/support_test.go
+++ b/discovery/support/gossip/support_test.go
@@ -9,8 +9,8 @@ package gossip_test
 import (
 	"testing"
 
-	"github.com/hyperledger/fabric-protos-go/gossip"
-	gossipSupport "github.com/hyperledger/fabric/discovery/support/gossip"
+	gp "github.com/hyperledger/fabric-protos-go/gossip"
+	"github.com/hyperledger/fabric/discovery/support/gossip"
 	"github.com/hyperledger/fabric/discovery/support/gossip/mocks"
 	"github.com/hyperledger/fabric/gossip/common"
 	"github.com/hyperledger/fabric/gossip/discovery"
@@ -20,16 +20,16 @@ import (
 
 func TestChannelExists(t *testing.T) {
 	g := &mocks.Gossip{}
-	sup := gossipSupport.NewDiscoverySupport(g)
+	sup := gossip.NewDiscoverySupport(g)
 	require.False(t, sup.ChannelExists(""))
 }
 
 func TestPeers(t *testing.T) {
 	g := &mocks.Gossip{}
-	sup := gossipSupport.NewDiscoverySupport(g)
-	p1Envelope := &gossip.Envelope{
+	sup := gossip.NewDiscoverySupport(g)
+	p1Envelope := &gp.Envelope{
 		Payload: []byte{4, 5, 6},
-		SecretEnvelope: &gossip.SecretEnvelope{
+		SecretEnvelope: &gp.SecretEnvelope{
 			Payload: []byte{1, 2, 3},
 		},
 	}
@@ -39,7 +39,7 @@ func TestPeers(t *testing.T) {
 	}
 	g.PeersReturnsOnCall(0, peers)
 	g.SelfMembershipInfoReturnsOnCall(0, discovery.NetworkMember{PKIid: common.PKIidType("p0"), Endpoint: "p0"})
-	p1ExpectedEnvelope := &gossip.Envelope{
+	p1ExpectedEnvelope := &gp.Envelope{
 		Payload: []byte{4, 5, 6},
 	}
 	expected := discovery.Members{{PKIid: common.PKIidType("p1"), Endpoint: "p1", Envelope: p1ExpectedEnvelope}, {PKIid: common.PKIidType("p0"), Endpoint: "p0"}}
@@ -48,9 +48,9 @@ func TestPeers(t *testing.T) {
 }
 
 func TestPeersOfChannel(t *testing.T) {
-	stateInfo := &gossip.GossipMessage{
-		Content: &gossip.GossipMessage_StateInfo{
-			StateInfo: &gossip.StateInfo{
+	stateInfo := &gp.GossipMessage{
+		Content: &gp.GossipMessage_StateInfo{
+			StateInfo: &gp.StateInfo{
 				PkiId: common.PKIidType("px"),
 			},
 		},
@@ -60,7 +60,7 @@ func TestPeersOfChannel(t *testing.T) {
 	g.SelfChannelInfoReturnsOnCall(0, nil)
 	g.SelfChannelInfoReturnsOnCall(1, sMsg)
 	g.PeersOfChannelReturnsOnCall(0, []discovery.NetworkMember{{PKIid: common.PKIidType("p1")}, {PKIid: common.PKIidType("p2")}})
-	sup := gossipSupport.NewDiscoverySupport(g)
+	sup := gossip.NewDiscoverySupport(g)
 	require.Empty(t, sup.PeersOfChannel(common.ChannelID("")))
 	expected := discovery.Members{{PKIid: common.PKIidType("p1")}, {PKIid: common.PKIidType("p2")}, {PKIid: common.PKIidType("px"), Envelope: sMsg.Envelope}}
 	require.Equal(t, expected, sup.PeersOfChannel(common.ChannelID("")))

--- a/gossip/service/gossip_service.go
+++ b/gossip/service/gossip_service.go
@@ -433,16 +433,16 @@ func (g *GossipService) createSelfSignedData() protoutil.SignedData {
 }
 
 // updateAnchors constructs a joinChannelMessage and sends it to the gossipSvc
-func (g *GossipService) updateAnchors(config Config) {
+func (g *GossipService) updateAnchors(configUpdate ConfigUpdate) {
 	myOrg := string(g.secAdv.OrgByPeerIdentity(api.PeerIdentityType(g.peerIdentity)))
-	if !g.amIinChannel(myOrg, config) {
-		logger.Error("Tried joining channel", config.ChannelID(), "but our org(", myOrg, "), isn't "+
-			"among the orgs of the channel:", orgListFromConfig(config), ", aborting.")
+	if !g.amIinChannel(myOrg, configUpdate) {
+		logger.Error("Tried joining channel", configUpdate.ChannelID, "but our org(", myOrg, "), isn't "+
+			"among the orgs of the channel:", orgListFromConfigUpdate(configUpdate), ", aborting.")
 		return
 	}
-	jcm := &joinChannelMessage{seqNum: config.Sequence(), members2AnchorPeers: map[string][]api.AnchorPeer{}}
+	jcm := &joinChannelMessage{seqNum: configUpdate.Sequence, members2AnchorPeers: map[string][]api.AnchorPeer{}}
 	anchorPeerEndpoints := map[string]struct{}{}
-	for _, appOrg := range config.Organizations() {
+	for _, appOrg := range configUpdate.Organizations {
 		logger.Debug(appOrg.MSPID(), "anchor peers:", appOrg.AnchorPeers())
 		jcm.members2AnchorPeers[appOrg.MSPID()] = []api.AnchorPeer{}
 		for _, ap := range appOrg.AnchorPeers() {
@@ -454,11 +454,11 @@ func (g *GossipService) updateAnchors(config Config) {
 			anchorPeerEndpoints[fmt.Sprintf("%s:%d", ap.Host, ap.Port)] = struct{}{}
 		}
 	}
-	g.anchorPeerTracker.update(config.ChannelID(), anchorPeerEndpoints)
+	g.anchorPeerTracker.update(configUpdate.ChannelID, anchorPeerEndpoints)
 
 	// Initialize new state provider for given committer
-	logger.Debug("Creating state provider for channelID", config.ChannelID())
-	g.JoinChan(jcm, common.ChannelID(config.ChannelID()))
+	logger.Debug("Creating state provider for channelID", configUpdate.ChannelID)
+	g.JoinChan(jcm, common.ChannelID(configUpdate.ChannelID))
 }
 
 // AddPayload appends message payload to for given chain
@@ -502,8 +502,8 @@ func (g *GossipService) newLeaderElectionComponent(channelID string, callback fu
 	return election.NewLeaderElectionService(adapter, string(PKIid), callback, config)
 }
 
-func (g *GossipService) amIinChannel(myOrg string, config Config) bool {
-	for _, orgName := range orgListFromConfig(config) {
+func (g *GossipService) amIinChannel(myOrg string, configUpdate ConfigUpdate) bool {
+	for _, orgName := range orgListFromConfigUpdate(configUpdate) {
 		if orgName == myOrg {
 			return true
 		}
@@ -533,9 +533,9 @@ func (g *GossipService) onStatusChangeFactory(channelID string, committer blocks
 	}
 }
 
-func orgListFromConfig(config Config) []string {
+func orgListFromConfigUpdate(config ConfigUpdate) []string {
 	var orgList []string
-	for _, appOrg := range config.Organizations() {
+	for _, appOrg := range config.Organizations {
 		orgList = append(orgList, appOrg.MSPID())
 	}
 	return orgList

--- a/gossip/service/gossip_service_test.go
+++ b/gossip/service/gossip_service_test.go
@@ -954,9 +954,11 @@ func TestChannelConfig(t *testing.T) {
 
 	require.Equal(t, uint64(1), jcm.SequenceNumber())
 
-	mc := &mockConfig{
-		sequence: 1,
-		orgs: map[string]channelconfig.ApplicationOrg{
+	cu := ConfigUpdate{
+		Sequence:         1,
+		ChannelID:        "channel-id",
+		OrdererAddresses: []string{"localhost:7050"},
+		Organizations: map[string]channelconfig.ApplicationOrg{
 			string(orgInChannelA): &appGrp{
 				mspID:       string(orgInChannelA),
 				anchorPeers: []*peer.AnchorPeer{{Host: "localhost", Port: 2001}},
@@ -966,8 +968,8 @@ func TestChannelConfig(t *testing.T) {
 	gService.JoinChan(jcm, gossipcommon.ChannelID("A"))
 	// use mock secAdv so that gService.secAdv.OrgByPeerIdentity can return the matched identity
 	gService.secAdv = &secAdvMock{}
-	gService.updateAnchors(mc)
-	require.True(t, gService.amIinChannel(string(orgInChannelA), mc))
+	gService.updateAnchors(cu)
+	require.True(t, gService.amIinChannel(string(orgInChannelA), cu))
 	require.True(t, gService.anchorPeerTracker.IsAnchorPeer("localhost:2001"))
 	require.False(t, gService.anchorPeerTracker.IsAnchorPeer("localhost:5000"))
 }


### PR DESCRIPTION
Replace the "gossipSupport" object used to expose configuration through the `Config` interface with a simple `ConfigUpdate` value object. The interface is not necessary to access static data from a configuration update.

FAB-15576