### PR TITLE
FAB-18067 Discovery support Implicit Collections

### DIFF
--- a/core/chaincode/lifecycle/metadata_provider_test.go
+++ b/core/chaincode/lifecycle/metadata_provider_test.go
@@ -78,6 +78,11 @@ var _ = Describe("MetadataProvider", func() {
 		))
 	})
 
+	It("returns metadata for implicit collections", func() {
+		metadata := metadataProvider.Metadata("testchannel", "cc-name", "_implicit_org_msp1")
+		Expect(metadata.CollectionPolicies).To(HaveKey("_implicit_org_msp1"))
+	})
+
 	Context("when the chaincode is not found by the ChaincodeInfoProvider", func() {
 		BeforeEach(func() {
 			fakeChaincodeInfoProvider.ChaincodeInfoReturns(nil, errors.New("scrumtrulescent"))

--- a/integration/discovery/discovery_test.go
+++ b/integration/discovery/discovery_test.go
@@ -645,6 +645,17 @@ var _ = Describe("DiscoveryService", func() {
 		Expect(discovered[0].Layouts).To(HaveLen(1))
 		Expect(discovered[0].Layouts[0].QuantitiesByGroup).To(ConsistOf(uint32(1), uint32(1)))
 
+		By("discovering endorsers for Org1 implicit collection")
+		endorsers.Collection = "mycc:_implicit_org_Org1MSP"
+		de = discoverEndorsers(network, endorsers)
+		Eventually(endorsersByGroups(de), network.EventuallyTimeout).Should(ConsistOf(
+			ConsistOf(network.DiscoveredPeer(org1Peer0)),
+		))
+		discovered = de()
+		Expect(discovered).To(HaveLen(1))
+		Expect(discovered[0].Layouts).To(HaveLen(1))
+		Expect(discovered[0].Layouts[0].QuantitiesByGroup).To(ConsistOf(uint32(1)))
+
 		By("trying to discover endorsers as an org3 admin")
 		endorsers = commands.Endorsers{
 			UserCert:  network.PeerUserCert(org3Peer0, "Admin"),


### PR DESCRIPTION
Implemented the fix as suggested by Yacov in his Jira comment.

Verified the fix works against the asset-transfer-secured-agreement sample which uses implicit collections.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
