### PR TITLE
Backport setEvent information to 2.2

### DIFF
--- a/docs/source/developapps/transactioncontext.md
+++ b/docs/source/developapps/transactioncontext.md
@@ -212,7 +212,9 @@ The APIs in the stub fall into the following categories:
 
     * [setEvent()](https://hyperledger.github.io/fabric-chaincode-node/{BRANCH}/api/fabric-shim.ChaincodeStub.html#setEvent__anchor)
 
-      Smart contracts use this API to add user events to a transaction response.
+      Smart contracts use this API to add an event to a transaction response.
+      Note that only a single event can be created in a transaction, and must
+      originate from the outer-most contract when contracts invoke each other via `invokeChaincode`.
       See interaction point **(5)**. These events are ultimately recorded on the
       blockchain and sent to listening applications at interaction point
       **(11)**.


### PR DESCRIPTION
closes #2958
Signed-off-by: D <d_kelsey@uk.ibm.com>

#### Type of change
- Documentation update

#### Description
backport setEvent information to 2.2

