### PR TITLE
Update discovery PeersOfChannel

### DIFF
--- a/discovery/support/gossip/support_test.go
+++ b/discovery/support/gossip/support_test.go
@@ -48,6 +48,9 @@ func TestPeers(t *testing.T) {
 }
 
 func TestPeersOfChannel(t *testing.T) {
+	g := &mocks.Gossip{}
+	sup := gossip.NewDiscoverySupport(g)
+
 	stateInfo := &gp.GossipMessage{
 		Content: &gp.GossipMessage_StateInfo{
 			StateInfo: &gp.StateInfo{
@@ -56,12 +59,29 @@ func TestPeersOfChannel(t *testing.T) {
 		},
 	}
 	sMsg, _ := protoext.NoopSign(stateInfo)
-	g := &mocks.Gossip{}
+
+	p1Envelope := &gp.Envelope{
+		Payload: []byte{4, 5, 6},
+		SecretEnvelope: &gp.SecretEnvelope{
+			Payload: []byte{1, 2, 3},
+		},
+	}
+	peers := []discovery.NetworkMember{
+		{PKIid: common.PKIidType("p1"), Endpoint: "p1", Envelope: p1Envelope},
+		{PKIid: common.PKIidType("p2")},
+	}
+
 	g.SelfChannelInfoReturnsOnCall(0, nil)
 	g.SelfChannelInfoReturnsOnCall(1, sMsg)
-	g.PeersOfChannelReturnsOnCall(0, []discovery.NetworkMember{{PKIid: common.PKIidType("p1")}, {PKIid: common.PKIidType("p2")}})
-	sup := gossip.NewDiscoverySupport(g)
+	g.PeersOfChannelReturnsOnCall(0, peers)
+	g.SelfMembershipInfoReturnsOnCall(0, discovery.NetworkMember{PKIid: common.PKIidType("p0"), Endpoint: "p0"})
+
 	require.Empty(t, sup.PeersOfChannel(common.ChannelID("")))
-	expected := discovery.Members{{PKIid: common.PKIidType("p1")}, {PKIid: common.PKIidType("p2")}, {PKIid: common.PKIidType("px"), Envelope: sMsg.Envelope}}
-	require.Equal(t, expected, sup.PeersOfChannel(common.ChannelID("")))
+
+	p1ExpectedEnvelope := &gp.Envelope{
+		Payload: []byte{4, 5, 6},
+	}
+	expected := discovery.Members{{PKIid: common.PKIidType("p1"), Endpoint: "p1", Envelope: p1ExpectedEnvelope}, {PKIid: common.PKIidType("p0"), Endpoint: "p0", Envelope: sMsg.Envelope}}
+	actual := sup.PeersOfChannel(common.ChannelID(""))
+	require.Equal(t, expected, actual)
 }


### PR DESCRIPTION
Update PeersOfChannel behaviour to match Peers function,
i.e. include endpoint in self memeber, only the peers that
have an external endpoint, and sanitizes the envelopes

Signed-off-by: James Taylor <jamest@uk.ibm.com>