### PR TITLE
Private Data Comparison

### DIFF
--- a/cmd/ledgerutil/main.go
+++ b/cmd/ledgerutil/main.go
@@ -68,7 +68,7 @@ func main() {
 
 		fmt.Print("\nSuccessfully compared snapshots. ")
 		if count == -1 {
-			fmt.Println("Both snapshot public state hashes were the same. No results were generated.")
+			fmt.Println("Both snapshot public state and private state hashes were the same. No results were generated.")
 		} else {
 			fmt.Printf("Results saved to %s. Total differences found: %d\n", outputDirPath, count)
 		}

--- a/internal/ledgerutil/compare.go
+++ b/internal/ledgerutil/compare.go
@@ -26,28 +26,31 @@ import (
 )
 
 const (
-	// AllDiffsByKey - Filename for the json output that contains all differences ordered by key
-	AllDiffsByKey = "all_diffs_by_key.json"
+	// AllPubDiffsByKey - Filename for the json output that contains all public differences ordered by key
+	AllPubDiffsByKey = "all_pub_diffs_by_key.json"
+	// AllPvtDiffsByKey - Filename for the json output that contains all private differences ordered by key
+	AllPvtDiffsByKey = "all_pvt_diffs_by_key.json"
 	// FirstDiffsByHeight - Filename for the json output that contains the first n differences ordered by height
 	FirstDiffsByHeight = "first_diffs_by_height.json"
 )
 
 // Compare - Compares two ledger snapshots and outputs the differences in snapshot records
 // This function will throw an error if the output directory already exist in the outputDirLoc
-// Function will return count of -1 if the public state hashes are the same
+// Function will return count of -1 if the public state and private state hashes are the same
 func Compare(snapshotDir1 string, snapshotDir2 string, outputDirLoc string, firstDiffs int) (count int, outputDirPath string, err error) {
-	var records diffRecordSlice
+	// firstRecords - Slice of diffRecords that stores found differences based on block height, used to generate first n differences output file
+	firstRecords := &firstRecords{records: &diffRecordSlice{}, highestRecord: &diffRecord{}, highestIndex: 0, limit: firstDiffs}
 
 	// Check the hashes between two files
 	hashPath1 := filepath.Join(snapshotDir1, kvledger.SnapshotSignableMetadataFileName)
 	hashPath2 := filepath.Join(snapshotDir2, kvledger.SnapshotSignableMetadataFileName)
 
-	equal, channelName, blockHeight, err := snapshotsComparable(hashPath1, hashPath2)
+	equalPub, equalPvt, channelName, blockHeight, err := hashesEqual(hashPath1, hashPath2)
 	if err != nil {
 		return 0, "", err
 	}
-	// Snapshot hashes are the same
-	if equal {
+	// Snapshot public and private hashes are the same
+	if equalPub && equalPvt {
 		return -1, "", nil
 	}
 
@@ -69,32 +72,81 @@ func Compare(snapshotDir1 string, snapshotDir2 string, outputDirLoc string, firs
 		return 0, "", errors.Errorf("%s already exists in %s. Choose a different location or remove the existing results. Aborting compare", outputDirName, outputDirLoc)
 	}
 
-	// Create the output files
-	allOutputFile, err := newJSONFileWriter(filepath.Join(outputDirPath, AllDiffsByKey))
-	if err != nil {
-		return 0, "", err
+	// Generate all public data differences between snapshots
+	if !equalPub {
+		snapshotPubReader1, err := privacyenabledstate.NewSnapshotReader(snapshotDir1,
+			privacyenabledstate.PubStateDataFileName, privacyenabledstate.PubStateMetadataFileName)
+		if err != nil {
+			return 0, "", err
+		}
+		snapshotPubReader2, err := privacyenabledstate.NewSnapshotReader(snapshotDir2,
+			privacyenabledstate.PubStateDataFileName, privacyenabledstate.PubStateMetadataFileName)
+		if err != nil {
+			return 0, "", err
+		}
+		outputPubFileWriter, err := findAndWriteDifferences(outputDirPath, AllPubDiffsByKey, snapshotPubReader1, snapshotPubReader2, firstDiffs, firstRecords)
+		if err != nil {
+			return 0, "", err
+		}
+		count += outputPubFileWriter.count
 	}
 
-	// Create snapshot readers to read both snapshots
-	snapshotReader1, err := privacyenabledstate.NewSnapshotReader(snapshotDir1,
-		privacyenabledstate.PubStateDataFileName, privacyenabledstate.PubStateMetadataFileName)
-	if err != nil {
-		return 0, "", err
+	// Generate all private data differences between snapshots
+	if !equalPvt {
+		snapshotPvtReader1, err := privacyenabledstate.NewSnapshotReader(snapshotDir1,
+			privacyenabledstate.PvtStateHashesFileName, privacyenabledstate.PvtStateHashesMetadataFileName)
+		if err != nil {
+			return 0, "", err
+		}
+		snapshotPvtReader2, err := privacyenabledstate.NewSnapshotReader(snapshotDir2,
+			privacyenabledstate.PvtStateHashesFileName, privacyenabledstate.PvtStateHashesMetadataFileName)
+		if err != nil {
+			return 0, "", err
+		}
+		outputPvtFileWriter, err := findAndWriteDifferences(outputDirPath, AllPvtDiffsByKey, snapshotPvtReader1, snapshotPvtReader2, firstDiffs, firstRecords)
+		if err != nil {
+			return 0, "", err
+		}
+		count += outputPvtFileWriter.count
 	}
-	snapshotReader2, err := privacyenabledstate.NewSnapshotReader(snapshotDir2,
-		privacyenabledstate.PubStateDataFileName, privacyenabledstate.PubStateMetadataFileName)
+
+	// Generate early differences output file
+	if firstDiffs != 0 {
+		firstDiffsOutputFileWriter, err := newJSONFileWriter(filepath.Join(outputDirPath, FirstDiffsByHeight))
+		if err != nil {
+			return 0, "", err
+		}
+		sort.Sort(*firstRecords.records)
+		for _, r := range *firstRecords.records {
+			firstDiffsOutputFileWriter.addRecord(*r)
+		}
+		err = firstDiffsOutputFileWriter.close()
+		if err != nil {
+			return 0, "", err
+		}
+	}
+
+	return count, outputDirPath, nil
+}
+
+// Finds the differing records between two snapshot data files using SnapshotReaders and saves differences
+// to an output file. Simultaneously, keep track of the first n differences.
+func findAndWriteDifferences(outputDirPath string, outputFilename string, snapshotReader1 *privacyenabledstate.SnapshotReader, snapshotReader2 *privacyenabledstate.SnapshotReader,
+	firstDiffs int, firstRecords *firstRecords) (outputFileWriter *jsonArrayFileWriter, err error) {
+	// Create the output file
+	outputFileWriter, err = newJSONFileWriter(filepath.Join(outputDirPath, outputFilename))
 	if err != nil {
-		return 0, "", err
+		return nil, err
 	}
 
 	// Read each snapshot record  to begin looking for differences
 	namespace1, snapshotRecord1, err := snapshotReader1.Next()
 	if err != nil {
-		return 0, "", err
+		return nil, err
 	}
 	namespace2, snapshotRecord2, err := snapshotReader2.Next()
 	if err != nil {
-		return 0, "", err
+		return nil, err
 	}
 
 	// Main snapshot record comparison loop
@@ -112,65 +164,65 @@ func Compare(snapshotDir1 string, snapshotDir2 string, outputDirLoc string, firs
 				// Keys are the same but records are different
 				diffRecord, err := newDiffRecord(namespace1, snapshotRecord1, snapshotRecord2)
 				if err != nil {
-					return 0, "", err
+					return nil, err
 				}
 				// Add difference to output JSON file
-				err = allOutputFile.addRecord(*diffRecord)
+				err = outputFileWriter.addRecord(*diffRecord)
 				if err != nil {
-					return 0, "", err
+					return nil, err
 				}
 				if firstDiffs != 0 {
-					records = append(records, diffRecord)
+					firstRecords.addRecord(diffRecord)
 				}
 			}
 			// Advance both snapshot readers
 			namespace1, snapshotRecord1, err = snapshotReader1.Next()
 			if err != nil {
-				return 0, "", err
+				return nil, err
 			}
 			namespace2, snapshotRecord2, err = snapshotReader2.Next()
 			if err != nil {
-				return 0, "", err
+				return nil, err
 			}
 
 		case 1: // Key 1 is bigger, snapshot 1 is missing a record
 			// Snapshot 2 has the missing record, add missing to output JSON file
 			diffRecord, err := newDiffRecord(namespace2, nil, snapshotRecord2)
 			if err != nil {
-				return 0, "", err
+				return nil, err
 			}
 			// Add missing record to output JSON file
-			err = allOutputFile.addRecord(*diffRecord)
+			err = outputFileWriter.addRecord(*diffRecord)
 			if err != nil {
-				return 0, "", err
+				return nil, err
 			}
 			if firstDiffs != 0 {
-				records = append(records, diffRecord)
+				firstRecords.addRecord(diffRecord)
 			}
 			// Advance the second snapshot reader
 			namespace2, snapshotRecord2, err = snapshotReader2.Next()
 			if err != nil {
-				return 0, "", err
+				return nil, err
 			}
 
 		case -1: // Key 2 is bigger, snapshot 2 is missing a record
 			// Snapshot 1 has the missing record, add missing to output JSON file
 			diffRecord, err := newDiffRecord(namespace1, snapshotRecord1, nil)
 			if err != nil {
-				return 0, "", err
+				return nil, err
 			}
 			// Add missing record to output JSON file
-			err = allOutputFile.addRecord(*diffRecord)
+			err = outputFileWriter.addRecord(*diffRecord)
 			if err != nil {
-				return 0, "", err
+				return nil, err
 			}
 			if firstDiffs != 0 {
-				records = append(records, diffRecord)
+				firstRecords.addRecord(diffRecord)
 			}
 			// Advance the first snapshot reader
 			namespace1, snapshotRecord1, err = snapshotReader1.Next()
 			if err != nil {
-				return 0, "", err
+				return nil, err
 			}
 
 		default:
@@ -186,18 +238,18 @@ func Compare(snapshotDir1 string, snapshotDir2 string, outputDirLoc string, firs
 			// Add missing to output JSON file
 			diffRecord, err := newDiffRecord(namespace1, snapshotRecord1, nil)
 			if err != nil {
-				return 0, "", err
+				return nil, err
 			}
-			err = allOutputFile.addRecord(*diffRecord)
+			err = outputFileWriter.addRecord(*diffRecord)
 			if err != nil {
-				return 0, "", err
+				return nil, err
 			}
 			if firstDiffs != 0 {
-				records = append(records, diffRecord)
+				firstRecords.addRecord(diffRecord)
 			}
 			namespace1, snapshotRecord1, err = snapshotReader1.Next()
 			if err != nil {
-				return 0, "", err
+				return nil, err
 			}
 		}
 
@@ -206,44 +258,62 @@ func Compare(snapshotDir1 string, snapshotDir2 string, outputDirLoc string, firs
 			// Add missing to output JSON file
 			diffRecord, err := newDiffRecord(namespace2, nil, snapshotRecord2)
 			if err != nil {
-				return 0, "", err
+				return nil, err
 			}
-			err = allOutputFile.addRecord(*diffRecord)
+			err = outputFileWriter.addRecord(*diffRecord)
 			if err != nil {
-				return 0, "", err
+				return nil, err
 			}
 			if firstDiffs != 0 {
-				records = append(records, diffRecord)
+				firstRecords.addRecord(diffRecord)
 			}
 			namespace2, snapshotRecord2, err = snapshotReader2.Next()
 			if err != nil {
-				return 0, "", err
+				return nil, err
 			}
 		}
 	}
 
-	err = allOutputFile.close()
+	err = outputFileWriter.close()
 	if err != nil {
-		return 0, "", err
+		return nil, err
 	}
 
-	// Create early differences output file
-	if firstDiffs != 0 {
-		firstDiffsOutputFile, err := newJSONFileWriter(filepath.Join(outputDirPath, FirstDiffsByHeight))
-		if err != nil {
-			return 0, "", err
-		}
-		sort.Sort(records)
-		for i := 0; i < firstDiffs && i < len(records); i++ {
-			firstDiffsOutputFile.addRecord(records[i])
-		}
-		err = firstDiffsOutputFile.close()
-		if err != nil {
-			return 0, "", err
+	return outputFileWriter, nil
+}
+
+// firstRecords is a struct used to hold only the earliest records up to a given limit
+type firstRecords struct {
+	records       *diffRecordSlice
+	highestRecord *diffRecord
+	highestIndex  int
+	limit         int
+}
+
+func (s *firstRecords) addRecord(r *diffRecord) {
+	if len(*s.records) < s.limit {
+		*s.records = append(*s.records, r)
+		s.setHighestRecord()
+	} else {
+		if r.lessThan(s.highestRecord) {
+			(*s.records)[s.highestIndex] = r
+			s.setHighestRecord()
 		}
 	}
+}
 
-	return allOutputFile.count, outputDirPath, nil
+func (s *firstRecords) setHighestRecord() {
+	if len(*s.records) == 1 {
+		s.highestRecord = (*s.records)[0]
+		s.highestIndex = 0
+		return
+	}
+	for i, r := range *s.records {
+		if s.highestRecord.lessThan(r) {
+			s.highestRecord = r
+			s.highestIndex = i
+		}
+	}
 }
 
 type diffRecordSlice []*diffRecord
@@ -257,13 +327,7 @@ func (s diffRecordSlice) Swap(i, j int) {
 }
 
 func (s diffRecordSlice) Less(i, j int) bool {
-	iBlockNum, iTxNum := s[i].getHeight()
-	jBlockNum, jTxNum := s[j].getHeight()
-
-	if iBlockNum == jBlockNum {
-		return iTxNum <= jTxNum
-	}
-	return iBlockNum < jBlockNum
+	return (s[i]).lessThan(s[j])
 }
 
 // diffRecord represents a diverging record in json
@@ -307,9 +371,20 @@ func newDiffRecord(namespace string, record1 *privacyenabledstate.SnapshotRecord
 }
 
 // Get height from a diffRecord
-func (d diffRecord) getHeight() (blockNum uint64, txNum uint64) {
+func (d *diffRecord) getHeight() (blockNum uint64, txNum uint64) {
 	r := earlierRecord(d.Record1, d.Record2)
 	return r.BlockNum, r.TxNum
+}
+
+// Returns true if d is an earlier diffRecord than e
+func (d *diffRecord) lessThan(e *diffRecord) bool {
+	dBlockNum, dTxNum := d.getHeight()
+	eBlockNum, eTxNum := e.getHeight()
+
+	if dBlockNum == eBlockNum {
+		return dTxNum <= eTxNum
+	}
+	return dBlockNum < eBlockNum
 }
 
 // snapshotRecord represents the data of a snapshot record in json
@@ -319,6 +394,7 @@ type snapshotRecord struct {
 	TxNum    uint64 `json:"txNum"`
 }
 
+// Returns the snapshotRecord with the earlier height
 func earlierRecord(r1 *snapshotRecord, r2 *snapshotRecord) *snapshotRecord {
 	if r1 == nil {
 		return r2
@@ -405,47 +481,58 @@ func readMetadata(fpath string) (*kvledger.SnapshotSignableMetadata, error) {
 	return &mdata, nil
 }
 
-// Compares hashes of snapshots
-func snapshotsComparable(fpath1 string, fpath2 string) (bool, string, uint64, error) {
+// Compares hashes of snapshots to determine if they can be compared, then returns channel name and block height for the output directory name
+// Return values:
+// equalPub - True if snapshot public data hashes are the same, false otherwise. If true, public differences will not be generated.
+// equalPvt - True if snapshot private data hashes are the same, false otherwise. If true, private differences will not be generated.
+// chName - Channel name shared between snapshots, used to name output directory. If channel names are not the same, no comparison is made.
+// lastBN - Block height shared between snapshots, used to name output directory. If block heights are not the same, no comparison is made.
+func hashesEqual(fpath1 string, fpath2 string) (equalPub bool, equalPvt bool, chName string, lastBN uint64, err error) {
 	var mdata1, mdata2 *kvledger.SnapshotSignableMetadata
 
 	// Read metadata from snapshot metadata filepaths
-	mdata1, err := readMetadata(fpath1)
+	mdata1, err = readMetadata(fpath1)
 	if err != nil {
-		return false, "", 0, err
+		return false, false, "", 0, err
 	}
 	mdata2, err = readMetadata(fpath2)
 	if err != nil {
-		return false, "", 0, err
+		return false, false, "", 0, err
 	}
 
 	if mdata1.ChannelName != mdata2.ChannelName {
-		return false, "", 0, errors.Errorf("the supplied snapshots appear to be non-comparable. Channel names do not match."+
+		return false, false, "", 0, errors.Errorf("the supplied snapshots appear to be non-comparable. Channel names do not match."+
 			"\nSnapshot1 channel name: %s\nSnapshot2 channel name: %s", mdata1.ChannelName, mdata2.ChannelName)
 	}
 
 	if mdata1.LastBlockNumber != mdata2.LastBlockNumber {
-		return false, "", 0, errors.Errorf("the supplied snapshots appear to be non-comparable. Last block numbers do not match."+
+		return false, false, "", 0, errors.Errorf("the supplied snapshots appear to be non-comparable. Last block numbers do not match."+
 			"\nSnapshot1 last block number: %v\nSnapshot2 last block number: %v", mdata1.LastBlockNumber, mdata2.LastBlockNumber)
 	}
 
 	if mdata1.LastBlockHashInHex != mdata2.LastBlockHashInHex {
-		return false, "", 0, errors.Errorf("the supplied snapshots appear to be non-comparable. Last block hashes do not match."+
+		return false, false, "", 0, errors.Errorf("the supplied snapshots appear to be non-comparable. Last block hashes do not match."+
 			"\nSnapshot1 last block hash: %s\nSnapshot2 last block hash: %s", mdata1.LastBlockHashInHex, mdata2.LastBlockHashInHex)
 	}
 
 	if mdata1.StateDBType != mdata2.StateDBType {
-		return false, "", 0, errors.Errorf("the supplied snapshots appear to be non-comparable. State db types do not match."+
+		return false, false, "", 0, errors.Errorf("the supplied snapshots appear to be non-comparable. State db types do not match."+
 			"\nSnapshot1 state db type: %s\nSnapshot2 state db type: %s", mdata1.StateDBType, mdata2.StateDBType)
 	}
 
 	pubDataHash1 := mdata1.FilesAndHashes[privacyenabledstate.PubStateDataFileName]
 	pubMdataHash1 := mdata1.FilesAndHashes[privacyenabledstate.PubStateMetadataFileName]
+	pvtDataHash1 := mdata1.FilesAndHashes[privacyenabledstate.PvtStateHashesFileName]
+	pvtMdataHash1 := mdata1.FilesAndHashes[privacyenabledstate.PvtStateHashesMetadataFileName]
 
 	pubDataHash2 := mdata2.FilesAndHashes[privacyenabledstate.PubStateDataFileName]
 	pubMdataHash2 := mdata2.FilesAndHashes[privacyenabledstate.PubStateMetadataFileName]
+	pvtDataHash2 := mdata2.FilesAndHashes[privacyenabledstate.PvtStateHashesFileName]
+	pvtMdataHash2 := mdata2.FilesAndHashes[privacyenabledstate.PvtStateHashesMetadataFileName]
 
-	return (pubDataHash1 == pubDataHash2 && pubMdataHash1 == pubMdataHash2), mdata1.ChannelName, mdata1.LastBlockNumber, nil
+	equalPub = pubDataHash1 == pubDataHash2 && pubMdataHash1 == pubMdataHash2
+	equalPvt = pvtDataHash1 == pvtDataHash2 && pvtMdataHash1 == pvtMdataHash2
+	return equalPub, equalPvt, mdata1.ChannelName, mdata1.LastBlockNumber, nil
 }
 
 // jsonArrayFileWriter writes a list of diffRecords to a json file


### PR DESCRIPTION
Resolves #2818

Signed-off-by: Julian Castrence <juliancastrence@ibm.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- New feature
- Improvement (improvement to code, performance, etc)

#### Description

- Compare command now generates a list of differences between the private data in a separate json output file.

<!--- Describe your changes in detail, including motivation. -->



<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

- [fabric #2818](https://app.zenhub.com/workspaces/fabric-57c43689b6f3d8060d082cf1/issues/hyperledger/fabric/2818)

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
