### PR TITLE
Improve error messages when no endorsers found

### DIFF
--- a/internal/pkg/gateway/api.go
+++ b/internal/pkg/gateway/api.go
@@ -56,7 +56,7 @@ func (gs *Server) Evaluate(ctx context.Context, request *gp.EvaluateRequest) (*g
 	endorser, err := gs.registry.evaluator(channel, chaincodeID, targetOrgs)
 	if err != nil {
 		if transientProtected {
-			return nil, status.Error(codes.Unavailable, "no endorsers found in the gateway's organization; retry specifying target organization(s) to protect transient data")
+			return nil, status.Errorf(codes.Unavailable, "no endorsers found in the gateway's organization; retry specifying target organization(s) to protect transient data: %s", err)
 		}
 		return nil, status.Errorf(codes.Unavailable, "%s", err)
 	}

--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -191,7 +191,7 @@ func TestEvaluate(t *testing.T) {
 			name:      "no endorsers",
 			plan:      endorsementPlan{},
 			members:   []networkMember{},
-			errString: "rpc error: code = Unavailable desc = no endorsing peers found for channel: test_channel",
+			errString: "rpc error: code = Unavailable desc = no endorsing peers found for chaincode test_chaincode in channel test_channel",
 		},
 		{
 			name: "five endorsers, prefer local org",
@@ -270,7 +270,7 @@ func TestEvaluate(t *testing.T) {
 				{"id5", "peer4:11051", "msp3", 7},
 			},
 			transientData: map[string][]byte{"transient-key": []byte("transient-value")},
-			errString:     "rpc error: code = Unavailable desc = no endorsers found in the gateway's organization; retry specifying target organization(s) to protect transient data",
+			errString:     "rpc error: code = Unavailable desc = no endorsers found in the gateway's organization; retry specifying target organization(s) to protect transient data: no endorsing peers found for chaincode test_chaincode in channel test_channel",
 		},
 		{
 			name: "evaluate with transient data and target (non-local) orgs should select the highest block height peer",
@@ -339,7 +339,7 @@ func TestEvaluate(t *testing.T) {
 					PKIid:    []byte("ill-defined"),
 				}})
 			},
-			errString: "rpc error: code = Unavailable desc = no endorsing peers found for channel: test_channel",
+			errString: "rpc error: code = Unavailable desc = no endorsing peers found for chaincode test_chaincode in channel test_channel",
 		},
 	}
 	for _, tt := range tests {
@@ -552,7 +552,7 @@ func TestEndorse(t *testing.T) {
 			postSetup: func(t *testing.T, def *preparedTest) {
 				def.discovery.PeersForEndorsementReturns(nil, fmt.Errorf("peach-melba"))
 			},
-			errString: "rpc error: code = Unavailable desc = discovery service failed to build endorsement plan: peach-melba",
+			errString: "rpc error: code = Unavailable desc = no combination of peers can be derived which satisfy the endorsement policy: peach-melba",
 		},
 		{
 			name: "discovery returns incomplete protos - nil layout",

--- a/internal/pkg/gateway/registry.go
+++ b/internal/pkg/gateway/registry.go
@@ -57,7 +57,7 @@ func (reg *registry) endorsers(channel string, interest *peer.ChaincodeInterest,
 	descriptor, err := reg.discovery.PeersForEndorsement(gossipcommon.ChannelID(channel), interest)
 	if err != nil {
 		logger.Errorw("PeersForEndorsement failed.", "error", err, "channel", channel, "ChaincodeInterest", proto.MarshalTextString(interest))
-		return nil, fmt.Errorf("discovery service failed to build endorsement plan: %s", err)
+		return nil, fmt.Errorf("no combination of peers can be derived which satisfy the endorsement policy: %s", err)
 	}
 
 	layouts := descriptor.GetLayouts()
@@ -236,7 +236,7 @@ func (reg *registry) evaluator(channel string, chaincode string, targetOrgs []st
 	if evaluator != nil {
 		return evaluator, nil
 	}
-	return nil, fmt.Errorf("no endorsing peers found for channel: %s", channel)
+	return nil, fmt.Errorf("no endorsing peers found for chaincode %s in channel %s", chaincode, channel)
 }
 
 func sorter(e []*endorserState, host string) func(i, j int) bool {


### PR DESCRIPTION
Clarify the wording in the error message returned from gateway Submit() when no endorsement plan can be created.

Add the chaincode name to the error message returned from Evaluate() when no endorsing peer can be found for the chaincode/channel combination.

Resolves https://github.com/hyperledger/fabric-gateway/issues/199

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
