### PR TITLE
Add slash command for invalid issue

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -1,0 +1,31 @@
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Slash Commands
+on:
+  issue_comment:
+    types:
+      - created
+      - edited
+jobs:
+  notify:
+    name: Invalid Issue Usage
+    if: contains(github.event.comment.body, '/invalid') && github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on Issue
+        uses: lindluni/issue-manager@v1.0.0
+        with:
+          action: comment
+          message: |
+            Thank you for opening this issue.
+
+            GitHub Issues is a tool for tracking bugs, feature requests, and work in general that relates directly to the Fabric codebase. It is not for general help requests. Please use one of the following forums to request help for your issue:
+
+            - RocketChat: https://chat.hyperledger.org
+            - Fabric Mailing List: fabric@lists.hyperledger.org
+      - name: Close Issue
+        uses: lindluni/issue-manager@v1.0.0
+        with:
+          action: close


### PR DESCRIPTION
Adds a "/invalid" command that when typed in an issue will let users know the purpose of GitHub issues and close the issue.

This can be used when a user opens an issue seeking help, rather than to report a bug or request a feature. Simply typing `/invalid` will reply to the issue with the below comment and automatically close the issue:

```
Thank you for opening this issue.

GitHub Issues is a tool for tracking bugs, feature requests, and work in general that 
relates directly to the Fabric codebase. It is not for general help requests. Please 
use one of the following forums to request help for your issue:

- RocketChat: https://chat.hyperledger.org
- Fabric Mailing List: fabric@lists.hyperledger.org
```

Signed-off-by: Brett Logan <lindluni@github.com>
