### PR TITLE
Gateway enabled by default

### DIFF
--- a/integration/gateway/endorsing_orgs_test.go
+++ b/integration/gateway/endorsing_orgs_test.go
@@ -45,8 +45,6 @@ var _ = Describe("GatewayService with endorsing orgs", func() {
 		config := nwo.ThreeOrgRaft()
 		network = nwo.New(config, testDir, client, StartPort(), components)
 
-		network.GatewayEnabled = true
-
 		network.GenerateConfigTree()
 		network.Bootstrap()
 

--- a/integration/gateway/gateway_test.go
+++ b/integration/gateway/gateway_test.go
@@ -51,8 +51,6 @@ var _ = Describe("GatewayService", func() {
 		config := nwo.BasicEtcdRaft()
 		network = nwo.New(config, testDir, client, StartPort(), components)
 
-		network.GatewayEnabled = true
-
 		network.GenerateConfigTree()
 		network.Bootstrap()
 

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -201,8 +201,8 @@ func New(c *Config, rootDir string, dockerClient *docker.Client, startPort int, 
 		Profiles:       c.Profiles,
 		Consortiums:    c.Consortiums,
 		Templates:      c.Templates,
-		TLSEnabled:     true,  // Set TLS enabled as true for default
-		GatewayEnabled: false, // Set Gateway enabled as false for default
+		TLSEnabled:     true, // Set TLS enabled as true for default
+		GatewayEnabled: true, // Set Gateway enabled as true for default
 
 		mutex:        &sync.Mutex{},
 		lastExecuted: make(map[string]time.Time),

--- a/internal/pkg/gateway/config/options.go
+++ b/internal/pkg/gateway/config/options.go
@@ -23,7 +23,7 @@ type Options struct {
 }
 
 var defaultOptions = Options{
-	Enabled:            false,
+	Enabled:            true,
 	EndorsementTimeout: 10 * time.Second,
 	DialTimeout:        30 * time.Second,
 }

--- a/internal/pkg/gateway/config/options_test.go
+++ b/internal/pkg/gateway/config/options_test.go
@@ -23,6 +23,12 @@ peer:
     dialTimeout: 2m
 `)
 
+var testConfigOff = []byte(`
+peer:
+  gateway:
+    enabled: false
+`)
+
 func TestDefaultOptions(t *testing.T) {
 	v := viper.New()
 	options := GetOptions(v)
@@ -39,6 +45,20 @@ func TestOverriddenOptions(t *testing.T) {
 		Enabled:            true,
 		EndorsementTimeout: 30 * time.Second,
 		DialTimeout:        2 * time.Minute,
+	}
+	require.Equal(t, expectedOptions, options)
+}
+
+func TestDisabledGatewayOption(t *testing.T) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	v.ReadConfig(bytes.NewBuffer(testConfigOff))
+	options := GetOptions(v)
+
+	expectedOptions := Options{
+		Enabled:            false,
+		EndorsementTimeout: 10 * time.Second,
+		DialTimeout:        30 * time.Second,
 	}
 	require.Equal(t, expectedOptions, options)
 }

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -46,6 +46,18 @@ peer:
     # When set to true, will override peer address.
     addressAutoDetect: false
 
+    # Settings for the Peer's gateway server.
+    gateway:
+        # Whether the gateway is enabled for this Peer.
+        enabled: true
+        # endorsementTimeout is the duration the gateway waits for a response
+        # from other endorsing peers before returning a timeout error to the client.
+        endorsementTimeout: 30s
+        # dialTimeout is the duration the gateway waits for a connection
+        # to other network nodes.
+        dialTimeout: 2m
+
+
     # Keepalive settings for peer server and clients
     keepalive:
         # Interval is the duration after which if the server does not see


### PR DESCRIPTION
In readiness for the Beta release, set the ‘Enabled’ config option of the gateway to ‘true’.
All peers will now have the gateway server enabled unless it is explicitly disbaled.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
