### PR TITLE
Mandate TLS 1.2 or higher in fabhttp package

### DIFF
--- a/common/fabhttp/fabhttp_suite_test.go
+++ b/common/fabhttp/fabhttp_suite_test.go
@@ -48,7 +48,7 @@ func generateCertificates(tempDir string) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func newHTTPClient(tlsDir string, withClientCert bool) *http.Client {
+func newHTTPClient(tlsDir string, withClientCert bool, tlsOpts ...func(config *tls.Config)) *http.Client {
 	clientCertPool := x509.NewCertPool()
 	caCert, err := ioutil.ReadFile(filepath.Join(tlsDir, "server-ca.pem"))
 	Expect(err).NotTo(HaveOccurred())
@@ -64,6 +64,10 @@ func newHTTPClient(tlsDir string, withClientCert bool) *http.Client {
 		)
 		Expect(err).NotTo(HaveOccurred())
 		tlsClientConfig.Certificates = []tls.Certificate{clientCert}
+	}
+
+	for _, opt := range tlsOpts {
+		opt(tlsClientConfig)
 	}
 
 	return &http.Client{

--- a/common/fabhttp/tls.go
+++ b/common/fabhttp/tls.go
@@ -39,6 +39,7 @@ func (t TLS) Config() (*tls.Config, error) {
 			caCertPool.AppendCertsFromPEM(caPem)
 		}
 		tlsConfig = &tls.Config{
+			MinVersion:   tls.VersionTLS12,
 			Certificates: []tls.Certificate{cert},
 			CipherSuites: comm.DefaultTLSCipherSuites,
 			ClientCAs:    caCertPool,

--- a/common/fabhttp/tls_test.go
+++ b/common/fabhttp/tls_test.go
@@ -65,6 +65,7 @@ var _ = Describe("TLS", func() {
 		tlsConfig.ClientCAs = nil
 
 		Expect(tlsConfig).To(Equal(&tls.Config{
+			MinVersion:   tls.VersionTLS12,
 			Certificates: []tls.Certificate{cert},
 			CipherSuites: []uint16{
 				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,


### PR DESCRIPTION
This commit ensures that the HTTP server that is spawned by the fabhttp package
only accepts TLS handshakes from clients that attempt to use TLS 1.2 or higher.

Change-Id: Ia25482d9c96f68506724a58258451311b3d63208
Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>
