### PR TITLE
Fix the result message in test_network.md

### DIFF
--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -191,7 +191,7 @@ channel with the default name of `mychannel`:
 If the command was successful, you can see the following message printed in your
 logs:
 ```
-========= Channel successfully joined ===========
+Channel 'mychannel' joined
 ```
 
 You can also use the channel flag to create a channel with custom name. As an


### PR DESCRIPTION
Fix the result message on running "./network.sh createChannel"

The result message format has been changed from the change of
test-network/scripts/createChannel.sh in hyperledger/fabric-samples
since
b690d8f Stop using deprecated outputAnchorPeersUpdate in test-network (#394)

#### Type of change
- Documentation update

#### Description
Fix the result message on running ```./network.sh createChannel```

The result message format has been changed from the change of
test-network/scripts/createChannel.sh in hyperledger/fabric-samples
since
[b690d8f Stop using deprecated outputAnchorPeersUpdate in test-network (#394)](https://github.com/hyperledger/fabric-samples/commit/b690d8f30f0e47f9512bc2620e95a413f54f6039#diff-848fb64f9085c01d8a264cf33696747f639a7bd6c7d48eb95e35ba1ffd5e7f70L64)

I've run the fabric-samples and have gotten the below log.
```
Channel 'mychannel' joined
```
