### PR TITLE
Remove redundant comma

### DIFF
--- a/discovery/service.go
+++ b/discovery/service.go
@@ -137,7 +137,7 @@ func (s *Service) chaincodeQuery(q *discovery.Query) *discovery.QueryResult {
 	for _, interest := range q.GetCcQuery().Interests {
 		desc, err := s.PeersForEndorsement(common2.ChannelID(q.Channel), interest)
 		if err != nil {
-			logger.Errorf("Failed constructing descriptor for chaincode %s,: %v", interest, err)
+			logger.Errorf("Failed constructing descriptor for chaincode %s: %v", interest, err)
 			return wrapError(errors.Errorf("failed constructing descriptor for %v", interest))
 		}
 		descriptors = append(descriptors, desc)

--- a/gossip/comm/comm_impl.go
+++ b/gossip/comm/comm_impl.go
@@ -482,7 +482,7 @@ func (c *commImpl) authenticateRemotePeer(stream stream, initiator, isProbe bool
 	}
 	// Final step - verify the signature on the connection message itself
 	verifier := func(peerIdentity []byte, signature, message []byte) error {
-		pkiID := c.idMapper.GetPKIidOfCert(api.PeerIdentityType(peerIdentity))
+		pkiID := c.idMapper.GetPKIidOfCert(peerIdentity)
 		return c.idMapper.Verify(pkiID, signature, message)
 	}
 	err = m.Verify(receivedMsg.Identity, verifier)


### PR DESCRIPTION
This commit removes a redundant comma in an error log message in discovery/service.go
    
Change-Id: I1daaf673d942ee7a44eefcb62316e5807f10bcc6
Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>
