### PR TITLE
Remove un-needed casts in discovery_impl.go

### DIFF
--- a/gossip/discovery/discovery_impl.go
+++ b/gossip/discovery/discovery_impl.go
@@ -619,8 +619,8 @@ func (d *gossipDiscoveryImpl) resurrectMember(am *protoext.SignedGossipMessage, 
 	}
 
 	delete(d.deadLastTS, string(pkiID))
-	d.deadMembership.Remove(common.PKIidType(pkiID))
-	d.aliveMembership.Put(common.PKIidType(pkiID), &protoext.SignedGossipMessage{GossipMessage: am.GossipMessage, Envelope: am.Envelope})
+	d.deadMembership.Remove(pkiID)
+	d.aliveMembership.Put(pkiID, &protoext.SignedGossipMessage{GossipMessage: am.GossipMessage, Envelope: am.Envelope})
 }
 
 func (d *gossipDiscoveryImpl) periodicalReconnectToDead() {
@@ -797,7 +797,7 @@ func (d *gossipDiscoveryImpl) aliveMsgAndInternalEndpoint() (*proto.GossipMessag
 					PkiId:    pkiID,
 				},
 				Timestamp: &proto.PeerTime{
-					IncNum: uint64(d.incTime),
+					IncNum: d.incTime,
 					SeqNum: seqNum,
 				},
 			},


### PR DESCRIPTION
This commit removes un-needed casts in gossip/discovery/discovery_impl.go

Change-Id: Ib5474b90f381e49e325936f4ed13d51d9cffce66
Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>
