### PR TITLE
[FAB-17900] Fixes numeric env variable override bug

### DIFF
--- a/common/viperutil/config_util.go
+++ b/common/viperutil/config_util.go
@@ -313,7 +313,7 @@ func bccspHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, e
 
 	config := factory.GetDefaultOpts()
 
-	err := mapstructure.Decode(data, config)
+	err := mapstructure.WeakDecode(data, config)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not decode bcssp type")
 	}


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description

Backport fix for version 1.4 for error: when setting ORDERER_GENERAL_BCCSP_PKCS11_SECURITY orderer variable, the orderer fails saying that the security value is a string and not an int.

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

[FAB-17900](https://jira.hyperledger.org/browse/FAB-17900)
[FAB-18457](https://jira.hyperledger.org/browse/FAB-18457)
https://github.com/hyperledger/fabric/pull/2573