### PR TITLE
Unit test flake when rpc server stream not closed

### DIFF
--- a/orderer/common/cluster/rpc_test.go
+++ b/orderer/common/cluster/rpc_test.go
@@ -66,12 +66,20 @@ func TestSendSubmitWithReport(t *testing.T) {
 	node2.stop()
 	node2.resurrect()
 
+	/*
+	 * allow the node2 to restart completely
+	 * if restart not complete, the existing stream able to successfully send
+	 * the next SubmitRequest which makes the testcase fails. Hence this delay
+	 * required
+	 */
+	time.Sleep(time.Second * 5)
+
 	var wg2 sync.WaitGroup
 	wg2.Add(1)
 
 	reportSubmitFailed := func(err error) {
-		require.EqualError(t, err, io.EOF.Error())
 		defer wg2.Done()
+		require.EqualError(t, err, io.EOF.Error())
 	}
 
 	err = node1RPC.SendSubmit(node2.nodeInfo.ID, &orderer.SubmitRequest{Channel: testChannel, Payload: &common.Envelope{Payload: []byte("2")}}, reportSubmitFailed)


### PR DESCRIPTION
#### Type of change
- Test update

#### Description
This Unit test fails randomly in more recent PR builds(https://dev.azure.com/Hyperledger/Fabric/_build/results?buildId=40922&view=logs&j=e306c17a-d139-54bf-a475-f5a11259cee7&t=1e3023a5-584f-52f3-49bc-66bd27d27b6d, https://dev.azure.com/Hyperledger/Fabric/_build/results?buildId=40557&view=logs&j=6b58850f-3858-5a05-33e2-5e41cbf03c4e&t=bddec1cf-ba37-5883-9c3e-fd1e8608f9a1, https://dev.azure.com/Hyperledger/Fabric/_build/results?buildId=40922&view=logs&j=e306c17a-d139-54bf-a475-f5a11259cee7&t=1e3023a5-584f-52f3-49bc-66bd27d27b6d)

Testcase: 
orderer/common/cluster_test.TestSendSubmitWithReport

Analysis/Observation: 
Problem 1: Testcase expects to fail at SubmitRequest after node server restarts with error EOF, but if restart not closed the streams before sendSubmit submitted; test fails. It is random failure. This PR introduces a delay between restart and submitRequest.

Problem 2: Calling t.FailNow() from other than main test go-routine, won't terminate all other subroutines. (which is called in this testcase from require.EqualError(t, err, io.EOF.Error())) This is the reason for the testcase hangs/blocked. https://pkg.go.dev/testing#B.FailNow.  Updated the testcase to signal & terminate the testcase from test main go-routine.

#### Related issues
#2835 

Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>