### PR TITLE
Update deploy_chaincode.md

### DIFF
--- a/docs/source/deploy_chaincode.md
+++ b/docs/source/deploy_chaincode.md
@@ -56,7 +56,7 @@ find . -name monitordocker.sh
 
 You can then start Logspout by running the following command:
 ```
-./monitordocker.sh net_test
+./monitordocker.sh fabric_test
 ```
 You should see output similar to the following:
 ```


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

The name of the test network in docker appears to be fabric_test rather than net_test.

This name is used by the monitordocker.sh logspout command.

```
docker network ls

NETWORK ID          NAME                DRIVER              SCOPE
4ba75e52d44c        bridge              bridge              local
d64c5715a632        fabric_test         bridge              local
ac3dcef617db        host                host                local
50a642dc26be        none                null                local
```

