### PR TITLE
Updated setting up environment documentation to reflect "brew cask" no longer being a valid command

### DIFF
--- a/docs/source/dev-setup/devenv.rst
+++ b/docs/source/dev-setup/devenv.rst
@@ -27,7 +27,7 @@ Once Homebrew is ready, installing the necessary prerequisites is very easy:
 ::
 
     brew install git go jq softhsm
-    brew cask install --appdir="/Applications" docker
+    brew install --cask docker
 
 Docker Desktop must be launched to complete the installation so be sure to open
 the application after installing it:


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Replaced "brew cask install --appdir=“/Applications” docker" with "brew install --cask docker"

Cask is no longer a brew command. When you want to install a Cask, you just do brew install or brew install --cask instead of brew cask install.

#### Additional details

N/A

#### Related issues

N/A
