### PR TITLE
platform/golang: loosen assertion for Go 1.16.2

### DIFF
--- a/core/chaincode/platforms/golang/list_test.go
+++ b/core/chaincode/platforms/golang/list_test.go
@@ -122,5 +122,6 @@ func Test_listModuleInfoFailure(t *testing.T) {
 	require.NoError(t, err, "failed to change to temporary directory")
 
 	_, err = listModuleInfo()
-	require.EqualError(t, err, "'go list' failed with: go: cannot find main module; see 'go help modules': exit status 1")
+	require.ErrorContains(t, err, "'go list' failed with: go: ")
+	require.ErrorContains(t, err, "see 'go help modules': exit status 1")
 }


### PR DESCRIPTION
The error messages for commands executed outside of a module were changed in Go 1.16.2. This change loosens our assertion to handle the old and new messages.