### PR TITLE
Feature/fix trouble with pkcs11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ $(BUILD_DIR)/image/%/Dockerfile: images/%/Dockerfile.in
 $(BUILD_DIR)/image/tools/$(DUMMY): $(BUILD_DIR)/image/tools/Dockerfile
 	$(eval TARGET = ${patsubst $(BUILD_DIR)/image/%/$(DUMMY),%,${@}})
 	@echo "Building docker $(TARGET)-image"
-	$(DBUILD) -t $(DOCKER_NS)/fabric-$(TARGET) -f $(@D)/Dockerfile .
+	$(DBUILD) -t $(DOCKER_NS)/fabric-$(TARGET) -f $(@D)/Dockerfile --build-arg GO_TAGS=$(GO_TAGS) .
 	docker tag $(DOCKER_NS)/fabric-$(TARGET) $(DOCKER_NS)/fabric-$(TARGET):$(DOCKER_TAG)
 	docker tag $(DOCKER_NS)/fabric-$(TARGET) $(DOCKER_NS)/fabric-$(TARGET):$(ARCH)-latest
 	docker tag $(DOCKER_NS)/fabric-$(TARGET) $(DOCKER_NS)/fabric-$(TARGET):$(BASE_VERSION)

--- a/common/viperutil/config_util.go
+++ b/common/viperutil/config_util.go
@@ -313,7 +313,7 @@ func bccspHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, e
 
 	config := factory.GetDefaultOpts()
 
-	err := mapstructure.Decode(data, config)
+	err := mapstructure.WeakDecode(data, config)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not decode bcssp type")
 	}

--- a/images/tools/Dockerfile.in
+++ b/images/tools/Dockerfile.in
@@ -8,7 +8,8 @@ RUN mkdir src && mkdir pkg && mkdir bin
 ADD . src/github.com/hyperledger/fabric
 WORKDIR /opt/gopath/src/github.com/hyperledger/fabric
 ENV EXECUTABLES go git curl
-RUN make configtxgen configtxlator cryptogen peer discover idemixgen
+ARG GO_TAGS
+RUN make configtxgen configtxlator cryptogen peer discover idemixgen GO_TAGS=${GO_TAGS}
 
 FROM _BASE_NS_/fabric-baseimage:_BASE_TAG_
 ENV FABRIC_CFG_PATH /etc/hyperledger/fabric


### PR DESCRIPTION
## Fix troubles with PKCS11

#### Type of change

- Bug fix

#### Description

Simple changes that fix these errors on 1.4 Path:
- When setting ORDERER_GENERAL_BCCSP_PKCS11_SECURITY orderer variable the orderer fails saying that the security value is a string and not an int.
- When running `GO_TAGS=pkcs11 make docker` the fabric-tools docker image doesn't include a PKCS11 provider.

#### Related issues

https://jira.hyperledger.org/browse/FAB-18457

