### PR TITLE
Don’t close connection if already closing

### DIFF
--- a/internal/pkg/gateway/endpoint.go
+++ b/internal/pkg/gateway/endpoint.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hyperledger/fabric/gossip/common"
 	"github.com/hyperledger/fabric/internal/pkg/comm"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 )
 
 type endorser struct {
@@ -62,7 +63,8 @@ func (ef *endpointFactory) newEndorser(pkiid common.PKIidType, address, mspid st
 		connectEndorser = peer.NewEndorserClient
 	}
 	close := func() error {
-		if conn != nil {
+		if conn != nil && conn.GetState() != connectivity.Shutdown {
+			logger.Infow("Closing connection to remote endorser", "address", address, "mspid", mspid)
 			return conn.Close()
 		}
 		return nil

--- a/internal/pkg/gateway/registry.go
+++ b/internal/pkg/gateway/registry.go
@@ -378,7 +378,6 @@ func (reg *registry) removeEndorser(endorser *endorser) {
 	reg.configLock.Lock()
 	defer reg.configLock.Unlock()
 
-	reg.logger.Infow("Closing connection to remote endorser", "address", endorser.address, "mspid", endorser.mspid)
 	err := endorser.closeConnection()
 	if err != nil {
 		reg.logger.Errorw("Failed to close connection to endorser", "address", endorser.address, "mspid", endorser.mspid, "err", err)


### PR DESCRIPTION
When a peer is shutdown, if the gateway attempts to send a proposal to it, it will fail and the gateway will close the connection and remove it from its registry.
Under stress, with multiple concurrent goroutines all attempting to use and then close the connection, the log gets flooded with the messages:
- (INFO) Attempting to close
- (ERROR) Failed to close.

This commit changes the behaviour so that it checks the grpc state before logging and attempting to close.  If it’s already shutting down, then it’s a no-op.

Resolves https://github.com/hyperledger/fabric-gateway/issues/265

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
