### PR TITLE
Gateway gRPC functions to return google.rpc.Status

### DIFF
--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -819,6 +819,7 @@ func serve(args []string) error {
 					&gateway.EndorserServerAdapter{Server: serverEndorser},
 					discoveryService,
 					peerInstance.GossipService.SelfMembershipInfo().Endpoint,
+					coreConfig.LocalMSPID,
 					coreConfig.GatewayOptions,
 				),
 			)

--- a/internal/pkg/gateway/api.go
+++ b/internal/pkg/gateway/api.go
@@ -11,64 +11,80 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/golang/protobuf/proto"
 	gp "github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/protoutil"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type endorserResponse struct {
 	pr  *peer.ProposalResponse
-	err error
+	err *gp.EndpointError
 }
 
 // Evaluate will invoke the transaction function as specified in the SignedProposal
 func (gs *Server) Evaluate(ctx context.Context, proposedTransaction *gp.ProposedTransaction) (*gp.Result, error) {
 	if proposedTransaction == nil {
-		return nil, fmt.Errorf("a proposed transaction is required")
+		return nil, status.Error(codes.InvalidArgument, "a proposed transaction is required")
 	}
 	signedProposal := proposedTransaction.Proposal
 	channel, chaincodeID, err := getChannelAndChaincodeFromSignedProposal(proposedTransaction.Proposal)
 	if err != nil {
-		// TODO need to specify status codes
-		return nil, fmt.Errorf("failed to unpack channel header: %w", err)
+		return nil, status.Errorf(codes.InvalidArgument, "failed to unpack transaction proposal: %s", err)
 	}
 
 	endorsers, err := gs.registry.endorsers(channel, chaincodeID)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.Unavailable, "%s", err)
 	}
 	if len(endorsers) == 0 {
-		return nil, fmt.Errorf("no endorsing peers found for channel: %s", proposedTransaction.ChannelId)
-	}
-	response, err := endorsers[0].client.ProcessProposal(ctx, signedProposal) // TODO choose suitable peer based on block height, etc (future user story)
-	if err != nil {
-		return nil, fmt.Errorf("failed to evaluate transaction: %w", err)
+		return nil, status.Errorf(codes.NotFound, "no endorsing peers found for channel: %s", proposedTransaction.ChannelId)
 	}
 
-	return getValueFromResponse(response)
+	endorser := endorsers[0] // TODO choose suitable peer based on block height, etc (future user story)
+	response, err := endorser.client.ProcessProposal(ctx, signedProposal)
+	if err != nil {
+		return nil, rpcError(
+			codes.Aborted,
+			"failed to evaluate transaction",
+			&gp.EndpointError{Address: endorser.address, MspId: endorser.mspid, Message: err.Error()},
+		)
+	}
+
+	value, err := getValueFromResponse(response)
+	if err != nil {
+		return nil, rpcError(
+			codes.Aborted,
+			"transaction evaluation error",
+			&gp.EndpointError{Address: endorser.address, MspId: endorser.mspid, Message: err.Error()},
+		)
+	}
+	return value, nil
 }
 
 // Endorse will collect endorsements by invoking the transaction function specified in the SignedProposal against
 // sufficient Peers to satisfy the endorsement policy.
 func (gs *Server) Endorse(ctx context.Context, proposedTransaction *gp.ProposedTransaction) (*gp.PreparedTransaction, error) {
 	if proposedTransaction == nil {
-		return nil, fmt.Errorf("a proposed transaction is required")
+		return nil, status.Error(codes.InvalidArgument, "a proposed transaction is required")
 	}
 	signedProposal := proposedTransaction.Proposal
 	if signedProposal == nil {
-		return nil, fmt.Errorf("the proposed transaction must contain a signed proposal")
+		return nil, status.Error(codes.InvalidArgument, "the proposed transaction must contain a signed proposal")
 	}
 	proposal, err := protoutil.UnmarshalProposal(signedProposal.ProposalBytes)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "failed to unpack transaction proposal: %s", err)
 	}
 	channel, chaincodeID, err := getChannelAndChaincodeFromSignedProposal(proposedTransaction.Proposal)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unpack channel header: %w", err)
+		return nil, status.Errorf(codes.InvalidArgument, "failed to unpack transaction proposal: %s", err)
 	}
 	endorsers, err := gs.registry.endorsers(channel, chaincodeID)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.Unavailable, "%s", err)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, gs.options.EndorsementTimeout)
