### PR TITLE
FAB-18472 Fix unit test hang when using softhsm 2.6.1

### DIFF
--- a/bccsp/factory/factory_test.go
+++ b/bccsp/factory/factory_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/hyperledger/fabric/bccsp/pkcs11"
@@ -77,7 +78,10 @@ BCCSP:
 			os.Exit(rc)
 		}
 	}
-	os.Exit(0)
+
+	// bypass the waiting for race detector done by os.Exit(0) as it hangs when used with
+	// softhsm 2.6.1
+	syscall.Exit(0)
 }
 
 func TestGetDefault(t *testing.T) {

--- a/bccsp/factory/pkcs11.go
+++ b/bccsp/factory/pkcs11.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const pkcs11Enabled = false
+const pkcs11Enabled = true
 
 // FactoryOpts holds configuration information used to initialize factory implementations
 type FactoryOpts struct {


### PR DESCRIPTION
Stop the unit tests from hanging when running the pkcs11 unit tests
with softhsm 2.6.1 on linux

Signed-off-by: D <d_kelsey@uk.ibm.com>
