### PR TITLE
[FAB-11334] - Adds a functional / integration test for peer unjoin 

### DIFF
--- a/integration/ledger/marbles_test.go
+++ b/integration/ledger/marbles_test.go
@@ -65,7 +65,7 @@ var _ = Describe("all shim APIs for non-private data", func() {
 		By("adding six marbles, marble-0 to marble-5")
 		for i := 0; i <= 5; i++ {
 			helper.invokeMarblesChaincode(ccName, peer, "initMarble", fmt.Sprintf("marble-%d", i), "blue", "35", "tom")
-			helper.waitUntilEqualLedgerHeight(height + i + 1)
+			helper.waitUntilAllPeersEqualLedgerHeight(height + i + 1)
 		}
 
 		By("getting marbles by range")

--- a/integration/nwo/commands/peer.go
+++ b/integration/nwo/commands/peer.go
@@ -87,6 +87,21 @@ func (n NodeResume) Args() []string {
 	}
 }
 
+type NodeUnjoin struct {
+	ChannelID string
+}
+
+func (n NodeUnjoin) SessionName() string {
+	return "peer-node-unjoin"
+}
+
+func (n NodeUnjoin) Args() []string {
+	return []string{
+		"node", "unjoin",
+		"--channelID", n.ChannelID,
+	}
+}
+
 type ChannelCreate struct {
 	ChannelID   string
 	Orderer     string


### PR DESCRIPTION
This integration test launches the peer unjoin command, simulating normal operation and some error / negative test cases.

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>

#### Type of change
- Test update

#### Description

This integration test targets the `peer node unjoin` CLI, both with positive and negative examples: 

- checks for error when unjoining a channel while the peer is running.
- checks for double-unjoin (unjoin unjoined)
- checks for partial unjoin:  If the unjoin fails, the next peer restart will attempt to resume the ledger purge.
- checks for normal unjoin

#### Related issues

