### PR TITLE
Check the package name on core/ledger/kvledger UT (#2987)

### DIFF
--- a/core/ledger/kvledger/snapshot_test.go
+++ b/core/ledger/kvledger/snapshot_test.go
@@ -568,7 +568,7 @@ func TestGenerateSnapshotErrors(t *testing.T) {
 		require.Error(t, err)
 		errStackTrace := fmt.Sprintf("%+v", err)
 		require.Contains(t, errStackTrace, "internal leveldb error while obtaining db iterator")
-		require.Contains(t, errStackTrace, "fabric/common/ledger/blkstorage/blockindex.go")
+		require.Contains(t, errStackTrace, "github.com/hyperledger/fabric/common/ledger/blkstorage")
 	})
 
 	t.Run("config history mgr returns error", func(t *testing.T) {
@@ -578,7 +578,7 @@ func TestGenerateSnapshotErrors(t *testing.T) {
 		require.Error(t, err)
 		errStackTrace := fmt.Sprintf("%+v", err)
 		require.Contains(t, errStackTrace, "internal leveldb error while obtaining db iterator")
-		require.Contains(t, errStackTrace, "fabric/core/ledger/confighistory/mgr.go")
+		require.Contains(t, errStackTrace, "github.com/hyperledger/fabric/core/ledger/confighistory")
 	})
 
 	t.Run("statedb returns error", func(t *testing.T) {


### PR DESCRIPTION
Check the package name not local file name including "fabric/"
on core/ledger/kvledger unit test

`core/ledger/kvledger` unit-test has been failed on a directory that not "fabric".

Signed-off-by: Justin Yang <justin.yang@themedium.io>

#### Type of change
- Test update

#### Description
Check the error message without "`fabric/`" in `core/ledger/kvledger/snapshot_test.go`
When you run the unit-test in a directory that is not "`fabric`", that unit-test will fail because of checking the filename starting "`fabric/`".

#### Additional details
* Problem
`core/ledger/kvledger/` unit test fails when running the unit-test in another directory, not `fabric/`

```
--- FAIL: TestGenerateSnapshotErrors (13.43s)
    --- FAIL: TestGenerateSnapshotErrors/block_store_returns_error (1.10s)
        snapshot_test.go:571:
            	Error Trace:	snapshot_test.go:571
            	Error:      	"leveldb: closed\ninternal leveldb error while obtaining db iterator\ngithub.com/hyperledger/fabric/common/ledger/util/leveldbhelper.(*DBHandle).GetIterator\n\t/Users/medium/src/hyperledger/fabrictest/common/ledger/util/leveldbhelper/leveldb_provider.go:262\ngithub.com/hyperledger/fabric/common/ledger/blkstorage.(*blockIndex).exportUniqueTxIDs\n\t/Users/medium/src/hyperledger/fabrictest/common/ledger/blkstorage/blockindex.go:304\ngithub.com/hyperledger/fabric/common/ledger/blkstorage.(*BlockStore).ExportTxIds\n\t/Users/medium/src/hyperledger/fabrictest/common/ledger/blkstorage/blockstore.go:105\ngithub.com/hyperledger/fabric/core/ledger/kvledger.(*kvLedger).generateSnapshot\n\t/Users/medium/src/hyperledger/fabrictest/core/ledger/kvledger/snapshot.go:114\ngithub.com/hyperledger/fabric/core/ledger/kvledger.TestGenerateSnapshotErrors.func4\n\t/Users/medium/src/hyperledger/fabrictest/core/ledger/kvledger/snapshot_test.go:567\ntesting.tRunner\n\t/usr/local/Cellar/go@1.14/1.14.15/libexec/src/testing/testing.go:1050\nruntime.goexit\n\t/usr/local/Cellar/go@1.14/1.14.15/libexec/src/runtime/asm_amd64.s:1373" does not contain "fabric/common/ledger/blkstorage/blockindex.go"
            	Test:       	TestGenerateSnapshotErrors/block_store_returns_error
    --- FAIL: TestGenerateSnapshotErrors/config_history_mgr_returns_error (1.32s)
        snapshot_test.go:581:
            	Error Trace:	snapshot_test.go:581
            	Error:      	"leveldb: closed\ninternal leveldb error while obtaining db iterator\ngithub.com/hyperledger/fabric/common/ledger/util/leveldbhelper.(*DBHandle).GetIterator\n\t/Users/medium/src/hyperledger/fabrictest/common/ledger/util/leveldbhelper/leveldb_provider.go:262\ngithub.com/hyperledger/fabric/core/ledger/confighistory.(*db).getNamespaceIterator\n\t/Users/medium/src/hyperledger/fabrictest/core/ledger/confighistory/db_helper.go:114\ngithub.com/hyperledger/fabric/core/ledger/confighistory.(*Retriever).ExportConfigHistory\n\t/Users/medium/src/hyperledger/fabrictest/core/ledger/confighistory/mgr.go:221\ngithub.com/hyperledger/fabric/core/ledger/kvledger.(*kvLedger).generateSnapshot\n\t/Users/medium/src/hyperledger/fabrictest/core/ledger/kvledger/snapshot.go:120\ngithub.com/hyperledger/fabric/core/ledger/kvledger.TestGenerateSnapshotErrors.func5\n\t/Users/medium/src/hyperledger/fabrictest/core/ledger/kvledger/snapshot_test.go:577\ntesting.tRunner\n\t/usr/local/Cellar/go@1.14/1.14.15/libexec/src/testing/testing.go:1050\nruntime.goexit\n\t/usr/local/Cellar/go@1.14/1.14.15/libexec/src/runtime/asm_amd64.s:1373" does not contain "fabric/core/ledger/confighistory/mgr.go"
            	Test:       	TestGenerateSnapshotErrors/config_history_mgr_returns_error

(...)

FAIL
coverage: 78.8% of statements
FAIL	github.com/hyperledger/fabric/core/ledger/kvledger	583.226s
```

* Reproduce procedure
1. `$ git clone https://github.com/hyperledger/fabric.git fabrictest` or `$ mv fabric fabrictest`
2. `$ cd fabrictest`
3. `$ make unit-test`
