### PR TITLE
Show what do not match

### DIFF
--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -682,7 +682,7 @@ func TestEndorse(t *testing.T) {
 				"g2": {{endorser: peer2Mock, height: 5}},     // msp2
 			},
 			localResponse: "different_response",
-			errString:     "rpc error: code = Aborted desc = failed to assemble transaction: ProposalResponsePayloads do not match",
+			errString:     "rpc error: code = Aborted desc = failed to assemble transaction: ProposalResponsePayloads do not match (base64):",
 		},
 		{
 			name: "discovery fails",

--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -682,7 +682,7 @@ func TestEndorse(t *testing.T) {
 				"g2": {{endorser: peer2Mock, height: 5}},     // msp2
 			},
 			localResponse: "different_response",
-			errString:     "rpc error: code = Aborted desc = failed to assemble transaction: ProposalResponsePayloads do not match (base64):",
+			errString:     "rpc error: code = Aborted desc = failed to assemble transaction: ProposalResponsePayloads do not match (base64): 'EhQaEgjIARoNbW9ja19yZXNwb25zZQ==' vs 'EhkaFwjIARoSZGlmZmVyZW50X3Jlc3BvbnNl'",
 		},
 		{
 			name: "discovery fails",

--- a/protoutil/txutils.go
+++ b/protoutil/txutils.go
@@ -8,8 +8,8 @@ package protoutil
 
 import (
 	"bytes"
-	b64 "encoding/base64"
 	"crypto/sha256"
+	b64 "encoding/base64"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
@@ -203,8 +203,8 @@ func createTx(
 		}
 
 		if !bytes.Equal(a1, r.Payload) {
-			return nil, errors.Errorf("ProposalResponsePayloads do not match (base64):\n %s\n vs\n %s",
-						b64.StdEncoding.EncodeToString(r.Payload), b64.StdEncoding.EncodeToString(a1))
+			return nil, errors.Errorf("ProposalResponsePayloads do not match (base64): '%s' vs '%s'",
+				b64.StdEncoding.EncodeToString(r.Payload), b64.StdEncoding.EncodeToString(a1))
 		}
 	}
 

--- a/protoutil/txutils.go
+++ b/protoutil/txutils.go
@@ -8,6 +8,7 @@ package protoutil
 
 import (
 	"bytes"
+	b64 "encoding/base64"
 	"crypto/sha256"
 
 	"github.com/golang/protobuf/proto"
@@ -202,7 +203,8 @@ func createTx(
 		}
 
 		if !bytes.Equal(a1, r.Payload) {
-			return nil, errors.Errorf("ProposalResponsePayloads do not match with %v", r)
+			return nil, errors.Errorf("ProposalResponsePayloads do not match (base64):\n %s\n vs\n %s",
+						b64.StdEncoding.EncodeToString(r.Payload), b64.StdEncoding.EncodeToString(a1))
 		}
 	}
 

--- a/protoutil/txutils.go
+++ b/protoutil/txutils.go
@@ -202,7 +202,7 @@ func createTx(
 		}
 
 		if !bytes.Equal(a1, r.Payload) {
-			return nil, errors.New("ProposalResponsePayloads do not match")
+			return nil, errors.Errorf("ProposalResponsePayloads do not match with %v", r)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: gqqnbig <gqqnb2005@gmail.com>

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

When  `peer chaincode invoke`  submits a request, if chaincode has bugs, it may return different responses on different nodes.

Before, the error message is like

> Error: could not assemble transaction: ProposalResponsePayloads do not match  - proposal response: version:1 response:<status:200 payload:"true" > payload:"\n \265\277\020\265\226D\035\361\001n\371K\013\274\021F\227\002?\261\204\370\327\363r\347\010\221\313\214\031\230\022\213\001\no\0227\n\n_lifecycle\022)\n'..." endorsement:<endorser:"\n\007Org2MSP\022\252\006-----BEGIN CERTIFICATE-----\nMIICKDCCAc+gA..." signature:"0D\002 J\\\300\307~\350\236\026\245H\003\337\2732\020\312\n\017Fa\306~\367x\356\347K\225\..." > 

That is it. Developers have no idea what mismatch what.

Now, with this PR, the error message is like 

> Error: could not assemble transaction: ProposalResponsePayloads do not match with version:1 response:<status:200 payload:"true" > payload:"\n \265\277\020\265\226D\035\361\001n\371K\013\274\021F\227\002?\261\204\370\327\363r\347\010\221\313\214\031\230\022\230\001\n|\0227\n\n_lifecycle\022)\n'\n..." endorsement:<endorser:"\n\007Org1MSP\022\252\006-----BEGIN CERTIFICATE-----\nMIICKDCCAc6gAwIBAgIQEO..." signature:"0E\002!\000\331p\034A\353t\261{\026#\177\211\371g\232\213\331\323\..." >
> &#45; proposal response: version:1 response:<status:200 payload:"true" > payload:"\n \265\277\020\265\226D\035\361\001n\371K\013\274\021F\227\002?\261\204\370\327\363r\347\010\221\313\214\031\230\022\213\001\no\0227\n\n_lifecycle\022)\n'..." endorsement:<endorser:"\n\007Org2MSP\022\252\006-----BEGIN CERTIFICATE-----\nMIICKDCCAc+gA..." signature:"0D\002 J\\\300\307~\350\236\026\245H\003\337\2732\020\312\n\017Fa\306~\367x\356\347K\225\..." > 


With this error message, developers can use text comparison tools to find out where the two responses start to differ, and they may get some cues.


Technically, only the payload part needs to be displayed, but I don't know how to format bytes as the toString method of  ProposalResponse does.

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
