### PR TITLE
Update x509.CertPool equality checks (release-2.3)

### DIFF
--- a/common/fabhttp/tls_test.go
+++ b/common/fabhttp/tls_test.go
@@ -59,6 +59,11 @@ var _ = Describe("TLS", func() {
 
 		tlsConfig, err := httpTLS.Config()
 		Expect(err).NotTo(HaveOccurred())
+
+		// https://go-review.googlesource.com/c/go/+/229917
+		Expect(tlsConfig.ClientCAs.Subjects()).To(Equal(clientCAPool.Subjects()))
+		tlsConfig.ClientCAs = nil
+
 		Expect(tlsConfig).To(Equal(&tls.Config{
 			MinVersion:   tls.VersionTLS12,
 			Certificates: []tls.Certificate{cert},
@@ -70,7 +75,6 @@ var _ = Describe("TLS", func() {
 				tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
 				tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
 			},
-			ClientCAs:  clientCAPool,
 			ClientAuth: tls.RequireAndVerifyClientCert,
 		}))
 	})


### PR DESCRIPTION
Go 1.16 changed the CertPool implementation to employ functions to
lazily acquire certificates. This change effectively breaks
`reflect.DeepEqual` used by our test assertions.

This commit changes the assertions compare certificate subjects instead
of the entire pool. While not the same, it's a close approximation.

See https://go-review.googlesource.com/c/go/+/229917

Signed-off-by: Matthew Sykes <sykesmat@us.ibm.com>
