### PR TITLE
Add explanation of stringArray (--peerAddresses)

### DIFF
--- a/docs/source/commands/peerchaincode.md
+++ b/docs/source/commands/peerchaincode.md
@@ -84,6 +84,11 @@ flags are
 
   Transient map of arguments in JSON encoding
 
+Flags of type stringArray are to be repeated rather than concatenating their
+values. For example, you will use `--peerAddresses localhost:9051
+--peerAddresses localhost:7051` rather than `--peerAddresses "localhost:9051
+localhost:7051"`.
+
 ## peer chaincode install
 ```
 Install a chaincode on a peer. This installs a chaincode deployment spec package (if provided) or packages the specified chaincode before subsequently installing it.

--- a/docs/wrappers/peer_chaincode_preamble.md
+++ b/docs/wrappers/peer_chaincode_preamble.md
@@ -78,3 +78,8 @@ flags are
 * `--transient <string>`
 
   Transient map of arguments in JSON encoding
+
+Flags of type stringArray are to be repeated rather than concatenating their
+values. For example, you will use `--peerAddresses localhost:9051
+--peerAddresses localhost:7051` rather than `--peerAddresses "localhost:9051
+localhost:7051"`.


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

I searched the documentations but didn't find they explain stringArray. 

I looked at the source code of github.com/spf13/pflag and guess I should use

 `--peerAddresses localhost:9051--peerAddresses localhost:7051` rather than `--peerAddresses "localhost:9051
localhost:7051"`.

I think this information should be added to the docs.


<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
