### PR TITLE
Update Docker Publish Script

### DIFF
--- a/ci/scripts/publish_docker.sh
+++ b/ci/scripts/publish_docker.sh
@@ -6,14 +6,13 @@ set -euo pipefail
 
 make docker
 
-wget -qO "$PWD/manifest-tool" https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-amd64
-chmod +x ./manifest-tool
+docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_PASSWORD}"
 
 for image in peer orderer ccenv tools; do
-  docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_PASSWORD}"
-  docker tag "hyperledger/fabric-${image}" "hyperledger/fabric-${image}:amd64-${RELEASE}"
-  docker push "hyperledger/fabric-${image}:amd64-${RELEASE}"
-
-  ./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-${image}:amd64-${RELEASE}" --target "hyperledger/fabric-${image}:${RELEASE}"
-  ./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-${image}:amd64-${RELEASE}" --target "hyperledger/fabric-${image}:$(sed 's/..$//' <<< ${RELEASE})"
+  for release in ${RELEASE} ${TWO_DIGIT_RELEASE}; do
+    docker tag "hyperledger/fabric-${image}" "hyperledger/fabric-${image}:amd64-${release}"
+    docker tag "hyperledger/fabric-${image}" "hyperledger/fabric-${image}:${release}"
+    docker push "hyperledger/fabric-${image}:amd64-${release}"
+    docker push "hyperledger/fabric-${image}:${release}"
+  done
 done


### PR DESCRIPTION
We no longer publish multi-arch images, remove the manifest tool and update the script to properly publish two-digit releases.

Signed-off-by: Brett Logan <lindluni@github.com>
