### PR TITLE
Update Go to v1.16.7 and alpine to 3.14 (release-2.2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@
 #   - unit-test - runs the go-test based unit tests
 #   - verify - runs unit tests for only the changed package tree
 
-ALPINE_VER ?= 3.12
+ALPINE_VER ?= 3.14
 BASE_VERSION = 2.2.3
 
 # 3rd party image version
@@ -76,7 +76,7 @@ METADATA_VAR += CommitSHA=$(EXTRA_VERSION)
 METADATA_VAR += BaseDockerLabel=$(BASE_DOCKER_LABEL)
 METADATA_VAR += DockerNamespace=$(DOCKER_NS)
 
-GO_VER = 1.15.7
+GO_VER = 1.16.7
 GO_TAGS ?=
 
 RELEASE_EXES = orderer $(TOOLS_EXES)

--- a/ci/azure-pipelines-merge.yml
+++ b/ci/azure-pipelines-merge.yml
@@ -11,7 +11,7 @@ pr: none
 variables:
   GOPATH: $(Agent.BuildDirectory)/go
   PATH: $(Agent.BuildDirectory)/go/bin:/usr/local/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-  GOVER: 1.15.7
+  GOVER: 1.16.7
 
 jobs:
   - job: UnitTests

--- a/ci/azure-pipelines-release.yml
+++ b/ci/azure-pipelines-release.yml
@@ -11,7 +11,7 @@ variables:
   - name: GOPATH
     value: $(Agent.BuildDirectory)/go
   - name: GOVER
-    value: 1.15.7
+    value: 1.16.7
 
 stages:
   - stage: BuildBinaries

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -11,7 +11,7 @@ pr:
 variables:
   GOPATH: $(Agent.BuildDirectory)/go
   PATH: $(Agent.BuildDirectory)/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-  GOVER: 1.15.7
+  GOVER: 1.16.7
 
 stages:
   - stage: VerifyBuild

--- a/core/chaincode/platforms/golang/platform.go
+++ b/core/chaincode/platforms/golang/platform.go
@@ -219,7 +219,7 @@ elif [ -f "/chaincode/input/src/%[2]s/go.mod" ]; then
     cd /chaincode/input/src/%[2]s
     GO111MODULE=on go build -v -mod=readonly %[1]s -o /chaincode/output/chaincode .
 else
-    GOPATH=/chaincode/input:$GOPATH go build -v %[1]s -o /chaincode/output/chaincode %[2]s
+    GO111MODULE=off GOPATH=/chaincode/input:$GOPATH go build -v %[1]s -o /chaincode/output/chaincode %[2]s
 fi
 echo Done!
 `

--- a/core/chaincode/platforms/golang/platform_test.go
+++ b/core/chaincode/platforms/golang/platform_test.go
@@ -379,7 +379,7 @@ elif [ -f "/chaincode/input/src/the-path/go.mod" ]; then
     cd /chaincode/input/src/the-path
     GO111MODULE=on go build -v -mod=readonly -ldflags "-linkmode external -extldflags '-static'" -o /chaincode/output/chaincode .
 else
-    GOPATH=/chaincode/input:$GOPATH go build -v -ldflags "-linkmode external -extldflags '-static'" -o /chaincode/output/chaincode the-path
+    GO111MODULE=off GOPATH=/chaincode/input:$GOPATH go build -v -ldflags "-linkmode external -extldflags '-static'" -o /chaincode/output/chaincode the-path
 fi
 echo Done!
 `,
@@ -420,7 +420,7 @@ elif [ -f "/chaincode/input/src/the-path/go.mod" ]; then
     cd /chaincode/input/src/the-path
     GO111MODULE=on go build -v -mod=readonly -ldflags "-linkmode external -extldflags '-static'" -o /chaincode/output/chaincode .
 else
-    GOPATH=/chaincode/input:$GOPATH go build -v -ldflags "-linkmode external -extldflags '-static'" -o /chaincode/output/chaincode the-path
+    GO111MODULE=off GOPATH=/chaincode/input:$GOPATH go build -v -ldflags "-linkmode external -extldflags '-static'" -o /chaincode/output/chaincode the-path
 fi
 echo Done!
 `,

--- a/core/chaincode/platforms/util/utils.go
+++ b/core/chaincode/platforms/util/utils.go
@@ -29,6 +29,10 @@ type DockerBuildOptions struct {
 	OutputStream io.Writer
 }
 
+func (dbo DockerBuildOptions) String() string {
+	return fmt.Sprintf("Image=%s Env=%s Cmd=%s)", dbo.Image, dbo.Env, dbo.Cmd)
+}
+
 //-------------------------------------------------------------------------------------------
 // DockerBuild
 //-------------------------------------------------------------------------------------------
@@ -60,7 +64,7 @@ func DockerBuild(opts DockerBuildOptions, client *docker.Client) error {
 		}
 	}
 
-	logger.Debugf("Attempting build with image %s", opts.Image)
+	logger.Debugf("Attempting build with options: %s", opts)
 
 	//-----------------------------------------------------------------------------------
 	// Ensure the image exists locally, or pull it from a registry if it doesn't
@@ -145,6 +149,7 @@ func DockerBuild(opts DockerBuildOptions, client *docker.Client) error {
 	}
 
 	if retval > 0 {
+		logger.Errorf("Docker build failed using options: %s", opts)
 		return fmt.Errorf("Error returned from build: %d \"%s\"", retval, stdout.String())
 	}
 

--- a/core/chaincode/platforms/util/utils_test.go
+++ b/core/chaincode/platforms/util/utils_test.go
@@ -105,3 +105,15 @@ func TestTwoDigitVersion(t *testing.T) {
 	actual = twoDigitVersion(version)
 	assert.Equal(t, expected, actual, `Error parsing two digit version. Expected "%s", got "%s"`, expected, actual)
 }
+
+func TestDockerBuildOptions(t *testing.T) {
+	buildOptions := DockerBuildOptions{
+		Image: "imageName",
+		Cmd:   "theCommand",
+		Env:   []string{"ENV_VARIABLE"},
+	}
+
+	actualBuildOptionsString := buildOptions.String()
+	expectedBuildOptionsString := "Image=imageName Env=[ENV_VARIABLE] Cmd=theCommand)"
+	assert.Equal(t, expectedBuildOptionsString, actualBuildOptionsString, `Expected "%s", got "%s"`, expectedBuildOptionsString, actualBuildOptionsString)
+}

--- a/vagrant/golang.sh
+++ b/vagrant/golang.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 GOROOT='/opt/go'
-GO_VERSION=1.15.7
+GO_VERSION=1.16.7
 
 # ----------------------------------------------------------------
 # Install Golang


### PR DESCRIPTION
Go module support is assumed starting in Go v1.16.

Therefore, for chaincodes without go modules (such as in the integration tests),
need to explicitly set GO111MODULE to off otherwise chaincode will not compile.
See Go v1.16 release notes for more details: https://golang.org/doc/go1.16#go-command

As part of troubleshooting the Go upgrade, also added debug for the chaincode
compile command.

Also update alpine to 3.14.