@@ -79,32 +95,47 @@ func (gs *Server) Endorse(ctx context.Context, proposedTransaction *gp.ProposedT
 	// send to all the endorsers
 	for _, e := range endorsers {
 		wg.Add(1)
-		go func(endorser *endorser) {
+		go func(e *endorser) {
 			defer wg.Done()
-			response, err := endorser.client.ProcessProposal(ctx, signedProposal)
-			responseCh <- &endorserResponse{pr: response, err: err}
+			response, err := e.client.ProcessProposal(ctx, signedProposal)
+			var detail *gp.EndpointError
+			if err != nil {
+				detail = &gp.EndpointError{Address: e.address, MspId: e.mspid, Message: err.Error()}
+				responseCh <- &endorserResponse{err: detail}
+				return
+			}
+			if response.Response.Status < 200 || response.Response.Status >= 400 {
+				// this is an error case and will be returned in the error details to the client
+				detail = &gp.EndpointError{Address: e.address, MspId: e.mspid, Message: fmt.Sprintf("error %d, %s", response.Response.Status, response.Response.Message)}
+			}
+			responseCh <- &endorserResponse{pr: response, err: detail}
 		}(e)
 	}
 	wg.Wait()
 	close(responseCh)
 
 	var responses []*peer.ProposalResponse
+	var errorDetails []proto.Message
 	for response := range responseCh {
 		if response.err != nil {
-			// TODO: we should retry, or attempt a different endorsement layout (if available)
-			return nil, fmt.Errorf("failed to process proposal: %w", response.err)
+			errorDetails = append(errorDetails, response.err)
+		} else {
+			responses = append(responses, response.pr)
 		}
-		responses = append(responses, response.pr)
+	}
+
+	if len(errorDetails) != 0 {
+		return nil, rpcError(codes.Aborted, "failed to endorse transaction", errorDetails...)
 	}
 
 	env, err := protoutil.CreateTx(proposal, responses...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to assemble transaction: %w", err)
+		return nil, status.Errorf(codes.Aborted, "failed to assemble transaction: %s", err)
 	}
 
 	retVal, err := getValueFromResponse(responses[0])
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract value from response payload: %w", err)
+		return nil, status.Errorf(codes.Aborted, "failed to extract value from response payload: %s", err)
 	}
 
 	preparedTxn := &gp.PreparedTransaction{
@@ -120,33 +151,41 @@ func (gs *Server) Endorse(ctx context.Context, proposedTransaction *gp.ProposedT
 // once the transaction is committed on a sufficient number of remoteEndorsers according to a defined policy.
 func (gs *Server) Submit(txn *gp.PreparedTransaction, cs gp.Gateway_SubmitServer) error {
 	if txn == nil {
-		return fmt.Errorf("a signed prepared transaction is required")
+		return status.Error(codes.InvalidArgument, "a signed prepared transaction is required")
 	}
 	if cs == nil {
-		return fmt.Errorf("a submit server is required")
+		return status.Error(codes.Internal, "a submit server is required")
 	}
 	orderers, err := gs.registry.orderers(txn.ChannelId)
 	if err != nil {
-		return err
+		return status.Errorf(codes.Unavailable, "%s", err)
 	}
 
 	if len(orderers) == 0 {
-		return fmt.Errorf("no broadcastClients discovered")
+		return status.Errorf(codes.NotFound, "no broadcastClients discovered")
 	}
 
-	// send to first orderer for now
+	orderer := orderers[0] // send to first orderer for now
 	logger.Info("Submitting txn to orderer")
-	if err := orderers[0].client.Send(txn.Envelope); err != nil {
-		return fmt.Errorf("failed to send envelope to orderer: %w", err)
+	if err := orderer.client.Send(txn.Envelope); err != nil {
+		return rpcError(
+			codes.Aborted,
+			"failed to send transaction to orderer",
+			&gp.EndpointError{Address: orderer.address, MspId: orderer.mspid, Message: err.Error()},
+		)
 	}
 
-	response, err := orderers[0].client.Recv()
+	response, err := orderer.client.Recv()
 	if err != nil {
-		return err
+		return rpcError(
+			codes.Aborted,
+			"failed to receive response from orderer",
+			&gp.EndpointError{Address: orderer.address, MspId: orderer.mspid, Message: err.Error()},
+		)
 	}
 
 	if response == nil {
-		return fmt.Errorf("received nil response from orderer")
+		return status.Error(codes.Aborted, "received nil response from orderer")
 	}
 
 	return cs.Send(&gp.Event{

--- a/internal/pkg/gateway/apiutils.go
+++ b/internal/pkg/gateway/apiutils.go
@@ -9,9 +9,12 @@ package gateway
 import (
 	"fmt"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/protoutil"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func getValueFromResponse(response *peer.ProposalResponse) (*gateway.Result, error) {
@@ -65,4 +68,15 @@ func getChannelAndChaincodeFromSignedProposal(signedProposal *peer.SignedProposa
 	}
 
 	return channelHeader.ChannelId, spec.ChaincodeSpec.ChaincodeId.Name, nil
+}
+
+func rpcError(code codes.Code, message string, details ...proto.Message) error {
+	st := status.New(code, message)
+	if len(details) != 0 {
+		std, err := st.WithDetails(details...)
+		if err == nil {
+			return std.Err()
+		} // otherwise return the error without the details
+	}
+	return st.Err()
 }

--- a/internal/pkg/gateway/gateway.go
+++ b/internal/pkg/gateway/gateway.go
@@ -30,10 +30,10 @@ func (e *EndorserServerAdapter) ProcessProposal(ctx context.Context, req *peer.S
 }
 
 // CreateServer creates an embedded instance of the Gateway.
-func CreateServer(localEndorser peer.EndorserClient, discovery Discovery, selfEndpoint string, options Options) *Server {
+func CreateServer(localEndorser peer.EndorserClient, discovery Discovery, localEndpoint string, localMSPID string, options Options) *Server {
 	gwServer := &Server{
 		registry: &registry{
-			localEndorser:       &endorser{client: localEndorser, endpointConfig: &endpointConfig{address: selfEndpoint}},
+			localEndorser:       &endorser{client: localEndorser, endpointConfig: &endpointConfig{address: localEndpoint, mspid: localMSPID}},
 			discovery:           discovery,
 			logger:              logger,
 			endpointFactory:     &endpointFactory{timeout: options.EndorsementTimeout},


### PR DESCRIPTION
Enhances the error reporting in the Gateway.
All gRPC functions return google.rpc.Status style message to the calling client.
If the error is as a result to a failed grpc call to an external peer or orderer, then that/those error(s) are added to the ‘details’ field of the Status message.
If it is caused by a non-success status code in the chaincde response message, then this is added to the details field and returned as an error to the caller.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
