### PR TITLE
Update private data docs - remove SDK reference

### DIFF
--- a/docs/source/private-data-arch.rst
+++ b/docs/source/private-data-arch.rst
@@ -13,15 +13,13 @@ used to control dissemination of private data at endorsement time and,
 optionally, whether the data will be purged.
 
 Beginning with the Fabric chaincode lifecycle introduced with Fabric v2.0, the
-collection definition is part of the chaincode definition. The collection is
-approved by channel members, and then deployed when the chaincode definition
-is committed to the channel. The collection file needs to be the same for all
-channel members. If you are using the peer CLI to approve and commit the
+collection definition is part of the chaincode definition. The chaincode including
+collection definition must be approved by the required channel members, and
+then becomes effective when the chaincode definition is committed to the channel.
+The collection definition that is approved must be identical for each of the required
+channel members. When using the peer CLI to approve and commit the
 chaincode definition, use the ``--collections-config`` flag to specify the path
-to the collection definition file. If you are using the Fabric SDK for Node.js,
-visit `How to install and start your chaincode <https://hyperledger.github.io/fabric-sdk-node/{BRANCH}/tutorial-chaincode-lifecycle.html>`_.
-To use the `previous lifecycle process <https://hyperledger-fabric.readthedocs.io/en/release-1.4/chaincode4noah.html>`_ to deploy a private data collection,
-use the ``--collections-config`` flag when `instantiating your chaincode <https://hyperledger-fabric.readthedocs.io/en/{BRANCH_DOC}/commands/peerchaincode.html#peer-chaincode-instantiate>`_.
+to the collection definition file.
 
 Collection definitions are composed of the following properties:
 


### PR DESCRIPTION
Remove reference to SDK since SDK is no longer used to deploy chaincode.
Also remove reference to legacy lifecycle (legacy lifecycle
remains fully documented in release-1.4 docs and in the main branch CLI reference doc).

Signed-off-by: David Enyeart <enyeart@us.ibm.com>