### PR TITLE
Removed early mentioning of organization R3

### DIFF
--- a/docs/source/network/network.md
+++ b/docs/source/network/network.md
@@ -18,7 +18,7 @@ In most cases, multiple [organizations](../glossary.html#organization) come toge
 
 Before we start, let's show you what we're aiming at! Here's a diagram representing the **final state** of our sample network.
 
-It might look complicated right now, but as we go through this topic, we will build up the network piece by piece, so that you see how the organizations R1, R2, R3 and R0 contribute infrastructure to the network to help form it. This infrastructure implements the blockchain network, and it is governed by policies agreed by the organizations who form the network -- for example, who can add new organizations. You'll discover how applications consume the ledger and smart contract services provided by the blockchain network.
+It might look complicated right now, but as we go through this topic, we will build up the network piece by piece, so that you see how the organizations R1, R2 and R0 contribute infrastructure to the network to help form it. This infrastructure implements the blockchain network, and it is governed by policies agreed by the organizations who form the network -- for example, who can add new organizations. You'll discover how applications consume the ledger and smart contract services provided by the blockchain network.
 
 ![network.1](./network.diagram.1.png)
 


### PR DESCRIPTION
#### Type of change

Documentation update

#### Description

Removed the early mentioning of organization R3 because R3 isn't part of the presented "final state of our sample network" but only added later on in another example extending this sample network.