### PR TITLE
[FAB-18508] ledger utility always outputs txNum

### DIFF
--- a/internal/ledger/compare.go
+++ b/internal/ledger/compare.go
@@ -188,21 +188,14 @@ func Compare(snapshotDir1 string, snapshotDir2 string, outputFile string) (count
 type diffRecord struct {
 	Namespace string          `json:"namespace,omitempty"`
 	Key       string          `json:"key,omitempty"`
-	Record1   *snapshotRecord `json:"snapshotrecord1,omitempty"`
-	Record2   *snapshotRecord `json:"snapshotrecord2,omitempty"`
+	Record1   *snapshotRecord `json:"snapshotrecord1"`
+	Record2   *snapshotRecord `json:"snapshotrecord2"`
 }
 
 // Creates a new diffRecord
 func newDiffRecord(namespace string, record1 *privacyenabledstate.SnapshotRecord,
 	record2 *privacyenabledstate.SnapshotRecord) (*diffRecord, error) {
-	// Empty snapshot
-	s0 := snapshotRecord{
-		Value:    "",
-		BlockNum: 0,
-		TxNum:    0,
-	}
-
-	var s1, s2 *snapshotRecord = &s0, &s0 // snapshot records
+	var s1, s2 *snapshotRecord = nil, nil // snapshot records
 	var k string                          // key
 	var err error
 
@@ -233,9 +226,9 @@ func newDiffRecord(namespace string, record1 *privacyenabledstate.SnapshotRecord
 
 // snapshotRecord represents the data of a snapshot record in json
 type snapshotRecord struct {
-	Value    string `json:"value,omitempty"`
-	BlockNum uint64 `json:"blockNum,omitempty"`
-	TxNum    uint64 `json:"txNum,omitempty"`
+	Value    string `json:"value"`
+	BlockNum uint64 `json:"blockNum"`
+	TxNum    uint64 `json:"txNum"`
 }
 
 // Creates a new SnapshotRecord

--- a/internal/ledger/compare_test.go
+++ b/internal/ledger/compare_test.go
@@ -53,7 +53,7 @@ func TestCompare(t *testing.T) {
 		},
 		{
 			namespace: "ns3", key: "k1", value: "v4",
-			blockNum: 2, txNum: 1, metadata: "md4",
+			blockNum: 2, txNum: 0, metadata: "md4",
 		},
 	}
 
@@ -72,7 +72,7 @@ func TestCompare(t *testing.T) {
 		},
 		{
 			namespace: "ns3", key: "k1", value: "v4",
-			blockNum: 2, txNum: 1, metadata: "md4",
+			blockNum: 2, txNum: 0, metadata: "md4",
 		},
 	}
 
@@ -87,7 +87,7 @@ func TestCompare(t *testing.T) {
 		},
 		{
 			namespace: "ns3", key: "k1", value: "v4",
-			blockNum: 2, txNum: 1, metadata: "md4",
+			blockNum: 2, txNum: 0, metadata: "md4",
 		},
 	}
 
@@ -177,14 +177,14 @@ func TestCompare(t *testing.T) {
 					"blockNum" : 1,
 					"txNum" : 1
 				},
-				"snapshotrecord2" : {}
+				"snapshotrecord2" : null
 			}
 		]`
 	expectedMissingResult2 := `[
 			{
 				"namespace" : "ns1",
 				"key" : "k2",
-				"snapshotrecord1" : {},
+				"snapshotrecord1" : null,
 				"snapshotrecord2" : {
 					"value" : "v2",
 					"blockNum" : 1,
@@ -201,7 +201,7 @@ func TestCompare(t *testing.T) {
 					"blockNum" : 1,
 					"txNum" : 2
 				},
-				"snapshotrecord2" : {}
+				"snapshotrecord2" : null
 			},
 			{
 				"namespace" : "ns3",
@@ -209,16 +209,16 @@ func TestCompare(t *testing.T) {
 				"snapshotrecord1" : {
 					"value" : "v4",
 					"blockNum" : 2,
-					"txNum" : 1
+					"txNum" : 0
 				},
-				"snapshotrecord2" : {}
+				"snapshotrecord2" : null
 			}
 		]`
 	expectedMissingTailResult2 := `[
 			{
 				"namespace" : "ns2",
 				"key" : "k1",
-				"snapshotrecord1" : {},
+				"snapshotrecord1" : null,
 				"snapshotrecord2" : {
 					"value" : "v3",
 					"blockNum" : 1,
@@ -228,11 +228,11 @@ func TestCompare(t *testing.T) {
 			{
 				"namespace" : "ns3",
 				"key" : "k1",
-				"snapshotrecord1" : {},
+				"snapshotrecord1" : null,
 				"snapshotrecord2" : {
 					"value" : "v4",
 					"blockNum" : 2,
-					"txNum" : 1
+					"txNum" : 0
 				}
 			}
 		]`
@@ -454,20 +454,12 @@ func TestJSONArrayFileWriter(t *testing.T) {
 				BlockNum: 472,
 				TxNum:    61,
 			},
-			Record2: &snapshotRecord{
-				Value:    "",
-				BlockNum: 0,
-				TxNum:    0,
-			},
+			Record2: nil,
 		},
 		{
 			Namespace: "xyz",
 			Key:       "key-44",
-			Record1: &snapshotRecord{
-				Value:    "",
-				BlockNum: 0,
-				TxNum:    0,
-			},
+			Record1:   nil,
 			Record2: &snapshotRecord{
 				Value:    "purple",
 				BlockNum: 566,
@@ -499,12 +491,12 @@ func TestJSONArrayFileWriter(t *testing.T) {
 				"blockNum" : 472,
 				"txNum" : 61
 			},
-			"snapshotrecord2" : {}
+			"snapshotrecord2" : null
 		},
 		{
 			"namespace" : "xyz",
 			"key" : "key-44",
-			"snapshotrecord1" : {},
+			"snapshotrecord1" : null,
 			"snapshotrecord2" : {
 				"value" : "purple",
 				"blockNum" : 566,


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

This patch fixes a bug reported in FAB-18508, and makes the ledger troubleshooting utility output always the record "txNum".

#### Additional details

The bug occurred when the target transaction is the first transaction of a block (txNum == 0). This patch removes the `omitempty` attributes from all the members of a record.

Note that this patch also changes the output when a key is missing in either snapshot. Instead of an empty object ({}) for the missing snapshot, the entire key (either "snapshotrecord1" or "snapshotrecord2") will be omitted.
(Refer to the changes in the test code)

#### Related issues

https://jira.hyperledger.org/projects/FAB/issues/FAB-18508