### PR TITLE
[FAB-18485]Fabric orderer - add config option for client keepalives

### DIFF
--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -73,6 +73,8 @@ type Cluster struct {
 
 // Keepalive contains configuration for gRPC servers.
 type Keepalive struct {
+	ClientInterval    time.Duration
+	ClientTimeout     time.Duration
 	ServerMinInterval time.Duration
 	ServerInterval    time.Duration
 	ServerTimeout     time.Duration
@@ -233,6 +235,13 @@ var Defaults = TopLevel{
 			ReplicationRetryTimeout:              time.Second * 5,
 			ReplicationPullTimeout:               time.Second * 5,
 			CertExpirationWarningThreshold:       time.Hour * 24 * 7,
+		},
+		Keepalive: Keepalive{
+			ClientInterval:    time.Minute * 1,
+			ClientTimeout:     time.Second * 20,
+			ServerInterval:    time.Hour * 2,
+			ServerTimeout:     time.Second * 20,
+			ServerMinInterval: time.Minute * 1,
 		},
 		LocalMSPDir: "msp",
 		LocalMSPID:  "SampleOrg",
@@ -414,6 +423,16 @@ func (c *TopLevel) completeInitialization(configDir string) {
 			c.General.Cluster.ReplicationBackgroundRefreshInterval = Defaults.General.Cluster.ReplicationBackgroundRefreshInterval
 		case c.General.Cluster.CertExpirationWarningThreshold == 0:
 			c.General.Cluster.CertExpirationWarningThreshold = Defaults.General.Cluster.CertExpirationWarningThreshold
+		case c.General.Keepalive.ClientInterval == 0:
+			c.General.Keepalive.ClientInterval = Defaults.General.Keepalive.ClientInterval
+		case c.General.Keepalive.ClientTimeout == 0:
+			c.General.Keepalive.ClientTimeout = Defaults.General.Keepalive.ClientTimeout
+		case c.General.Keepalive.ServerInterval == 0:
+			c.General.Keepalive.ServerInterval = Defaults.General.Keepalive.ServerInterval
+		case c.General.Keepalive.ServerTimeout == 0:
+			c.General.Keepalive.ServerTimeout = Defaults.General.Keepalive.ServerTimeout
+		case c.General.Keepalive.ServerMinInterval == 0:
+			c.General.Keepalive.ServerMinInterval = Defaults.General.Keepalive.ServerMinInterval
 		case c.Kafka.TLS.Enabled && c.Kafka.TLS.Certificate == "":
 			logger.Panicf("General.Kafka.TLS.Certificate must be set if General.Kafka.TLS.Enabled is set to true.")
 		case c.Kafka.TLS.Enabled && c.Kafka.TLS.PrivateKey == "":

--- a/orderer/common/localconfig/config_test.go
+++ b/orderer/common/localconfig/config_test.go
@@ -314,3 +314,24 @@ func TestChannelParticipationDefaults(t *testing.T) {
 	require.Equal(t, cfg.ChannelParticipation.Enabled, Defaults.ChannelParticipation.Enabled)
 	require.Equal(t, cfg.ChannelParticipation.MaxRequestBodySize, Defaults.ChannelParticipation.MaxRequestBodySize)
 }
+
+func TestKeepaliveConfig(t *testing.T) {
+	os.Setenv("ORDERER_GENERAL_KEEPALIVE_CLIENTINTERVAL", "30s")
+	os.Setenv("ORDERER_GENERAL_KEEPALIVE_SERVERINTERVAL", "60s")
+	os.Setenv("ORDERER_GENERAL_KEEPALIVE_SERVERTIMEOUT", "30s")
+	defer os.Unsetenv("ORDERER_GENERAL_KEEPALIVE_CLIENTINTERVAL")
+	defer os.Unsetenv("ORDERER_GENERAL_KEEPALIVE_SERVERINTERVAL")
+	defer os.Unsetenv("ORDERER_GENERAL_KEEPALIVE_SERVERTIMEOUT")
+	cleanup := configtest.SetDevFabricConfigPath(t)
+	defer cleanup()
+
+	cc := &configCache{}
+	cfg, err := cc.load()
+	require.NoError(t, err, "Load good config returned unexpected error")
+	require.NotNil(t, cfg, "Could not load config")
+	require.Equal(t, 30*time.Second, cfg.General.Keepalive.ClientInterval)
+	require.Equal(t, Defaults.General.Keepalive.ClientTimeout, cfg.General.Keepalive.ClientTimeout)
+	require.Equal(t, Defaults.General.Keepalive.ServerMinInterval, cfg.General.Keepalive.ServerMinInterval)
+	require.Equal(t, 60*time.Second, cfg.General.Keepalive.ServerInterval)
+	require.Equal(t, 30*time.Second, cfg.General.Keepalive.ServerTimeout)
+}

--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -532,9 +532,13 @@ func configureClusterListener(conf *localconfig.TopLevel, generalConf comm.Serve
 }
 
 func initializeClusterClientConfig(conf *localconfig.TopLevel) (comm.ClientConfig, bool) {
+	kaOpts := comm.DefaultKeepaliveOptions
+	kaOpts.ClientTimeout = conf.General.Keepalive.ClientTimeout
+	kaOpts.ClientInterval = conf.General.Keepalive.ClientInterval
+
 	cc := comm.ClientConfig{
 		AsyncConnect: true,
-		KaOpts:       comm.DefaultKeepaliveOptions,
+		KaOpts:       kaOpts,
 		DialTimeout:  conf.General.Cluster.DialTimeout,
 		SecOpts:      comm.SecureOptions{},
 	}
@@ -636,11 +640,7 @@ func initializeServerConfig(conf *localconfig.TopLevel, metricsProvider metrics.
 		logger.Infof("Starting orderer with %s enabled", msg)
 	}
 	kaOpts := comm.DefaultKeepaliveOptions
-	// keepalive settings
-	// ServerMinInterval must be greater than 0
-	if conf.General.Keepalive.ServerMinInterval > time.Duration(0) {
-		kaOpts.ServerMinInterval = conf.General.Keepalive.ServerMinInterval
-	}
+	kaOpts.ServerMinInterval = conf.General.Keepalive.ServerMinInterval
 	kaOpts.ServerInterval = conf.General.Keepalive.ServerInterval
 	kaOpts.ServerTimeout = conf.General.Keepalive.ServerTimeout
 

--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -155,11 +155,11 @@ func TestInitializeServerConfig(t *testing.T) {
 	require.Equal(t, [][]byte{expectedContent}, sc.SecOpts.ClientRootCAs)
 
 	sc = initializeServerConfig(conf, nil)
-	defaultOpts := comm.DefaultKeepaliveOptions
-	require.Equal(t, defaultOpts.ServerMinInterval, sc.KaOpts.ServerMinInterval)
+	require.Equal(t, time.Duration(0), sc.KaOpts.ServerMinInterval)
 	require.Equal(t, time.Duration(0), sc.KaOpts.ServerInterval)
 	require.Equal(t, time.Duration(0), sc.KaOpts.ServerTimeout)
 	require.Equal(t, 7*time.Second, sc.ConnectionTimeout)
+
 	testDuration := 10 * time.Second
 	conf.General.Keepalive = localconfig.Keepalive{
 		ServerMinInterval: testDuration,

--- a/sampleconfig/orderer.yaml
+++ b/sampleconfig/orderer.yaml
@@ -41,6 +41,11 @@ General:
         ClientRootCAs:
     # Keepalive settings for the GRPC server.
     Keepalive:
+        # ClientInterval is the time between pings to server
+        ClientInterval: 60s
+        # ClientTimeout is the duration the client waits for a response from
+        # a server before closing the connection
+        ClientTimeout: 20s
         # ServerMinInterval is the minimum permitted time between client pings.
         # If clients send pings more frequently, the server will
         # disconnect them.


### PR DESCRIPTION
added config option for orderer client keepalives.  Defaults defined as per the
existing hard coded values. 

Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>


