### PR TITLE
Fix broken links for international workgroups (#2920)

### DIFF
--- a/docs/source/advice_for_writers.md
+++ b/docs/source/advice_for_writers.md
@@ -59,7 +59,7 @@ wiki](https://wiki.hyperledger.org/display/fabric/Documentation+Working+Group).
 
 Each of the international languages has a welcoming workgroup that you are
 encouraged to join. View the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups).
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups).
 See what your favorite workgroup is doing, and get connected with them.
 Each workgroup has a list of members and their contact information.
 

--- a/docs/source/international_languages.md
+++ b/docs/source/international_languages.md
@@ -30,7 +30,7 @@ create a new language workgroup.
 It's much easier to translate, maintain, and manage a language repository if you
 collaborate with other translators. Start this process by adding a new workgroup
 to the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups),
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups),
 using one of the existing workgroup pages as an exemplar.
 
 Document how your workgroup will collaborate; meetings, chat and mailing lists


### PR DESCRIPTION
The list of international workgroups was moved
from https://wiki.hyperledger.org/display/fabric/International+groups
to https://wiki.hyperledger.org/display/I18N/International+groups.

Signed-off-by: Justin Yang <justin.yang@themedium.io>

#### Type of change

- Documentation update

#### Description
Broken links have been used in the documentation.

#### Additional details
The list of international workgroups was moved
from https://wiki.hyperledger.org/display/fabric/International+groups
to https://wiki.hyperledger.org/display/I18N/International+groups.
But the documentation has used the old one.

#### Related issues
#2920 (https://github.com/hyperledger/fabric/issues/2920)

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->
