### PR TITLE
[FAB-18521] Fixing flaky IT, send remove tx to another node

### DIFF
--- a/integration/raft/cft_test.go
+++ b/integration/raft/cft_test.go
@@ -329,8 +329,6 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			}, orderers, peer, network)
 
 			By("Removing OSN from the channel")
-			removeConsenter(network, peer, victim, "systemchannel", victimCertBytes)
-
 			remainedOrderers := []*nwo.Orderer{}
 			remainedRunners := []*ginkgomon.Runner{}
 
@@ -342,6 +340,9 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 				remainedRunners = append(remainedRunners, ordererRunners[i])
 			}
 
+			removeConsenter(network, peer, remainedOrderers[0], "systemchannel", victimCertBytes)
+
+			By("Asserting all remaining nodes got last block")
 			assertBlockReception(map[string]int{
 				"systemchannel": 2,
 			}, remainedOrderers, peer, network)


### PR DESCRIPTION
PR #2748, introduced new IT to ensure the fix. However, there is some flakiness manifested with this IT, caused by sending the remove consenter transaction to the "to be removed" node. Removing the consenter is a config transaction where codes after sending it ensure a new block with the config update successfully committed, which is the root cause for the flakiness. Once OSN is removed from the channel, it no longer can server deliver requests for clients trying to fetch from it.

This commit, fixes it by sending remove OSN config updated transaction
to a different node instead.

Signed-off-by: Artem Barger <artem@bargr.net>