### PR TITLE
Fix the fix for race condition in Finder unit test

### DIFF
--- a/internal/pkg/gateway/commit/finder_test.go
+++ b/internal/pkg/gateway/commit/finder_test.go
@@ -32,6 +32,7 @@ func TestFinder(t *testing.T) {
 				select {
 				case commitSend <- msg:
 				case <-done:
+					return
 				}
 			}
 		}()


### PR DESCRIPTION
At the end of the unit test, correctly stop the goroutine used to ensure that commit messages are available to read at the point the listener attaches.