### PR TITLE
[FAB-18484] Return transaction forwarding result back to the client synchronously

### DIFF
--- a/orderer/common/cluster/rpc_test.go
+++ b/orderer/common/cluster/rpc_test.go
@@ -26,6 +26,72 @@ import (
 	"google.golang.org/grpc"
 )
 
+func noopReport(_ error) {
+}
+
+func TestSendSubmitWithReport(t *testing.T) {
+	t.Parallel()
+	node1 := newTestNode(t)
+	node2 := newTestNode(t)
+
+	var receptionWaitGroup sync.WaitGroup
+	receptionWaitGroup.Add(1)
+	node2.handler.On("OnSubmit", testChannel, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		receptionWaitGroup.Done()
+	})
+
+	defer node1.stop()
+	defer node2.stop()
+
+	config := []cluster.RemoteNode{node1.nodeInfo, node2.nodeInfo}
+	node1.c.Configure(testChannel, config)
+	node2.c.Configure(testChannel, config)
+
+	node1RPC := &cluster.RPC{
+		Logger:        flogging.MustGetLogger("test"),
+		Timeout:       time.Hour,
+		StreamsByType: cluster.NewStreamsByType(),
+		Channel:       testChannel,
+		Comm:          node1.c,
+	}
+
+	// Wait for connections to be established
+	time.Sleep(time.Second * 5)
+
+	err := node1RPC.SendSubmit(node2.nodeInfo.ID, &orderer.SubmitRequest{Channel: testChannel, Payload: &common.Envelope{Payload: []byte("1")}}, noopReport)
+	require.NoError(t, err)
+	receptionWaitGroup.Wait() // Wait for message to be received
+
+	// Restart the node
+	node2.stop()
+	node2.resurrect()
+
+	var wg2 sync.WaitGroup
+	wg2.Add(1)
+
+	reportSubmitFailed := func(err error) {
+		require.EqualError(t, err, io.EOF.Error())
+		defer wg2.Done()
+	}
+
+	err = node1RPC.SendSubmit(node2.nodeInfo.ID, &orderer.SubmitRequest{Channel: testChannel, Payload: &common.Envelope{Payload: []byte("2")}}, reportSubmitFailed)
+	require.NoError(t, err)
+
+	wg2.Wait()
+
+	// Ensure stale stream is cleaned up and removed from the mapping
+	require.Len(t, node1RPC.StreamsByType[cluster.SubmitOperation], 0)
+
+	// Wait for connection to be re-established
+	time.Sleep(time.Second * 5)
+
+	// Send again, this time it should be received
+	receptionWaitGroup.Add(1)
+	err = node1RPC.SendSubmit(node2.nodeInfo.ID, &orderer.SubmitRequest{Channel: testChannel, Payload: &common.Envelope{Payload: []byte("3")}}, noopReport)
+	require.NoError(t, err)
+	receptionWaitGroup.Wait()
+}
+
 func TestRPCChangeDestination(t *testing.T) {
 	// We send a Submit() to 2 different nodes - 1 and 2.
 	// The first invocation of Submit() establishes a stream with node 1
@@ -82,8 +148,8 @@ func TestRPCChangeDestination(t *testing.T) {
 	streamToNode1.On("Recv").Return(nil, io.EOF)
 	streamToNode2.On("Recv").Return(nil, io.EOF)
 
-	rpc.SendSubmit(1, &orderer.SubmitRequest{Channel: "mychannel"})
-	rpc.SendSubmit(2, &orderer.SubmitRequest{Channel: "mychannel"})
+	rpc.SendSubmit(1, &orderer.SubmitRequest{Channel: "mychannel"}, noopReport)
+	rpc.SendSubmit(2, &orderer.SubmitRequest{Channel: "mychannel"}, noopReport)
 
 	sent.Wait()
 	streamToNode1.AssertNumberOfCalls(t, "Send", 1)
@@ -111,7 +177,7 @@ func TestSend(t *testing.T) {
 	}
 
 	submit := func(rpc *cluster.RPC) error {
-		err := rpc.SendSubmit(1, submitRequest)
+		err := rpc.SendSubmit(1, submitRequest, noopReport)
 		return err
 	}
 
@@ -291,7 +357,7 @@ func TestRPCGarbageCollection(t *testing.T) {
 
 	defineMocks(1)
 
-	rpc.SendSubmit(1, &orderer.SubmitRequest{Channel: "mychannel"})
+	rpc.SendSubmit(1, &orderer.SubmitRequest{Channel: "mychannel"}, noopReport)
 	// Wait for the message to arrive
 	sent.Wait()
 	// Ensure the stream is initialized in the mapping
@@ -311,7 +377,7 @@ func TestRPCGarbageCollection(t *testing.T) {
 	defineMocks(2)
 
 	// Send a message to a different node.
-	rpc.SendSubmit(2, &orderer.SubmitRequest{Channel: "mychannel"})
+	rpc.SendSubmit(2, &orderer.SubmitRequest{Channel: "mychannel"}, noopReport)
 	// The mapping should be now cleaned from the previous stream.
 	require.Len(t, mapping[cluster.SubmitOperation], 1)
 	require.Equal(t, uint64(2), mapping[cluster.SubmitOperation][2].ID)

--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -184,6 +184,7 @@ var _ = Describe("Chain", func() {
 			fakeFields = newFakeMetricsFields()
 
 			opts = etcdraft.Options{
+				RPCTimeout:        time.Second * 5,
 				RaftID:            1,
 				Clock:             clock,
 				TickInterval:      interval,
@@ -2634,7 +2635,28 @@ var _ = Describe("Chain", func() {
 				})
 			})
 
+			When("gRPC stream to leader is stuck", func() {
+				BeforeEach(func() {
+					c2.opts.RPCTimeout = time.Second
+					network.Lock()
+					network.delayWG.Add(1)
+					network.Unlock()
+				})
+				It("correctly times out", func() {
+					err := c2.Order(env, 0)
+					Expect(err).To(MatchError("timed out (1s) waiting on forwarding to 1"))
+					network.delayWG.Done()
+				})
+			})
+
 			When("leader is disconnected", func() {
+				It("correctly returns a failure to the client when forwarding from a follower", func() {
+					network.disconnect(1)
+
+					err := c2.Order(env, 0)
+					Expect(err).To(MatchError("connection lost"))
+				})
+
 				It("proactively steps down to follower", func() {
 					network.disconnect(1)
 
@@ -3371,6 +3393,7 @@ func newChain(
 	fakeFields := newFakeMetricsFields()
 
 	opts := etcdraft.Options{
+		RPCTimeout:          timeout,
 		RaftID:              uint64(id),
 		Clock:               clock,
 		TickInterval:        interval,
@@ -3537,6 +3560,7 @@ func (c *chain) getStepFunc() stepFunc {
 }
 
 type network struct {
+	delayWG sync.WaitGroup
 	sync.RWMutex
 
 	leader uint64
@@ -3615,21 +3639,30 @@ func (n *network) addChain(c *chain) {
 		return c.step(dest, msg)
 	}
 
-	c.rpc.SendSubmitStub = func(dest uint64, msg *orderer.SubmitRequest) error {
+	c.rpc.SendSubmitStub = func(dest uint64, msg *orderer.SubmitRequest, f func(error)) error {
 		if !n.linked(c.id, dest) {
-			return errors.Errorf("connection refused")
+			err := errors.Errorf("connection refused")
+			f(err)
+			return err
 		}
 
 		if !n.connected(c.id) || !n.connected(dest) {
-			return errors.Errorf("connection lost")
+			err := errors.Errorf("connection lost")
+			f(err)
+			return err
 		}
 
 		n.RLock()
 		target := n.chains[dest]
 		n.RUnlock()
 		go func() {
+			n.Lock()
+			n.delayWG.Wait()
+			n.Unlock()
+
 			defer GinkgoRecover()
 			target.Submit(msg, c.id)
+			f(nil)
 		}()
 		return nil
 	}

--- a/orderer/consensus/etcdraft/consenter.go
+++ b/orderer/consensus/etcdraft/consenter.go
@@ -200,6 +200,7 @@ func (c *Consenter) HandleChain(support consensus.ConsenterSupport, metadata *co
 	}
 
 	opts := Options{
+		RPCTimeout:    c.OrdererConfig.General.Cluster.RPCTimeout,
 		RaftID:        id,
 		Clock:         clock.NewClock(),
 		MemoryStorage: raft.NewMemoryStorage(),

--- a/orderer/consensus/etcdraft/mocks/mock_rpc.go
+++ b/orderer/consensus/etcdraft/mocks/mock_rpc.go
@@ -21,11 +21,12 @@ type FakeRPC struct {
 	sendConsensusReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SendSubmitStub        func(uint64, *orderer.SubmitRequest) error
+	SendSubmitStub        func(uint64, *orderer.SubmitRequest, func(err error)) error
 	sendSubmitMutex       sync.RWMutex
 	sendSubmitArgsForCall []struct {
 		arg1 uint64
 		arg2 *orderer.SubmitRequest
+		arg3 func(err error)
 	}
 	sendSubmitReturns struct {
 		result1 error
@@ -98,17 +99,18 @@ func (fake *FakeRPC) SendConsensusReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeRPC) SendSubmit(arg1 uint64, arg2 *orderer.SubmitRequest) error {
+func (fake *FakeRPC) SendSubmit(arg1 uint64, arg2 *orderer.SubmitRequest, arg3 func(err error)) error {
 	fake.sendSubmitMutex.Lock()
 	ret, specificReturn := fake.sendSubmitReturnsOnCall[len(fake.sendSubmitArgsForCall)]
 	fake.sendSubmitArgsForCall = append(fake.sendSubmitArgsForCall, struct {
 		arg1 uint64
 		arg2 *orderer.SubmitRequest
-	}{arg1, arg2})
-	fake.recordInvocation("SendSubmit", []interface{}{arg1, arg2})
+		arg3 func(err error)
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("SendSubmit", []interface{}{arg1, arg2, arg3})
 	fake.sendSubmitMutex.Unlock()
 	if fake.SendSubmitStub != nil {
-		return fake.SendSubmitStub(arg1, arg2)
+		return fake.SendSubmitStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -123,17 +125,17 @@ func (fake *FakeRPC) SendSubmitCallCount() int {
 	return len(fake.sendSubmitArgsForCall)
 }
 
-func (fake *FakeRPC) SendSubmitCalls(stub func(uint64, *orderer.SubmitRequest) error) {
+func (fake *FakeRPC) SendSubmitCalls(stub func(uint64, *orderer.SubmitRequest, func(err error)) error) {
 	fake.sendSubmitMutex.Lock()
 	defer fake.sendSubmitMutex.Unlock()
 	fake.SendSubmitStub = stub
 }
 
-func (fake *FakeRPC) SendSubmitArgsForCall(i int) (uint64, *orderer.SubmitRequest) {
+func (fake *FakeRPC) SendSubmitArgsForCall(i int) (uint64, *orderer.SubmitRequest, func(err error)) {
 	fake.sendSubmitMutex.RLock()
 	defer fake.sendSubmitMutex.RUnlock()
 	argsForCall := fake.sendSubmitArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeRPC) SendSubmitReturns(result1 error) {


### PR DESCRIPTION
This commit makes a Raft follower wait for the transaction forwarded to the leader to be sent into
the gRPC stream, and returns the result (success or failure) back to the client accordingly.

Before this commmit, the behavior was that it returns success after enqueueing it into the message queue,
which might have resulted in the transaction being dropped but a success being returned to the client.

Change-Id: I0cd45540be4988845663eb0c68f76fed2ff25b94
Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>
