### PR TITLE
Update doc for default chaincode instantiation policy (release-1.4)

### DIFF
--- a/docs/source/chaincode4noah.rst
+++ b/docs/source/chaincode4noah.rst
@@ -109,7 +109,7 @@ for the chaincode. The instantiation policy has the same format as an
 endorsement policy and specifies which identities can instantiate the
 chaincode. In the example above, only the admin of OrgA is allowed to
 instantiate the chaincode. If no policy is provided, the default policy
-is used, which only allows the admin identity of the peer's MSP to
+is used, which allows an admin from any of the channel MSPs to
 instantiate chaincode.
 
 Package signing


### PR DESCRIPTION
Update doc to indicate that default chaincode instantiation policy
is any channel admin.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>