### PR TITLE
Fix a typo in CouchDB tutorial

### DIFF
--- a/docs/source/couchdb_tutorial.rst
+++ b/docs/source/couchdb_tutorial.rst
@@ -508,7 +508,7 @@ previous example.
 
 A query that does not include all fields in the index will have to scan the full
 database instead. For example, the query below searches for the owner, without
-specifying the type of item owned. Since the ownerIndexDoc contains both
+specifying the type of item owned. Since the indexOwnerDoc contains both
 the ``owner`` and ``docType`` fields, this query will not be able to use the
 index.
 


### PR DESCRIPTION
Signed-off-by: Atsushi Neki <nekiaiken@gmail.com>

Fix an incorrect index document name within a sentence, which was found while translating into other language. 

#### Type of change

- Documentation update

#### Description

Fix an incorrect index document name `ownerIndexDoc` within a sentence to `indexOwnerDoc` which is the name used in chaincode index configuration in this tutorial. 

