### PR TITLE
Reword evaluate() error message

### DIFF
--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -198,7 +198,7 @@ func TestEvaluate(t *testing.T) {
 			name:      "no endorsers",
 			plan:      endorsementPlan{},
 			members:   []networkMember{},
-			errString: "rpc error: code = Unavailable desc = no endorsing peers found for chaincode test_chaincode in channel test_channel",
+			errString: "rpc error: code = Unavailable desc = no peers available to evaluate chaincode test_chaincode in channel test_channel",
 		},
 		{
 			name: "five endorsers, prefer local org",
@@ -277,7 +277,7 @@ func TestEvaluate(t *testing.T) {
 				{"id5", "peer4:11051", "msp3", 7},
 			},
 			transientData: map[string][]byte{"transient-key": []byte("transient-value")},
-			errString:     "rpc error: code = Unavailable desc = no endorsers found in the gateway's organization; retry specifying target organization(s) to protect transient data: no endorsing peers found for chaincode test_chaincode in channel test_channel",
+			errString:     "rpc error: code = Unavailable desc = no endorsers found in the gateway's organization; retry specifying target organization(s) to protect transient data: no peers available to evaluate chaincode test_chaincode in channel test_channel",
 		},
 		{
 			name: "evaluate with transient data and target (non-local) orgs should select the highest block height peer",
@@ -399,7 +399,7 @@ func TestEvaluate(t *testing.T) {
 					PKIid:    []byte("ill-defined"),
 				}})
 			},
-			errString: "rpc error: code = Unavailable desc = no endorsing peers found for chaincode test_chaincode in channel test_channel",
+			errString: "rpc error: code = Unavailable desc = no peers available to evaluate chaincode test_chaincode in channel test_channel",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/pkg/gateway/registry.go
+++ b/internal/pkg/gateway/registry.go
@@ -231,7 +231,7 @@ func (reg *registry) evaluator(channel string, chaincode string, targetOrgs []st
 		groupEndorsers := map[string][]*endorser{"g1": allEndorsers}
 		return newPlan(layout, groupEndorsers), nil
 	}
-	return nil, fmt.Errorf("no endorsing peers found for chaincode %s in channel %s", chaincode, channel)
+	return nil, fmt.Errorf("no peers available to evaluate chaincode %s in channel %s", chaincode, channel)
 }
 
 func sorter(e []*endorserState, host string) func(i, j int) bool {


### PR DESCRIPTION
When no suitable peers are available to evaluate a transaction, the registry returns an error.  The message should be reworded to make clear it is being used for evaluation rather than endorsement.

Resolves https://github.com/hyperledger/fabric-gateway/issues/282

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
