### PR TITLE
Add integration tests for `calculatepackageid` command

### DIFF
--- a/integration/nwo/commands/peer.go
+++ b/integration/nwo/commands/peer.go
@@ -275,6 +275,28 @@ func (c ChaincodePackageLegacy) Args() []string {
 	return args
 }
 
+type ChaincodeCalculatePackageID struct {
+	PackageFile string
+	ClientAuth  bool
+}
+
+func (c ChaincodeCalculatePackageID) SessionName() string {
+	return "peer-lifecycle-chaincode-calculatepackageid"
+}
+
+func (c ChaincodeCalculatePackageID) Args() []string {
+	args := []string{
+		"lifecycle", "chaincode", "calculatepackageid",
+		c.PackageFile,
+	}
+
+	if c.ClientAuth {
+		args = append(args, "--clientauth")
+	}
+
+	return args
+}
+
 type ChaincodeInstall struct {
 	PackageFile   string
 	PeerAddresses []string

--- a/integration/nwo/deploy.go
+++ b/integration/nwo/deploy.go
@@ -170,6 +170,15 @@ func PackageChaincodeLegacy(n *Network, chaincode Chaincode, peer *Peer) {
 	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
 }
 
+func CheckPackageID(n *Network, packageFile string, packageID string, peer *Peer) {
+	sess, err := n.PeerAdminSession(peer, commands.ChaincodeCalculatePackageID{
+		PackageFile: packageFile,
+		ClientAuth:  n.ClientAuthRequired,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(sess, n.EventuallyTimeout).Should(gbytes.Say(fmt.Sprintf(`\QPackage ID: %s\E`, packageID)))
+}
+
 func InstallChaincode(n *Network, chaincode Chaincode, peers ...*Peer) {
 	// Ensure 'jq' exists in path, because we need it to build chaincode
 	if _, err := exec.LookPath("jq"); err != nil {
@@ -189,6 +198,7 @@ func InstallChaincode(n *Network, chaincode Chaincode, peers ...*Peer) {
 		EventuallyWithOffset(1, sess, n.EventuallyTimeout).Should(gexec.Exit())
 
 		EnsureInstalled(n, chaincode.Label, chaincode.PackageID, p)
+		CheckPackageID(n, chaincode.PackageFile, chaincode.PackageID, p)
 	}
 }
 


### PR DESCRIPTION
This patch adds integration tests for `calculatepackageid` command.

#### Type of change

- Test update

#### Description

This patch adds integration tests for `calculatepackageid` command.

#### Additional details

#### Related issues

- https://github.com/hyperledger/fabric/issues/2976
- https://github.com/hyperledger/fabric/pull/2981
 
After this PR is merged, I'm going to submit some patches to add some output options as a separate PR in sequence.