### PR TITLE
ProposalResponse error should return error

### DIFF
--- a/core/endorser/endorser.go
+++ b/core/endorser/endorser.go
@@ -345,7 +345,7 @@ func (e *Endorser) ProcessProposal(ctx context.Context, signedProp *pb.SignedPro
 	pResp, err := e.ProcessProposalSuccessfullyOrError(up)
 	if err != nil {
 		endorserLogger.Warnw("Failed to invoke chaincode", "channel", up.ChannelHeader.ChannelId, "chaincode", up.ChaincodeName, "error", err.Error())
-		return &pb.ProposalResponse{Response: &pb.Response{Status: 500, Message: err.Error()}}, nil
+		return &pb.ProposalResponse{Response: &pb.Response{Status: 500, Message: err.Error()}}, err
 	}
 
 	if pResp.Endorsement != nil || up.ChannelHeader.ChannelId == "" {

--- a/core/endorser/endorser_test.go
+++ b/core/endorser/endorser_test.go
@@ -286,7 +286,7 @@ var _ = Describe("Endorser", func() {
 
 		It("returns the error, but with no payload encoded", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError("endorsing with plugin failed: fake-endorserment-error"))
 			Expect(proposalResponse.Payload).To(BeNil())
 			Expect(proposalResponse.Response).To(Equal(&pb.Response{
 				Status:  500,
@@ -337,7 +337,7 @@ var _ = Describe("Endorser", func() {
 
 		It("returns a response with the error", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError("fake-simulator-error"))
 			Expect(proposalResponse.Payload).To(BeNil())
 			Expect(proposalResponse.Response).To(Equal(&pb.Response{
 				Status:  500,
@@ -361,7 +361,7 @@ var _ = Describe("Endorser", func() {
 
 		It("returns a response with the error", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError("fake-history-error"))
 			Expect(proposalResponse.Payload).To(BeNil())
 			Expect(proposalResponse.Response).To(Equal(&pb.Response{
 				Status:  500,
@@ -478,7 +478,7 @@ var _ = Describe("Endorser", func() {
 
 		It("returns an error in the response", func() {
 			proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError("make sure the chaincode chaincode-name has been successfully defined on channel channel-id and try again: fake-definition-error"))
 			Expect(proposalResponse.Response).To(Equal(&pb.Response{
 				Status:  500,
 				Message: "make sure the chaincode chaincode-name has been successfully defined on channel channel-id and try again: fake-definition-error",
@@ -508,7 +508,7 @@ var _ = Describe("Endorser", func() {
 
 		It("returns a response with the error and no payload", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError("error in simulation: fake-chaincode-execution-error"))
 			Expect(proposalResponse.Payload).To(BeNil())
 			Expect(proposalResponse.Response).To(Equal(&pb.Response{
 				Status:  500,
@@ -541,7 +541,7 @@ var _ = Describe("Endorser", func() {
 
 		It("returns a response with the error and no payload", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError("error in simulation: fake-private-data-error"))
 			Expect(proposalResponse.Payload).To(BeNil())
 			Expect(proposalResponse.Response).To(Equal(&pb.Response{
 				Status:  500,
@@ -564,7 +564,7 @@ var _ = Describe("Endorser", func() {
 
 		It("returns a response with the error and no payload", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError("error in simulation: failed to obtain ledger height for channel 'channel-id': fake-block-height-error"))
 			Expect(proposalResponse.Payload).To(BeNil())
 			Expect(proposalResponse.Response).To(Equal(&pb.Response{
 				Status:  500,
@@ -878,7 +878,7 @@ var _ = Describe("Endorser", func() {
 
 			It("returns an error to the client", func() {
 				proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(MatchError("error in simulation: lscc upgrade/deploy should not include a code packages"))
 				Expect(proposalResponse.Response).To(Equal(&pb.Response{
 					Status:  500,
 					Message: "error in simulation: lscc upgrade/deploy should not include a code packages",
@@ -900,7 +900,7 @@ var _ = Describe("Endorser", func() {
 
 			It("returns an error to the client", func() {
 				proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(MatchError("error in simulation: Private data is forbidden to be used in instantiate"))
 				Expect(proposalResponse.Response).To(Equal(&pb.Response{
 					Status:  500,
 					Message: "error in simulation: Private data is forbidden to be used in instantiate",
@@ -922,7 +922,7 @@ var _ = Describe("Endorser", func() {
 
 			It("returns an error to the client", func() {
 				proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(MatchError("error in simulation: bad simulation"))
 				Expect(proposalResponse.Response).To(Equal(&pb.Response{
 					Status:  500,
 					Message: "error in simulation: bad simulation",
@@ -941,7 +941,7 @@ var _ = Describe("Endorser", func() {
 
 			It("returns an error to the client", func() {
 				proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(MatchError("error in simulation: proto: Marshal called with nil"))
 				Expect(proposalResponse.Response).To(Equal(&pb.Response{
 					Status:  500,
 					Message: "error in simulation: proto: Marshal called with nil",
@@ -957,7 +957,7 @@ var _ = Describe("Endorser", func() {
 
 			It("returns an error and increments the metric", func() {
 				proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(MatchError("error in simulation: fake-legacy-init-error"))
 				Expect(proposalResponse.Response).To(Equal(&pb.Response{
 					Status:  500,
 					Message: "error in simulation: fake-legacy-init-error",
@@ -981,7 +981,7 @@ var _ = Describe("Endorser", func() {
 
 			It("triggers the legacy init, and returns the response from lscc", func() {
 				proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(MatchError("error in simulation: attempting to deploy a system chaincode deploy-name/channel-id"))
 				Expect(proposalResponse.Response).To(Equal(&pb.Response{
 					Status:  500,
 					Message: "error in simulation: attempting to deploy a system chaincode deploy-name/channel-id",
@@ -999,7 +999,7 @@ var _ = Describe("Endorser", func() {
 
 			It("returns an error to the client", func() {
 				proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(MatchError("error in simulation: error unmarshalling ChaincodeDeploymentSpec: unexpected EOF"))
 				Expect(proposalResponse.Response).To(Equal(&pb.Response{
 					Status:  500,
 					Message: "error in simulation: error unmarshalling ChaincodeDeploymentSpec: unexpected EOF",
@@ -1039,7 +1039,7 @@ var _ = Describe("Endorser", func() {
 
 		It("returns an error to the client", func() {
 			proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError("error in simulation: failed to obtain collections config: no collection config for chaincode \"myCC\""))
 			Expect(proposalResponse.Response).To(Equal(&pb.Response{
 				Status:  500,
 				Message: "error in simulation: failed to obtain collections config: no collection config for chaincode \"myCC\"",

--- a/integration/lifecycle/lifecycle_test.go
+++ b/integration/lifecycle/lifecycle_test.go
@@ -191,9 +191,8 @@ var _ = Describe("Lifecycle", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(1))
-		Expect(sess.Err).To(gbytes.Say("Error: endorsement failure during query. response: status:500 " +
-			"message:\"make sure the chaincode My_1st-Chaincode has been successfully defined on channel testchannel and try " +
-			"again: chaincode definition for 'My_1st-Chaincode' exists, but chaincode is not installed\""))
+		Expect(sess.Err).To(gbytes.Say("make sure the chaincode My_1st-Chaincode has been successfully defined on channel testchannel and try " +
+			"again: chaincode definition for 'My_1st-Chaincode' exists, but chaincode is not installed"))
 
 		By("setting the correct package ID to restore the chaincode")
 		chaincode.PackageID = savedPackageID

--- a/integration/pvtdata/pvtdata_test.go
+++ b/integration/pvtdata/pvtdata_test.go
@@ -135,7 +135,7 @@ var _ bool = Describe("PrivateData", func() {
 				},
 				WaitForEvent: true,
 			}
-			expectedErrMsg := `Error: endorsement failure during invoke. response: status:500 message:"error in simulation: failed to distribute private collection`
+			expectedErrMsg := `error in simulation: failed to distribute private collection`
 			invokeChaincodeExpectErr(network, network.Peer("Org1", "peer0"), command, expectedErrMsg)
 		})
 


### PR DESCRIPTION
A transaction proposal can fail for two reasons:
1) The chaincode return an error (status 500) response
2) Some infrastructure error occurs or error generated in the peer.

For case (1), the ProcessProposal() function will return the ProposalResponse and a nil error.
For case (2), most error paths return both a newly generated status 500 response and the error.  There is one path though (the one that invokes the simulateProposal) that just returns a status 500 response, but a nil error.
This means that client applications (via SDKs or Gateway) cannot destinguish between chaincode raised errors (case 1) and infrastructure errors (case 2).  This is a problem for the gateway which needs to destinguish these two situations in its retry logic.

This commit fixes this by returning the original error (instead of nil) as well as the generated ProposalResponse for this error path.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
