### PR TITLE
Add vendor directories into chaincode code package tar when install golang chaincode

### DIFF
--- a/core/chaincode/platforms/golang/package.go
+++ b/core/chaincode/platforms/golang/package.go
@@ -105,10 +105,11 @@ func findSource(gopath, pkg string) (SourceMap, error) {
 				return nil
 			}
 
-			// Allow import of META-INF metadata directories into chaincode code package tar.
+			// Allow import of META-INF metadata directories and vendor directories into chaincode code package tar.
 			// META-INF directories contain chaincode metadata artifacts such as statedb index definitions
-			if isMetadataDir(path, tld) {
-				logger.Debug("Files in META-INF directory will be included in code package tar:", path)
+			// vendor directories contain chaincode vendor dependencies
+			if isMetadataDir(path, tld) || isVendorDir(path, tld) {
+				logger.Debug("Files in META-INF and vendor directory will be included in code package tar:", path)
 				return nil
 			}
 
@@ -143,4 +144,9 @@ func findSource(gopath, pkg string) (SourceMap, error) {
 // isMetadataDir checks to see if the current path is in the META-INF directory at the root of the chaincode directory
 func isMetadataDir(path, tld string) bool {
 	return strings.HasPrefix(path, filepath.Join(tld, "META-INF"))
+}
+
+// isVendorDir checks to see if the current path is in the vendor directory at the root of the chaincode directory
+func isVendorDir(path, tld string) bool {
+	return strings.HasPrefix(path, filepath.Join(tld, "vendor"))
 }


### PR DESCRIPTION
Signed-off-by: xuchengli <lixucheng@aliyun.com>

If chaincode dependency have multi-level directory, only META-INF metadata directory will be added into chaincode code package tar, other dependency directories will be skipped. So when instantiate chaincode it will throw error of missing file or directory. By adding vendor directory at the root of chaincode directory will avoid the issue.

Jira issue: https://jira.hyperledger.org/browse/FAB-18467

- Bug fix

Test:
1. Compile peer binary based on the patch.
2. Restart peer using the latest peer binary.
3. Install and instantiate the chaincode with multi-level vendor dependency directories. The test chaincode is: https://github.com/xuchengli/fabric-chaincode/tree/main/src/test-1