### PR TITLE
Clarify "identity expired" error messages (#2685)

### DIFF
--- a/common/deliver/acl.go
+++ b/common/deliver/acl.go
@@ -57,7 +57,7 @@ type SessionAccessControl struct {
 // changes.
 func (ac *SessionAccessControl) Evaluate() error {
 	if !ac.sessionEndTime.IsZero() && time.Now().After(ac.sessionEndTime) {
-		return errors.Errorf("client identity expired %v before", time.Since(ac.sessionEndTime))
+		return errors.Errorf("deliver client identity expired %v before", time.Since(ac.sessionEndTime))
 	}
 
 	policyCheckNeeded := !ac.usedAtLeastOnce

--- a/common/deliver/acl_test.go
+++ b/common/deliver/acl_test.go
@@ -116,7 +116,7 @@ var _ = Describe("SessionAccessControl", func() {
 			err = sac.Evaluate()
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(sac.Evaluate).Should(MatchError(ContainSubstring("client identity expired")))
+			Eventually(sac.Evaluate).Should(MatchError(ContainSubstring("deliver client identity expired")))
 		})
 	})
 

--- a/core/handlers/auth/filter/expiration.go
+++ b/core/handlers/auth/filter/expiration.go
@@ -48,7 +48,7 @@ func validateProposal(signedProp *peer.SignedProposal) error {
 	}
 	expirationTime := crypto.ExpiresAt(sh.Creator)
 	if !expirationTime.IsZero() && time.Now().After(expirationTime) {
-		return errors.New("identity expired")
+		return errors.New("proposal client identity expired")
 	}
 	return nil
 }

--- a/core/handlers/auth/filter/expiration_test.go
+++ b/core/handlers/auth/filter/expiration_test.go
@@ -95,7 +95,7 @@ func TestExpirationCheckFilter(t *testing.T) {
 	// Scenario I: Expired x509 identity
 	sp := createValidSignedProposal(t, createX509Identity(t, "expiredCert.pem"))
 	_, err := auth.ProcessProposal(context.Background(), sp)
-	assert.Equal(t, err.Error(), "identity expired")
+	assert.Equal(t, err.Error(), "proposal client identity expired")
 	assert.False(t, nextEndorser.invoked)
 
 	// Scenario II: Not expired x509 identity

--- a/gossip/identity/identity.go
+++ b/gossip/identity/identity.go
@@ -135,7 +135,7 @@ func (is *identityMapperImpl) Put(pkiID common.PKIidType, identity api.PeerIdent
 	var expirationTimer *time.Timer
 	if !expirationDate.IsZero() {
 		if time.Now().After(expirationDate) {
-			return errors.New("identity expired")
+			return errors.New("gossipping peer identity expired")
 		}
 		// Identity would be wiped out a millisecond after its expiration date
 		timeToLive := time.Until(expirationDate.Add(time.Millisecond))

--- a/gossip/identity/identity_test.go
+++ b/gossip/identity/identity_test.go
@@ -268,7 +268,7 @@ func TestExpiration(t *testing.T) {
 	err := idStore.Put(x509PkiID, x509Identity)
 	assert.NoError(t, err)
 	err = idStore.Put(expiredX509PkiID, expiredX509Identity)
-	assert.Equal(t, "identity expired", err.Error())
+	assert.Equal(t, "gossipping peer identity expired", err.Error())
 	err = idStore.Put(nonX509PkiID, nonX509Identity)
 	assert.NoError(t, err)
 	err = idStore.Put(notSupportedPkiID, notSupportedIdentity)

--- a/integration/raft/cft_test.go
+++ b/integration/raft/cft_test.go
@@ -728,7 +728,7 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			p, err := nwo.Broadcast(network, orderer, channelCreateTxn)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(p.Status).To(Equal(common.Status_BAD_REQUEST))
-			Expect(p.Info).To(ContainSubstring("identity expired"))
+			Expect(p.Info).To(ContainSubstring("broadcast client identity expired"))
 
 			By("Attempting to fetch a block from orderer and failing")
 			denv := CreateDeliverEnvelope(network, orderer, 0, network.SystemChannel.Name)
@@ -737,7 +737,7 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			block, err := nwo.Deliver(network, orderer, denv)
 			Expect(err).To(HaveOccurred())
 			Expect(block).To(BeNil())
-			Eventually(runner.Err(), time.Minute, time.Second).Should(gbytes.Say("client identity expired"))
+			Eventually(runner.Err(), time.Minute, time.Second).Should(gbytes.Say("deliver client identity expired"))
 
 			By("Killing orderer")
 			ordererProc.Signal(syscall.SIGTERM)

--- a/orderer/common/msgprocessor/expiration.go
+++ b/orderer/common/msgprocessor/expiration.go
@@ -51,5 +51,5 @@ func (exp *expirationRejectRule) Apply(message *common.Envelope) error {
 	if expirationTime.IsZero() || time.Now().Before(expirationTime) {
 		return nil
 	}
-	return errors.New("identity expired")
+	return errors.New("broadcast client identity expired")
 }

--- a/orderer/common/msgprocessor/expiration_test.go
+++ b/orderer/common/msgprocessor/expiration_test.go
@@ -109,7 +109,7 @@ func TestExpirationRejectRule(t *testing.T) {
 		mockCapabilities.ExpirationCheckReturns(true)
 		err := NewExpirationRejectRule(mockResources).Apply(env)
 		assert.Error(t, err)
-		assert.Equal(t, err.Error(), "identity expired")
+		assert.Equal(t, err.Error(), "broadcast client identity expired")
 
 		mockCapabilities.ExpirationCheckReturns(false)
 		err = NewExpirationRejectRule(mockResources).Apply(env)


### PR DESCRIPTION
Peer and Orderer have several "identity expired" error messages.
Clarify error messages to indicate which identity has expired.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
