### PR TITLE
Pass go tags to tools container (bp #2136) 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ $(BUILD_DIR)/image/%/Dockerfile: images/%/Dockerfile.in
 $(BUILD_DIR)/image/tools/$(DUMMY): $(BUILD_DIR)/image/tools/Dockerfile
 	$(eval TARGET = ${patsubst $(BUILD_DIR)/image/%/$(DUMMY),%,${@}})
 	@echo "Building docker $(TARGET)-image"
-	$(DBUILD) -t $(DOCKER_NS)/fabric-$(TARGET) -f $(@D)/Dockerfile .
+	$(DBUILD) -t $(DOCKER_NS)/fabric-$(TARGET) -f $(@D)/Dockerfile --build-arg GO_TAGS=$(GO_TAGS) .
 	docker tag $(DOCKER_NS)/fabric-$(TARGET) $(DOCKER_NS)/fabric-$(TARGET):$(DOCKER_TAG)
 	docker tag $(DOCKER_NS)/fabric-$(TARGET) $(DOCKER_NS)/fabric-$(TARGET):$(ARCH)-latest
 	docker tag $(DOCKER_NS)/fabric-$(TARGET) $(DOCKER_NS)/fabric-$(TARGET):$(BASE_VERSION)

--- a/images/tools/Dockerfile.in
+++ b/images/tools/Dockerfile.in
@@ -8,7 +8,8 @@ RUN mkdir src && mkdir pkg && mkdir bin
 ADD . src/github.com/hyperledger/fabric
 WORKDIR /opt/gopath/src/github.com/hyperledger/fabric
 ENV EXECUTABLES go git curl
-RUN make configtxgen configtxlator cryptogen peer discover idemixgen
+ARG GO_TAGS
+RUN make configtxgen configtxlator cryptogen peer discover idemixgen GO_TAGS=${GO_TAGS}
 
 FROM _BASE_NS_/fabric-baseimage:_BASE_TAG_
 ENV FABRIC_CFG_PATH /etc/hyperledger/fabric


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Backport to version 1.4 to fix trouble: when running GO_TAGS=pkcs11 make docker, the fabric-tools docker image doesn't include a PKCS11 provider.

#### Related issues

https://lists.hyperledger.org/g/fabric/topic/error_using_hsm_in_fabric/78302231?p=
https://github.com/hyperledger/fabric/pull/2136
[FAB-18457](https://jira.hyperledger.org/browse/FAB-18457)
https://github.com/hyperledger/fabric/pull/2573