### PR TITLE
[FAB-16951] Alternative mechanisms to find pkcs11 key

### DIFF
--- a/bccsp/pkcs11/conf.go
+++ b/bccsp/pkcs11/conf.go
@@ -26,6 +26,7 @@ type PKCS11Opts struct {
 	Pin            string `json:"pin"`
 	SoftwareVerify bool   `json:"softwareverify,omitempty"`
 	Immutable      bool   `json:"immutable,omitempty"`
+	AltID          string `json:"altid"`
 
 	sessionCacheSize        int
 	createSessionRetries    int


### PR DESCRIPTION
This modification adds a parameter called AltID to the PKCS11 BCCSP module.
When this parameter is set, the generateECKey and findKeyPairFromSKI functions
will use this alternative ID as the CKA_ID and CKA_LABEL to store and use the
associated private key.
This code change is required in situations where the HSM does not allow
modification of the CKA_ID after creation.
This code change includes corresponding unit-test and has been tested against
the SoftHSM, but still needs to be tested against AWS CloudHSM.

Signed-off-by: Luc Desrosiers <ldesrosi@uk.ibm.com>

#### Type of change

- New feature

#### Description

This pull request addresses an issue associated with using the PKCS11 module with the AWS CloudHSM.  As this HSM does not support the modify or copy operations, the SKI cannot be computed and used to update the key LABEL and ID.  
This modification allows to specify via configuration the ID to look up.  
  
#### Additional details. 
  
Port of the related feature added to the 1.4 release.  
Unit-tests have been added to cover the new capability.  
  
#### Related issues. 
  
[FAB-16951 - Add support for alternative mechanisms for locating pkcs11 keys](https://jira.hyperledger.org/browse/FAB-16951). 
  

