### PR TITLE
[FAB-18484] Return transaction forwarding result back to the client synchronously

### DIFF
--- a/orderer/common/cluster/rpc_test.go
+++ b/orderer/common/cluster/rpc_test.go
@@ -26,6 +26,72 @@ import (
 	"google.golang.org/grpc"
 )
 
+func noopReport(_ error) {
+}
+
+func TestSendSubmitWithReport(t *testing.T) {
+	t.Parallel()
+	node1 := newTestNode(t)
+	node2 := newTestNode(t)
+
+	var receptionWaitGroup sync.WaitGroup
+	receptionWaitGroup.Add(1)
+	node2.handler.On("OnSubmit", testChannel, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		receptionWaitGroup.Done()
+	})
+
+	defer node1.stop()
+	defer node2.stop()
+
+	config := []cluster.RemoteNode{node1.nodeInfo, node2.nodeInfo}
+	node1.c.Configure(testChannel, config)
+	node2.c.Configure(testChannel, config)
+
+	node1RPC := &cluster.RPC{
+		Logger:        flogging.MustGetLogger("test"),
+		Timeout:       time.Hour,
+		StreamsByType: cluster.NewStreamsByType(),
+		Channel:       testChannel,
+		Comm:          node1.c,
+	}
+
+	// Wait for connections to be established
+	time.Sleep(time.Second * 5)
+
+	err := node1RPC.SendSubmit(node2.nodeInfo.ID, &orderer.SubmitRequest{Channel: testChannel, Payload: &common.Envelope{Payload: []byte("1")}}, noopReport)
+	assert.NoError(t, err)
+	receptionWaitGroup.Wait() // Wait for message to be received
+
+	// Restart the node
+	node2.stop()
+	node2.resurrect()
+
+	var wg2 sync.WaitGroup
+	wg2.Add(1)
+
+	reportSubmitFailed := func(err error) {
+		assert.EqualError(t, err, io.EOF.Error())
+		defer wg2.Done()
+	}
+
+	err = node1RPC.SendSubmit(node2.nodeInfo.ID, &orderer.SubmitRequest{Channel: testChannel, Payload: &common.Envelope{Payload: []byte("2")}}, reportSubmitFailed)
+	assert.NoError(t, err)
+
+	wg2.Wait()
+
+	// Ensure stale stream is cleaned up and removed from the mapping
+	assert.Len(t, node1RPC.StreamsByType[cluster.SubmitOperation], 0)
+
+	// Wait for connection to be re-established
+	time.Sleep(time.Second * 5)
+
+	// Send again, this time it should be received
+	receptionWaitGroup.Add(1)
+	err = node1RPC.SendSubmit(node2.nodeInfo.ID, &orderer.SubmitRequest{Channel: testChannel, Payload: &common.Envelope{Payload: []byte("3")}}, noopReport)
+	assert.NoError(t, err)
+	receptionWaitGroup.Wait()
+}
+
 func TestRPCChangeDestination(t *testing.T) {
 	// We send a Submit() to 2 different nodes - 1 and 2.
 	// The first invocation of Submit() establishes a stream with node 1
@@ -82,8 +148,8 @@ func TestRPCChangeDestination(t *testing.T) {
 	streamToNode1.On("Recv").Return(nil, io.EOF)
 	streamToNode2.On("Recv").Return(nil, io.EOF)
 
-	rpc.SendSubmit(1, &orderer.SubmitRequest{Channel: "mychannel"})
-	rpc.SendSubmit(2, &orderer.SubmitRequest{Channel: "mychannel"})
+	rpc.SendSubmit(1, &orderer.SubmitRequest{Channel: "mychannel"}, noopReport)
+	rpc.SendSubmit(2, &orderer.SubmitRequest{Channel: "mychannel"}, noopReport)
 
 	sent.Wait()
 	streamToNode1.AssertNumberOfCalls(t, "Send", 1)
@@ -111,7 +177,7 @@ func TestSend(t *testing.T) {
 	}
 
 	submit := func(rpc *cluster.RPC) error {
-		err := rpc.SendSubmit(1, submitRequest)
+		err := rpc.SendSubmit(1, submitRequest, noopReport)
 		return err
 	}
 
@@ -291,7 +357,7 @@ func TestRPCGarbageCollection(t *testing.T) {
 
 	defineMocks(1)
 
-	rpc.SendSubmit(1, &orderer.SubmitRequest{Channel: "mychannel"})
+	rpc.SendSubmit(1, &orderer.SubmitRequest{Channel: "mychannel"}, noopReport)
 	// Wait for the message to arrive
 	sent.Wait()
 	// Ensure the stream is initialized in the mapping
@@ -311,7 +377,7 @@ func TestRPCGarbageCollection(t *testing.T) {
 	defineMocks(2)
 
 	// Send a message to a different node.
-	rpc.SendSubmit(2, &orderer.SubmitRequest{Channel: "mychannel"})
+	rpc.SendSubmit(2, &orderer.SubmitRequest{Channel: "mychannel"}, noopReport)
 	// The mapping should be now cleaned from the previous stream.
 	assert.Len(t, mapping[cluster.SubmitOperation], 1)
 	assert.Equal(t, uint64(2), mapping[cluster.SubmitOperation][2].ID)

--- a/orderer/consensus/etcdraft/chain.go
+++ b/orderer/consensus/etcdraft/chain.go
@@ -75,7 +75,7 @@ type Configurator interface {
 // RPC is used to mock the transport layer in tests.
 type RPC interface {
 	SendConsensus(dest uint64, msg *orderer.ConsensusRequest) error
-	SendSubmit(dest uint64, request *orderer.SubmitRequest) error
+	SendSubmit(dest uint64, request *orderer.SubmitRequest, report func(err error)) error
 }
 
 //go:generate counterfeiter -o mocks/mock_blockpuller.go . BlockPuller
@@ -93,7 +93,8 @@ type CreateBlockPuller func() (BlockPuller, error)
 
 // Options contains all the configurations relevant to the chain.
 type Options struct {
-	RaftID uint64
+	RPCTimeout time.Duration
+	RaftID     uint64
 
 	Clock clock.Clock
 
@@ -508,8 +509,7 @@ func (c *Chain) Submit(req *orderer.SubmitRequest, sender uint64) error {
 		}
 
 		if lead != c.raftID {
-			if err := c.rpc.SendSubmit(lead, req); err != nil {
-				c.Metrics.ProposalFailures.Add(1)
+			if err := c.forwardToLeader(lead, req); err != nil {
 				return err
 			}
 		}
@@ -519,6 +519,38 @@ func (c *Chain) Submit(req *orderer.SubmitRequest, sender uint64) error {
 		return errors.Errorf("chain is stopped")
 	}
 
+	return nil
+}
+
+func (c *Chain) forwardToLeader(lead uint64, req *orderer.SubmitRequest) error {
+	c.logger.Infof("Forwarding transaction to the leader %d", lead)
+	timer := time.NewTimer(c.opts.RPCTimeout)
+	defer timer.Stop()
+
+	sentChan := make(chan struct{})
+	atomicErr := &atomic.Value{}
+
+	report := func(err error) {
+		if err != nil {
+			atomicErr.Store(err.Error())
+			c.Metrics.ProposalFailures.Add(1)
+		}
+		close(sentChan)
+	}
+
+	c.rpc.SendSubmit(lead, req, report)
+
+	select {
+	case <-sentChan:
+	case <-c.doneC:
+		return errors.Errorf("chain is stopped")
+	case <-timer.C:
+		return errors.Errorf("timed out (%v) waiting on forwarding to %d", c.opts.RPCTimeout, lead)
+	}
+
+	if atomicErr.Load() != nil {
+		return errors.Errorf(atomicErr.Load().(string))
+	}
 	return nil
 }
 

--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -178,6 +178,7 @@ var _ = Describe("Chain", func() {
 			fakeFields = newFakeMetricsFields()
 
 			opts = etcdraft.Options{
+				RPCTimeout:        time.Second * 5,
 				RaftID:            1,
 				Clock:             clock,
 				TickInterval:      interval,
@@ -2573,7 +2574,28 @@ var _ = Describe("Chain", func() {
 				})
 			})
 
+			When("gRPC stream to leader is stuck", func() {
+				BeforeEach(func() {
+					c2.opts.RPCTimeout = time.Second
+					network.Lock()
+					network.delayWG.Add(1)
+					network.Unlock()
+				})
+				It("correctly times out", func() {
+					err := c2.Order(env, 0)
+					Expect(err).To(MatchError("timed out (1s) waiting on forwarding to 1"))
+					network.delayWG.Done()
+				})
+			})
+
 			When("leader is disconnected", func() {
+				It("correctly returns a failure to the client when forwarding from a follower", func() {
+					network.disconnect(1)
+
+					err := c2.Order(env, 0)
+					Expect(err).To(MatchError("connection lost"))
+				})
+
 				It("proactively steps down to follower", func() {
 					network.disconnect(1)
 
@@ -3308,6 +3330,7 @@ func newChain(
 	fakeFields := newFakeMetricsFields()
 
 	opts := etcdraft.Options{
+		RPCTimeout:          timeout,
 		RaftID:              uint64(id),
 		Clock:               clock,
 		TickInterval:        interval,
@@ -3473,6 +3496,7 @@ func (c *chain) getStepFunc() stepFunc {
 }
 
 type network struct {
+	delayWG sync.WaitGroup
 	sync.RWMutex
 
 	leader uint64
@@ -3551,21 +3575,30 @@ func (n *network) addChain(c *chain) {
 		return c.step(dest, msg)
 	}
 
-	c.rpc.SendSubmitStub = func(dest uint64, msg *orderer.SubmitRequest) error {
+	c.rpc.SendSubmitStub = func(dest uint64, msg *orderer.SubmitRequest, f func(error)) error {
 		if !n.linked(c.id, dest) {
-			return errors.Errorf("connection refused")
+			err := errors.Errorf("connection refused")
+			f(err)
+			return err
 		}
 
 		if !n.connected(c.id) || !n.connected(dest) {
-			return errors.Errorf("connection lost")
+			err := errors.Errorf("connection lost")
+			f(err)
+			return err
 		}
 
 		n.RLock()
 		target := n.chains[dest]
 		n.RUnlock()
 		go func() {
+			n.Lock()
+			n.delayWG.Wait()
+			n.Unlock()
+
 			defer GinkgoRecover()
 			target.Submit(msg, c.id)
+			f(nil)
 		}()
 		return nil
 	}

--- a/orderer/consensus/etcdraft/consenter.go
+++ b/orderer/consensus/etcdraft/consenter.go
@@ -197,6 +197,7 @@ func (c *Consenter) HandleChain(support consensus.ConsenterSupport, metadata *co
 	}
 
 	opts := Options{
+		RPCTimeout:    c.OrdererConfig.General.Cluster.RPCTimeout,
 		RaftID:        id,
 		Clock:         clock.NewClock(),
 		MemoryStorage: raft.NewMemoryStorage(),

--- a/orderer/consensus/etcdraft/mocks/mock_rpc.go
+++ b/orderer/consensus/etcdraft/mocks/mock_rpc.go
@@ -21,11 +21,12 @@ type FakeRPC struct {
 	sendConsensusReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SendSubmitStub        func(uint64, *orderer.SubmitRequest) error
+	SendSubmitStub        func(uint64, *orderer.SubmitRequest, func(err error)) error
 	sendSubmitMutex       sync.RWMutex
 	sendSubmitArgsForCall []struct {
 		arg1 uint64
 		arg2 *orderer.SubmitRequest
+		arg3 func(err error)
 	}
 	sendSubmitReturns struct {
 		result1 error
@@ -98,17 +99,18 @@ func (fake *FakeRPC) SendConsensusReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeRPC) SendSubmit(arg1 uint64, arg2 *orderer.SubmitRequest) error {
+func (fake *FakeRPC) SendSubmit(arg1 uint64, arg2 *orderer.SubmitRequest, arg3 func(err error)) error {
 	fake.sendSubmitMutex.Lock()
 	ret, specificReturn := fake.sendSubmitReturnsOnCall[len(fake.sendSubmitArgsForCall)]
 	fake.sendSubmitArgsForCall = append(fake.sendSubmitArgsForCall, struct {
 		arg1 uint64
 		arg2 *orderer.SubmitRequest
-	}{arg1, arg2})
-	fake.recordInvocation("SendSubmit", []interface{}{arg1, arg2})
+		arg3 func(err error)
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("SendSubmit", []interface{}{arg1, arg2, arg3})
 	fake.sendSubmitMutex.Unlock()
 	if fake.SendSubmitStub != nil {
-		return fake.SendSubmitStub(arg1, arg2)
+		return fake.SendSubmitStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -123,17 +125,17 @@ func (fake *FakeRPC) SendSubmitCallCount() int {
 	return len(fake.sendSubmitArgsForCall)
 }
 
-func (fake *FakeRPC) SendSubmitCalls(stub func(uint64, *orderer.SubmitRequest) error) {
+func (fake *FakeRPC) SendSubmitCalls(stub func(uint64, *orderer.SubmitRequest, func(err error)) error) {
 	fake.sendSubmitMutex.Lock()
 	defer fake.sendSubmitMutex.Unlock()
 	fake.SendSubmitStub = stub
 }
 
-func (fake *FakeRPC) SendSubmitArgsForCall(i int) (uint64, *orderer.SubmitRequest) {
+func (fake *FakeRPC) SendSubmitArgsForCall(i int) (uint64, *orderer.SubmitRequest, func(err error)) {
 	fake.sendSubmitMutex.RLock()
 	defer fake.sendSubmitMutex.RUnlock()
 	argsForCall := fake.sendSubmitArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeRPC) SendSubmitReturns(result1 error) {


### PR DESCRIPTION
This commit makes a Raft follower wait for the transaction forwarded to the leader to be sent into
the gRPC stream, and returns the result (success or failure) back to the client accordingly.

Before this commmit, the behavior was that it returns success after enqueueing it into the message queue,
which might have resulted in the transaction being dropped but a success being returned to the client.

Change-Id: I0cd45540be4988845663eb0c68f76fed2ff25b94
Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>
