### PR TITLE
Evaluate() error response for node chaincode

### DIFF
--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -309,11 +309,11 @@ func TestEvaluate(t *testing.T) {
 				proposalResponseStatus:  400,
 				proposalResponseMessage: "Mock chaincode error",
 			},
-			errString: "rpc error: code = Unknown desc = error 400, Mock chaincode error",
+			errString: "rpc error: code = Unknown desc = error returned from chaincode: Mock chaincode error",
 			errDetails: []*pb.EndpointError{{
 				Address: "peer1:8051",
 				MspId:   "msp1",
-				Message: "error 400, Mock chaincode error",
+				Message: "error 400 returned from chaincode test_chaincode on channel test_channel: Mock chaincode error",
 			}},
 		},
 		{

--- a/internal/pkg/gateway/apiutils.go
+++ b/internal/pkg/gateway/apiutils.go
@@ -17,31 +17,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func getTransactionResponse(response *peer.ProposalResponse) (*peer.Response, error) {
-	var retVal *peer.Response
-
-	if response.GetPayload() != nil {
-		payload, err := protoutil.UnmarshalProposalResponsePayload(response.Payload)
-		if err != nil {
-			return nil, err
-		}
-
-		extension, err := protoutil.UnmarshalChaincodeAction(payload.Extension)
-		if err != nil {
-			return nil, err
-		}
-
-		if extension.GetResponse() != nil {
-			if extension.Response.Status < 200 || extension.Response.Status >= 400 {
-				return nil, fmt.Errorf("error %d, %s", extension.Response.Status, extension.Response.Message)
-			}
-			retVal = extension.Response
-		}
-	}
-
-	return retVal, nil
-}
-
 func getChannelAndChaincodeFromSignedProposal(signedProposal *peer.SignedProposal) (string, string, bool, error) {
 	if signedProposal == nil {
 		return "", "", false, fmt.Errorf("a signed proposal is required")


### PR DESCRIPTION
The gateway Evaluate() method is not returning the error response to the client for node chaincodes. The code path for node chaincode errors is different than for Go chaincodes (this is a known separate issue).
It turns out the endorser is handling this difference and populates the Response field of the ProposalResponse accordingly.  The gateway needs to use this field rather than the one in the ChaincodeAction structure.

Resolves https://github.com/hyperledger/fabric-gateway/issues/193

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
