### PR TITLE
Gateway endorsement retry logic

### DIFF
--- a/internal/pkg/gateway/apiutils.go
+++ b/internal/pkg/gateway/apiutils.go
@@ -64,12 +64,3 @@ func wrappedRpcError(err error, message string, details ...proto.Message) error 
 func errorDetail(e *endpointConfig, err error) *gp.ErrorDetail {
 	return &gp.ErrorDetail{Address: e.address, MspId: e.mspid, Message: err.Error()}
 }
-
-func detailsAsString(details ...proto.Message) string {
-	var detailStrings []string
-	for _, detail := range details {
-		detailStrings = append(detailStrings, "{"+detail.String()+"}")
-	}
-
-	return fmt.Sprint(detailStrings)
-}

--- a/internal/pkg/gateway/endorsement.go
+++ b/internal/pkg/gateway/endorsement.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2021 IBM All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package gateway
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/hyperledger/fabric-protos-go/peer"
+)
+
+type layout struct {
+	required     map[string]int // group -> quantity
+	endorsements []*peer.ProposalResponse
+}
+
+// The plan structure is initialised with an endorsement plan from discovery. It is used to manage the
+// set of peers to be targeted for endorsement, to collect endorsements received from peers, to provide
+// alternative peers for retry in the case of failure, and to trigger when the policy is satisfied.
+// Note that this structure and its methods assume that each endorsing peer is in one and only one group.
+// This is a constraint of the current algorithm in the discovery service.
+type plan struct {
+	layouts        []*layout
+	groupEndorsers map[string][]*endorser // group -> endorsing peers
+	groupIds       map[string]string      // peer pkiid -> group
+	nextLayout     int
+	size           int
+	planLock       sync.Mutex
+}
+
+// construct and initialise an endorsement plan
+func newPlan(layouts []*layout, groupEndorsers map[string][]*endorser) *plan {
+	// Initialize the size with the total number of endorsers across all plans.  This is required to
+	// determine the theoretical maximum channel buffer size when requesting endorsement across multiple goroutines.
+	var size int
+	groupIds := map[string]string{}
+	for group, endorsers := range groupEndorsers {
+		size += len(endorsers)
+		for _, endorser := range endorsers {
+			groupIds[endorser.pkiid.String()] = group
+		}
+	}
+	return &plan{
+		layouts:        layouts,
+		groupEndorsers: groupEndorsers,
+		groupIds:       groupIds,
+		size:           size,
+		planLock:       sync.Mutex{},
+	}
+}
+
+// endorsers returns an array of endorsing peers representing the next layout in the list of available layouts
+func (p *plan) endorsers() []*endorser {
+	p.planLock.Lock()
+	defer p.planLock.Unlock()
+
+	var endorsers []*endorser
+	for endorsers == nil {
+		// Skip over any defunct layouts.
+		for p.nextLayout < len(p.layouts) && p.layouts[p.nextLayout] == nil {
+			p.nextLayout++
+		}
+		if p.nextLayout >= len(p.layouts) {
+			return nil
+		}
+		for group, qty := range p.layouts[p.nextLayout].required {
+			if qty > len(p.groupEndorsers[group]) {
+				// requires more group endorsers than available - abandon this layout
+				endorsers = nil
+				p.layouts[p.nextLayout] = nil
+				p.nextLayout++
+				break
+			}
+			// remove the first qty endorsers from the front of this group
+			endorsers = append(endorsers, p.groupEndorsers[group][0:qty]...)
+			p.groupEndorsers[group] = p.groupEndorsers[group][qty:]
+		}
+	}
+	return endorsers
+}
+
+// Invoke update when an endorsement has been successfully received for the given endorser.
+// All layouts containing the group that contains this endorser are updated with the endorsement.
+// Returns array of endorsements, if at least one layout in the plan has been satisfied, otherwise nil.
+func (p *plan) update(endorser *endorser, endorsement *peer.ProposalResponse) []*peer.ProposalResponse {
+	p.planLock.Lock()
+	defer p.planLock.Unlock()
+
+	group := p.groupIds[endorser.pkiid.String()]
+	endorsers := p.groupEndorsers[group]
+
+	// remove the endorser from this group
+	// this is required if the given endorser was not originally provided by this plan instance (e.g. firstEndorser)
+	for i, e := range endorsers {
+		if bytes.Equal(e.pkiid, endorser.pkiid) {
+			p.groupEndorsers[group] = append(endorsers[:i], endorsers[i+1:]...)
+			break
+		}
+	}
+
+	for i := p.nextLayout; i < len(p.layouts); i++ {
+		layout := p.layouts[i]
+		if layout == nil {
+			continue
+		}
+		if quantity, ok := layout.required[group]; ok {
+			layout.required[group] = quantity - 1
+			layout.endorsements = append(layout.endorsements, endorsement)
+			if layout.required[group] == 0 {
+				// this group for this layout is complete - remove from map
+				delete(layout.required, group)
+				if len(layout.required) == 0 {
+					// no groups left - this layout is now satisfied
+					return layout.endorsements
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// Invoke retry if an endorsement fails for the given endorser.
+// Returns the next endorser in the same group as given endorser with which to retry the proposal, or nil if there are no more.
+func (p *plan) retry(endorser *endorser) *endorser {
+	p.planLock.Lock()
+	defer p.planLock.Unlock()
+
+	group := p.groupIds[endorser.pkiid.String()]
+
+	// next endorser for this layout
+	if len(p.groupEndorsers[group]) > 0 {
+		next := p.groupEndorsers[group][0]
+		p.groupEndorsers[group] = p.groupEndorsers[group][1:]
+		return next
+	}
+
+	// There are no more peers in this group, so will abandon this group entirely and remove all layouts that use it
+	// Clearly the current layout was using it, so remove that
+	// To avoid memory re-allocations, mark them as nil
+	for i := p.nextLayout; i < len(p.layouts); i++ {
+		layout := p.layouts[i]
+		if layout != nil {
+			if _, exists := layout.required[group]; exists {
+				p.layouts[i] = nil
+			}
+		}
+	}
+	// continue with the next layout
+	p.nextLayout++
+
+	return nil
+}

--- a/internal/pkg/gateway/endorsement_test.go
+++ b/internal/pkg/gateway/endorsement_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2021 IBM All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package gateway
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSingleLayoutPlan(t *testing.T) {
+	layouts := []*layout{
+		{required: map[string]int{"g1": 1, "g2": 2}},
+	}
+	groupEndorsers := map[string][]*endorser{
+		"g1": {peer1Mock},
+		"g2": {peer2Mock, peer3Mock},
+	}
+	plan := newPlan(layouts, groupEndorsers)
+	require.Equal(t, plan.size, 3) // total number of endorsers in all layouts
+
+	endorsers := plan.endorsers()
+	require.Len(t, endorsers, 3)
+	require.ElementsMatch(t, endorsers, []*endorser{peer1Mock, peer2Mock, peer3Mock})
+
+	response1 := &peer.ProposalResponse{Payload: []byte("p1")}
+	response2 := &peer.ProposalResponse{Payload: []byte("p2")}
+	response3 := &peer.ProposalResponse{Payload: []byte("p3")}
+
+	endorsements := plan.update(peer1Mock, response1)
+	require.Nil(t, endorsements)
+	endorsements = plan.update(peer2Mock, response2)
+	require.Nil(t, endorsements)
+	endorsements = plan.update(peer3Mock, response3)
+	require.Len(t, endorsements, 3)
+	require.ElementsMatch(t, endorsements, []*peer.ProposalResponse{response1, response2, response3})
+}
+
+func TestSingleLayoutRetry(t *testing.T) {
+	layouts := []*layout{
+		{required: map[string]int{"g1": 1, "g2": 2}},
+	}
+	groupEndorsers := map[string][]*endorser{
+		"g1": {localhostMock, peer1Mock},
+		"g2": {peer2Mock, peer3Mock, peer4Mock},
+	}
+	plan := newPlan(layouts, groupEndorsers)
+	require.Equal(t, plan.size, 5) // total number of endorsers in all layouts
+
+	endorsers := plan.endorsers()
+	require.Len(t, endorsers, 3)
+	require.ElementsMatch(t, endorsers, []*endorser{localhostMock, peer2Mock, peer3Mock})
+
+	response1 := &peer.ProposalResponse{Payload: []byte("p1")}
+	response2 := &peer.ProposalResponse{Payload: []byte("p2")}
+	response3 := &peer.ProposalResponse{Payload: []byte("p3")}
+
+	retry := plan.retry(localhostMock)
+	require.Equal(t, peer1Mock, retry)
+	endorsements := plan.update(retry, response1)
+	require.Nil(t, endorsements)
+	endorsements = plan.update(peer2Mock, response2)
+	require.Nil(t, endorsements)
+	retry = plan.retry(peer3Mock)
+	require.Equal(t, peer4Mock, retry)
+	endorsements = plan.update(retry, response3)
+	require.Len(t, endorsements, 3)
+	require.ElementsMatch(t, endorsements, []*peer.ProposalResponse{response1, response2, response3})
+}
+
+func TestMultiLayoutRetry(t *testing.T) {
+	layouts := []*layout{
+		{required: map[string]int{"g1": 1, "g2": 1}},
+		{required: map[string]int{"g1": 1, "g3": 1}},
+		{required: map[string]int{"g2": 1, "g3": 1}},
+	}
+	groupEndorsers := map[string][]*endorser{
+		"g1": {localhostMock, peer1Mock},
+		"g2": {peer2Mock, peer3Mock},
+		"g3": {peer4Mock},
+	}
+	plan := newPlan(layouts, groupEndorsers)
+	require.Equal(t, plan.size, 5) // total number of endorsers in all layouts
+
+	endorsers := plan.endorsers()
+	require.Len(t, endorsers, 2)
+	require.ElementsMatch(t, endorsers, []*endorser{localhostMock, peer2Mock})
+
+	response1 := &peer.ProposalResponse{Payload: []byte("p1")}
+	response2 := &peer.ProposalResponse{Payload: []byte("p2")}
+
+	// localhost (g1) fails, returns peer1 to retry
+	retry := plan.retry(localhostMock)
+	require.Equal(t, peer1Mock, retry)
+
+	// peer2 (g2) succeeds
+	endorsements := plan.update(peer2Mock, response1)
+	require.Nil(t, endorsements)
+
+	// peer1 (g1) also fails - returns nil, since no more peers in g1
+	retry = plan.retry(retry)
+	require.Nil(t, retry)
+
+	// get endorsers for next layout - should be layout 3 because second layout also required g1
+	endorsers = plan.endorsers()
+	// layout 3 requires endorsement from g2 & g3, but we already have one for g2, so just need g3 peer
+	require.Len(t, endorsers, 1)
+	require.Equal(t, peer4Mock, endorsers[0])
+
+	endorsements = plan.update(peer4Mock, response2)
+	require.Len(t, endorsements, 2)
+	require.ElementsMatch(t, endorsements, []*peer.ProposalResponse{response1, response2})
+}
+
+func TestMultiLayoutFailures(t *testing.T) {
+	layouts := []*layout{
+		{required: map[string]int{"g1": 1, "g2": 1, "g3": 1}},
+		{required: map[string]int{"g1": 1, "g2": 2}},
+		{required: map[string]int{"g1": 2, "g2": 1}},
+	}
+	groupEndorsers := map[string][]*endorser{
+		"g1": {localhostMock, peer1Mock},
+		"g2": {peer2Mock, peer3Mock},
+		"g3": {peer4Mock},
+	}
+	plan := newPlan(layouts, groupEndorsers)
+	require.Equal(t, plan.size, 5) // total number of endorsers in all layouts
+
+	endorsers := plan.endorsers() // first layout
+	require.Len(t, endorsers, 3)
+	require.ElementsMatch(t, endorsers, []*endorser{localhostMock, peer2Mock, peer4Mock})
+
+	response1 := &peer.ProposalResponse{Payload: []byte("p1")}
+	response2 := &peer.ProposalResponse{Payload: []byte("p2")}
+
+	// localhost (g1) succeeds
+	endorsements := plan.update(localhostMock, response1)
+	require.Nil(t, endorsements)
+
+	// peer2 (g2) fails - returns peer3 to retry
+	retry := plan.retry(peer2Mock)
+	require.Equal(t, peer3Mock, retry)
+
+	// peer4 (g3) also fails - returns nil, since no more peers in g3
+	g3retry := plan.retry(peer4Mock)
+	require.Nil(t, g3retry)
+
+	// retry g2 - succeeds
+	endorsements = plan.update(retry, response2)
+	require.Nil(t, endorsements)
+
+	// nothing more to try in this layout - get endorsers for next layout
+	// layout 2 requires a second endorsement from g2, but all g2 peers have been tried - only 1 succeeded
+	// should return layout 3 which requires a second endorsement from g1
+	endorsers = plan.endorsers()
+	require.Len(t, endorsers, 1)
+	require.Equal(t, peer1Mock, endorsers[0])
+
+	// this one fails too
+	retry = plan.retry(peer1Mock)
+	// no more in this group
+	require.Nil(t, retry)
+	endorsers = plan.endorsers()
+	// we've run out of layouts - failed to endorse!
+	require.Nil(t, endorsers)
+}
+
+func TestMultiPlan(t *testing.T) {
+	layouts1 := []*layout{
+		{required: map[string]int{"g1": 1}},
+	}
+	groupEndorsers1 := map[string][]*endorser{
+		"g1": {localhostMock, peer1Mock},
+	}
+	// plan 1 is used to determine the first endorser
+	plan1 := newPlan(layouts1, groupEndorsers1)
+	require.Equal(t, plan1.size, 2)
+
+	layouts2 := []*layout{
+		{required: map[string]int{"g1": 1, "g2": 1}},
+		{required: map[string]int{"g1": 1, "g3": 1}},
+		{required: map[string]int{"g2": 1, "g3": 1}},
+	}
+	groupEndorsers2 := map[string][]*endorser{
+		"g1": {localhostMock, peer1Mock},
+		"g2": {peer2Mock, peer3Mock},
+		"g3": {peer4Mock},
+	}
+	// plan 2 is derived from the chaincode interest from the first endorsement
+	plan2 := newPlan(layouts2, groupEndorsers2)
+	require.Equal(t, plan2.size, 5)
+
+	endorsers := plan1.endorsers()
+	require.Len(t, endorsers, 1)
+	require.ElementsMatch(t, endorsers, []*endorser{localhostMock})
+
+	response1 := &peer.ProposalResponse{Payload: []byte("p1")}
+	response2 := &peer.ProposalResponse{Payload: []byte("p2")}
+
+	// localhost succeeds, remove from plan 2
+	endorsers = plan2.endorsers()
+	require.Len(t, endorsers, 2)
+	endorsements := plan2.update(localhostMock, response1)
+	require.Nil(t, endorsements)
+
+	// peer2 (g2) succeeds
+	endorsements = plan2.update(peer2Mock, response2)
+	require.Len(t, endorsements, 2)
+	require.ElementsMatch(t, endorsements, []*peer.ProposalResponse{response1, response2})
+}
+
+func TestMultiPlanNoOverlap(t *testing.T) {
+	layouts1 := []*layout{
+		{required: map[string]int{"g1": 1}},
+	}
+	groupEndorsers1 := map[string][]*endorser{
+		"g1": {localhostMock, peer1Mock},
+	}
+	// plan 1 is used to determine the first endorser
+	plan1 := newPlan(layouts1, groupEndorsers1)
+	require.Equal(t, plan1.size, 2)
+
+	layouts2 := []*layout{
+		{required: map[string]int{"g2": 1, "g3": 1}},
+	}
+	groupEndorsers2 := map[string][]*endorser{
+		"g2": {peer2Mock, peer3Mock},
+		"g3": {peer4Mock},
+	}
+	// plan 2 is derived from the chaincode interest from the first endorsement, but doesn't include first endorser
+	plan2 := newPlan(layouts2, groupEndorsers2)
+	require.Equal(t, plan2.size, 3)
+
+	endorsers := plan1.endorsers()
+	require.Len(t, endorsers, 1)
+	require.ElementsMatch(t, endorsers, []*endorser{localhostMock})
+
+	response1 := &peer.ProposalResponse{Payload: []byte("p1")}
+	response2 := &peer.ProposalResponse{Payload: []byte("p2")}
+	response3 := &peer.ProposalResponse{Payload: []byte("p2")}
+
+	// localhost succeeds, try to remove from plan 2 (should be no-op)
+	endorsers = plan2.endorsers()
+	require.Len(t, endorsers, 2)
+	endorsements := plan2.update(localhostMock, response1)
+	require.Nil(t, endorsements)
+
+	// peer2 (g2) succeeds
+	endorsements = plan2.update(peer2Mock, response2)
+	require.Nil(t, endorsements)
+
+	// peer4 (g3) succeeds
+	endorsements = plan2.update(peer4Mock, response3)
+	require.Len(t, endorsements, 2)
+	require.ElementsMatch(t, endorsements, []*peer.ProposalResponse{response2, response3})
+}

--- a/internal/pkg/gateway/endpoint.go
+++ b/internal/pkg/gateway/endpoint.go
@@ -19,7 +19,8 @@ import (
 )
 
 type endorser struct {
-	client peer.EndorserClient
+	client          peer.EndorserClient
+	closeConnection func() error
 	*endpointConfig
 }
 
@@ -60,9 +61,16 @@ func (ef *endpointFactory) newEndorser(pkiid common.PKIidType, address, mspid st
 	if connectEndorser == nil {
 		connectEndorser = peer.NewEndorserClient
 	}
+	close := func() error {
+		if conn != nil {
+			return conn.Close()
+		}
+		return nil
+	}
 	return &endorser{
-		client:         connectEndorser(conn),
-		endpointConfig: &endpointConfig{pkiid: pkiid, address: address, mspid: mspid, tlsRootCerts: tlsRootCerts},
+		client:          connectEndorser(conn),
+		closeConnection: close,
+		endpointConfig:  &endpointConfig{pkiid: pkiid, address: address, mspid: mspid, tlsRootCerts: tlsRootCerts},
 	}, nil
 }
 


### PR DESCRIPTION
Rather than selecting one layout from the discovery endorsement plan and failing if one of the endorsers fails, this commit attempts to create a set of endorsements by retrying the proposal on other endorser until one of the layouts is satisfied.
Additionally, rather than connect to all peers in a channel once on first usage and then never update that cache, this commit adds support for later additions and removals to/from the cache and closing stale connections to peers.

Resolves #2914 

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
