### PR TITLE
Use protoc-gen-go 1.3.3 for generating fabric protos

### DIFF
--- a/common/grpclogging/testpb/echo.pb.go
+++ b/common/grpclogging/testpb/echo.pb.go
@@ -96,11 +96,11 @@ var fileDescriptor_08134aea513e0001 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // EchoServiceClient is the client API for EchoService service.
 //
@@ -111,10 +111,10 @@ type EchoServiceClient interface {
 }
 
 type echoServiceClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewEchoServiceClient(cc *grpc.ClientConn) EchoServiceClient {
+func NewEchoServiceClient(cc grpc.ClientConnInterface) EchoServiceClient {
 	return &echoServiceClient{cc}
 }
 

--- a/common/grpcmetrics/testpb/echo.pb.go
+++ b/common/grpcmetrics/testpb/echo.pb.go
@@ -96,11 +96,11 @@ var fileDescriptor_08134aea513e0001 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // EchoServiceClient is the client API for EchoService service.
 //
@@ -111,10 +111,10 @@ type EchoServiceClient interface {
 }
 
 type echoServiceClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewEchoServiceClient(cc *grpc.ClientConn) EchoServiceClient {
+func NewEchoServiceClient(cc grpc.ClientConnInterface) EchoServiceClient {
 	return &echoServiceClient{cc}
 }
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -17,3 +17,5 @@ require (
 	honnef.co/go/tools v0.1.1
 	mvdan.cc/gofumpt v0.1.0
 )
+
+replace github.com/golang/protobuf => github.com/golang/protobuf v1.3.3

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -178,6 +178,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
+github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=


### PR DESCRIPTION
A previous commit [#2113](https://github.com/hyperledger/fabric/pull/2113/files#diff-11f03b0f97705b85807a720c4608013062002af3604f046a09a2571b0ae02554L9) upgraded the protobuf in tools while the protobuf in fabric dependencies is still 1.3.3. This upgrade was caused by swagger inclusion.

In the current form, `make protos` causes to use upgraded version of protoc-gen-go. This, in turn, requires to upgrade the protobuf lib in the fabric dependancies -- which we could not until we resolve some issues. See [FAB-18363](https://jira.hyperledger.org/browse/FAB-18363).

Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- Bug fix