### PR TITLE
fix Windows SyncDir issue

### DIFF
--- a/ci/scripts/create_binary_package.sh
+++ b/ci/scripts/create_binary_package.sh
@@ -8,4 +8,7 @@ make "release/${TARGET}"
 mkdir "release/${TARGET}/config"
 mv sampleconfig/*yaml "release/${TARGET}/config"
 cd "release/${TARGET}"
+if [ "$TARGET" == "windows-amd64" ]
+    for FILE in bin/*; do mv $FILE $FILE.exe; done
+fi
 tar -czvf "hyperledger-fabric-${TARGET}-${RELEASE}.tar.gz" bin config

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -52,22 +52,6 @@ func CreateAndSyncFile(filePath string, content []byte, perm os.FileMode) error 
 	return nil
 }
 
-// SyncDir fsyncs the given dir
-func SyncDir(dirPath string) error {
-	dir, err := os.Open(dirPath)
-	if err != nil {
-		return errors.Wrapf(err, "error while opening dir:%s", dirPath)
-	}
-	if err := dir.Sync(); err != nil {
-		dir.Close()
-		return errors.Wrapf(err, "error while synching dir:%s", dirPath)
-	}
-	if err := dir.Close(); err != nil {
-		return errors.Wrapf(err, "error while closing dir:%s", dirPath)
-	}
-	return err
-}
-
 // SyncParentDir fsyncs the parent dir of the given path
 func SyncParentDir(path string) error {
 	return SyncDir(filepath.Dir(path))

--- a/internal/fileutil/syncdir.go
+++ b/internal/fileutil/syncdir.go
@@ -1,0 +1,31 @@
+// +build !windows
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fileutil
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// SyncDir fsyncs the given dir
+func SyncDir(dirPath string) error {
+	dir, err := os.Open(dirPath)
+	if err != nil {
+		return errors.Wrapf(err, "error while opening dir:%s", dirPath)
+	}
+	if err := dir.Sync(); err != nil {
+		dir.Close()
+		return errors.Wrapf(err, "error while synching dir:%s", dirPath)
+	}
+	if err := dir.Close(); err != nil {
+		return errors.Wrapf(err, "error while closing dir:%s", dirPath)
+	}
+	return err
+}

--- a/internal/fileutil/syncdir_windows.go
+++ b/internal/fileutil/syncdir_windows.go
@@ -1,0 +1,12 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fileutil
+
+// SyncDir this is a noop on windows
+func SyncDir(dirPath string) error {
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: D <d_kelsey@uk.ibm.com>

closes #2984 

#### Type of change

- Bug fix

#### Description

On windows it's not valid to invoke Sync on a directory, it results in an error "Handle is invalid"

#### Additional details

As windows is there only as a development platform, removing the attempt to Sync on a dir restores the ability for Peer and Orderer to run natively on Windows Desktop platforms.

Included as well is ensuring the downloadable windows package contains .exe files so they are usable straight away (no extra rename once unpacked is required)

