### PR TITLE
docs: Use html_style property instead of add_stylesheet()

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,6 +11,6 @@ Pygments==2.1.3
 pytz==2016.4
 six==1.10.0
 snowballstemmer==1.2.1
-Sphinx==1.7.2
-sphinx-rtd-theme==0.2.5b2
+Sphinx==1.8.0
+sphinx-rtd-theme==0.4.2
 recommonmark==0.4.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -126,6 +126,8 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_style = 'css/custom.css'
+
 def placeholderReplace(app, docname, source):
     result = source[0]
     for key in app.config.placeholder_replacements:
@@ -134,7 +136,6 @@ def placeholderReplace(app, docname, source):
 
 
 def setup(app):
-    app.add_stylesheet('css/custom.css')
     app.add_config_value('placeholder_replacements', {}, True)
     app.connect('source-read', placeholderReplace)
 


### PR DESCRIPTION
add_stylesheet() is deprecated since Sphinx 1.8

Fix this build error on Sphinx 1.8 or higher

Exception occurred:
  File "docs/source/conf.py", line 137, in setup
    app.add_stylesheet('css/custom.css')
AttributeError: 'Sphinx' object has no attribute 'add_stylesheet'

Signed-off-by: Justin Yang <justin.yang@themedium.io>

#### Type of change
- Bug fix

#### Description
add_stylesheet() is deprecated since Sphinx 1.8 (https://www.sphinx-doc.org/en/master/extdev/appapi.html)

> Changed in version 1.8: Renamed from app.add_stylesheet(). And it allows keyword arguments as attributes of link tag.

Fix this build error on Sphinx 1.8 or higher
```
Exception occurred:
  File "docs/source/conf.py", line 137, in setup
    app.add_stylesheet('css/custom.css')
AttributeError: 'Sphinx' object has no attribute 'add_stylesheet'
```

The latest version is 4.2.0 now. 