### PR TITLE
Wire function parameter to its actual usage

### DIFF
--- a/common/channelconfig/util.go
+++ b/common/channelconfig/util.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hyperledger/fabric-protos-go/orderer/etcdraft"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/bccsp"
-	"github.com/hyperledger/fabric/bccsp/factory"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 )
@@ -257,7 +256,7 @@ func ValidateCapabilities(block *cb.Block, bccsp bccsp.BCCSP) error {
 
 // ExtractMSPIDsForApplicationOrgs extracts MSPIDs for application organizations
 func ExtractMSPIDsForApplicationOrgs(block *cb.Block, bccsp bccsp.BCCSP) ([]string, error) {
-	cc, err := extractChannelConfig(block, factory.GetDefault())
+	cc, err := extractChannelConfig(block, bccsp)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Wiring function input parameter to its actual usage

Signed-off-by: Artem Barger <bartem@il.ibm.com>
