### PR TITLE
FABGW-6 Use concurrent go routines for endorsement

### DIFF
--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -273,8 +273,7 @@ func (c *Config) load() error {
 		c.DeliverClientKeepaliveOptions.ClientTimeout = viper.GetDuration("peer.keepalive.deliveryClient.timeout")
 	}
 
-	c.GatewayOptions = gateway.DefaultOptions()
-	c.GatewayOptions.Enabled = viper.GetBool("peer.gateway.enabled")
+	c.GatewayOptions = gateway.GetOptions(viper.GetViper())
 
 	c.VMEndpoint = viper.GetString("vm.endpoint")
 	c.VMDockerTLSEnabled = viper.GetBool("vm.docker.tls.enabled")

--- a/core/peer/config_test.go
+++ b/core/peer/config_test.go
@@ -276,6 +276,7 @@ func TestGlobalConfig(t *testing.T) {
 	viper.Set("peer.chaincodeAddress", "0.0.0.0:7052")
 	viper.Set("peer.validatorPoolSize", 1)
 	viper.Set("peer.gateway.enabled", true)
+	viper.Set("peer.gateway.endorsementTimeout", 10*time.Second)
 
 	viper.Set("vm.endpoint", "unix:///var/run/docker.sock")
 	viper.Set("vm.docker.tls.enabled", false)
@@ -372,7 +373,8 @@ func TestGlobalConfig(t *testing.T) {
 		DockerCA:   filepath.Join(cwd, "test/vm/tls/ca/file"),
 
 		GatewayOptions: gateway.Options{
-			Enabled: true,
+			Enabled:            true,
+			EndorsementTimeout: 10 * time.Second,
 		},
 	}
 
@@ -392,6 +394,7 @@ func TestGlobalConfigDefault(t *testing.T) {
 		ValidatorPoolSize:             runtime.NumCPU(),
 		VMNetworkMode:                 "host",
 		DeliverClientKeepaliveOptions: comm.DefaultKeepaliveOptions,
+		GatewayOptions:                gateway.GetOptions(viper.GetViper()),
 	}
 
 	require.Equal(t, expectedConfig, coreConfig)
@@ -446,6 +449,7 @@ func TestPropagateEnvironment(t *testing.T) {
 				Path:                 "/testPath",
 			},
 		},
