### PR TITLE
Add GO111MODULE=on to command

### DIFF
--- a/docs/source/chaincode4ade.rst
+++ b/docs/source/chaincode4ade.rst
@@ -383,7 +383,7 @@ Now let's compile your chaincode.
 
 .. code:: bash
 
-  go get -u github.com/hyperledger/fabric/core/chaincode/shim@v1.4
+  GO111MODULE=on go get -u github.com/hyperledger/fabric/core/chaincode/shim@v1.4
   go build
 
 Assuming there are no errors, now we can proceed to the next step, testing


### PR DESCRIPTION
Go modules are on by default now in the latest versions
of Go. Users who have cloned their projects onto their
GOPATH however will be unable to download the dependency
if they are GOM111ODULE is in `auto` or `off` mode. Adding
the GO111MODULE parameter to the command will ensure
all users are able to download the dependency.

Signed-off-by: Brett Logan <lindluni@github.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix
- New feature
- Improvement (improvement to code, performance, etc)
- Test update
- Documentation update

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
