### PR TITLE
Better gRPC error on context error from CommitStatus service

### DIFF
--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -1198,6 +1198,16 @@ func TestCommitStatus(t *testing.T) {
 				BlockNumber: 101,
 			},
 		},
+		{
+			name:      "context timeout",
+			finderErr: context.DeadlineExceeded,
+			errString: "rpc error: code = DeadlineExceeded desc = context deadline exceeded",
+		},
+		{
+			name:      "context canceled",
+			finderErr: context.Canceled,
+			errString: "rpc error: code = Canceled desc = context canceled",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1624,7 +1634,7 @@ func TestNilArgs(t *testing.T) {
 }
 
 func TestRpcErrorWithBadDetails(t *testing.T) {
-	err := rpcError(codes.InvalidArgument, "terrible error", nil)
+	err := newRpcError(codes.InvalidArgument, "terrible error", nil)
 	require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "terrible error"))
 }
 
@@ -1741,7 +1751,6 @@ func prepareTest(t *testing.T, tt *testDef) *preparedTest {
 	dialer.Returns(nil, nil)
 	server.registry.endpointFactory = createEndpointFactory(t, epDef, dialer.Spy)
 
-	require.NoError(t, err, "Failed to sign the proposal")
 	ctx := context.WithValue(context.Background(), contextKey("orange"), "apples")
 
 	pt := &preparedTest{


### PR DESCRIPTION
Rather than always return a FailedPrecondition error on failure obtaining commit status, return either a DeadlineExceeded or Canceled error on a context error. This may happen if the call is cancelled from the client end, either by an explicit context cancel or timeout.