### PR TITLE
fix invalid memory panic when release db in high concurrency of chaincode query

### DIFF
--- a/vendor/github.com/syndtr/goleveldb/leveldb/db_iter.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/db_iter.go
@@ -335,7 +335,7 @@ func (i *dbIter) Value() []byte {
 }
 
 func (i *dbIter) Release() {
-	if i.dir != dirReleased {
+	if i.dir != dirReleased && i.db != nil {
 		// Clear the finalizer.
 		runtime.SetFinalizer(i, nil)
 


### PR DESCRIPTION
Signed-off-by: wuqiaomin <wuqiaomin2@huawei.com>

Type of change
- Bug fix

Description
In the condition of high concurrency of chaincode query, peer will crash after TXSimulator finish SimulateProposal, because queryExecutor's dbItr release db again and the function AddInt32 in Release will panic.
Hence, inspect whether db is nil before dbIter release db. 