### PR TITLE
Introduce ability to map subject key identifers to key objects with read-only CKA_ID attributes (release-2.3)

### DIFF
--- a/bccsp/pkcs11/conf.go
+++ b/bccsp/pkcs11/conf.go
@@ -21,13 +21,22 @@ type PKCS11Opts struct {
 	Hash     string `json:"hash"`
 
 	// PKCS11 options
-	Library        string `json:"library"`
-	Label          string `json:"label"`
-	Pin            string `json:"pin"`
-	SoftwareVerify bool   `json:"softwareverify,omitempty"`
-	Immutable      bool   `json:"immutable,omitempty"`
+	Library        string         `json:"library"`
+	Label          string         `json:"label"`
+	Pin            string         `json:"pin"`
+	SoftwareVerify bool           `json:"softwareverify,omitempty"`
+	Immutable      bool           `json:"immutable,omitempty"`
+	AltID          string         `json:"altid,omitempty"`
+	KeyIDs         []KeyIDMapping `json:"keyids,omitempty" mapstructure:"keyids"`
 
 	sessionCacheSize        int
 	createSessionRetries    int
 	createSessionRetryDelay time.Duration
+}
+
+// A KeyIDMapping associates the CKA_ID attribute of a cryptoki object with a
+// subject key identifer.
+type KeyIDMapping struct {
+	SKI string `json:"ski,omitempty"`
+	ID  string `json:"id,omitempty"`
 }

