### PR TITLE
FAB-18417 Improve snapshot dir error message

### DIFF
--- a/core/ledger/kvledger/kv_ledger_provider.go
+++ b/core/ledger/kvledger/kv_ledger_provider.go
@@ -251,10 +251,10 @@ func (p *Provider) initSnapshotDir() error {
 		return errors.Wrapf(err, "error while deleting the dir: %s", inProgressSnapshotsPath)
 	}
 	if err := os.MkdirAll(inProgressSnapshotsPath, 0755); err != nil {
-		return errors.Wrapf(err, "error while creating the dir: %s", inProgressSnapshotsPath)
+		return errors.Wrapf(err, "error while creating the dir: %s, ensure peer has write access to configured ledger.snapshots.rootDir directory", inProgressSnapshotsPath)
 	}
 	if err := os.MkdirAll(completedSnapshotsPath, 0755); err != nil {
-		return errors.Wrapf(err, "error while creating the dir: %s", completedSnapshotsPath)
+		return errors.Wrapf(err, "error while creating the dir: %s, ensure peer has write access to configured ledger.snapshots.rootDir directory", completedSnapshotsPath)
 	}
 	return fileutil.SyncDir(snapshotsRootDir)
 }


### PR DESCRIPTION
Users upgrading to v2.3 don't always know to configure ledger.snapshots.rootDir.
In cases where peer doesn't have write access to this directory,
the error message now mentions the property to configure.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>