+		GatewayOptions: gateway.GetOptions(viper.GetViper()),
 	}
 	require.Equal(t, expectedConfig, coreConfig)
 }

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -825,7 +825,12 @@ func serve(args []string) error {
 			logger.Info("Starting peer with Gateway enabled")
 			gatewayprotos.RegisterGatewayServer(
 				peerServer.Server(),
-				gateway.CreateServer(&gateway.EndorserServerAdapter{Server: serverEndorser}, discoveryService, peerInstance.GossipService.SelfMembershipInfo().Endpoint),
+				gateway.CreateServer(
+					&gateway.EndorserServerAdapter{Server: serverEndorser},
+					discoveryService,
+					peerInstance.GossipService.SelfMembershipInfo().Endpoint,
+					coreConfig.GatewayOptions,
+				),
 			)
 		} else {
 			logger.Warning("Discovery service must be enabled for embedded gateway")

--- a/internal/pkg/gateway/apiutils.go
+++ b/internal/pkg/gateway/apiutils.go
@@ -9,48 +9,10 @@ package gateway
 import (
 	"fmt"
 
-	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/protoutil"
 )
-
-type nilSigner struct {
-	creator []byte
-}
-
-func (s *nilSigner) Sign([]byte) ([]byte, error) {
-	return nil, nil
-}
-
-func (s *nilSigner) Serialize() ([]byte, error) {
-	return s.creator, nil
-}
-
-func createUnsignedTx(
-	proposal *peer.Proposal,
-	resps ...*peer.ProposalResponse,
-) (*common.Envelope, error) {
-	// extract the Creator from the signature header
-	hdr, err := protoutil.UnmarshalHeader(proposal.Header)
-	if err != nil {
-		return nil, err
-	}
-	shdr, err := protoutil.UnmarshalSignatureHeader(hdr.SignatureHeader)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO the creation of this dummy signer containing the serialised creator from the Proposal
-	// is required because protoutil.CreateSignedTx contains a check that they match.
-	// However, there is a comment there about removing that check.  If removed, the code could be
-	// refactored to remove the need for this kludge.
-	dummySigner := &nilSigner{
-		creator: shdr.Creator,
-	}
-
-	return protoutil.CreateSignedTx(proposal, dummySigner, resps...)
-}
 
 func getValueFromResponse(response *peer.ProposalResponse) (*gateway.Result, error) {
 	var retVal []byte

--- a/internal/pkg/gateway/config.go
+++ b/internal/pkg/gateway/config.go
@@ -6,15 +6,33 @@ SPDX-License-Identifier: Apache-2.0
 
 package gateway
 
+import (
+	"time"
+
+	"github.com/spf13/viper"
+)
+
 // GatewayOptions is used to configure the gateway settings
 type Options struct {
 	// GatewayEnabled is used to enable the gateway service
-	Enabled bool
+	Enabled            bool
+	EndorsementTimeout time.Duration
+}
+
+var defaultOptions = Options{
+	Enabled:            false,
+	EndorsementTimeout: 10 * time.Second,
 }
 
 // DefaultOptions gets the default Gateway configuration Options
-func DefaultOptions() Options {
-	return Options{
-		Enabled: false,
+func GetOptions(v *viper.Viper) Options {
+	options := defaultOptions
+	if v.IsSet("peer.gateway.enabled") {
+		options.Enabled = v.GetBool("peer.gateway.enabled")
 	}
+	if v.IsSet("peer.gateway.endorsementTimeout") {
+		options.EndorsementTimeout = v.GetDuration("peer.gateway.endorsementTimeout")
+	}
+
+	return options
 }

--- a/internal/pkg/gateway/config_test.go
+++ b/internal/pkg/gateway/config_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package gateway
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+var testConfig = []byte(`
+peer:
+  gateway:
+    enabled: true
+    endorsementTimeout: 30s
+`)
+
+func TestDefaultOptions(t *testing.T) {
+	v := viper.New()
+	options := GetOptions(v)
+	require.Equal(t, defaultOptions, options)
+}
+
+func TestOverriddenOptions(t *testing.T) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	v.ReadConfig(bytes.NewBuffer(testConfig))
+	options := GetOptions(v)
+
+	expectedOptions := Options{
+		Enabled:            true,
+		EndorsementTimeout: 30 * time.Second,
+	}
+	require.Equal(t, expectedOptions, options)
+}

--- a/internal/pkg/gateway/gateway.go
+++ b/internal/pkg/gateway/gateway.go
@@ -19,6 +19,7 @@ var logger = flogging.MustGetLogger("gateway")
 // Server represents the GRPC server for the Gateway.
 type Server struct {
 	registry *registry
+	options  Options
 }
 
 type EndorserServerAdapter struct {
@@ -30,7 +31,7 @@ func (e *EndorserServerAdapter) ProcessProposal(ctx context.Context, req *peer.S
 }
 
 // CreateServer creates an embedded instance of the Gateway.
-func CreateServer(localEndorser peer.EndorserClient, discovery Discovery, selfEndpoint string) *Server {
+func CreateServer(localEndorser peer.EndorserClient, discovery Discovery, selfEndpoint string, options Options) *Server {
 	gwServer := &Server{
 		registry: &registry{
 			localEndorser:       localEndorser,
@@ -44,6 +45,7 @@ func CreateServer(localEndorser peer.EndorserClient, discovery Discovery, selfEn
 			tlsRootCerts:        map[string][][]byte{},
 			channelsInitialized: map[string]bool{},
 		},
+		options: options,
 	}
 
 	return gwServer


### PR DESCRIPTION
Replace the current sequential logic for getting multiple endorsements with concurrent fan-out/fan-in using go routines
Add configurable endorsement timeout option to the global config and pass through to gateway

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>

