### PR TITLE
Fix the project status to 'Graduated' instead of 'Active'

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 [![GoDoc](https://godoc.org/github.com/hyperledger/fabric?status.svg)](https://godoc.org/github.com/hyperledger/fabric)
 [![Documentation Status](https://readthedocs.org/projects/hyperledger-fabric/badge/?version=latest)](http://hyperledger-fabric.readthedocs.io/en/latest)
 
-This project is an _Active_ Hyperledger project. For more information on the history of this project see the [Fabric wiki page](https://wiki.hyperledger.org/display/fabric). Information on what _Active_ entails can be found in
-the [Hyperledger Project Lifecycle document](https://wiki.hyperledger.org/display/HYP/Project+Lifecycle).
+This project is a _Graduated_ Hyperledger project. For more information on the history of this project see the [Fabric wiki page](https://wiki.hyperledger.org/display/fabric). Information on what _Graduated_ entails can be found in
+the [Hyperledger Project Lifecycle document](https://tsc.hyperledger.org/project-lifecycle.html).
 Hyperledger Fabric is a platform for distributed ledger solutions, underpinned
 by a modular architecture delivering high degrees of confidentiality,
 resiliency, flexibility and scalability. It is designed to support pluggable

--- a/docs/source/status.rst
+++ b/docs/source/status.rst
@@ -1,8 +1,8 @@
 Status
 =================
 
-Hyperledger Fabric is in the *Active* state. For more information on the history of this project see our `wiki page <https://wiki.hyperledger.org/display/fabric/Hyperledger+Fabric>`__. Information on what *Active* entails can be found in
-the Hyperledger `Project Lifecycle document <https://wiki.hyperledger.org/display/HYP/Project+Lifecycle>`__.
+Hyperledger Fabric is in the *Graduated* state. For more information on the history of this project see our `wiki page <https://wiki.hyperledger.org/display/fabric/Hyperledger+Fabric>`__. Information on what *Graduated* entails can be found in
+the Hyperledger `Project Lifecycle document <https://tsc.hyperledger.org/project-lifecycle.html>`__.
 
 .. Licensed under Creative Commons Attribution 4.0 International License
    https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
This patch fixes the project status to 'Graduated' in some docs, instead of 'Active' as the former name.
Also, this update the link to the Hyperledger Lifecycle document to the new location.

#### Type of change

- Bug fix
- Documentation update

#### Description

This patch fixes the project status to 'Graduated' in some docs, instead of 'Active' as the former name.
Also, this update the link to the Hyperledger Lifecycle document to the new location.

#### Additional details


#### Related issues

