### PR TITLE
docs: Add the path of softhsm2.conf for macOS

### DIFF
--- a/docs/source/dev-setup/devenv.rst
+++ b/docs/source/dev-setup/devenv.rst
@@ -109,7 +109,8 @@ SoftHSM generally requires additional configuration before it can be used. For
 example, the default configuration will attempt to store token data in a system
 directory that unprivileged users are unable to write to.
 
-SoftHSM configuration typically involves copying ``/etc/softhsm/softhsm2.conf`` to
+SoftHSM configuration typically involves copying ``/etc/softhsm/softhsm2.conf``
+(or ``/usr/local/etc/softhsm/softhsm2.conf`` for macOS) to
 ``$HOME/.config/softhsm2/softhsm2.conf`` and changing ``directories.tokendir``
 to an appropriate location. Please see the man page for ``softhsm2.conf`` for
 details.


### PR DESCRIPTION
Signed-off-by: Justin Yang <justin.yang@themedium.io>

#### Type of change
- Documentation update

#### Description
There are no ```softhsm``` directory and ```softhsm2.conf``` file under ```/etc/``` for macOS.
There is ```softhsm2.conf``` file under ```/usr/local/etc/softhsm/``` by brew installation.
