### PR TITLE
FABGW-6 endpoint factory to use refactored comms

### DIFF
--- a/core/peer/config_test.go
+++ b/core/peer/config_test.go
@@ -277,6 +277,7 @@ func TestGlobalConfig(t *testing.T) {
 	viper.Set("peer.validatorPoolSize", 1)
 	viper.Set("peer.gateway.enabled", true)
 	viper.Set("peer.gateway.endorsementTimeout", 10*time.Second)
+	viper.Set("peer.gateway.dialTimeout", 60*time.Second)
 
 	viper.Set("vm.endpoint", "unix:///var/run/docker.sock")
 	viper.Set("vm.docker.tls.enabled", false)
@@ -375,6 +376,7 @@ func TestGlobalConfig(t *testing.T) {
 		GatewayOptions: gateway.Options{
 			Enabled:            true,
 			EndorsementTimeout: 10 * time.Second,
+			DialTimeout:        60 * time.Second,
 		},
 	}
 

--- a/internal/pkg/gateway/apiutils.go
+++ b/internal/pkg/gateway/apiutils.go
@@ -29,7 +29,7 @@ func getValueFromResponse(response *peer.ProposalResponse) (*gateway.Result, err
 		}
 
 		if extension != nil && extension.Response != nil {
-			if extension.Response.Status > 200 {
+			if extension.Response.Status < 200 || extension.Response.Status >= 400 {
 				return nil, fmt.Errorf("error %d, %s", extension.Response.Status, extension.Response.Message)
 			}
 			retVal = extension.Response.Payload

--- a/internal/pkg/gateway/config.go
+++ b/internal/pkg/gateway/config.go
@@ -12,16 +12,20 @@ import (
 	"github.com/spf13/viper"
 )
 
-// GatewayOptions is used to configure the gateway settings
+// GatewayOptions is used to configure the gateway settings.
 type Options struct {
-	// GatewayEnabled is used to enable the gateway service
-	Enabled            bool
+	// GatewayEnabled is used to enable the gateway service.
+	Enabled bool
+	// EndorsementTimeout is used to specify the maximum time to wait for endorsement responses from external peers.
 	EndorsementTimeout time.Duration
+	// DialTimeout is used to specify the maximum time to wait for connecting to external peers and orderer nodes.
+	DialTimeout time.Duration
 }
 
 var defaultOptions = Options{
 	Enabled:            false,
 	EndorsementTimeout: 10 * time.Second,
+	DialTimeout:        30 * time.Second,
 }
 
 // DefaultOptions gets the default Gateway configuration Options
@@ -32,6 +36,9 @@ func GetOptions(v *viper.Viper) Options {
 	}
 	if v.IsSet("peer.gateway.endorsementTimeout") {
 		options.EndorsementTimeout = v.GetDuration("peer.gateway.endorsementTimeout")
+	}
+	if v.IsSet("peer.gateway.dialTimeout") {
+		options.DialTimeout = v.GetDuration("peer.gateway.dialTimeout")
 	}
 
 	return options

--- a/internal/pkg/gateway/config_test.go
+++ b/internal/pkg/gateway/config_test.go
@@ -20,6 +20,7 @@ peer:
   gateway:
     enabled: true
     endorsementTimeout: 30s
+    dialTimeout: 2m
 `)
 
 func TestDefaultOptions(t *testing.T) {
@@ -37,6 +38,7 @@ func TestOverriddenOptions(t *testing.T) {
 	expectedOptions := Options{
 		Enabled:            true,
 		EndorsementTimeout: 30 * time.Second,
+		DialTimeout:        2 * time.Minute,
 	}
 	require.Equal(t, expectedOptions, options)
 }

--- a/internal/pkg/gateway/endpoint.go
+++ b/internal/pkg/gateway/endpoint.go
@@ -8,6 +8,7 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	ab "github.com/hyperledger/fabric-protos-go/orderer"
@@ -16,31 +17,96 @@ import (
 	"google.golang.org/grpc"
 )
 
-func newEndorser(address string, tlsRootCerts [][]byte) (peer.EndorserClient, error) {
-	conn, err := newConnection(address, tlsRootCerts)
+type endorser struct {
+	client peer.EndorserClient
+	*endpointConfig
+}
+
+type orderer struct {
+	client ab.AtomicBroadcast_BroadcastClient
+	*endpointConfig
+}
+
+type endpointConfig struct {
+	address string
+	mspid   string
+}
+
+type (
+	endorserConnector func(*grpc.ClientConn) peer.EndorserClient
+	ordererConnector  func(*grpc.ClientConn) (ab.AtomicBroadcast_BroadcastClient, error)
+	dialer            func(ctx context.Context, target string, opts ...grpc.DialOption) (*grpc.ClientConn, error)
+)
+
+type endpointFactory struct {
+	timeout         time.Duration
+	connectEndorser endorserConnector
+	connectOrderer  ordererConnector
+	dialer          dialer
+}
+
+func (ef *endpointFactory) newEndorser(address, mspid string, tlsRootCerts [][]byte) (*endorser, error) {
+	conn, err := ef.newConnection(address, tlsRootCerts)
 	if err != nil {
 		return nil, err
 	}
-	return peer.NewEndorserClient(conn), nil
+	connectEndorser := ef.connectEndorser
+	if connectEndorser == nil {
+		connectEndorser = peer.NewEndorserClient
+	}
+	return &endorser{
+		client:         connectEndorser(conn),
+		endpointConfig: &endpointConfig{address: address, mspid: mspid},
+	}, nil
 }
 
-func newOrderer(address string, tlsRootCerts [][]byte) (ab.AtomicBroadcast_BroadcastClient, error) {
-	conn, err := newConnection(address, tlsRootCerts)
+func (ef *endpointFactory) newOrderer(address, mspid string, tlsRootCerts [][]byte) (*orderer, error) {
+	conn, err := ef.newConnection(address, tlsRootCerts)
 	if err != nil {
 		return nil, err
 	}
-	abc := ab.NewAtomicBroadcastClient(conn)
-	return abc.Broadcast(context.TODO()) // TODO build a context using timeouts specified in the gateway config (future user story)
+	connectOrderer := ef.connectOrderer
+	if connectOrderer == nil {
+		connectOrderer = defaultOrdererConnector
+	}
+	client, err := connectOrderer(conn)
+	if err != nil {
+		return nil, err
+	}
+	return &orderer{
+		client:         client,
+		endpointConfig: &endpointConfig{address: address, mspid: mspid},
+	}, nil
 }
 
-func newConnection(address string, tlsRootCerts [][]byte) (*grpc.ClientConn, error) {
+func (ef *endpointFactory) newConnection(address string, tlsRootCerts [][]byte) (*grpc.ClientConn, error) {
 	config := comm.ClientConfig{
 		SecOpts: comm.SecureOptions{
 			UseTLS:            len(tlsRootCerts) > 0,
 			ServerRootCAs:     tlsRootCerts,
 			RequireClientCert: false,
 		},
-		DialTimeout: 5 * time.Second, // TODO from config
+		DialTimeout: ef.timeout,
 	}
-	return config.Dial(address)
+	dialOpts, err := config.DialOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), ef.timeout)
+	defer cancel()
+
+	dialer := ef.dialer
+	if dialer == nil {
+		dialer = grpc.DialContext
+	}
+	conn, err := dialer(ctx, address, dialOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new connection: %w", err)
+	}
+	return conn, nil
+}
+
+func defaultOrdererConnector(conn *grpc.ClientConn) (ab.AtomicBroadcast_BroadcastClient, error) {
+	return ab.NewAtomicBroadcastClient(conn).Broadcast(context.Background())
 }

--- a/internal/pkg/gateway/gateway.go
+++ b/internal/pkg/gateway/gateway.go
@@ -8,7 +8,6 @@ package gateway
 import (
 	"context"
 
-	ab "github.com/hyperledger/fabric-protos-go/orderer"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/common/flogging"
 	"google.golang.org/grpc"
@@ -34,14 +33,12 @@ func (e *EndorserServerAdapter) ProcessProposal(ctx context.Context, req *peer.S
 func CreateServer(localEndorser peer.EndorserClient, discovery Discovery, selfEndpoint string, options Options) *Server {
 	gwServer := &Server{
 		registry: &registry{
-			localEndorser:       localEndorser,
+			localEndorser:       &endorser{client: localEndorser, endpointConfig: &endpointConfig{address: selfEndpoint}},
 			discovery:           discovery,
-			selfEndpoint:        selfEndpoint,
 			logger:              logger,
-			endorserFactory:     newEndorser,
-			ordererFactory:      newOrderer,
-			remoteEndorsers:     map[string]peer.EndorserClient{},
-			broadcastClients:    map[string]ab.AtomicBroadcast_BroadcastClient{},
+			endpointFactory:     &endpointFactory{timeout: options.EndorsementTimeout},
+			remoteEndorsers:     map[string]*endorser{},
+			broadcastClients:    map[string]*orderer{},
 			tlsRootCerts:        map[string][][]byte{},
 			channelsInitialized: map[string]bool{},
 		},

--- a/internal/pkg/gateway/mocks/abclient.go
+++ b/internal/pkg/gateway/mocks/abclient.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-type Orderer struct {
+type ABClient struct {
 	CloseSendStub        func() error
 	closeSendMutex       sync.RWMutex
 	closeSendArgsForCall []struct {
@@ -102,7 +102,7 @@ type Orderer struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Orderer) CloseSend() error {
+func (fake *ABClient) CloseSend() error {
 	fake.closeSendMutex.Lock()
 	ret, specificReturn := fake.closeSendReturnsOnCall[len(fake.closeSendArgsForCall)]
 	fake.closeSendArgsForCall = append(fake.closeSendArgsForCall, struct {
@@ -119,19 +119,19 @@ func (fake *Orderer) CloseSend() error {
 	return fakeReturns.result1
 }
 
-func (fake *Orderer) CloseSendCallCount() int {
+func (fake *ABClient) CloseSendCallCount() int {
 	fake.closeSendMutex.RLock()
 	defer fake.closeSendMutex.RUnlock()
 	return len(fake.closeSendArgsForCall)
 }
 
-func (fake *Orderer) CloseSendCalls(stub func() error) {
+func (fake *ABClient) CloseSendCalls(stub func() error) {
 	fake.closeSendMutex.Lock()
 	defer fake.closeSendMutex.Unlock()
 	fake.CloseSendStub = stub
 }
 
-func (fake *Orderer) CloseSendReturns(result1 error) {
+func (fake *ABClient) CloseSendReturns(result1 error) {
 	fake.closeSendMutex.Lock()
 	defer fake.closeSendMutex.Unlock()
 	fake.CloseSendStub = nil
@@ -140,7 +140,7 @@ func (fake *Orderer) CloseSendReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *Orderer) CloseSendReturnsOnCall(i int, result1 error) {
+func (fake *ABClient) CloseSendReturnsOnCall(i int, result1 error) {
 	fake.closeSendMutex.Lock()
 	defer fake.closeSendMutex.Unlock()
 	fake.CloseSendStub = nil
@@ -154,7 +154,7 @@ func (fake *Orderer) CloseSendReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *Orderer) Context() context.Context {
+func (fake *ABClient) Context() context.Context {
 	fake.contextMutex.Lock()
 	ret, specificReturn := fake.contextReturnsOnCall[len(fake.contextArgsForCall)]
 	fake.contextArgsForCall = append(fake.contextArgsForCall, struct {
@@ -171,19 +171,19 @@ func (fake *Orderer) Context() context.Context {
 	return fakeReturns.result1
 }
 
-func (fake *Orderer) ContextCallCount() int {
+func (fake *ABClient) ContextCallCount() int {
 	fake.contextMutex.RLock()
 	defer fake.contextMutex.RUnlock()
 	return len(fake.contextArgsForCall)
 }
 
-func (fake *Orderer) ContextCalls(stub func() context.Context) {
+func (fake *ABClient) ContextCalls(stub func() context.Context) {
 	fake.contextMutex.Lock()
 	defer fake.contextMutex.Unlock()
 	fake.ContextStub = stub
 }
 
-func (fake *Orderer) ContextReturns(result1 context.Context) {
+func (fake *ABClient) ContextReturns(result1 context.Context) {
 	fake.contextMutex.Lock()
 	defer fake.contextMutex.Unlock()
 	fake.ContextStub = nil
@@ -192,7 +192,7 @@ func (fake *Orderer) ContextReturns(result1 context.Context) {
 	}{result1}
 }
 
-func (fake *Orderer) ContextReturnsOnCall(i int, result1 context.Context) {
+func (fake *ABClient) ContextReturnsOnCall(i int, result1 context.Context) {
 	fake.contextMutex.Lock()
 	defer fake.contextMutex.Unlock()
 	fake.ContextStub = nil
@@ -206,7 +206,7 @@ func (fake *Orderer) ContextReturnsOnCall(i int, result1 context.Context) {
 	}{result1}
 }
 
-func (fake *Orderer) Header() (metadata.MD, error) {
+func (fake *ABClient) Header() (metadata.MD, error) {
 	fake.headerMutex.Lock()
 	ret, specificReturn := fake.headerReturnsOnCall[len(fake.headerArgsForCall)]
 	fake.headerArgsForCall = append(fake.headerArgsForCall, struct {
@@ -223,19 +223,19 @@ func (fake *Orderer) Header() (metadata.MD, error) {
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *Orderer) HeaderCallCount() int {
+func (fake *ABClient) HeaderCallCount() int {
 	fake.headerMutex.RLock()
 	defer fake.headerMutex.RUnlock()
 	return len(fake.headerArgsForCall)
 }
 
-func (fake *Orderer) HeaderCalls(stub func() (metadata.MD, error)) {
+func (fake *ABClient) HeaderCalls(stub func() (metadata.MD, error)) {
 	fake.headerMutex.Lock()
 	defer fake.headerMutex.Unlock()
 	fake.HeaderStub = stub
 }
 
-func (fake *Orderer) HeaderReturns(result1 metadata.MD, result2 error) {
+func (fake *ABClient) HeaderReturns(result1 metadata.MD, result2 error) {
 	fake.headerMutex.Lock()
 	defer fake.headerMutex.Unlock()
 	fake.HeaderStub = nil
@@ -245,7 +245,7 @@ func (fake *Orderer) HeaderReturns(result1 metadata.MD, result2 error) {
 	}{result1, result2}
 }
 
-func (fake *Orderer) HeaderReturnsOnCall(i int, result1 metadata.MD, result2 error) {
+func (fake *ABClient) HeaderReturnsOnCall(i int, result1 metadata.MD, result2 error) {
 	fake.headerMutex.Lock()
 	defer fake.headerMutex.Unlock()
 	fake.HeaderStub = nil
@@ -261,7 +261,7 @@ func (fake *Orderer) HeaderReturnsOnCall(i int, result1 metadata.MD, result2 err
 	}{result1, result2}
 }
 
-func (fake *Orderer) Recv() (*orderer.BroadcastResponse, error) {
+func (fake *ABClient) Recv() (*orderer.BroadcastResponse, error) {
 	fake.recvMutex.Lock()
 	ret, specificReturn := fake.recvReturnsOnCall[len(fake.recvArgsForCall)]
 	fake.recvArgsForCall = append(fake.recvArgsForCall, struct {
@@ -278,19 +278,19 @@ func (fake *Orderer) Recv() (*orderer.BroadcastResponse, error) {
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *Orderer) RecvCallCount() int {
+func (fake *ABClient) RecvCallCount() int {
 	fake.recvMutex.RLock()
 	defer fake.recvMutex.RUnlock()
 	return len(fake.recvArgsForCall)
 }
 
-func (fake *Orderer) RecvCalls(stub func() (*orderer.BroadcastResponse, error)) {
+func (fake *ABClient) RecvCalls(stub func() (*orderer.BroadcastResponse, error)) {
 	fake.recvMutex.Lock()
 	defer fake.recvMutex.Unlock()
 	fake.RecvStub = stub
 }
 
-func (fake *Orderer) RecvReturns(result1 *orderer.BroadcastResponse, result2 error) {
+func (fake *ABClient) RecvReturns(result1 *orderer.BroadcastResponse, result2 error) {
 	fake.recvMutex.Lock()
 	defer fake.recvMutex.Unlock()
 	fake.RecvStub = nil
@@ -300,7 +300,7 @@ func (fake *Orderer) RecvReturns(result1 *orderer.BroadcastResponse, result2 err
 	}{result1, result2}
 }
 
-func (fake *Orderer) RecvReturnsOnCall(i int, result1 *orderer.BroadcastResponse, result2 error) {
+func (fake *ABClient) RecvReturnsOnCall(i int, result1 *orderer.BroadcastResponse, result2 error) {
 	fake.recvMutex.Lock()
 	defer fake.recvMutex.Unlock()
 	fake.RecvStub = nil
@@ -316,7 +316,7 @@ func (fake *Orderer) RecvReturnsOnCall(i int, result1 *orderer.BroadcastResponse
 	}{result1, result2}
 }
 
-func (fake *Orderer) RecvMsg(arg1 interface{}) error {
+func (fake *ABClient) RecvMsg(arg1 interface{}) error {
 	fake.recvMsgMutex.Lock()
 	ret, specificReturn := fake.recvMsgReturnsOnCall[len(fake.recvMsgArgsForCall)]
 	fake.recvMsgArgsForCall = append(fake.recvMsgArgsForCall, struct {
@@ -334,26 +334,26 @@ func (fake *Orderer) RecvMsg(arg1 interface{}) error {
 	return fakeReturns.result1
 }
 
-func (fake *Orderer) RecvMsgCallCount() int {
+func (fake *ABClient) RecvMsgCallCount() int {
 	fake.recvMsgMutex.RLock()
 	defer fake.recvMsgMutex.RUnlock()
 	return len(fake.recvMsgArgsForCall)
 }
 
-func (fake *Orderer) RecvMsgCalls(stub func(interface{}) error) {
+func (fake *ABClient) RecvMsgCalls(stub func(interface{}) error) {
 	fake.recvMsgMutex.Lock()
 	defer fake.recvMsgMutex.Unlock()
 	fake.RecvMsgStub = stub
 }
 
-func (fake *Orderer) RecvMsgArgsForCall(i int) interface{} {
+func (fake *ABClient) RecvMsgArgsForCall(i int) interface{} {
 	fake.recvMsgMutex.RLock()
 	defer fake.recvMsgMutex.RUnlock()
 	argsForCall := fake.recvMsgArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *Orderer) RecvMsgReturns(result1 error) {
+func (fake *ABClient) RecvMsgReturns(result1 error) {
 	fake.recvMsgMutex.Lock()
 	defer fake.recvMsgMutex.Unlock()
 	fake.RecvMsgStub = nil
@@ -362,7 +362,7 @@ func (fake *Orderer) RecvMsgReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *Orderer) RecvMsgReturnsOnCall(i int, result1 error) {
+func (fake *ABClient) RecvMsgReturnsOnCall(i int, result1 error) {
 	fake.recvMsgMutex.Lock()
 	defer fake.recvMsgMutex.Unlock()
 	fake.RecvMsgStub = nil
@@ -376,7 +376,7 @@ func (fake *Orderer) RecvMsgReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *Orderer) Send(arg1 *common.Envelope) error {
+func (fake *ABClient) Send(arg1 *common.Envelope) error {
 	fake.sendMutex.Lock()
 	ret, specificReturn := fake.sendReturnsOnCall[len(fake.sendArgsForCall)]
 	fake.sendArgsForCall = append(fake.sendArgsForCall, struct {
@@ -394,26 +394,26 @@ func (fake *Orderer) Send(arg1 *common.Envelope) error {
 	return fakeReturns.result1
 }
 
-func (fake *Orderer) SendCallCount() int {
+func (fake *ABClient) SendCallCount() int {
 	fake.sendMutex.RLock()
 	defer fake.sendMutex.RUnlock()
 	return len(fake.sendArgsForCall)
 }
 
-func (fake *Orderer) SendCalls(stub func(*common.Envelope) error) {
+func (fake *ABClient) SendCalls(stub func(*common.Envelope) error) {
 	fake.sendMutex.Lock()
 	defer fake.sendMutex.Unlock()
 	fake.SendStub = stub
 }
 
-func (fake *Orderer) SendArgsForCall(i int) *common.Envelope {
+func (fake *ABClient) SendArgsForCall(i int) *common.Envelope {
 	fake.sendMutex.RLock()
 	defer fake.sendMutex.RUnlock()
 	argsForCall := fake.sendArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *Orderer) SendReturns(result1 error) {
+func (fake *ABClient) SendReturns(result1 error) {
 	fake.sendMutex.Lock()
 	defer fake.sendMutex.Unlock()
 	fake.SendStub = nil
@@ -422,7 +422,7 @@ func (fake *Orderer) SendReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *Orderer) SendReturnsOnCall(i int, result1 error) {
+func (fake *ABClient) SendReturnsOnCall(i int, result1 error) {
 	fake.sendMutex.Lock()
 	defer fake.sendMutex.Unlock()
 	fake.SendStub = nil
@@ -436,7 +436,7 @@ func (fake *Orderer) SendReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *Orderer) SendMsg(arg1 interface{}) error {
+func (fake *ABClient) SendMsg(arg1 interface{}) error {
 	fake.sendMsgMutex.Lock()
 	ret, specificReturn := fake.sendMsgReturnsOnCall[len(fake.sendMsgArgsForCall)]
 	fake.sendMsgArgsForCall = append(fake.sendMsgArgsForCall, struct {
@@ -454,26 +454,26 @@ func (fake *Orderer) SendMsg(arg1 interface{}) error {
 	return fakeReturns.result1
 }
 
-func (fake *Orderer) SendMsgCallCount() int {
+func (fake *ABClient) SendMsgCallCount() int {
 	fake.sendMsgMutex.RLock()
 	defer fake.sendMsgMutex.RUnlock()
 	return len(fake.sendMsgArgsForCall)
 }
 
-func (fake *Orderer) SendMsgCalls(stub func(interface{}) error) {
+func (fake *ABClient) SendMsgCalls(stub func(interface{}) error) {
 	fake.sendMsgMutex.Lock()
 	defer fake.sendMsgMutex.Unlock()
 	fake.SendMsgStub = stub
 }
 
-func (fake *Orderer) SendMsgArgsForCall(i int) interface{} {
+func (fake *ABClient) SendMsgArgsForCall(i int) interface{} {
 	fake.sendMsgMutex.RLock()
 	defer fake.sendMsgMutex.RUnlock()
 	argsForCall := fake.sendMsgArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *Orderer) SendMsgReturns(result1 error) {
+func (fake *ABClient) SendMsgReturns(result1 error) {
 	fake.sendMsgMutex.Lock()
 	defer fake.sendMsgMutex.Unlock()
 	fake.SendMsgStub = nil
@@ -482,7 +482,7 @@ func (fake *Orderer) SendMsgReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *Orderer) SendMsgReturnsOnCall(i int, result1 error) {
+func (fake *ABClient) SendMsgReturnsOnCall(i int, result1 error) {
 	fake.sendMsgMutex.Lock()
 	defer fake.sendMsgMutex.Unlock()
 	fake.SendMsgStub = nil
@@ -496,7 +496,7 @@ func (fake *Orderer) SendMsgReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *Orderer) Trailer() metadata.MD {
+func (fake *ABClient) Trailer() metadata.MD {
 	fake.trailerMutex.Lock()
 	ret, specificReturn := fake.trailerReturnsOnCall[len(fake.trailerArgsForCall)]
 	fake.trailerArgsForCall = append(fake.trailerArgsForCall, struct {
@@ -513,19 +513,19 @@ func (fake *Orderer) Trailer() metadata.MD {
 	return fakeReturns.result1
 }
 
-func (fake *Orderer) TrailerCallCount() int {
+func (fake *ABClient) TrailerCallCount() int {
 	fake.trailerMutex.RLock()
 	defer fake.trailerMutex.RUnlock()
 	return len(fake.trailerArgsForCall)
 }
 
-func (fake *Orderer) TrailerCalls(stub func() metadata.MD) {
+func (fake *ABClient) TrailerCalls(stub func() metadata.MD) {
 	fake.trailerMutex.Lock()
 	defer fake.trailerMutex.Unlock()
 	fake.TrailerStub = stub
 }
 
-func (fake *Orderer) TrailerReturns(result1 metadata.MD) {
+func (fake *ABClient) TrailerReturns(result1 metadata.MD) {
 	fake.trailerMutex.Lock()
 	defer fake.trailerMutex.Unlock()
 	fake.TrailerStub = nil
@@ -534,7 +534,7 @@ func (fake *Orderer) TrailerReturns(result1 metadata.MD) {
 	}{result1}
 }
 
-func (fake *Orderer) TrailerReturnsOnCall(i int, result1 metadata.MD) {
+func (fake *ABClient) TrailerReturnsOnCall(i int, result1 metadata.MD) {
 	fake.trailerMutex.Lock()
 	defer fake.trailerMutex.Unlock()
 	fake.TrailerStub = nil
@@ -548,7 +548,7 @@ func (fake *Orderer) TrailerReturnsOnCall(i int, result1 metadata.MD) {
 	}{result1}
 }
 
-func (fake *Orderer) Invocations() map[string][][]interface{} {
+func (fake *ABClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.closeSendMutex.RLock()
@@ -574,7 +574,7 @@ func (fake *Orderer) Invocations() map[string][][]interface{} {
 	return copiedInvocations
 }
 
-func (fake *Orderer) recordInvocation(key string, args []interface{}) {
+func (fake *ABClient) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {


### PR DESCRIPTION
Refactored the endpoint factory code in the gateway to better use the refactored comms package.  Allows the code to be unit tested with fairly good coverage.
Resolved the final TODO on configurable connection timeout

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
