### PR TITLE
Improve health checker docs

### DIFF
--- a/docs/source/cc_launcher.md
+++ b/docs/source/cc_launcher.md
@@ -8,7 +8,7 @@ Starting with Fabric 2.0, External Builders and Launchers address these limitati
 
 Note that if no configured external builder claims a chaincode package, the peer will attempt to process the package as if it were created with the standard Fabric packaging tools such as the peer CLI or node SDK.
 
-**Note:** This is an advanced feature which unless your builders and launchers are simple enough, such as those used in the [basic asset transfer external chaincode Fabric sample](https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/asset-transfer-basic/chaincode-external), will likely require custom packaging of the peer image with everything your builders and launchers depend on. For example, the following samples use `go` and `bash`, which are not included in the current official `fabric-peer` image. 
+**Note:** This is an advanced feature which will likely require custom packaging of the peer image with everything your builders and launchers depend on unless your builders and launchers are simple enough, such as those used in the [basic asset transfer external chaincode Fabric sample](https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/asset-transfer-basic/chaincode-external). For example, the following samples use `go` and `bash`, which are not included in the current official `fabric-peer` image.
 
 ## External builder model
 
@@ -197,6 +197,8 @@ Note: The following environment variables are always propagated to external buil
 When an `externalBuilder` configuration is present, the peer will iterate over the list of builders in the order provided, invoking `bin/detect` until one completes successfully. If no builder completes `detect` successfully, the peer will fallback to using the legacy Docker build process implemented within the peer. This means that external builders are completely optional.
 
 In the example above, the peer will attempt to use "my-golang-builder", followed by "noop-builder", and finally the peer internal build process.
+
+If you do not need to fallback to the legacy Docker build process for your chaincodes, you can remove the Docker endpoint from the peer `core.yaml` `vm.endpoint` configuration. This will also remove the Docker daemon health check.
 
 ## Chaincode packages
 

--- a/docs/source/operations_service.rst
+++ b/docs/source/operations_service.rst
@@ -279,7 +279,8 @@ intended to be compatible with the liveness probe model used by Kubernetes but
 can be used in other contexts.
 
 When a ``GET /healthz`` request is received, the operations service will call all
-registered health checkers for the process. When all of the health checkers
+registered health checkers for the process to ensure all registered services and
+dependencies are available. When all of the health checkers
 return successfully, the operations service will respond with a ``200 "OK"`` and a
 JSON body:
 
@@ -307,8 +308,10 @@ information about which health checker failed:
     ]
   }
 
-In the current version, the only health check that is registered is for Docker.
-Future versions will be enhanced to add additional health checks.
+The peer has the following health checks available:
+
+- Docker daemon health check (if a Docker endpoint is configured for chaincodes)
+- CouchDB health check (if CouchDB is configured as the state database)
 
 When TLS is enabled, a valid client certificate is not required to use this
 service unless ``clientAuthRequired`` is set to ``true``.

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -498,6 +498,8 @@ vm:
     # unix:///var/run/docker.sock
     # http://localhost:2375
     # https://localhost:2376
+    # If you utilize external chaincode builders and don't need the default Docker chaincode builder,
+    # the endpoint should be unconfigured so that the peer's Docker health checker doesn't get registered.
     endpoint: unix:///var/run/docker.sock
 
     # settings for docker vms
@@ -581,6 +583,7 @@ chaincode:
     # List of directories to treat as external builders and launchers for
     # chaincode. The external builder detection processing will iterate over the
     # builders in the order specified below.
+    # If you don't need to fallback to the default Docker builder, also unconfigure vm.endpoint above.
     # To override this property via env variable use CORE_CHAINCODE_EXTERNALBUILDERS: [{name: x, path: dir1}, {name: y, path: dir2}]
     externalBuilders: []
         # - path: /path/to/directory


### PR DESCRIPTION
Add more details about health checkers, including ability
to not register Docker health checker if using
external chaincode builders.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>