### PR TITLE
Update docs to clarify that an implicit collection can not have an index

### DIFF
--- a/docs/source/private_data_tutorial.rst
+++ b/docs/source/private_data_tutorial.rst
@@ -976,6 +976,11 @@ automatically deployed upon chaincode instantiation on the channel when
 the  ``--collections-config`` flag is specified pointing to the location of
 the collection JSON file.
 
+.. note:: It is not possible to create an index for use with an implict private data collection.
+          An implicit collection is based on the organizations name and is created automatically. The format of the name
+          is ``_implicit_org_<OrgsMSPid>``
+          Please see `FAB-17916 <https://jira.hyperledger.org/browse/FAB-17916>`__ for more information.
+
 Clean up
 --------
 


### PR DESCRIPTION
Signed-off-by: Matthew B White <whitemat@uk.ibm.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

- Documentation update

#### Description

An updated tutorial on private data collections to note that the implicit collections can not have indexes



#### Related issues

FAB-17916 <https://jira.hyperledger.org/browse/FAB-17916>
