### PR TITLE
Clarify bootstrap.sh message when fabric-samples tag not found

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -66,7 +66,7 @@ cloneSamplesRepo() {
         echo "===> Checking out v${VERSION} of hyperledger/fabric-samples"
         git checkout -q v${VERSION}
     else
-        echo "fabric-samples v${VERSION} does not exist, defaulting main"
+        echo "fabric-samples v${VERSION} does not exist, defaulting to main. fabric-samples main branch is intended to work with recent versions of fabric."
         git checkout -q main
     fi
 }


### PR DESCRIPTION
The latest versions of fabric are not tagged in fabric-samples repository.
This is so that users that are using the download script
and trying the most recent Fabric versions will
automatically get the latest samples improvements/fixes, rather
than getting an old tagged version of the samples.
This works since the maintainers try to keep recent versions
of Fabric compatible with latest fabric-samples.
If there is an incompatibility introduced (e.g. the switch to
osnadmin in v2.3), at that point the maintainers tag
fabric-samples to align with Fabric versions (e.g.
v2.2.3 Fabric works with v2.2.3 of samples without osnadmin use).
This commit simply improves the message that download
script users receive so that they know that using the
fabric-samples main branch is acceptable.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
