### PR TITLE
Replace WaitGroups with channels and timeouts

### DIFF
--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -1222,7 +1222,7 @@ func (n *Network) Discover(command Command) (*gexec.Session, error) {
 	return n.StartSession(cmd, command.SessionName())
 }
 
-// OSNAdmin starts a gexec.Session for the provided osnadmin command.
+// Osnadmin starts a gexec.Session for the provided osnadmin command.
 func (n *Network) Osnadmin(command Command) (*gexec.Session, error) {
 	cmd := NewCommand(n.Components.Osnadmin(), command)
 	return n.StartSession(cmd, command.SessionName())

--- a/scripts/help_docs.sh
+++ b/scripts/help_docs.sh
@@ -69,10 +69,7 @@ generateOrCheck() {
   fi
 }
 
-action="generate"
-if [ "$#" -ge 1 ] && [ "$1" == "check" ]; then
-  action="check"
-fi
+action="${1:-generate}"
 
 commands=("peer version")
 generateOrCheck \


### PR DESCRIPTION
A `sync.WaitGroup` does not have a timeout mechanism. If a test is told to `Wait` on a `WaitGroup` and the required number of `Done` calls never get made, the test will hang until the testing package finally kills it. When that happens, we get some stack traces but we lose a lot of time and a fair bit of information.

After hitting the 20m test time out in common/cluster three times in one week, I decided it's time to add a proper timeout.

This commit switches from a WaitGroup to a channel, a sync.Once, and a select on the channel close and a timeout condition. This should result in test failures instead of termination from the testing package.