### PR TITLE
FAB-18529 added null check in channel header parsing

### DIFF
--- a/protoutil/commonutils.go
+++ b/protoutil/commonutils.go
@@ -212,6 +212,10 @@ func IsConfigBlock(block *cb.Block) bool {
 
 // ChannelHeader returns the *cb.ChannelHeader for a given *cb.Envelope.
 func ChannelHeader(env *cb.Envelope) (*cb.ChannelHeader, error) {
+	if env == nil {
+		return nil, errors.New("Invalid envelope payload. can't be nil")
+	}
+
 	envPayload, err := UnmarshalPayload(env.Payload)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description
Fuzz testing has reported SEGV while sending incomplete/null
message request to orderer.  When the submit request payload
is null, the orderer fails with SEGV while trying to parse/read 
the channel header.

Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>