### PR TITLE
docs: fix typo in comment

### DIFF
--- a/common/ledger/blkstorage/blockfile_mgr.go
+++ b/common/ledger/blkstorage/blockfile_mgr.go
@@ -340,7 +340,7 @@ func (mgr *blockfileMgr) addBlock(block *common.Block) error {
 		return errors.WithMessage(err, "error saving blockfiles file info to db")
 	}
 
-	// Index block file location pointer updated with file suffex and offset for the new block
+	// Index block file location pointer updated with file suffix and offset for the new block
 	blockFLP := &fileLocPointer{fileSuffixNum: newBlkfilesInfo.latestFileNumber}
 	blockFLP.offset = currentOffset
 	// shift the txoffset because we prepend length of bytes before block bytes


### PR DESCRIPTION
#### Type of change
 * Documentation update
 
#### Description
This change fixes a typo in a comment in `main/common/ledger/blkstorage/blockfile_mgr.go`

