### PR TITLE
Nominate Andrew Coleman as Fabric maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,7 @@ See [the documentation on Maintainers](https://hyperledger-fabric.readthedocs.io
 | Name | GitHub | Chat | email
 |------|--------|------|----------------------
 | Alessandro Sorniotti | [ale-linux][ale-linux] | aso | <ale.linux@sopit.net>
+| Andrew Coleman | [andrew-coleman][andrew-coleman] | andrew-coleman | <andrew_coleman@uk.ibm.com>
 | Artem Barger | [c0rwin][c0rwin] | c0rwin | <artem@bargr.net>
 | Senthilnathan Natarajan | [cendhu][cendhu] | Senthil1 | <cendhu@gmail.com>
 | Dave Enyeart | [denyeart][denyeart] | dave.enyeart | <enyeart@us.ibm.com>
@@ -57,6 +58,7 @@ See [the documentation on Maintainers](https://hyperledger-fabric.readthedocs.io
 | Will Lahti | [wlahti][wlahti] | wlahti | <will.lahti@gmail.com>
 
 [ale-linux]: https://github.com/ale-linux
+[andrew-coleman]: https://github.com/andrew-coleman
 [binhn]: https://github.com/binhn
 [lindluni]: https://github.com/lindluni
 [c0rwin]: https://github.com/c0rwin


### PR DESCRIPTION
I would like to nominate Andrew Coleman as a Fabric maintainer.
Andrew has many years experience with Fabric, especially Fabric
SDKs where he has been a maintainer and lead developer.
Last year, Andrew demonstrated his Go expertise while working
on the fabric-sdk-go contract programming model.
In the past year Andrew has been working in the core Fabric
repository, leading the Fabric Gateway feature from RFC and community
discussions through implementation, test, and a successful beta preview.
Andrew has also picked up skill in other areas of the peer, and
has been reviewing PRs, extending tests, and coaching others.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>