### PR TITLE
FABGW-8: Hook commit notifier into Gateway service

### DIFF
--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -825,6 +825,9 @@ func serve(args []string) error {
 				gateway.CreateServer(
 					&gateway.EndorserServerAdapter{Server: serverEndorser},
 					discoveryService,
+					&gateway.PeerNotifierAdapter{
+						Peer: peerInstance,
+					},
 					peerInstance.GossipService.SelfMembershipInfo().Endpoint,
 					coreConfig.LocalMSPID,
 					coreConfig.GatewayOptions,

--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hyperledger/fabric/gossip/api"
 	"github.com/hyperledger/fabric/gossip/common"
 	gdiscovery "github.com/hyperledger/fabric/gossip/discovery"
+	"github.com/hyperledger/fabric/internal/pkg/gateway/commit/mock"
 	"github.com/hyperledger/fabric/internal/pkg/gateway/config"
 	"github.com/hyperledger/fabric/internal/pkg/gateway/mocks"
 	idmocks "github.com/hyperledger/fabric/internal/pkg/identity/mocks"
@@ -512,7 +513,7 @@ func TestCommitStatus(t *testing.T) {
 }
 
 func TestNilArgs(t *testing.T) {
-	server := CreateServer(&mocks.EndorserClient{}, &mocks.Discovery{}, "localhost:7051", "msp1", config.GetOptions(viper.New()))
+	server := CreateServer(&mocks.EndorserClient{}, &mocks.Discovery{}, &mock.NotificationSupplier{}, "localhost:7051", "msp1", config.GetOptions(viper.New()))
 	ctx := context.Background()
 
 	_, err := server.Evaluate(ctx, nil)
@@ -595,7 +596,7 @@ func prepareTest(t *testing.T, tt *testDef) *preparedTest {
 		EndorsementTimeout: endorsementTimeout,
 	}
 
-	server := CreateServer(localEndorser, disc, "localhost:7051", "msp1", options)
+	server := CreateServer(localEndorser, disc, &mock.NotificationSupplier{}, "localhost:7051", "msp1", options)
 
 	dialer := &mocks.Dialer{}
 	dialer.Returns(nil, nil)

--- a/internal/pkg/gateway/commit/channelnotifier.go
+++ b/internal/pkg/gateway/commit/channelnotifier.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 IBM All Rights Reserved.
+Copyright IBM Corp. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/pkg/gateway/commit/notifier.go
+++ b/internal/pkg/gateway/commit/notifier.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 IBM All Rights Reserved.
+Copyright IBM Corp. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
@@ -37,10 +37,6 @@ type Notification struct {
 
 // NewNotifier constructor.
 func NewNotifier(supplier NotificationSupplier) *Notifier {
-	if supplier == nil {
-		return nil
-	}
-
 	return &Notifier{
 		supplier:         supplier,
 		channelNotifiers: make(map[string]*channelLevelNotifier),

--- a/internal/pkg/gateway/commit/notifier_test.go
+++ b/internal/pkg/gateway/commit/notifier_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 IBM All Rights Reserved.
+Copyright IBM Corp. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
@@ -27,11 +27,6 @@ func TestNotifier(t *testing.T) {
 
 		return commit.NewNotifier(notificationSupplier)
 	}
-
-	t.Run("NewNotifier with nil ledger returns nil", func(t *testing.T) {
-		result := commit.NewNotifier(nil)
-		require.Nil(t, result)
-	})
 
 	t.Run("Notify", func(t *testing.T) {
 		t.Run("returns error from notification supplier", func(t *testing.T) {

--- a/internal/pkg/gateway/commitadapter.go
+++ b/internal/pkg/gateway/commitadapter.go
@@ -1,0 +1,26 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package gateway
+
+import (
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/peer"
+	"github.com/pkg/errors"
+)
+
+type PeerNotifierAdapter struct {
+	Peer *peer.Peer
+}
+
+func (adapter *PeerNotifierAdapter) CommitNotifications(done <-chan struct{}, channelName string) (<-chan *ledger.CommitNotification, error) {
+	channel := adapter.Peer.Channel(channelName)
+	if channel == nil {
+		return nil, errors.Errorf("channel does not exist: %s", channelName)
+	}
+
+	return channel.Ledger().CommitNotificationsChannel(done)
+}


### PR DESCRIPTION
Still not executed at runtime. Just establishing the integration point and peer adapter to allow use later.

Note that this PR is just reinstating some changes that got lost from #2477, possibly during rebasing around merge conflicts.