### PR TITLE
Handle unsuccessful status from Gateway orderer send

### DIFF
--- a/internal/pkg/gateway/api.go
+++ b/internal/pkg/gateway/api.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-protos-go/common"
 	gp "github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/protoutil"
@@ -189,6 +190,10 @@ func (gs *Server) Submit(ctx context.Context, request *gp.SubmitRequest) (*gp.Su
 
 	if response == nil {
 		return nil, status.Error(codes.Aborted, "received nil response from orderer")
+	}
+
+	if response.Status != common.Status_SUCCESS {
+		return nil, status.Errorf(codes.Aborted, "received unsuccessful response from orderer: %s", common.Status_name[int32(response.Status)])
 	}
 
 	return &gp.SubmitResponse{}, nil

--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -442,6 +442,23 @@ func TestSubmit(t *testing.T) {
 			},
 			errString: "received nil response from orderer",
 		},
+		{
+			name: "orderer returns unsuccessful response",
+			plan: endorsementPlan{
+				"g1": {"localhost:7051"},
+			},
+			postSetup: func(def *preparedTest) {
+				def.server.registry.endpointFactory.connectOrderer = func(_ *grpc.ClientConn) (ab.AtomicBroadcast_BroadcastClient, error) {
+					abc := &mocks.ABClient{}
+					response := &ab.BroadcastResponse{
+						Status: cp.Status_BAD_REQUEST,
+					}
+					abc.RecvReturns(response, nil)
+					return abc, nil
+				}
+			},
+			errString: cp.Status_name[int32(cp.Status_BAD_REQUEST)],
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Gateway Submit() returned a successful response if the transaction was submitted to the orderer but the orderer responded with an unsuccessful status code. This change returns an appropriate error message including the status from an unsuccessful send to the orderer.