### PR TITLE
removing -a from docker ps command as it lists stopped containers also

### DIFF
--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -132,7 +132,7 @@ components. Run the following command to list all of Docker containers that
 are running on your machine. You should see the three nodes that were created by
 the `network.sh` script:
 ```
-docker ps -a
+docker ps
 ```
 
 Each node and user that interacts with a Fabric network needs to belong to an


### PR DESCRIPTION
Signed-off-by: System Administrator <root@Rahuls-MacBook-Air.local>

Removing -a from 'docker ps' commnand, since it lists stopped containers also

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix
- New feature
- Improvement (improvement to code, performance, etc)
- Test update
- Documentation update

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
