### PR TITLE
Remove redundant type cast

### DIFF
--- a/gossip/comm/comm_impl.go
+++ b/gossip/comm/comm_impl.go
@@ -482,7 +482,7 @@ func (c *commImpl) authenticateRemotePeer(stream stream, initiator, isProbe bool
 	}
 	// Final step - verify the signature on the connection message itself
 	verifier := func(peerIdentity []byte, signature, message []byte) error {
-		pkiID := c.idMapper.GetPKIidOfCert(api.PeerIdentityType(peerIdentity))
+		pkiID := c.idMapper.GetPKIidOfCert(peerIdentity)
 		return c.idMapper.Verify(pkiID, signature, message)
 	}
 	err = m.Verify(receivedMsg.Identity, verifier)


### PR DESCRIPTION
This commit removes a redundant type cast in gossip/comm/comm_impl.go

Change-Id: Ie8b921a5097f0d05f6645e67c31940c9daec0eb5
Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>
