### PR TITLE
Update Sphinx to v1.8.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,6 +11,6 @@ Pygments==2.1.3
 pytz==2016.4
 six==1.10.0
 snowballstemmer==1.2.1
-Sphinx==1.8.0
+Sphinx==1.8.2
 sphinx-rtd-theme==0.4.2
 recommonmark==0.4.0


### PR DESCRIPTION
A recent commit updated the doc generation tool, sphinx, from v1.7.2 to v1.8.0.  However, this broke the ability to generate and review the docs from a forked branch.
This is due to a known bug in Sphinx which was fixed on v1.8.2 (https://github.com/sphinx-doc/sphinx/issues/5519).
This commit updates the dependency to this version.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
