### PR TITLE
[FAB-18530] fix: add validation for chaincode name when packaging chaincode

### DIFF
--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -97,6 +97,7 @@ Flags:
   -h, --help                           help for package
       --label string                   The package label contains a human-readable description of the package
   -l, --lang string                    Language the chaincode is written in (default "golang")
+  -n, --name string                    Name of the chaincode
   -p, --path string                    Path to the chaincode
       --peerAddresses stringArray      The addresses of the peers to connect to
       --tlsRootCertFiles stringArray   If TLS is enabled, the paths to the TLS root cert files of the peers to connect to. The order and number of certs specified should match the --peerAddresses flag

--- a/integration/nwo/commands/peer.go
+++ b/integration/nwo/commands/peer.go
@@ -201,6 +201,7 @@ func (c ChannelFetch) Args() []string {
 }
 
 type ChaincodePackage struct {
+	Name       string
 	Path       string
 	Lang       string
 	Label      string
@@ -215,6 +216,7 @@ func (c ChaincodePackage) SessionName() string {
 func (c ChaincodePackage) Args() []string {
 	args := []string{
 		"lifecycle", "chaincode", "package",
+		"--name", c.Name,
 		"--path", c.Path,
 		"--lang", c.Lang,
 		"--label", c.Label,

--- a/integration/nwo/deploy.go
+++ b/integration/nwo/deploy.go
@@ -147,6 +147,7 @@ func PackageAndInstallChaincode(n *Network, chaincode Chaincode, peers ...*Peer)
 
 func PackageChaincode(n *Network, chaincode Chaincode, peer *Peer) {
 	sess, err := n.PeerAdminSession(peer, commands.ChaincodePackage{
+		Name:       chaincode.Name,
 		Path:       chaincode.Path,
 		Lang:       chaincode.Lang,
 		Label:      chaincode.Label,

--- a/internal/peer/lifecycle/chaincode/package_test.go
+++ b/internal/peer/lifecycle/chaincode/package_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Package", func() {
 
 			input = &chaincode.PackageInput{
 				OutputFile: "testDir/testPackage",
+				Name:       "testName",
 				Path:       "testPath",
 				Type:       "testType",
 				Label:      "testLabel",
@@ -77,7 +78,29 @@ var _ = Describe("Package", func() {
 
 			metadata, err := readMetadataFromBytes(pkgTarGzBytes)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(metadata).To(MatchJSON(`{"path":"normalizedPath","type":"testType","label":"testLabel"}`))
+			Expect(metadata).To(MatchJSON(`{"name":"testName","path":"normalizedPath","type":"testType","label":"testLabel"}`))
+		})
+
+		Context("when the name is not provided", func() {
+			BeforeEach(func() {
+				input.Name = ""
+			})
+
+			It("returns an error", func() {
+				err := packager.Package()
+				Expect(err).To(MatchError("chaincode name must be specified"))
+			})
+		})
+
+		Context("when the name is not valid", func() {
+			BeforeEach(func() {
+				input.Name = "testName_1.2.3"
+			})
+
+			It("returns an error", func() {
+				err := packager.Package()
+				Expect(err).To(MatchError("invalid chaincode name 'testName_1.2.3'. Names can only consist of alphanumerics, '_', and '-' and can only begin with alphanumerics"))
+			})
 		})
 
 		Context("when the path is not provided", func() {
@@ -178,6 +201,7 @@ var _ = Describe("Package", func() {
 			packageCmd.SilenceUsage = true
 			packageCmd.SetArgs([]string{
 				"testPackage",
+				"--name=testName",
 				"--path=testPath",
 				"--lang=golang",
 				"--label=testLabel",


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>


#### Type of change
- Bug fix

#### Description
I am able to package and install chaincode with names which are not valid,
```
peer lifecycle chaincode package cc_1.0.0.tar.gz --path ../../fabric-chaincode-poc --lang golang --label cc_1.0.0_1.0
+ res=0
Chaincode is packaged
Installing chaincode on peer0.org1...
Using organization 1
peer lifecycle chaincode install cc_1.0.0.tar.gz
+ res=0
2021-07-27 12:16:13.991 EDT [cli.lifecycle.chaincode] submitInstallProposal -> INFO 001 Installed remotely: response:<status:200 payload:"\nMcc_1.0.0_1.0:5e0f5e9f4e8bc50706a74ac24ba855bcf267c469d1931812b9f5a80381d4f035\022\014cc_1.0.0_1.0" > 
2021-07-27 12:16:13.991 EDT [cli.lifecycle.chaincode] submitInstallProposal -> INFO 002 Chaincode code package identifier: cc_1.0.0_1.0:5e0f5e9f4e8bc50706a74ac24ba855bcf267c469d1931812b9f5a80381d4f035
Chaincode is installed on peer0.org2
```
but then it fails during approval (with the message mentioned in the issue):
```
+ peer lifecycle chaincode approveformyorg -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile /home/ankitm123/work/fabric-samples/test-network/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem --channelID mychannel --name cc_1.2.3 --version 1.0 --package-id cc_1.2.3_1.0:81221a01ec04a1e2502d5b2746d0a047619878fca818b9894c6a15f366254e42 --sequence 1
+ res=1
Error: proposal failed with status: 500 - failed to invoke backing implementation of 'ApproveChaincodeDefinitionForMyOrg': error validating chaincode definition: invalid chaincode name 'cc_1.2.3'. Names can only consist of alphanumerics, '_', and '-' and can only begin with alphanumerics
```
I think chaincode name should be validated as early as `peer lifecycle chaincode package`.

This PR adds a `--name` flag to the package subcommand, and validates that the provided name is valid.


#### Additional details

After this change:
```
➜  test-network git:(main) peer lifecycle chaincode package cc_1.1.tar.gz --path ../../fabric-chaincode-poc --lang golang --label cc_1.1.0  
Error: chaincode name must be specified

➜  test-network git:(main) peer lifecycle chaincode package cc_1.tar.gz --path ../../fabric-chaincode-poc --lang golang --label cc_1.1.0 --name cc_1.0.0
Error: invalid chaincode name 'cc_1.0.0'. Names can only consist of alphanumerics, '_', and '-' and can only begin with alphanumerics

➜  test-network git:(main) peer lifecycle chaincode package cc_1.1.tar.gz --path ../../fabric-chaincode-poc --lang golang --label cc_1.1.0 --name cc
```

#### Related issues
https://jira.hyperledger.org/browse/FAB-18530
https://jira.hyperledger.org/browse/FAB-18409

#### Release Note



