### PR TITLE
Use correct timeout option

### DIFF
--- a/internal/pkg/gateway/gateway.go
+++ b/internal/pkg/gateway/gateway.go
@@ -82,7 +82,7 @@ func newServer(localEndorser peerproto.EndorserClient, discovery Discovery, find
 			localEndorser:      &endorser{client: localEndorser, endpointConfig: &endpointConfig{pkiid: localPKIID, address: localEndpoint, mspid: localMSPID}},
 			discovery:          discovery,
 			logger:             logger,
-			endpointFactory:    &endpointFactory{timeout: options.EndorsementTimeout},
+			endpointFactory:    &endpointFactory{timeout: options.DialTimeout},
 			remoteEndorsers:    map[string]*endorser{},
 			channelInitialized: map[string]bool{},
 		},


### PR DESCRIPTION
The gateway’s endpoint connection factory is currently using the EndorsementTimeout option when making connections.  It should be using the DialTimeout.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
