### PR TITLE
Add chaincode err message to Evaluate err message

### DIFF
--- a/internal/pkg/gateway/api.go
+++ b/internal/pkg/gateway/api.go
@@ -88,7 +88,7 @@ func (gs *Server) Evaluate(ctx context.Context, request *gp.EvaluateRequest) (*g
 			endpointErr := errorDetail(endorser.endpointConfig, err)
 			errDetails = append(errDetails, endpointErr)
 			// this is a chaincode error response - don't retry
-			return nil, rpcError(codes.Aborted, "evaluate call to endorser returned an error response, see attached details for more info", errDetails...)
+			return nil, rpcError(codes.Aborted, "evaluate call to endorser returned error: "+response.Message, errDetails...)
 		}
 	}
 

--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -316,7 +316,7 @@ func TestEvaluate(t *testing.T) {
 				proposalResponseStatus:  400,
 				proposalResponseMessage: "Mock chaincode error",
 			},
-			errString: "rpc error: code = Aborted desc = evaluate call to endorser returned an error response, see attached details for more info",
+			errString: "rpc error: code = Aborted desc = evaluate call to endorser returned error: Mock chaincode error",
 			errDetails: []*pb.ErrorDetail{{
 				Address: "peer1:8051",
 				MspId:   "msp1",


### PR DESCRIPTION
In a previous commit which implemented retry logic for the evaluate method, the error(s) produced by remote endorsers were added to the Details field of the gateway error with a generic error message at the top level.
In the case of a proposal response containing a chaincode generated error, no retry is performed and so the error message should also be at the top level (as it used to be before that earlier commit).

This commit adds the chaincode error message back into the message returned by the gateway, and will restore the behaviour expected by the scenario tests in the SDKs.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
