### PR TITLE
Improve output formats of calculatepackageid

### DIFF
--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -519,7 +519,7 @@ peer lifecycle chaincode calculatepackageid mycc.tar.gz
 A successful command will return the package ID for the packaged chaincode.
 
 ```
-Package ID: myccv1:cc7bb5f50a53c207f68d37e9423c32f968083282e5ffac00d41ffc5768dc1873
+myccv1:cc7bb5f50a53c207f68d37e9423c32f968083282e5ffac00d41ffc5768dc1873
 ```
 
 ### peer lifecycle chaincode approveformyorg example

--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -210,6 +210,7 @@ Usage:
 Flags:
       --connectionProfile string       The fully qualified path to the connection profile that provides the necessary connection information for the network. Note: currently only supported for providing peer connection information
   -h, --help                           help for calculatepackageid
+  -O, --output string                  The output format for query results. Default is human-readable plain-text. json is currently the only supported format.
       --peerAddresses stringArray      The addresses of the peers to connect to
       --tlsRootCertFiles stringArray   If TLS is enabled, the paths to the TLS root cert files of the peers to connect to. The order and number of certs specified should match the --peerAddresses flag
 
@@ -521,6 +522,20 @@ A successful command will return the package ID for the packaged chaincode.
 ```
 myccv1:cc7bb5f50a53c207f68d37e9423c32f968083282e5ffac00d41ffc5768dc1873
 ```
+
+  * You can also use the `--output` flag to have the CLI format the output as JSON.
+
+    ```
+    peer lifecycle chaincode calculatepackageid mycc.tar.gz --output json
+    ```
+
+    If successful, the command will return the chaincode package ID as JSON.
+
+    ```
+    {
+      "package_id": "myccv1:cc7bb5f50a53c207f68d37e9423c32f968083282e5ffac00d41ffc5768dc1873"
+    }
+    ```
 
 ### peer lifecycle chaincode approveformyorg example
 

--- a/docs/wrappers/peer_lifecycle_chaincode_postscript.md
+++ b/docs/wrappers/peer_lifecycle_chaincode_postscript.md
@@ -122,6 +122,20 @@ A successful command will return the package ID for the packaged chaincode.
 myccv1:cc7bb5f50a53c207f68d37e9423c32f968083282e5ffac00d41ffc5768dc1873
 ```
 
+  * You can also use the `--output` flag to have the CLI format the output as JSON.
+
+    ```
+    peer lifecycle chaincode calculatepackageid mycc.tar.gz --output json
+    ```
+
+    If successful, the command will return the chaincode package ID as JSON.
+
+    ```
+    {
+      "package_id": "myccv1:cc7bb5f50a53c207f68d37e9423c32f968083282e5ffac00d41ffc5768dc1873"
+    }
+    ```
+
 ### peer lifecycle chaincode approveformyorg example
 
 Once the chaincode package has been installed on your peers, you can approve

--- a/docs/wrappers/peer_lifecycle_chaincode_postscript.md
+++ b/docs/wrappers/peer_lifecycle_chaincode_postscript.md
@@ -119,7 +119,7 @@ peer lifecycle chaincode calculatepackageid mycc.tar.gz
 A successful command will return the package ID for the packaged chaincode.
 
 ```
-Package ID: myccv1:cc7bb5f50a53c207f68d37e9423c32f968083282e5ffac00d41ffc5768dc1873
+myccv1:cc7bb5f50a53c207f68d37e9423c32f968083282e5ffac00d41ffc5768dc1873
 ```
 
 ### peer lifecycle chaincode approveformyorg example

--- a/integration/nwo/deploy.go
+++ b/integration/nwo/deploy.go
@@ -176,7 +176,7 @@ func CheckPackageID(n *Network, packageFile string, packageID string, peer *Peer
 		ClientAuth:  n.ClientAuthRequired,
 	})
 	Expect(err).NotTo(HaveOccurred())
-	Eventually(sess, n.EventuallyTimeout).Should(gbytes.Say(fmt.Sprintf(`\QPackage ID: %s\E`, packageID)))
+	Eventually(sess, n.EventuallyTimeout).Should(gbytes.Say(fmt.Sprintf(`\Q%s\E`, packageID)))
 }
 
 func InstallChaincode(n *Network, chaincode Chaincode, peers ...*Peer) {

--- a/internal/peer/lifecycle/chaincode/calculatepackageid.go
+++ b/internal/peer/lifecycle/chaincode/calculatepackageid.go
@@ -103,7 +103,7 @@ func (p *PackageIDCalculator) PackageID() error {
 
 	packageID := persistence.PackageID(metadata.Label, pkgBytes)
 
-	fmt.Fprintf(p.Writer, "Package ID: %s\n", packageID)
+	fmt.Fprintf(p.Writer, "%s\n", packageID)
 	return nil
 }
 

--- a/internal/peer/lifecycle/chaincode/calculatepackageid_test.go
+++ b/internal/peer/lifecycle/chaincode/calculatepackageid_test.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package chaincode_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/hyperledger/fabric/internal/peer/lifecycle/chaincode"
@@ -84,6 +86,23 @@ var _ = Describe("CalculatePackageID", func() {
 			It("returns an error", func() {
 				err := packageIDCalculator.PackageID()
 				Expect(err).To(MatchError(ContainSubstring("could not parse as a chaincode install package")))
+			})
+		})
+
+		Context("when JSON-formatted output is requested", func() {
+			BeforeEach(func() {
+				packageIDCalculator.Input.OutputFormat = "json"
+			})
+
+			It("calculates the package IDs for chaincodes and writes the output as JSON", func() {
+				err := packageIDCalculator.PackageID()
+				Expect(err).NotTo(HaveOccurred())
+				expectedOutput := &chaincode.CalculatePackageIDOutput{
+					PackageID: "Real-Label:fb3edf9621c5e3d864079d8c9764205f4db09d7021cfa4124aa79f4edcc2f64a",
+				}
+				json, err := json.MarshalIndent(expectedOutput, "", "\t")
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(packageIDCalculator.Writer).Should(gbytes.Say(fmt.Sprintf(`\Q%s\E`, string(json))))
 			})
 		})
 	})

--- a/internal/peer/lifecycle/chaincode/calculatepackageid_test.go
+++ b/internal/peer/lifecycle/chaincode/calculatepackageid_test.go
@@ -49,7 +49,7 @@ var _ = Describe("CalculatePackageID", func() {
 		It("calculates the package IDs for chaincodes", func() {
 			err := packageIDCalculator.PackageID()
 			Expect(err).NotTo(HaveOccurred())
-			Eventually(packageIDCalculator.Writer).Should(gbytes.Say("Package ID: Real-Label:fb3edf9621c5e3d864079d8c9764205f4db09d7021cfa4124aa79f4edcc2f64a\n"))
+			Eventually(packageIDCalculator.Writer).Should(gbytes.Say("Real-Label:fb3edf9621c5e3d864079d8c9764205f4db09d7021cfa4124aa79f4edcc2f64a\n"))
 		})
 
 		Context("when the chaincode install package is not provided", func() {


### PR DESCRIPTION
This PR improves the output formats of `calculatepackageid` command.

#### Type of change
- New feature
- Documentation update

#### Description

This patch removes the prefix from the output format of calculatepackageid.
With this patch, the command returns only the package ID by default.

Also, this PR adds an output option for `calculatepackageid` command:
- `-O json`: to output as JSON format

#### Additional details

#### Related issues
- https://github.com/hyperledger/fabric/issues/2976

#### Related PRs
- https://github.com/hyperledger/fabric/pull/2981
