### PR TITLE
Improve error message for invalid consenter cert

### DIFF
--- a/orderer/consensus/etcdraft/util.go
+++ b/orderer/consensus/etcdraft/util.go
@@ -247,7 +247,7 @@ func VerifyConfigMetadata(metadata *etcdraft.ConfigMetadata, verifyOpts x509.Ver
 			return errors.Errorf("metadata has nil consenter")
 		}
 		if err := validateConsenterTLSCerts(consenter, verifyOpts, true); err != nil {
-			return err
+			return errors.WithMessagef(err, "consenter %s:%d has invalid certificate", consenter.Host, consenter.Port)
 		}
 	}
 


### PR DESCRIPTION
When channel config had an invalid consenter cert, the error message did not indicate which cert was being verified.
The error message now indicates that a consenter cert is invalid, and which consenter cert is invalid.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>