--- a/bccsp/pkcs11/pkcs11.go
+++ b/bccsp/pkcs11/pkcs11.go
@@ -41,6 +41,7 @@ type Provider struct {
 	softVerify bool
 	immutable  bool
 
+	getKeyIDForSKI          func(ski []byte) []byte
 	createSessionRetries    int
 	createSessionRetryDelay time.Duration
 
@@ -56,6 +57,19 @@ type Provider struct {
 // Ensure we satisfy the BCCSP interfaces.
 var _ bccsp.BCCSP = (*Provider)(nil)
 
+// An Option is used to configure the Provider.
+type Option func(p *Provider) error
+
+// WithKeyMapper returns an option that configures the Provider to use the
+// provided function to map a subject key identifier to a cryptoki CKA_ID
+// identifer.
+func WithKeyMapper(mapper func([]byte) []byte) Option {
+	return func(p *Provider) error {
+		p.getKeyIDForSKI = mapper
+		return nil
+	}
+}
+
 // New returns a new instance of a BCCSP that uses PKCS#11 standard interfaces
 // to generate and use elliptic curve key pairs for signing and verification using
 // curves that satisfy the requested security level from opts.
@@ -63,7 +77,7 @@ var _ bccsp.BCCSP = (*Provider)(nil)
 // All other cryptographic functions are delegated to a software based BCCSP
 // implementation that is configured to use the security level and hashing
 // familly from opts and the key store that is provided.
-func New(opts PKCS11Opts, keyStore bccsp.KeyStore) (*Provider, error) {
+func New(opts PKCS11Opts, keyStore bccsp.KeyStore, options ...Option) (*Provider, error) {
 	curve, err := curveForSecurityLevel(opts.Security)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed initializing configuration")
@@ -92,6 +106,7 @@ func New(opts PKCS11Opts, keyStore bccsp.KeyStore) (*Provider, error) {
 	csp := &Provider{
 		BCCSP:                   swCSP,
 		curve:                   curve,
+		getKeyIDForSKI:          func(ski []byte) []byte { return ski },
 		createSessionRetries:    opts.createSessionRetries,
 		createSessionRetryDelay: opts.createSessionRetryDelay,
 		sessPool:                sessPool,
@@ -100,6 +115,12 @@ func New(opts PKCS11Opts, keyStore bccsp.KeyStore) (*Provider, error) {
 		keyCache:                map[string]bccsp.Key{},
 		softVerify:              opts.SoftwareVerify,
 		immutable:               opts.Immutable,
+	}
+
+	for _, o := range options {
+		if err := o(csp); err != nil {
+			return nil, err
+		}
 	}
 
 	return csp.initialize(opts)
@@ -697,7 +718,7 @@ func (csp *Provider) findKeyPairFromSKI(session pkcs11.SessionHandle, ski []byte
 
 	template := []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_CLASS, ktype),
-		pkcs11.NewAttribute(pkcs11.CKA_ID, ski),
+		pkcs11.NewAttribute(pkcs11.CKA_ID, csp.getKeyIDForSKI(ski)),
 	}
 	if err := csp.ctx.FindObjectsInit(session, template); err != nil {
 		return 0, err

--- a/bccsp/pkcs11/pkcs11_test.go
+++ b/bccsp/pkcs11/pkcs11_test.go
@@ -49,9 +49,9 @@ func newKeyStore(t *testing.T) (bccsp.KeyStore, func()) {
 	return ks, func() { os.RemoveAll(tempDir) }
 }
 
-func newProvider(t *testing.T, opts PKCS11Opts) (*Provider, func()) {
+func newProvider(t *testing.T, opts PKCS11Opts, options ...Option) (*Provider, func()) {
 	ks, ksCleanup := newKeyStore(t)
-	csp, err := New(opts, ks)
+	csp, err := New(opts, ks, options...)
 	require.NoError(t, err)
 
 	cleanup := func() {
@@ -332,6 +332,74 @@ func TestECDSASign(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Invalid digest. Cannot be empty")
 	})
+}
+
+type mapper struct {
+	input  []byte
+	result []byte
+}
+
+func (m *mapper) skiToID(ski []byte) []byte {
+	m.input = ski
+	return m.result
+}
+
+func TestKeyMapper(t *testing.T) {
+	mapper := &mapper{}
+	csp, cleanup := newProvider(t, defaultOptions(), WithKeyMapper(mapper.skiToID))
+	defer cleanup()
+
+	k, err := csp.KeyGen(&bccsp.ECDSAKeyGenOpts{Temporary: false})
+	require.NoError(t, err)
+
+	digest, err := csp.Hash([]byte("Hello World"), &bccsp.SHAOpts{})
+	require.NoError(t, err)
+
+	sess, err := csp.getSession()
+	require.NoError(t, err, "failed to get session")
+	defer csp.returnSession(sess)
+
+	newID := []byte("mapped-id")
+	updateKeyIdentifier(t, csp.ctx, sess, pkcs11.CKO_PUBLIC_KEY, k.SKI(), newID)
+	updateKeyIdentifier(t, csp.ctx, sess, pkcs11.CKO_PRIVATE_KEY, k.SKI(), newID)
+
+	t.Run("ToMissingID", func(t *testing.T) {
+		csp.clearCaches()
+		mapper.result = k.SKI()
+		_, err := csp.Sign(k, digest, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Private key not found")
+		require.Equal(t, k.SKI(), mapper.input, "expected mapper to receive ski %x, got %x", k.SKI(), mapper.input)
+	})
+	t.Run("ToNewID", func(t *testing.T) {
+		csp.clearCaches()
+		mapper.result = newID
+		signature, err := csp.Sign(k, digest, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, signature, "signature must not be empty")
+		require.Equal(t, k.SKI(), mapper.input, "expected mapper to receive ski %x, got %x", k.SKI(), mapper.input)
+	})
+}
+
+func updateKeyIdentifier(t *testing.T, pctx *pkcs11.Ctx, sess pkcs11.SessionHandle, class uint, currentID, newID []byte) {
+	pkt := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, class),
+		pkcs11.NewAttribute(pkcs11.CKA_ID, currentID),
+	}
+	err := pctx.FindObjectsInit(sess, pkt)
+	require.NoError(t, err)
+
+	objs, _, err := pctx.FindObjects(sess, 1)
+	require.NoError(t, err)
+	require.Len(t, objs, 1)
+
+	err = pctx.FindObjectsFinal(sess)
+	require.NoError(t, err)
+
+	err = pctx.SetAttributeValue(sess, objs[0], []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_ID, newID),
+	})
+	require.NoError(t, err)
 }
 
 func TestECDSAVerify(t *testing.T) {

--- a/integration/nwo/fabricconfig/core.go
+++ b/integration/nwo/fabricconfig/core.go
@@ -184,6 +184,14 @@ type PKCS11 struct {
 	Pin      string `yaml:"Pin,omitempty"`
 	Label    string `yaml:"Label,omitempty"`
 	Library  string `yaml:"Library,omitempty"`
+
+	AltID  string         `yaml:"AltID,omitempty"`
+	KeyIDs []KeyIDMapping `yaml:"KeyIDs,omitempty"`
+}
+
+type KeyIDMapping struct {
+	SKI string `yaml:"SKI,omitempty"`
+	ID  string `yaml:"ID,omitempty"`
 }
 
 type DeliveryClient struct {


### PR DESCRIPTION
Add support for mapping subject key identifiers to cryptoki object CKA_ID attributes. This allows Fabric to use keys from token providers that do not support CKA_ID attribute modification.

Backport of #2486 