### PR TITLE
Bugfix: loadLastConfig wrongly returns nil instead of error

### DIFF
--- a/orderer/common/follower/follower_chain.go
+++ b/orderer/common/follower/follower_chain.go
@@ -561,7 +561,7 @@ func (c *Chain) loadLastConfig() error {
 	}
 	lastConfig := c.ledgerResources.Block(index)
 	if lastConfig == nil {
-		return errors.WithMessagef(err, "could not retrieve config block from index %d", index)
+		return errors.Errorf("could not retrieve config block from index %d", index)
 	}
 	c.lastConfig = lastConfig
 	return nil


### PR DESCRIPTION
Trivial bugfix - should use Errorf() here instead of WithMessagef()

#### Type of change

- Bug fix

#### Description

Should use Errorf() here instead of WithMessagef() because "err" here is always nil, hence WithMessagef() always returned nil instead of the expected error.