### PR TITLE
Clarify orderers seeing the transaction data

### DIFF
--- a/docs/source/Fabric-FAQ.rst
+++ b/docs/source/Fabric-FAQ.rst
@@ -56,7 +56,12 @@ Security & Access Control
   Do the orderers see the transaction data?
 
 :Answer:
-  No, the orderers only order transactions, they do not open the transactions.
+  Orderers receive endorsed transactions that are submitted from application
+  clients. The endorsed payload contains the chaincode execution results
+  including the ReadSet and WriteSet information. The orderers only validate
+  the submitter's identity and order transactions, they do not open the
+  endorsed transactions.
+
   If you do not want the data to go through the orderers at all, then utilize
   the private data feature of Fabric.  Alternatively, you can hash or encrypt
   the data in the client application before calling chaincode. If you encrypt


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Having the answer start with a `No` is misleading. Beginners
who generally rely on FAQ section to understand the fundamentals
thought that orderers do not receive any information about a
transaction.

With the explanation on what is available with orderers clarifies
the intent served in this FAQ. i.e. Orderers do get the
transaction but at their goodwill they will not open the
transaction, as they do not have a need to open them.

#### Additional details

NA, documentation update

#### Related issues

None