### PR TITLE
Add debug for policy defaults

### DIFF
--- a/core/aclmgmt/defaultaclprovider.go
+++ b/core/aclmgmt/defaultaclprovider.go
@@ -129,6 +129,7 @@ func (d *defaultACLProviderImpl) CheckACL(resName string, channelID string, idin
 			return fmt.Errorf("Unmapped policy for %s", resName)
 		}
 	}
+	aclLogger.Debugw("Applying default access policy for resource", "channel", channelID, "policy", policy, "resource", resName)
 
 	switch typedData := idinfo.(type) {
 	case *pb.SignedProposal:


### PR DESCRIPTION
When troubleshooting issues, it is helpful to know which policy is
applied for resource requests.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>