### PR TITLE
Introduce ability to map subject key identifers to key objects with read-only CKA_ID attributes (release-2.2)

### DIFF
--- a/bccsp/factory/pkcs11factory.go
+++ b/bccsp/factory/pkcs11factory.go
@@ -9,6 +9,8 @@ SPDX-License-Identifier: Apache-2.0
 package factory
 
 import (
+	"encoding/hex"
+
 	"github.com/hyperledger/fabric/bccsp"
 	"github.com/hyperledger/fabric/bccsp/pkcs11"
 	"github.com/hyperledger/fabric/bccsp/sw"
@@ -35,8 +37,27 @@ func (f *PKCS11Factory) Get(config *FactoryOpts) (bccsp.BCCSP, error) {
 		return nil, errors.New("Invalid config. It must not be nil.")
 	}
 
-	p11Opts := config.Pkcs11Opts
+	p11Opts := *config.Pkcs11Opts
 	ks := sw.NewDummyKeyStore()
+	mapper := skiMapper(p11Opts)
 
-	return pkcs11.New(*p11Opts, ks)
+	return pkcs11.New(p11Opts, ks, pkcs11.WithKeyMapper(mapper))
+}
+
+func skiMapper(p11Opts pkcs11.PKCS11Opts) func([]byte) []byte {
+	keyMap := map[string]string{}
+	for _, k := range p11Opts.KeyIDs {
+		keyMap[k.SKI] = k.ID
+	}
+
+	return func(ski []byte) []byte {
+		keyID := hex.EncodeToString(ski)
+		if id, ok := keyMap[keyID]; ok {
+			return []byte(id)
+		}
+		if p11Opts.AltID != "" {
+			return []byte(p11Opts.AltID)
+		}
+		return ski
+	}
 }

--- a/bccsp/pkcs11/conf.go
+++ b/bccsp/pkcs11/conf.go
@@ -76,9 +76,18 @@ type PKCS11Opts struct {
 	Ephemeral bool `mapstructure:"tempkeys,omitempty" json:"tempkeys,omitempty"`
 
 	// PKCS11 options
-	Library    string `mapstructure:"library" json:"library"`
-	Label      string `mapstructure:"label" json:"label"`
-	Pin        string `mapstructure:"pin" json:"pin"`
-	SoftVerify bool   `mapstructure:"softwareverify,omitempty" json:"softwareverify,omitempty"`
-	Immutable  bool   `mapstructure:"immutable,omitempty" json:"immutable,omitempty"`
+	Library    string         `mapstructure:"library" json:"library"`
+	Label      string         `mapstructure:"label" json:"label"`
+	Pin        string         `mapstructure:"pin" json:"pin"`
+	SoftVerify bool           `mapstructure:"softwareverify,omitempty" json:"softwareverify,omitempty"`
+	Immutable  bool           `mapstructure:"immutable,omitempty" json:"immutable,omitempty"`
+	AltID      string         `json:"altid,omitempty"`
+	KeyIDs     []KeyIDMapping `json:"keyids,omitempty" mapstructure:"keyids"`
+}
+
+// A KeyIDMapping associates the CKA_ID attribute of a cryptoki object with a
+// subject key identifer.
+type KeyIDMapping struct {
+	SKI string `json:"ski,omitempty"`
+	ID  string `json:"id,omitempty"`
 }

--- a/bccsp/pkcs11/pkcs11_test.go
+++ b/bccsp/pkcs11/pkcs11_test.go
@@ -565,6 +565,107 @@ func TestECDSASign(t *testing.T) {
 	require.Contains(t, err.Error(), "Invalid digest. Cannot be empty")
 }
 
