### PR TITLE
Maintain order of transactions in the commit notification

### DIFF
--- a/core/ledger/kvledger/kv_ledger_test.go
+++ b/core/ledger/kvledger/kv_ledger_test.go
@@ -1159,18 +1159,20 @@ func TestCommitNotifications(t *testing.T) {
 		require.Equal(t,
 			&ledger.CommitNotification{
 				BlockNumber: 1,
-				TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-					"txid_1": {
+				TxsInfo: []*ledger.CommitNotificationTxInfo{
+					{
+						TxID:               "txid_1",
+						TxType:             common.HeaderType_ENDORSER_TRANSACTION,
 						ValidationCode:     peer.TxValidationCode_BAD_RWSET,
 						ChaincodeID:        &peer.ChaincodeID{Name: "cc1"},
 						ChaincodeEventData: []byte("cc1_event"),
-						TxType:             common.HeaderType_ENDORSER_TRANSACTION,
 					},
-					"txid_2": {
+					{
+						TxID:               "txid_2",
+						TxType:             common.HeaderType_ENDORSER_TRANSACTION,
 						ValidationCode:     peer.TxValidationCode_VALID,
 						ChaincodeID:        &peer.ChaincodeID{Name: "cc2"},
 						ChaincodeEventData: []byte("cc2_event"),
-						TxType:             common.HeaderType_ENDORSER_TRANSACTION,
 					},
 				},
 			},
@@ -1195,7 +1197,7 @@ func TestCommitNotifications(t *testing.T) {
 		require.Equal(t,
 			&ledger.CommitNotification{
 				BlockNumber: 1,
-				TxsByTxID:   map[string]*ledger.CommitNotificationTxInfo{},
+				TxsInfo:     []*ledger.CommitNotificationTxInfo{},
 			},
 			commitNotification,
 		)
@@ -1279,15 +1281,17 @@ func TestCommitNotificationsOnBlockCommit(t *testing.T) {
 	require.Equal(t,
 		&ledger.CommitNotification{
 			BlockNumber: 1,
-			TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-				"txid_1": {
+			TxsInfo: []*ledger.CommitNotificationTxInfo{
+				{
 					TxType:             common.HeaderType_ENDORSER_TRANSACTION,
+					TxID:               "txid_1",
 					ValidationCode:     peer.TxValidationCode_VALID,
 					ChaincodeID:        &peer.ChaincodeID{Name: "foo", Version: "v1"},
 					ChaincodeEventData: []byte("foo-event"),
 				},
-				"txid_2": {
+				{
 					TxType:             common.HeaderType_ENDORSER_TRANSACTION,
+					TxID:               "txid_2",
 					ValidationCode:     peer.TxValidationCode_MVCC_READ_CONFLICT,
 					ChaincodeID:        &peer.ChaincodeID{Name: "bar", Version: "v2"},
 					ChaincodeEventData: []byte("bar-event"),

--- a/core/ledger/ledger_interface.go
+++ b/core/ledger/ledger_interface.go
@@ -733,10 +733,12 @@ type HashProvider interface {
 	GetHash(opts bccsp.HashOpts) (hash.Hash, error)
 }
 
-// CommitNotification is sent on each block commit to the channel returned by PeerLedger.CommitNotificationsChannel()
+// CommitNotification is sent on each block commit to the channel returned by PeerLedger.CommitNotificationsChannel().
+// TxsInfo field contains the info about individual transactions in the block in the order the transactions appear in the block
+// The transactions with a unique and non-empty txID are included in the notification
 type CommitNotification struct {
 	BlockNumber uint64
-	TxsByTxID   map[string]*CommitNotificationTxInfo
+	TxsInfo     []*CommitNotificationTxInfo
 }
 
 // CommitNotificationTxInfo contains the details of a transaction that is included in the CommitNotification
@@ -745,6 +747,7 @@ type CommitNotification struct {
 // However, it is guaranteed be non-nil if the transaction is a valid endorser transaction.
 type CommitNotificationTxInfo struct {
 	TxType             common.HeaderType
+	TxID               string
 	ValidationCode     peer.TxValidationCode
 	ChaincodeID        *peer.ChaincodeID
 	ChaincodeEventData []byte

--- a/internal/pkg/gateway/commit/channelnotifier.go
+++ b/internal/pkg/gateway/commit/channelnotifier.go
@@ -48,10 +48,10 @@ func (notifier *channelLevelNotifier) run() {
 }
 
 func (notifier *channelLevelNotifier) receiveBlock(blockCommit *ledger.CommitNotification) {
-	for transactionID, txInfo := range blockCommit.TxsByTxID {
+	for _, txInfo := range blockCommit.TxsInfo {
 		n := &notification{
 			BlockNumber:    blockCommit.BlockNumber,
-			TransactionID:  transactionID,
+			TransactionID:  txInfo.TxID,
 			ValidationCode: txInfo.ValidationCode,
 		}
 		notifier.notify(n)

--- a/internal/pkg/gateway/commit/finder_test.go
+++ b/internal/pkg/gateway/commit/finder_test.go
@@ -90,8 +90,9 @@ func TestFinder(t *testing.T) {
 		commitSend := make(chan *ledger.CommitNotification)
 		msg := &ledger.CommitNotification{
 			BlockNumber: 1,
-			TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-				"TX_ID": {
+			TxsInfo: []*ledger.CommitNotificationTxInfo{
+				{
+					TxID:           "TX_ID",
 					ValidationCode: peer.TxValidationCode_MVCC_READ_CONFLICT,
 				},
 			},

--- a/internal/pkg/gateway/commit/notifier_test.go
+++ b/internal/pkg/gateway/commit/notifier_test.go
@@ -56,8 +56,9 @@ func TestNotifier(t *testing.T) {
 
 			commitSend <- &ledger.CommitNotification{
 				BlockNumber: 1,
-				TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-					"TX_ID": {
+				TxsInfo: []*ledger.CommitNotificationTxInfo{
+					{
+						TxID:           "TX_ID",
 						ValidationCode: peer.TxValidationCode_MVCC_READ_CONFLICT,
 					},
 				},
@@ -82,11 +83,13 @@ func TestNotifier(t *testing.T) {
 
 			commitSend <- &ledger.CommitNotification{
 				BlockNumber: 1,
-				TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-					"WRONG_TX_ID": {
+				TxsInfo: []*ledger.CommitNotificationTxInfo{
+					{
+						TxID:           "WRONG_TX_ID",
 						ValidationCode: peer.TxValidationCode_VALID,
 					},
-					"TX_ID": {
+					{
+						TxID:           "TX_ID",
 						ValidationCode: peer.TxValidationCode_MVCC_READ_CONFLICT,
 					},
 				},
@@ -111,16 +114,18 @@ func TestNotifier(t *testing.T) {
 
 			commitSend <- &ledger.CommitNotification{
 				BlockNumber: 1,
-				TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-					"WRONG_TX_ID": {
+				TxsInfo: []*ledger.CommitNotificationTxInfo{
+					{
+						TxID:           "WRONG_TX_ID",
 						ValidationCode: peer.TxValidationCode_VALID,
 					},
 				},
 			}
 			commitSend <- &ledger.CommitNotification{
 				BlockNumber: 2,
-				TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-					"TX_ID": {
+				TxsInfo: []*ledger.CommitNotificationTxInfo{
+					{
+						TxID:           "TX_ID",
 						ValidationCode: peer.TxValidationCode_MVCC_READ_CONFLICT,
 					},
 				},
@@ -145,16 +150,18 @@ func TestNotifier(t *testing.T) {
 
 			commitSend <- &ledger.CommitNotification{
 				BlockNumber: 1,
-				TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-					"TX_ID": {
+				TxsInfo: []*ledger.CommitNotificationTxInfo{
+					{
+						TxID:           "TX_ID",
 						ValidationCode: peer.TxValidationCode_MVCC_READ_CONFLICT,
 					},
 				},
 			}
 			commitSend <- &ledger.CommitNotification{
 				BlockNumber: 2,
-				TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-					"TX_ID": {
+				TxsInfo: []*ledger.CommitNotificationTxInfo{
+					{
+						TxID:           "TX_ID",
 						ValidationCode: peer.TxValidationCode_MVCC_READ_CONFLICT,
 					},
 				},
@@ -179,16 +186,18 @@ func TestNotifier(t *testing.T) {
 
 			commitSend <- &ledger.CommitNotification{
 				BlockNumber: 1,
-				TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-					"TX_ID": {
+				TxsInfo: []*ledger.CommitNotificationTxInfo{
+					{
+						TxID:           "TX_ID",
 						ValidationCode: peer.TxValidationCode_MVCC_READ_CONFLICT,
 					},
 				},
 			}
 			commitSend <- &ledger.CommitNotification{
 				BlockNumber: 2,
-				TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-					"TX_ID": {
+				TxsInfo: []*ledger.CommitNotificationTxInfo{
+					{
+						TxID:           "TX_ID",
 						ValidationCode: peer.TxValidationCode_VALID,
 					},
 				},
@@ -211,8 +220,9 @@ func TestNotifier(t *testing.T) {
 			close(done)
 			commitSend <- &ledger.CommitNotification{
 				BlockNumber: 1,
-				TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-					"TX_ID": {
+				TxsInfo: []*ledger.CommitNotificationTxInfo{
+					{
+						TxID:           "TX_ID",
 						ValidationCode: peer.TxValidationCode_MVCC_READ_CONFLICT,
 					},
 				},
@@ -235,8 +245,9 @@ func TestNotifier(t *testing.T) {
 
 			commitSend <- &ledger.CommitNotification{
 				BlockNumber: 1,
-				TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-					"TX_ID": {
+				TxsInfo: []*ledger.CommitNotificationTxInfo{
+					{
+						TxID:           "TX_ID",
 						ValidationCode: peer.TxValidationCode_MVCC_READ_CONFLICT,
 					},
 				},
@@ -268,8 +279,9 @@ func TestNotifier(t *testing.T) {
 			close(done)
 			commitSend <- &ledger.CommitNotification{
 				BlockNumber: 1,
-				TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-					"TX_ID": {
+				TxsInfo: []*ledger.CommitNotificationTxInfo{
+					{
+						TxID:           "TX_ID",
 						ValidationCode: peer.TxValidationCode_MVCC_READ_CONFLICT,
 					},
 				},
@@ -348,8 +360,9 @@ func TestNotifier(t *testing.T) {
 
 			commitSend2 <- &ledger.CommitNotification{
 				BlockNumber: 1,
-				TxsByTxID: map[string]*ledger.CommitNotificationTxInfo{
-					"TX_ID": {
+				TxsInfo: []*ledger.CommitNotificationTxInfo{
+					{
+						TxID:           "TX_ID",
 						ValidationCode: peer.TxValidationCode_MVCC_READ_CONFLICT,
 					},
 				},


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
Maintain order of transactions in the commit notification so the gateway can deliver the clients the chaincode events in the same and consistent order.

