### PR TITLE
Remove redundant casts

### DIFF
--- a/discovery/service.go
+++ b/discovery/service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hyperledger/fabric/common/util"
 	"github.com/hyperledger/fabric/discovery/protoext"
 	common2 "github.com/hyperledger/fabric/gossip/common"
-	discovery2 "github.com/hyperledger/fabric/gossip/discovery"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 )
@@ -181,7 +180,7 @@ func (s *Service) channelMembershipResponse(q *discovery.Query) *discovery.Query
 		return wrapError(err)
 	}
 	membersByOrgs := make(map[string]*discovery.Peers)
-	chanPeerByID := discovery2.Members(chanPeers).ByID()
+	chanPeerByID := chanPeers.ByID()
 	for org, ids2Peers := range s.computeMembership(q) {
 		membersByOrgs[org] = &discovery.Peers{}
 		for id, peer := range ids2Peers {
@@ -211,7 +210,7 @@ func (s *Service) localMembershipResponse(q *discovery.Query) *discovery.QueryRe
 
 func (s *Service) computeMembership(_ *discovery.Query) map[string]peerMapping {
 	peersByOrg := make(map[string]peerMapping)
-	peerAliveInfo := discovery2.Members(s.Peers()).ByID()
+	peerAliveInfo := s.Peers().ByID()
 	for org, peerIdentities := range s.IdentityInfo().ByOrg() {
 		peersForCurrentOrg := make(peerMapping)
 		peersByOrg[org] = peersForCurrentOrg

--- a/gossip/comm/comm_impl.go
+++ b/gossip/comm/comm_impl.go
@@ -482,7 +482,7 @@ func (c *commImpl) authenticateRemotePeer(stream stream, initiator, isProbe bool
 	}
 	// Final step - verify the signature on the connection message itself
 	verifier := func(peerIdentity []byte, signature, message []byte) error {
-		pkiID := c.idMapper.GetPKIidOfCert(api.PeerIdentityType(peerIdentity))
+		pkiID := c.idMapper.GetPKIidOfCert(peerIdentity)
 		return c.idMapper.Verify(pkiID, signature, message)
 	}
 	err = m.Verify(receivedMsg.Identity, verifier)


### PR DESCRIPTION
This commit removes redundant casts in discovery/service.go
    
Change-Id: I6b52ba91ccbe0ffeb696943aafa12fa3e07012fd
Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>
