### PR TITLE
FABGW-25 Endorse using generated ChaincodeInterest

### DIFF
--- a/internal/pkg/gateway/gateway.go
+++ b/internal/pkg/gateway/gateway.go
@@ -26,6 +26,7 @@ type Server struct {
 	eventer      Eventer
 	policy       ACLChecker
 	options      config.Options
+	logger       *flogging.FabricLogger
 }
 
 type EndorserServerAdapter struct {
@@ -86,6 +87,7 @@ func newServer(localEndorser peerproto.EndorserClient, discovery Discovery, find
 		eventer:      eventer,
 		policy:       policy,
 		options:      options,
+		logger:       logger,
 	}
 
 	return gwServer

--- a/internal/pkg/gateway/registry.go
+++ b/internal/pkg/gateway/registry.go
@@ -13,21 +13,22 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/hyperledger/fabric-protos-go/peer"
+
 	"github.com/golang/protobuf/proto"
 	dp "github.com/hyperledger/fabric-protos-go/discovery"
 	"github.com/hyperledger/fabric-protos-go/gossip"
-	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/common/flogging"
 	gossipapi "github.com/hyperledger/fabric/gossip/api"
-	"github.com/hyperledger/fabric/gossip/common"
+	gossipcommon "github.com/hyperledger/fabric/gossip/common"
 	gossipdiscovery "github.com/hyperledger/fabric/gossip/discovery"
 )
 
 type Discovery interface {
 	Config(channel string) (*dp.ConfigResult, error)
 	IdentityInfo() gossipapi.PeerIdentitySet
-	PeersForEndorsement(channel common.ChannelID, interest *peer.ChaincodeInterest) (*dp.EndorsementDescriptor, error)
-	PeersOfChannel(common.ChannelID) gossipdiscovery.Members
+	PeersForEndorsement(channel gossipcommon.ChannelID, interest *peer.ChaincodeInterest) (*dp.EndorsementDescriptor, error)
+	PeersOfChannel(gossipcommon.ChannelID) gossipdiscovery.Members
 }
 
 type registry struct {
@@ -49,44 +50,38 @@ type endorserState struct {
 }
 
 // Returns a set of endorsers that satisfies the endorsement plan for the given chaincode on a channel.
-func (reg *registry) endorsers(channel string, chaincode string) ([]*endorser, error) {
-	err := reg.registerChannel(channel)
-	if err != nil {
-		return nil, err
-	}
-
+func (reg *registry) endorsers(channel string, interest *peer.ChaincodeInterest, preferOrg string) ([]*endorser, error) {
 	var endorsers []*endorser
+	var reserveEndorsers []*endorser
 
-	interest := &peer.ChaincodeInterest{
-		Chaincodes: []*peer.ChaincodeCall{{
-			Name: chaincode,
-		}},
-	}
-
-	descriptor, err := reg.discovery.PeersForEndorsement(common.ChannelID(channel), interest)
+	descriptor, err := reg.discovery.PeersForEndorsement(gossipcommon.ChannelID(channel), interest)
 	if err != nil {
-		return nil, err
+		logger.Errorw("PeersForEndorsement failed.", "error", err, "channel", channel, "ChaincodeInterest", proto.MarshalTextString(interest))
+		return nil, fmt.Errorf("discovery service failed to build endorsement plan: %s", err)
 	}
+
+	layouts := descriptor.GetLayouts()
 
 	reg.configLock.RLock()
 	defer reg.configLock.RUnlock()
 
-	for _, layout := range descriptor.GetLayouts() {
+	for _, layout := range layouts {
 		var receivers []*endorserState // The set of peers the client needs to request endorsements from
 		abandonLayout := false
+		hasPreferredOrg := false
 		for group, quantity := range layout.GetQuantitiesByGroup() {
 			// Select n remoteEndorsers from each group sorted by block height
-
-			// block heights
 			var groupPeers []*endorserState
 			for _, peer := range descriptor.GetEndorsersByGroups()[group].GetPeers() {
+				// extract block height
 				msg := &gossip.GossipMessage{}
-				err := proto.Unmarshal(peer.GetStateInfo().GetPayload(), msg)
+				err = proto.Unmarshal(peer.GetStateInfo().GetPayload(), msg)
 				if err != nil {
 					return nil, err
 				}
-
 				height := msg.GetStateInfo().GetProperties().GetLedgerHeight()
+
+				// extract endpoint
 				err = proto.Unmarshal(peer.GetMembershipInfo().GetPayload(), msg)
 				if err != nil {
 					return nil, err
@@ -104,6 +99,10 @@ func (reg *registry) endorsers(channel string, chaincode string) ([]*endorser, e
 					continue
 				}
 
+				if endorser.mspid == preferOrg {
+					hasPreferredOrg = true
+				}
+
 				groupPeers = append(groupPeers, &endorserState{peer: peer, endorser: endorser, height: height})
 			}
 
@@ -116,6 +115,7 @@ func (reg *registry) endorsers(channel string, chaincode string) ([]*endorser, e
 			// sort by decreasing height
 			sort.Slice(groupPeers, sorter(groupPeers, reg.localEndorser.address))
 
+			// put the local org peers at the head of the slice
 			receivers = append(receivers, groupPeers[0:quantity]...)
 		}
 
@@ -127,7 +127,22 @@ func (reg *registry) endorsers(channel string, chaincode string) ([]*endorser, e
 		for _, peer := range receivers {
 			endorsers = append(endorsers, peer.endorser)
 		}
+
+		// if this plan doesn't contain the `preferOrg` org, abandon it in favour of one that does, since we already have a local endorsement
+		// but save it in reserve in case there are no layouts with the local org
+		if preferOrg != "" && !hasPreferredOrg {
+			if reserveEndorsers == nil {
+				reserveEndorsers = endorsers
+			}
+			// try the next layout
+			continue
+		}
+
 		return endorsers, nil
+	}
+
+	if reserveEndorsers != nil {
+		return reserveEndorsers, nil
 	}
 
 	return nil, fmt.Errorf("failed to select a set of endorsers that satisfy the endorsement policy")
@@ -135,11 +150,6 @@ func (reg *registry) endorsers(channel string, chaincode string) ([]*endorser, e
 
 // endorsersForOrgs returns a set of endorsers owned by the given orgs for the given chaincode on a channel.
 func (reg *registry) endorsersForOrgs(channel string, chaincode string, endorsingOrgs []string) ([]*endorser, error) {
-	err := reg.registerChannel(channel)
-	if err != nil {
-		return nil, err
-	}
-
 	endorsersByOrg := reg.endorsersByOrg(channel, chaincode)
 
 	var endorsers []*endorser
@@ -161,7 +171,7 @@ func (reg *registry) endorsersForOrgs(channel string, chaincode string, endorsin
 func (reg *registry) endorsersByOrg(channel string, chaincode string) map[string][]*endorserState {
 	endorsersByOrg := make(map[string][]*endorserState)
 
-	members := reg.discovery.PeersOfChannel(common.ChannelID(channel))
+	members := reg.discovery.PeersOfChannel(gossipcommon.ChannelID(channel))
 
 	reg.configLock.RLock()
 	defer reg.configLock.RUnlock()
@@ -202,12 +212,8 @@ func (reg *registry) endorsersByOrg(channel string, chaincode string) map[string
 // evaluator returns a single endorser, preferably from local org, if available
 // targetOrgs specifies the orgs that are allowed receive the request, due to private data restrictions
 func (reg *registry) evaluator(channel string, chaincode string, targetOrgs []string) (*endorser, error) {
-	err := reg.registerChannel(channel)
-	if err != nil {
-		return nil, err
-	}
-
 	endorsersByOrg := reg.endorsersByOrg(channel, chaincode)
+
 	// If no targetOrgs are specified (i.e. no restrictions), then populate with all available orgs
 	if len(targetOrgs) == 0 {
 		for org := range endorsersByOrg {
@@ -319,9 +325,9 @@ func (reg *registry) registerChannel(channel string) error {
 
 	// get the remoteEndorsers for the channel
 	peers := map[string]string{}
-	members := reg.discovery.PeersOfChannel(common.ChannelID(channel))
+	members := reg.discovery.PeersOfChannel(gossipcommon.ChannelID(channel))
 	for _, member := range members {
-		id := member.PKIid.String() // TODO this is fragile
+		id := member.PKIid.String()
 		peers[id] = member.PreferredEndpoint()
 	}
 	for mspid, infoset := range reg.discovery.IdentityInfo().ByOrg() {

--- a/protoutil/unmarshalers.go
+++ b/protoutil/unmarshalers.go
@@ -9,6 +9,8 @@ package protoutil
 import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric-protos-go/ledger/rwset"
+	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/pkg/errors"
@@ -154,6 +156,27 @@ func UnmarshalChaincodeProposalPayload(bytes []byte) (*peer.ChaincodeProposalPay
 	cpp := &peer.ChaincodeProposalPayload{}
 	err := proto.Unmarshal(bytes, cpp)
 	return cpp, errors.Wrap(err, "error unmarshalling ChaincodeProposalPayload")
+}
+
+// UnmarshalTxReadWriteSet unmarshals bytes to a TxReadWriteSet
+func UnmarshalTxReadWriteSet(bytes []byte) (*rwset.TxReadWriteSet, error) {
+	rws := &rwset.TxReadWriteSet{}
+	err := proto.Unmarshal(bytes, rws)
+	return rws, errors.Wrap(err, "error unmarshalling TxReadWriteSet")
+}
+
+// UnmarshalKVRWSet unmarshals bytes to a KVRWSet
+func UnmarshalKVRWSet(bytes []byte) (*kvrwset.KVRWSet, error) {
+	rws := &kvrwset.KVRWSet{}
+	err := proto.Unmarshal(bytes, rws)
+	return rws, errors.Wrap(err, "error unmarshalling KVRWSet")
+}
+
+// UnmarshalHashedRWSet unmarshals bytes to a HashedRWSet
+func UnmarshalHashedRWSet(bytes []byte) (*kvrwset.HashedRWSet, error) {
+	hrws := &kvrwset.HashedRWSet{}
+	err := proto.Unmarshal(bytes, hrws)
+	return hrws, errors.Wrap(err, "error unmarshalling HashedRWSet")
 }
 
 // UnmarshalSignaturePolicy unmarshals bytes to a SignaturePolicyEnvelope


### PR DESCRIPTION
Change the Endorse() method logic as described in the design document attached to the Jira.
- Process proposal on local org peer.
- Using the ChaincodeInterest in the propsal response, invoke discovery to obtain a layout that contains the local org
- Obtain the remaining endorsements
- Build the transaction to send back to the client.

Extra unit tests added to test the new logic.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
