### PR TITLE
Fix incorrect error message in Gateway submit

### DIFF
--- a/internal/pkg/gateway/api.go
+++ b/internal/pkg/gateway/api.go
@@ -187,7 +187,7 @@ func (gs *Server) Submit(ctx context.Context, request *gp.SubmitRequest) (*gp.Su
 	if err != nil {
 		return nil, rpcError(
 			codes.Aborted,
-			"failed to send transaction to orderer",
+			"failed to create BroadcastClient",
 			&gp.EndpointError{Address: orderer.address, MspId: orderer.mspid, Message: err.Error()},
 		)
 	}

--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -437,7 +437,7 @@ func TestSubmit(t *testing.T) {
 				proposalResponseStatus: 200,
 				ordererBroadcastError:  status.Error(codes.FailedPrecondition, "Orderer not listening!"),
 			},
-			errString: "rpc error: code = Aborted desc = failed to send transaction to orderer",
+			errString: "rpc error: code = Aborted desc = failed to create BroadcastClient",
 			errDetails: []*pb.EndpointError{{
 				Address: "orderer:7050",
 				MspId:   "msp1",


### PR DESCRIPTION
As pointed out in previous PR review, the error message was incorrect when the gateway can’t connect to the BroadcastClient. (https://github.com/hyperledger/fabric/pull/2508#discussion_r601777021)

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
