### PR TITLE
Prepared tx must be signed before submission

### DIFF
--- a/integration/gateway/gateway_test.go
+++ b/integration/gateway/gateway_test.go
@@ -156,6 +156,9 @@ var _ = Describe("GatewayService", func() {
 			Expect(proto.Equal(result, expectedResult)).To(BeTrue(), "Expected\n\t%#v\nto proto.Equal\n\t%#v", result, expectedResult)
 
 			preparedTransaction := endorseResponse.GetPreparedTransaction()
+			preparedTransaction.Signature, err = signingIdentity.Sign(preparedTransaction.Payload)
+			Expect(err).NotTo(HaveOccurred())
+
 			submitRequest := &gateway.SubmitRequest{
 				TransactionId:       transactionID,
 				ChannelId:           "testchannel",

--- a/internal/pkg/gateway/api.go
+++ b/internal/pkg/gateway/api.go
@@ -154,7 +154,10 @@ func (gs *Server) Submit(ctx context.Context, request *gp.SubmitRequest) (*gp.Su
 	}
 	txn := request.GetPreparedTransaction()
 	if txn == nil {
-		return nil, status.Error(codes.InvalidArgument, "a signed prepared transaction is required")
+		return nil, status.Error(codes.InvalidArgument, "a prepared transaction is required")
+	}
+	if len(txn.Signature) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "prepared transaction must be signed")
 	}
 	orderers, err := gs.registry.orderers(request.ChannelId)
 	if err != nil {

--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -471,6 +471,18 @@ func TestSubmit(t *testing.T) {
 	}
 }
 
+func TestSubmitUnsigned(t *testing.T) {
+	server := &Server{}
+	req := &pb.SubmitRequest{
+		TransactionId:       "transaction-id",
+		ChannelId:           "channel-id",
+		PreparedTransaction: &cp.Envelope{},
+	}
+	_, err := server.Submit(context.Background(), req)
+	require.Error(t, err)
+	require.Equal(t, err, status.Error(codes.InvalidArgument, "prepared transaction must be signed"))
+}
+
 func TestCommitStatus(t *testing.T) {
 	tests := []testDef{
 		{


### PR DESCRIPTION
The integration test isn't signing the prepared transaction before submission and the transaction is being rejected by the orderer. This change adds an explicit check for the signature in the gateway and fixes the test to add the signature.