### PR TITLE
Fix link in `international_languages.md`

### DIFF
--- a/docs/source/international_languages.md
+++ b/docs/source/international_languages.md
@@ -148,7 +148,7 @@ Before your new language can be published to the documentation website, you must
 translate the following topics.  These topics help users and translators of your
 new language get started.
 
-* [Fabric front page](https://hyperledger-fabric.readthedocs.io/zh_CN/{BRANCH_DOC}/)
+* [Fabric front page](https://hyperledger-fabric.readthedocs.io/en/{BRANCH_DOC}/)
 
   This is your advert! Thanks to you, users can now see that the documentation
   is available in their language. It might not be complete yet, but its clear


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

This patch fixes a link in internal_languages.md.
The link should refer to the original English page like the other links.

#### Additional details

#### Related issues
