### PR TITLE
Enable HTTPS remote connection for CouchDB instance

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb.go
@@ -471,9 +471,14 @@ func (couchInstance *couchInstance) maxBatchUpdateSize() int {
 
 // url returns the URL for the CouchDB instance.
 func (couchInstance *couchInstance) url() string {
+	scheme := "http"
+	if couchInstance.conf.TLS.Enabled {
+		scheme += "s"
+	}
+
 	URL := &url.URL{
 		Host:   couchInstance.conf.Address,
-		Scheme: "http",
+		Scheme: scheme,
 	}
 	return URL.String()
 }

--- a/core/ledger/ledger_interface.go
+++ b/core/ledger/ledger_interface.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/bccsp"
+	"github.com/hyperledger/fabric/common/fabhttp"
 	commonledger "github.com/hyperledger/fabric/common/ledger"
 	"github.com/hyperledger/fabric/common/metrics"
 )
@@ -73,6 +74,9 @@ type CouchDBConfig struct {
 	Username string
 	// Password is the password for Username.
 	Password string
+	// TLS represents the TLS configuration to connect to the CouchDB instance
+	// using HTTPS
+	TLS fabhttp.TLS
 	// MaxRetries is the maximum number of times to retry CouchDB operations on
 	// failure.
 	MaxRetries int


### PR DESCRIPTION
<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- New feature

#### Description

This pull request aims to allow the Peer to connect to a remote Couchdb instance through HTTPS

#### Additional details

I will update the tests accordingly ASAP.

#### Related issues

None