### PR TITLE
Fix link in `international_languages.md`

### DIFF
--- a/docs/source/international_languages.md
+++ b/docs/source/international_languages.md
@@ -150,7 +150,7 @@ Before your new language can be published to the documentation website, you must
 translate the following topics.  These topics help users and translators of your
 new language get started.
 
-* [Fabric front page](https://hyperledger-fabric.readthedocs.io/zh_CN/latest/)
+* [Fabric front page](https://hyperledger-fabric.readthedocs.io/en/latest/)
 
   This is your advert! Thanks to you, users can now see that the documentation
   is available in their language. It might not be complete yet, but its clear


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

This patch fixes a link in `international_languages.md`.
The link should refer to the original English page like the other links.

#### Additional details

- Related to https://github.com/hyperledger/fabric/pull/2510

#### Related issues
