### PR TITLE
Docs: Modify fabric version from 1.4.11 (non-existent) to 1.4.7 (late…

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -48,12 +48,12 @@ the binaries and images.
 
 .. note:: If you want a specific release, pass a version identifier for Fabric,
           Fabric-ca and thirdparty Docker images.
-          The command below demonstrates how to download **Fabric v1.4.11**
+          The command below demonstrates how to download **Fabric v1.4.7**
 
 .. code:: bash
 
   curl -sSL http://bit.ly/2ysbOFE | bash -s -- <fabric_version> <fabric-ca_version> <thirdparty_version>
-  curl -sSL http://bit.ly/2ysbOFE | bash -s -- 1.4.11 1.4.9 0.4.22
+  curl -sSL http://bit.ly/2ysbOFE | bash -s -- 1.4.7 1.4.9 0.4.22
 
 .. note:: If you get an error running the above curl command, you may
           have too old a version of curl that does not handle


### PR DESCRIPTION
…st stable 1.4.x release) in install.rst

Since version 1.4.11 does not exists, the installed version falls back to the main branch of fabric (i.e 2.3) when we run the curl command.
This change is fairly easy to miss during the installation.

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Documentation update

#### Description

It may seem that the curl command was meant to be given as an example, but I think it's fair to say many people will actually run that command and end up downloading fabric 2.3, which unfortunately is incompatible with the 1.4 docs.
That was the main reason behind changing the version from 1.4.11 to 1.4.7

