### PR TITLE
Provide commit events from ledger

### DIFF
--- a/core/chaincode/mock/peer_ledger.go
+++ b/core/chaincode/mock/peer_ledger.go
@@ -38,6 +38,19 @@ type PeerLedger struct {
 	commitLegacyReturnsOnCall map[int]struct {
 		result1 error
 	}
+	CommitNotificationsChannelStub        func(<-chan struct{}) (<-chan *ledger.CommitNotification, error)
+	commitNotificationsChannelMutex       sync.RWMutex
+	commitNotificationsChannelArgsForCall []struct {
+		arg1 <-chan struct{}
+	}
+	commitNotificationsChannelReturns struct {
+		result1 <-chan *ledger.CommitNotification
+		result2 error
+	}
+	commitNotificationsChannelReturnsOnCall map[int]struct {
+		result1 <-chan *ledger.CommitNotification
+		result2 error
+	}
 	CommitPvtDataOfOldBlocksStub        func([]*ledger.ReconciledPvtdata, ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error)
 	commitPvtDataOfOldBlocksMutex       sync.RWMutex
 	commitPvtDataOfOldBlocksArgsForCall []struct {
@@ -426,6 +439,69 @@ func (fake *PeerLedger) CommitLegacyReturnsOnCall(i int, result1 error) {
 	fake.commitLegacyReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *PeerLedger) CommitNotificationsChannel(arg1 <-chan struct{}) (<-chan *ledger.CommitNotification, error) {
+	fake.commitNotificationsChannelMutex.Lock()
+	ret, specificReturn := fake.commitNotificationsChannelReturnsOnCall[len(fake.commitNotificationsChannelArgsForCall)]
+	fake.commitNotificationsChannelArgsForCall = append(fake.commitNotificationsChannelArgsForCall, struct {
+		arg1 <-chan struct{}
+	}{arg1})
+	fake.recordInvocation("CommitNotificationsChannel", []interface{}{arg1})
+	fake.commitNotificationsChannelMutex.Unlock()
+	if fake.CommitNotificationsChannelStub != nil {
+		return fake.CommitNotificationsChannelStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.commitNotificationsChannelReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelCallCount() int {
+	fake.commitNotificationsChannelMutex.RLock()
+	defer fake.commitNotificationsChannelMutex.RUnlock()
+	return len(fake.commitNotificationsChannelArgsForCall)
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelCalls(stub func(<-chan struct{}) (<-chan *ledger.CommitNotification, error)) {
+	fake.commitNotificationsChannelMutex.Lock()
+	defer fake.commitNotificationsChannelMutex.Unlock()
+	fake.CommitNotificationsChannelStub = stub
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelArgsForCall(i int) <-chan struct{} {
+	fake.commitNotificationsChannelMutex.RLock()
+	defer fake.commitNotificationsChannelMutex.RUnlock()
+	argsForCall := fake.commitNotificationsChannelArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelReturns(result1 <-chan *ledger.CommitNotification, result2 error) {
+	fake.commitNotificationsChannelMutex.Lock()
+	defer fake.commitNotificationsChannelMutex.Unlock()
+	fake.CommitNotificationsChannelStub = nil
+	fake.commitNotificationsChannelReturns = struct {
+		result1 <-chan *ledger.CommitNotification
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelReturnsOnCall(i int, result1 <-chan *ledger.CommitNotification, result2 error) {
+	fake.commitNotificationsChannelMutex.Lock()
+	defer fake.commitNotificationsChannelMutex.Unlock()
+	fake.CommitNotificationsChannelStub = nil
+	if fake.commitNotificationsChannelReturnsOnCall == nil {
+		fake.commitNotificationsChannelReturnsOnCall = make(map[int]struct {
+			result1 <-chan *ledger.CommitNotification
+			result2 error
+		})
+	}
+	fake.commitNotificationsChannelReturnsOnCall[i] = struct {
+		result1 <-chan *ledger.CommitNotification
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *PeerLedger) CommitPvtDataOfOldBlocks(arg1 []*ledger.ReconciledPvtdata, arg2 ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error) {
@@ -1596,6 +1672,8 @@ func (fake *PeerLedger) Invocations() map[string][][]interface{} {
 	defer fake.closeMutex.RUnlock()
 	fake.commitLegacyMutex.RLock()
 	defer fake.commitLegacyMutex.RUnlock()
+	fake.commitNotificationsChannelMutex.RLock()
+	defer fake.commitNotificationsChannelMutex.RUnlock()
 	fake.commitPvtDataOfOldBlocksMutex.RLock()
 	defer fake.commitPvtDataOfOldBlocksMutex.RUnlock()
 	fake.doesPvtDataInfoExistMutex.RLock()

--- a/core/committer/txvalidator/v14/validator_test.go
+++ b/core/committer/txvalidator/v14/validator_test.go
@@ -1544,6 +1544,10 @@ func (m *mockLedger) CancelSnapshotRequest(height uint64) error {
 	return nil
 }
 
+func (m *mockLedger) CommitNotificationsChannel(done <-chan struct{}) (<-chan *ledger.CommitNotification, error) {
+	return nil, nil
+}
+
 // mockQueryExecutor mock of the query executor,
 // needed to simulate inability to access state db, e.g.
 // the case where due to db failure it's not possible to

--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -887,6 +887,16 @@ func (l *kvLedger) GetMissingPvtDataTracker() (ledger.MissingPvtDataTracker, err
 	return l, nil
 }
 
+// CommitNotificationsChannel returns a read-only channel on which ledger sends a `CommitNotification`
+// when a block is committed. The CommitNotification contains entries for the transactions from the committed block,
+// which are not malformed, carry a legitimate TxID, and in addition, are not marked as a duplicate transaction.
+// The consumer can close the 'done' channel to signal that the notifications are no longer needed. This will cause the
+// CommitNotifications channel to close. There is expected to be only one consumer at a time. The function returns error
+// if already a CommitNotification channel is active.
+func (l *kvLedger) CommitNotificationsChannel(done <-chan struct{}) (<-chan *ledger.CommitNotification, error) {
+	return nil, errors.New("yet-to-implement")
+}
+
 // Close closes `KVLedger`.
 // Currently this function is only used by test code. The caller should make sure no in-progress commit
 // or snapshot generation before calling this function. Otherwise, the ledger may have unknown behavior

--- a/core/peer/mock/peer_ledger.go
+++ b/core/peer/mock/peer_ledger.go
@@ -38,6 +38,19 @@ type PeerLedger struct {
 	commitLegacyReturnsOnCall map[int]struct {
 		result1 error
 	}
+	CommitNotificationsChannelStub        func(<-chan struct{}) (<-chan *ledger.CommitNotification, error)
+	commitNotificationsChannelMutex       sync.RWMutex
+	commitNotificationsChannelArgsForCall []struct {
+		arg1 <-chan struct{}
+	}
+	commitNotificationsChannelReturns struct {
+		result1 <-chan *ledger.CommitNotification
+		result2 error
+	}
+	commitNotificationsChannelReturnsOnCall map[int]struct {
+		result1 <-chan *ledger.CommitNotification
+		result2 error
+	}
 	CommitPvtDataOfOldBlocksStub        func([]*ledger.ReconciledPvtdata, ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error)
 	commitPvtDataOfOldBlocksMutex       sync.RWMutex
 	commitPvtDataOfOldBlocksArgsForCall []struct {
@@ -426,6 +439,69 @@ func (fake *PeerLedger) CommitLegacyReturnsOnCall(i int, result1 error) {
 	fake.commitLegacyReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *PeerLedger) CommitNotificationsChannel(arg1 <-chan struct{}) (<-chan *ledger.CommitNotification, error) {
+	fake.commitNotificationsChannelMutex.Lock()
+	ret, specificReturn := fake.commitNotificationsChannelReturnsOnCall[len(fake.commitNotificationsChannelArgsForCall)]
+	fake.commitNotificationsChannelArgsForCall = append(fake.commitNotificationsChannelArgsForCall, struct {
+		arg1 <-chan struct{}
+	}{arg1})
+	fake.recordInvocation("CommitNotificationsChannel", []interface{}{arg1})
+	fake.commitNotificationsChannelMutex.Unlock()
+	if fake.CommitNotificationsChannelStub != nil {
+		return fake.CommitNotificationsChannelStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.commitNotificationsChannelReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelCallCount() int {
+	fake.commitNotificationsChannelMutex.RLock()
+	defer fake.commitNotificationsChannelMutex.RUnlock()
+	return len(fake.commitNotificationsChannelArgsForCall)
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelCalls(stub func(<-chan struct{}) (<-chan *ledger.CommitNotification, error)) {
+	fake.commitNotificationsChannelMutex.Lock()
+	defer fake.commitNotificationsChannelMutex.Unlock()
+	fake.CommitNotificationsChannelStub = stub
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelArgsForCall(i int) <-chan struct{} {
+	fake.commitNotificationsChannelMutex.RLock()
+	defer fake.commitNotificationsChannelMutex.RUnlock()
+	argsForCall := fake.commitNotificationsChannelArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelReturns(result1 <-chan *ledger.CommitNotification, result2 error) {
+	fake.commitNotificationsChannelMutex.Lock()
+	defer fake.commitNotificationsChannelMutex.Unlock()
+	fake.CommitNotificationsChannelStub = nil
+	fake.commitNotificationsChannelReturns = struct {
+		result1 <-chan *ledger.CommitNotification
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelReturnsOnCall(i int, result1 <-chan *ledger.CommitNotification, result2 error) {
+	fake.commitNotificationsChannelMutex.Lock()
+	defer fake.commitNotificationsChannelMutex.Unlock()
+	fake.CommitNotificationsChannelStub = nil
+	if fake.commitNotificationsChannelReturnsOnCall == nil {
+		fake.commitNotificationsChannelReturnsOnCall = make(map[int]struct {
+			result1 <-chan *ledger.CommitNotification
+			result2 error
+		})
+	}
+	fake.commitNotificationsChannelReturnsOnCall[i] = struct {
+		result1 <-chan *ledger.CommitNotification
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *PeerLedger) CommitPvtDataOfOldBlocks(arg1 []*ledger.ReconciledPvtdata, arg2 ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error) {
@@ -1596,6 +1672,8 @@ func (fake *PeerLedger) Invocations() map[string][][]interface{} {
 	defer fake.closeMutex.RUnlock()
 	fake.commitLegacyMutex.RLock()
 	defer fake.commitLegacyMutex.RUnlock()
+	fake.commitNotificationsChannelMutex.RLock()
+	defer fake.commitNotificationsChannelMutex.RUnlock()
 	fake.commitPvtDataOfOldBlocksMutex.RLock()
 	defer fake.commitPvtDataOfOldBlocksMutex.RUnlock()
 	fake.doesPvtDataInfoExistMutex.RLock()

--- a/internal/peer/node/mock/peer_ledger.go
+++ b/internal/peer/node/mock/peer_ledger.go
@@ -38,6 +38,19 @@ type PeerLedger struct {
 	commitLegacyReturnsOnCall map[int]struct {
 		result1 error
 	}
+	CommitNotificationsChannelStub        func(<-chan struct{}) (<-chan *ledger.CommitNotification, error)
+	commitNotificationsChannelMutex       sync.RWMutex
+	commitNotificationsChannelArgsForCall []struct {
+		arg1 <-chan struct{}
+	}
+	commitNotificationsChannelReturns struct {
+		result1 <-chan *ledger.CommitNotification
+		result2 error
+	}
+	commitNotificationsChannelReturnsOnCall map[int]struct {
+		result1 <-chan *ledger.CommitNotification
+		result2 error
+	}
 	CommitPvtDataOfOldBlocksStub        func([]*ledger.ReconciledPvtdata, ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error)
 	commitPvtDataOfOldBlocksMutex       sync.RWMutex
 	commitPvtDataOfOldBlocksArgsForCall []struct {
@@ -426,6 +439,69 @@ func (fake *PeerLedger) CommitLegacyReturnsOnCall(i int, result1 error) {
 	fake.commitLegacyReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *PeerLedger) CommitNotificationsChannel(arg1 <-chan struct{}) (<-chan *ledger.CommitNotification, error) {
+	fake.commitNotificationsChannelMutex.Lock()
+	ret, specificReturn := fake.commitNotificationsChannelReturnsOnCall[len(fake.commitNotificationsChannelArgsForCall)]
+	fake.commitNotificationsChannelArgsForCall = append(fake.commitNotificationsChannelArgsForCall, struct {
+		arg1 <-chan struct{}
+	}{arg1})
+	fake.recordInvocation("CommitNotificationsChannel", []interface{}{arg1})
+	fake.commitNotificationsChannelMutex.Unlock()
+	if fake.CommitNotificationsChannelStub != nil {
+		return fake.CommitNotificationsChannelStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.commitNotificationsChannelReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelCallCount() int {
+	fake.commitNotificationsChannelMutex.RLock()
+	defer fake.commitNotificationsChannelMutex.RUnlock()
+	return len(fake.commitNotificationsChannelArgsForCall)
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelCalls(stub func(<-chan struct{}) (<-chan *ledger.CommitNotification, error)) {
+	fake.commitNotificationsChannelMutex.Lock()
+	defer fake.commitNotificationsChannelMutex.Unlock()
+	fake.CommitNotificationsChannelStub = stub
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelArgsForCall(i int) <-chan struct{} {
+	fake.commitNotificationsChannelMutex.RLock()
+	defer fake.commitNotificationsChannelMutex.RUnlock()
+	argsForCall := fake.commitNotificationsChannelArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelReturns(result1 <-chan *ledger.CommitNotification, result2 error) {
+	fake.commitNotificationsChannelMutex.Lock()
+	defer fake.commitNotificationsChannelMutex.Unlock()
+	fake.CommitNotificationsChannelStub = nil
+	fake.commitNotificationsChannelReturns = struct {
+		result1 <-chan *ledger.CommitNotification
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *PeerLedger) CommitNotificationsChannelReturnsOnCall(i int, result1 <-chan *ledger.CommitNotification, result2 error) {
+	fake.commitNotificationsChannelMutex.Lock()
+	defer fake.commitNotificationsChannelMutex.Unlock()
+	fake.CommitNotificationsChannelStub = nil
+	if fake.commitNotificationsChannelReturnsOnCall == nil {
+		fake.commitNotificationsChannelReturnsOnCall = make(map[int]struct {
+			result1 <-chan *ledger.CommitNotification
+			result2 error
+		})
+	}
+	fake.commitNotificationsChannelReturnsOnCall[i] = struct {
+		result1 <-chan *ledger.CommitNotification
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *PeerLedger) CommitPvtDataOfOldBlocks(arg1 []*ledger.ReconciledPvtdata, arg2 ledger.MissingPvtDataInfo) ([]*ledger.PvtdataHashMismatch, error) {
@@ -1596,6 +1672,8 @@ func (fake *PeerLedger) Invocations() map[string][][]interface{} {
 	defer fake.closeMutex.RUnlock()
 	fake.commitLegacyMutex.RLock()
 	defer fake.commitLegacyMutex.RUnlock()
+	fake.commitNotificationsChannelMutex.RLock()
+	defer fake.commitNotificationsChannelMutex.RUnlock()
 	fake.commitPvtDataOfOldBlocksMutex.RLock()
 	defer fake.commitPvtDataOfOldBlocksMutex.RUnlock()
 	fake.doesPvtDataInfoExistMutex.RLock()


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Description

This PR introduces a function in ledger that provides a channel that can be to receive the commit events. This function is intended to be used by the embedded gateway to notify the clients that are waiting for a transaction to be committed.