+func defaultOptions() PKCS11Opts {
+	lib, pin, label := FindPKCS11Lib()
+	return PKCS11Opts{
+		Library:    lib,
+		Label:      label,
+		Pin:        pin,
+		HashFamily: "SHA2",
+		SecLevel:   256,
+		SoftVerify: false,
+	}
+}
+
+func newKeyStore(t *testing.T) (bccsp.KeyStore, func()) {
+	tempDir, err := ioutil.TempDir("", "pkcs11_ks")
+	require.NoError(t, err)
+	ks, err := sw.NewFileBasedKeyStore(nil, tempDir, false)
+	require.NoError(t, err)
+
+	return ks, func() { os.RemoveAll(tempDir) }
+}
+
+func newProvider(t *testing.T, opts PKCS11Opts, options ...Option) (*impl, func()) {
+	ks, ksCleanup := newKeyStore(t)
+	csp, err := New(opts, ks, options...)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		csp.(*impl).ctx.Destroy()
+		ksCleanup()
+	}
+	return csp.(*impl), cleanup
+}
+
+type mapper struct {
+	input  []byte
+	result []byte
+}
+
+func (m *mapper) skiToID(ski []byte) []byte {
+	m.input = ski
+	return m.result
+}
+
+func TestKeyMapper(t *testing.T) {
+	mapper := &mapper{}
+	csp, cleanup := newProvider(t, defaultOptions(), WithKeyMapper(mapper.skiToID))
+	defer cleanup()
+
+	k, err := csp.KeyGen(&bccsp.ECDSAKeyGenOpts{Temporary: false})
+	require.NoError(t, err)
+
+	digest, err := csp.Hash([]byte("Hello World"), &bccsp.SHAOpts{})
+	require.NoError(t, err)
+
+	sess, err := csp.getSession()
+	require.NoError(t, err, "failed to get session")
+	defer csp.returnSession(sess)
+
+	newID := []byte("mapped-id")
+	updateKeyIdentifier(t, csp.ctx, sess, pkcs11.CKO_PUBLIC_KEY, k.SKI(), newID)
+	updateKeyIdentifier(t, csp.ctx, sess, pkcs11.CKO_PRIVATE_KEY, k.SKI(), newID)
+
+	t.Run("ToMissingID", func(t *testing.T) {
+		csp.clearCaches()
+		mapper.result = k.SKI()
+		_, err := csp.Sign(k, digest, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Private key not found")
+		require.Equal(t, k.SKI(), mapper.input, "expected mapper to receive ski %x, got %x", k.SKI(), mapper.input)
+	})
+	t.Run("ToNewID", func(t *testing.T) {
+		csp.clearCaches()
+		mapper.result = newID
+		signature, err := csp.Sign(k, digest, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, signature, "signature must not be empty")
+		require.Equal(t, k.SKI(), mapper.input, "expected mapper to receive ski %x, got %x", k.SKI(), mapper.input)
+	})
+}
+
+func updateKeyIdentifier(t *testing.T, pctx *pkcs11.Ctx, sess pkcs11.SessionHandle, class uint, currentID, newID []byte) {
+	pkt := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, class),
+		pkcs11.NewAttribute(pkcs11.CKA_ID, currentID),
+	}
+	err := pctx.FindObjectsInit(sess, pkt)
+	require.NoError(t, err)
+
+	objs, _, err := pctx.FindObjects(sess, 1)
+	require.NoError(t, err)
+	require.Len(t, objs, 1)
+
+	err = pctx.FindObjectsFinal(sess)
+	require.NoError(t, err)
+
+	err = pctx.SetAttributeValue(sess, objs[0], []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_ID, newID),
+	})
+	require.NoError(t, err)
+}
+
 func TestECDSAVerify(t *testing.T) {
 	k, err := currentBCCSP.KeyGen(&bccsp.ECDSAKeyGenOpts{Temporary: false})
 	if err != nil {

--- a/integration/nwo/fabricconfig/core.go
+++ b/integration/nwo/fabricconfig/core.go
@@ -184,6 +184,14 @@ type PKCS11 struct {
 	Pin      string `yaml:"Pin,omitempty"`
 	Label    string `yaml:"Label,omitempty"`
 	Library  string `yaml:"Library,omitempty"`
+
+	AltID  string         `yaml:"AltID,omitempty"`
+	KeyIDs []KeyIDMapping `yaml:"KeyIDs,omitempty"`
+}
+
+type KeyIDMapping struct {
+	SKI string `yaml:"SKI,omitempty"`
+	ID  string `yaml:"ID,omitempty"`
 }
 
 type DeliveryClient struct {


### PR DESCRIPTION
Add support for mapping subject key identifiers to cryptoki object CKA_ID attributes. This allows Fabric to use keys from token providers that do not support CKA_ID attribute modification.

Backport #2486 