### PR TITLE
docs: Don't apply the syntax highlighting of python

### DIFF
--- a/docs/source/readwrite.rst
+++ b/docs/source/readwrite.rst
@@ -117,7 +117,7 @@ shows the snapshot of the world state against which the transactions are
 simulated and the sequence of read and write activities performed by
 each of these transactions.
 
-::
+.. code-block:: none
 
     World state: (k1,1,v1), (k2,1,v2), (k3,1,v3), (k4,1,v4), (k5,1,v5)
     T1 -> Write(k1, v1'), Write(k2, v2')


### PR DESCRIPTION
The syntax highlighting of pyhon is applied in the example
of read() and write() transactions.
For readability, don't apply the syntax highlighting.

Signed-off-by: Justin Yang <justin.yang@themedium.io>

#### Type of change
- Documentation update

#### Description
Fix the style of the example of transactions in [Read-Write set semantics](https://hyperledger-fabric.readthedocs.io/en/latest/readwrite.html) document for readability.
The fix makes showing them as just plain text.

The syntax highlighting of python has been applied in the below example.

> World state: (k1,1,v1), (k2,1,v2), (k3,1,v3), (k4,1,v4), (k5,1,v5)
> T1 -> Write(k1, v1'), Write(k2, v2')
> T2 -> Read(k1), Write(k3, v3')
> T3 -> Write(k2, v2'')
> T4 -> Write(k2, v2'''), read(k2)
> T5 -> Write(k6, v6'), read(k5)

The style of python string has been applied in ```'), Write(k2,v2'``` in T1', ```')``` in T2, `''` in T3, and
```
'''), read(k2)
T5 -> Write(k6, v6'), read(k5)
```
as multiline.
