### PR TITLE
Skip plugin tests when the `noplugin` build tag is used

### DIFF
--- a/core/handlers/library/noplugin_test.go
+++ b/core/handlers/library/noplugin_test.go
@@ -1,0 +1,12 @@
+// +build noplugin
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package library
+
+func init() {
+	noplugin = true
+}


### PR DESCRIPTION
Make sure builds can complete when `GO_TAGS="noplugin"` is set in the environment.