### PR TITLE
Document ledger.snapshots.rootDir

### DIFF
--- a/docs/source/deploypeer/peerchecklist.md
+++ b/docs/source/deploypeer/peerchecklist.md
@@ -112,7 +112,7 @@ localMspId: SampleOrg
 # modification that might corrupt the peer operations.
 fileSystemPath: /var/hyperledger/production
 ```
-- **`fileSystemPath`**: (Default value should be overridden.) This is the path to the ledger and installed chaincodes on the local filesystem of the peer. It can be an absolute path or relative to `FABRIC_CFG_PATH`. It defaults to `/var/hyperledger/production`. The user running the peer needs to own and have write access to this directory. **The best practice is to store this data in persistent storage**. This prevents the ledger and any installed chaincodes from being lost if your peer containers are destroyed for some reason.
+- **`fileSystemPath`**: (Default value should be overridden.) This is the path to the ledger and installed chaincodes on the local filesystem of the peer. It can be an absolute path or relative to `FABRIC_CFG_PATH`. It defaults to `/var/hyperledger/production`. The user running the peer needs to own and have write access to this directory. **The best practice is to store this data in persistent storage**. This prevents the ledger and any installed chaincodes from being lost if your peer containers are destroyed for some reason. Note that ledger snapshots will be written to  `ledger.snapshots.rootDir`, described in the [ledger.* section](#ledger).
 
 ## peer.gossip.*
 

--- a/docs/source/deploypeer/peerdeploy.md
+++ b/docs/source/deploypeer/peerdeploy.md
@@ -80,7 +80,13 @@ Note that the local MSP contains the signed certificate (public key) and the pri
 
 ### Storage
 
-You must provision persistent storage for your ledger. If you are not using an external chaincode builder and launcher, you should factor in storage for that as well. The default location for the ledger is located at `/var/hyperledger/production`. Ensure that your peer has write access to the folder. If you choose to use a different location, provide that path in the `peer.fileSystemPath` parameter in the `core.yaml` file. If you decide to use Kubernetes or Docker, recall that in a containerized environment local storage disappears when the container goes away, so you will need to provision or mount persistent storage for the ledger before you deploy a peer.
+You must provision persistent storage for your ledger files. The following properties in `core.yaml` dictates where ledger files and snapshots are written:
+* `peer.fileSystemPath` - defaults to `/var/hyperledger/production`
+* `ledger.snapshots.rootDir` - defaults to `/var/hyperledger/production/snapshots`
+
+Ensure that your peer has write access to these directories.
+
+If you decide to use Kubernetes or Docker, recall that in a containerized environment local storage disappears when the container goes away, so you will need to provision or mount persistent storage for the ledger before you deploy a peer.
 
 ### Configuration of `core.yaml`
 


### PR DESCRIPTION
Clarify that peer needs write access to ledger.snapshots.rootDir directory.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
