### PR TITLE
Introduce ability to map subject key identifers to key objects with read-only CKA_ID attributes

### DIFF
--- a/bccsp/pkcs11/conf.go
+++ b/bccsp/pkcs11/conf.go
@@ -21,13 +21,22 @@ type PKCS11Opts struct {
 	Hash     string `json:"hash"`
 
 	// PKCS11 options
-	Library        string `json:"library"`
-	Label          string `json:"label"`
-	Pin            string `json:"pin"`
-	SoftwareVerify bool   `json:"softwareverify,omitempty"`
-	Immutable      bool   `json:"immutable,omitempty"`
+	Library        string         `json:"library"`
+	Label          string         `json:"label"`
+	Pin            string         `json:"pin"`
+	SoftwareVerify bool           `json:"softwareverify,omitempty"`
+	Immutable      bool           `json:"immutable,omitempty"`
+	AltID          string         `json:"altid,omitempty"`
+	KeyIDs         []KeyIDMapping `json:"keyids,omitempty" mapstructure:"keyids"`
 
 	sessionCacheSize        int
 	createSessionRetries    int
 	createSessionRetryDelay time.Duration
+}
+
+// A KeyIDMapping associates the CKA_ID attribute of a cryptoki object with a
+// subject key identifer.
+type KeyIDMapping struct {
+	SKI string `json:"ski,omitempty"`
+	ID  string `json:"id,omitempty"`
 }

--- a/integration/nwo/fabricconfig/core.go
+++ b/integration/nwo/fabricconfig/core.go
@@ -184,6 +184,14 @@ type PKCS11 struct {
 	Pin      string `yaml:"Pin,omitempty"`
 	Label    string `yaml:"Label,omitempty"`
 	Library  string `yaml:"Library,omitempty"`
+
+	AltID  string         `yaml:"AltID,omitempty"`
+	KeyIDs []KeyIDMapping `yaml:"KeyIDs,omitempty"`
+}
+
+type KeyIDMapping struct {
+	SKI string `yaml:"SKI,omitempty"`
+	ID  string `yaml:"ID,omitempty"`
 }
 
 type DeliveryClient struct {

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -345,6 +345,10 @@ func (n *Network) WriteOrdererConfig(o *Orderer, config *fabricconfig.Orderer) {
 
 	err = ioutil.WriteFile(n.OrdererConfigPath(o), ordererBytes, 0o644)
 	Expect(err).NotTo(HaveOccurred())
+
+	pw := gexec.NewPrefixedWriter(fmt.Sprintf("[updated-%s#orderer.yaml] ", o.ID()), ginkgo.GinkgoWriter)
+	_, err = pw.Write(ordererBytes)
+	Expect(err).NotTo(HaveOccurred())
 }
 
 // ReadConfigTxConfig  unmarshals the configtx.yaml and returns an
@@ -406,6 +410,10 @@ func (n *Network) WritePeerConfig(p *Peer, config *fabricconfig.Core) {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = ioutil.WriteFile(n.PeerConfigPath(p), coreBytes, 0o644)
+	Expect(err).NotTo(HaveOccurred())
+
+	pw := gexec.NewPrefixedWriter(fmt.Sprintf("[updated-%s#core.yaml] ", p.ID()), ginkgo.GinkgoWriter)
+	_, err = pw.Write(coreBytes)
 	Expect(err).NotTo(HaveOccurred())
 }
 


### PR DESCRIPTION
Add support for mapping subject key identifiers to cryptoki object CKA_ID attributes. This allows Fabric to use keys from token providers that do not support CKA_ID attribute modification.