### PR TITLE
FABGW-8: Tidy up commit notifier

### DIFF
--- a/internal/pkg/gateway/commit/notifier.go
+++ b/internal/pkg/gateway/commit/notifier.go
@@ -73,11 +73,11 @@ func (notifier *Notifier) channelNotifier(channelName string) (*channelLevelNoti
 	defer notifier.lock.Unlock()
 
 	result := notifier.channelNotifiers[channelName]
-	if result != nil {
+	if result != nil && !result.isClosed() {
 		return result, nil
 	}
 
-	commitChannel, err := notifier.supplier.CommitNotifications(nil, channelName)
+	commitChannel, err := notifier.supplier.CommitNotifications(notifier.cancel, channelName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Complete implementation and test coverage for new commit listeners following failure of notification supplier. This is never expected to happen at runtime but, if it did, the behaviour of the commit notifier would have been unhelpful in identifying and diagnosing a problem.