### PR TITLE
Update boostrap.sh for test network

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -49,7 +49,7 @@ dockerPull() {
 cloneSamplesRepo() {
     # clone (if needed) hyperledger/fabric-samples and checkout corresponding
     # version to the binaries and docker images to be downloaded
-    if [ -d first-network ]; then
+    if [ -d test-network ]; then
         # if we are in the fabric-samples repo, checkout corresponding version
         echo "==> Already in fabric-samples repo"
     elif [ -d fabric-samples ]; then


### PR DESCRIPTION
Signed-off-by: Nikhil Gupta <ngupta@symbridge.com>


#### Type of change

- Bug fix

#### Description

Replace reference to first-network in bootstrap.sh with test network. Currently, have to be careful not to issue the command from withing the samples directory, because it will only create another clone another copy of the samples. 