### PR TITLE
Fix spelling mistakes in the Github Contributions page

### DIFF
--- a/docs/source/github/github.rst
+++ b/docs/source/github/github.rst
@@ -154,7 +154,7 @@ Perform the following steps to commit and push your code to your forked reposito
 
 .. note::
 
-   Hyperledger requires that commits be signed by the commiter.
+   Hyperledger requires that commits be signed by the committer.
    When issuing the `commit` command, specify the `-s` flag to
    automatically add your signature to your commit.
 
@@ -196,7 +196,7 @@ repository from which you created your fork and begin the code review process.
 - You can now choose one of two options for creating your pull request.
   In the green `Create Pull Request` box select the down-arrow to the right of it.
 - You can choose the first option to open your pull request as-is.
-  This will automatically assign the repostiories maintainers as reviewers for
+  This will automatically assign the repositories maintainers as reviewers for
   your pull request.
 - You can choose the second option to open your pull request as a draft.
   Opening your pull request as a draft will not assign any reviewers, but will
@@ -208,7 +208,7 @@ by navigating to the `Checks` tab of the pull request.
 
 .. warning::
 
-   If you bypass the perscribed pull request process and generate a pull request
+   If you bypass the prescribed pull request process and generate a pull request
    from an edit you made using GitHub's editor UI, you must manually add your
    signature to the commit message when the commit is generated in the UI.
 


### PR DESCRIPTION
Signed-off-by: Nikhil Gupta <ngupta@symbridge.com>

#### Type of change

- Bug fix
- Documentation update