### PR TITLE
v2.4.0-alpha release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@
 #   - verify - runs unit tests for only the changed package tree
 
 ALPINE_VER ?= 3.13
-BASE_VERSION = 2.4.0
+BASE_VERSION = 2.4.0-alpha
 
 # 3rd party image version
 # These versions are also set in the runners in ./integration/runners/

--- a/release_notes/v2.4.0-alpha.md
+++ b/release_notes/v2.4.0-alpha.md
@@ -1,8 +1,38 @@
-v2.4.0 <Release Month Day, Year>
-================================
+v2.4.0-alpha Release Notes - April 15, 2021
+===========================================
+
+New features
+------------
+
+**FABGW-1: Fabric Gateway Technical Preview**
+
+The Hyperledger Fabric v2.4.0 Alpha contains a technical preview of the new Fabric Gateway feature.
+
+The Fabric Gateway is a new component that will implement much of the high-level 'gateway' programming model in the Fabric peer,
+enabling the removal of much of the transaction submission and query logic from client applications, and shifting it to a common gateway component running within the Fabric peer.
+The various client SDKs can therefore be slimmer, more consistent, and require less maintenance.
+
+
+The Fabric Gateway will also simplify the administrative overhead of running a Fabric network because client applications
+will be able to connect and submit transactions via a single network port rather than the current situation where ports
+have to be opened from a client application to multiple peers across potentially multiple organizations.
+
+The Fabric Gateway technical preview is delivered along with slim SDKs in the [https://github.com/hyperledger/fabric-gateway](https://github.com/hyperledger/fabric-gateway) repository,
+along with [client application samples](https://github.com/hyperledger/fabric-gateway/tree/main/samples).
+
 
 Improvements
 ------------
+
+**peer and orderer - Implement legacy name constraints verification for Go 1.15**
+
+These changes reproduce the Go 1.14 name constraint verification in the MSP.
+Without these changes, certificate chains that would fail verification in Go 1.14 would
+successfully validate in Go 1.15 due to the change mentioned in the [Go 1.15 release notes](https://golang.org/doc/go1.15#commonname).
+Specifically, if a signing certificate contains a name constraint, the leaf certificate
+does not include SAN extensions, and the leaf's common name looks like a host name,
+then the additional verification is performed to ensure deterministic behavior relative
+to prior Fabric releases.
 
 **peer and orderer - Default log record format improvements**
 
@@ -14,18 +44,37 @@ and add a visual break between the logging module name and log message text.
 
 
 Fixes
-------------
+-----
+All fixes as of v2.3.1 are included in v2.4.0-alpha. Additionally, the following fixes are made in v2.4.0-alpha.
+
+  **FAB-18427: orderer - Report correct reason of stream abort in orderer cluster**
+
+This commit fixes a bug that makes the cluster communication infrastructure
+always report an "aborted" reason after a stream terminates.
+
+
 **FAB-18424: peer - Ledger snapshot request submission with special value "blockNumber 0"**
 
-If a ledger snapshot request is submitted with the special value "blockNumber 0", peer is expected to translate the request to last committed block. This patch fixes the issue where, it may happen sometimes that the request is transtlated to block number 1 instead of last committed block. This leads to the situation where no snapshot gets generated, including any future snapshot requests. If you have ever used this special value, we encourage you to check the list of pending snapshots requests. If you notice one or more pending requests that are for the the block numbers lower than the latest committed block, cancel such requests to enable the further snapshot requests to be processed.
+If a ledger snapshot request is submitted with the special value "blockNumber 0", peer is expected to translate the request to last committed block.
+This patch fixes the issue where, it may happen sometimes that the request is translated to block number 1 instead of last committed block.
+This leads to the situation where no snapshot gets generated, including any future snapshot requests.
+If you have ever used this special value, we encourage you to check the list of pending snapshots requests with `peer snapshot listpending`.
+If you notice one or more pending requests that are for the the block numbers lower than the latest committed block, cancel such requests with `peer snapshot cancelrequest` to enable the further snapshot requests to be processed.
+
+**FAB-18304: peer and orderer - Fix leveldb manifest corruption**
+
+This fix updates the version of goleveldb. The prior version of goleveldb had a bug which
+could cause manifest corruption in crash scenarios, especially in disk full crash scenarios.
+With a corrupted goleveldb database, the peer or orderer would fail to start with error
+"panic: Error opening leveldb: leveldb: manifest corrupted".
 
 
 Dependencies
 ------------
-Fabric v2.4.0 has been tested with the following dependencies:
-* Go 1.14.12
+Fabric v2.4.0-alpha has been tested with the following dependencies:
+* Go 1.15.7
 * CouchDB v3.1.1
-
+* Alpine images 3.13
 
 Deprecations (existing)
 -----------------------


### PR DESCRIPTION
Add v2.4.0-alpha release notes. Highlight the Fabric Gateway technical preview.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>