### PR TITLE
Improve an error message in `InstallChaincode`

### DIFF
--- a/core/chaincode/lifecycle/lifecycle.go
+++ b/core/chaincode/lifecycle/lifecycle.go
@@ -685,7 +685,7 @@ func (ef *ExternalFunctions) InstallChaincode(chaincodeInstallPackage []byte) (*
 		// installed a chaincode with this package id
 		<-buildStatus.Done()
 		if buildStatus.Err() == nil {
-			return nil, errors.New("chaincode already successfully installed")
+			return nil, errors.Errorf("chaincode already successfully installed (package ID '%s')", packageID)
 		}
 		buildStatus = ef.BuildRegistry.ResetBuildStatus(packageID)
 	}

--- a/core/chaincode/lifecycle/lifecycle_test.go
+++ b/core/chaincode/lifecycle/lifecycle_test.go
@@ -392,7 +392,7 @@ var _ = Describe("ExternalFunctions", func() {
 
 			It("does not attempt to rebuild it itself", func() {
 				_, err := ef.InstallChaincode([]byte("cc-package"))
-				Expect(err).To(MatchError("chaincode already successfully installed"))
+				Expect(err).To(MatchError("chaincode already successfully installed (package ID 'fake-hash')"))
 				Expect(fakeChaincodeBuilder.BuildCallCount()).To(Equal(0))
 			})
 		})


### PR DESCRIPTION
This patch adds the package ID to the error message in the case of 'chaincode already successfully installed'.

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

In case a 'chaincode already successfully installed' error occurs when installing a chaincode, Fabric admins cannot to know the package ID. In this case, if multiple chaincode packages with the same label are installed, it is not possible to identify them later by using `queryinstalled`.

So, this patch adds the package ID to the error message in the case of 'chaincode already successfully installed'.

#### Additional details

#### Related issues
