### PR TITLE
FAB-18482 Unable to specify peer's chaincode.externalBuilders as an env variable

### DIFF
--- a/common/viperutil/config_util.go
+++ b/common/viperutil/config_util.go
@@ -449,3 +449,19 @@ func (c *ConfigParser) EnhancedExactUnmarshal(output interface{}) error {
 	}
 	return decoder.Decode(leafKeys)
 }
+
+// YamlStringToStructHook is a hook for viper(viper.Unmarshal(*,*, here)), it is able to parse a string of minified yaml into a slice of structs
+func YamlStringToStructHook(m interface{}) func(rf reflect.Kind, rt reflect.Kind, data interface{}) (interface{}, error) {
+	return func(rf reflect.Kind, rt reflect.Kind, data interface{}) (interface{}, error) {
+		if rf != reflect.String || rt != reflect.Slice {
+			return data, nil
+		}
+
+		raw := data.(string)
+		if raw == "" {
+			return m, nil
+		}
+
+		return m, yaml.UnmarshalStrict([]byte(raw), &m)
+	}
+}

--- a/core/chaincode/config_test.go
+++ b/core/chaincode/config_test.go
@@ -36,6 +36,7 @@ var _ = Describe("Config", func() {
 			viper.Set("chaincode.logging.format", "test-chaincode-logging-format")
 			viper.Set("chaincode.logging.level", "warning")
 			viper.Set("chaincode.logging.shim", "warning")
+			viper.Set("chaincode.system.somecc", true)
 
 			config := chaincode.GlobalConfig()
 			Expect(config.TLSEnabled).To(BeTrue())
@@ -46,6 +47,7 @@ var _ = Describe("Config", func() {
 			Expect(config.LogFormat).To(Equal("test-chaincode-logging-format"))
 			Expect(config.LogLevel).To(Equal("warn"))
 			Expect(config.ShimLogLevel).To(Equal("warn"))
+			Expect(config.SCCAllowlist).To(Equal(map[string]bool{"somecc": true}))
 		})
 
 		Context("when an invalid keepalive is configured", func() {

--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -28,6 +28,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/hyperledger/fabric/common/viperutil"
 	"github.com/hyperledger/fabric/core/config"
 	"github.com/hyperledger/fabric/internal/pkg/comm"
 	gatewayconfig "github.com/hyperledger/fabric/internal/pkg/gateway/config"
@@ -286,10 +287,12 @@ func (c *Config) load() error {
 
 	c.ChaincodePull = viper.GetBool("chaincode.pull")
 	var externalBuilders []ExternalBuilder
-	err = viper.UnmarshalKey("chaincode.externalBuilders", &externalBuilders)
+
+	err = viper.UnmarshalKey("chaincode.externalBuilders", &externalBuilders, viper.DecodeHook(viperutil.YamlStringToStructHook(externalBuilders)))
 	if err != nil {
 		return err
 	}
+
 	c.ExternalBuilders = externalBuilders
 	for builderIndex, builder := range c.ExternalBuilders {
 		if builder.Path == "" {

--- a/core/peer/config_test.go
+++ b/core/peer/config_test.go
@@ -456,6 +456,26 @@ func TestPropagateEnvironment(t *testing.T) {
 	require.Equal(t, expectedConfig, coreConfig)
 }
 
+func TestExternalBuilderConfigAsEnvVar(t *testing.T) {
+	defer viper.Reset()
+	viper.Set("peer.address", "localhost:8080")
+	viper.Set("chaincode.externalBuilders", "[{name: relative, path: relative/plugin_dir, propagateEnvironment: [ENVVAR_NAME_TO_PROPAGATE_FROM_PEER, GOPROXY]}, {name: absolute, path: /absolute/plugin_dir}]")
+	coreConfig, err := GlobalConfig()
+	require.NoError(t, err)
+
+	require.Equal(t, []ExternalBuilder{
+		{
+			Path:                 "relative/plugin_dir",
+			Name:                 "relative",
+			PropagateEnvironment: []string{"ENVVAR_NAME_TO_PROPAGATE_FROM_PEER", "GOPROXY"},
+		},
+		{
+			Path: "/absolute/plugin_dir",
+			Name: "absolute",
+		},
+	}, coreConfig.ExternalBuilders)
+}
+
 func TestMissingExternalBuilderPath(t *testing.T) {
 	defer viper.Reset()
 	viper.Set("peer.address", "localhost:8080")

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -562,6 +562,7 @@ chaincode:
     # List of directories to treat as external builders and launchers for
     # chaincode. The external builder detection processing will iterate over the
     # builders in the order specified below.
+    # To override this property via env variable use CORE_CHAINCODE_EXTERNALBUILDERS: [{name: x, path: dir1}, {name: y, path: dir2}]
     externalBuilders: []
         # - path: /path/to/directory
         #   name: descriptive-builder-name


### PR DESCRIPTION
<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

As the HLF doc says, it's possible to override each config param via env variables, however, it isn't true for chaincode.externalBuilders 

Also, added a small expectation to a test for `chaincode.system` configuration

#### Related issues

https://jira.hyperledger.org/browse/FAB-18482
