### PR TITLE
Improve wording of log message

### DIFF
--- a/internal/pkg/gateway/api.go
+++ b/internal/pkg/gateway/api.go
@@ -189,14 +189,16 @@ func (gs *Server) Endorse(ctx context.Context, request *gp.EndorseRequest) (*gp.
 			}
 		}
 
-		gs.logger.Infow("Endorsement required from:", func() []interface{} {
-			var es []interface{}
-			for _, e := range endorsers {
-				es = append(es, e.mspid)
-				es = append(es, e.address)
-			}
-			return es
-		}()...)
+		if len(endorsers) > 0 {
+			gs.logger.Infow("Seeking extra endorsements from:", func() []interface{} {
+				var es []interface{}
+				for _, e := range endorsers {
+					es = append(es, e.mspid)
+					es = append(es, e.address)
+				}
+				return es
+			}()...)
+		}
 	}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
The log message that indicates which, if any, extra endorsers are required by the gateway is unclear.
This commit improves the wording.

Resolves https://github.com/hyperledger/fabric-gateway/issues/203

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
