### PR TITLE
FAB 18365 IT flake evictionsuspector failed to read eviction 

### DIFF
--- a/orderer/consensus/etcdraft/eviction_test.go
+++ b/orderer/consensus/etcdraft/eviction_test.go
@@ -169,14 +169,6 @@ func TestEvictionSuspector(t *testing.T) {
 			halt:                       t.Fail,
 		},
 		{
-			description:                "our height is the highest",
-			expectedLog:                "Our height is higher or equal than the height of the orderer we pulled the last block from, aborting",
-			evictionSuspicionThreshold: 10*time.Minute - time.Second,
-			blockPuller:                puller,
-			height:                     10,
-			halt:                       t.Fail,
-		},
-		{
 			description:                "failed pulling the block",
 			expectedLog:                "Cannot confirm our own eviction from the channel: bad block",
 			evictionSuspicionThreshold: 10*time.Minute - time.Second,
@@ -193,6 +185,15 @@ func TestEvictionSuspector(t *testing.T) {
 			blockPuller:                puller,
 			height:                     9,
 			halt:                       t.Fail,
+		},
+		{
+			description:                "our height is the highest",
+			expectedLog:                "Our height is higher or equal than the height of the orderer we pulled the last block from, aborting",
+			evictionSuspicionThreshold: 10*time.Minute - time.Second,
+			amIInChannelReturns:        cluster.ErrNotInChannel,
+			blockPuller:                puller,
+			height:                     10,
+			halt:                       func() {},
 		},
 		{
 			description:                 "we are not in the channel",


### PR DESCRIPTION
#### Description
In failing case, the OSN being removed has committed the config change but failed to receive apply_config msg to halt the chain. This state is defined to be handled as part of the eviction suspicion logic. But it failed when evictionsuspector failed to check from lastconfig block if chain is up-to-date. 

Fix: Updated the order of statements which looks at the latest config block and block height validation.

#### Type of change
- Bug fix

Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>