### PR TITLE
Facilitate unaware threshold signature endorsement

### DIFF
--- a/common/policies/inquire/compare.go
+++ b/common/policies/inquire/compare.go
@@ -21,6 +21,7 @@ type ComparablePrincipal struct {
 	ou        *msp.OrganizationUnit
 	role      *msp.MSPRole
 	mspID     string
+	idBytes   []byte
 }
 
 // Equal returns whether this ComparablePrincipal is equal to the given ComparablePrincipal.
@@ -44,6 +45,8 @@ func NewComparablePrincipal(principal *msp.MSPPrincipal) *ComparablePrincipal {
 		return cp.ToRole()
 	case msp.MSPPrincipal_ORGANIZATION_UNIT:
 		return cp.ToOURole()
+	case msp.MSPPrincipal_IDENTITY:
+		return cp.ToIdentity()
 	}
 	mapping := msp.MSPPrincipal_Classification_name[int32(principal.PrincipalClassification)]
 	logger.Warning("Received an unsupported principal type:", principal.PrincipalClassification, "mapped to", mapping)
@@ -101,6 +104,10 @@ func (cp *ComparablePrincipal) IsA(other *ComparablePrincipal) bool {
 		return this.role.Role == other.role.Role
 	}
 
+	if this.principal.PrincipalClassification == msp.MSPPrincipal_IDENTITY {
+		return bytes.Equal(this.idBytes, other.idBytes) && this.mspID == other.mspID
+	}
+
 	// Else, we can't say anything, because we have no knowledge
 	// about the OUs that make up the MSP roles - so return false
 	return false
@@ -116,6 +123,19 @@ func (cp *ComparablePrincipal) ToOURole() *ComparablePrincipal {
 	}
 	cp.mspID = ouRole.MspIdentifier
 	cp.ou = ouRole
+	return cp
+}
+
+// ToIdentity converts this ComparablePrincipal to Identity principal, and returns nil on failure
+func (cp *ComparablePrincipal) ToIdentity() *ComparablePrincipal {
+	sID := &msp.SerializedIdentity{}
+	err := proto.Unmarshal(cp.principal.Principal, sID)
+	if err != nil {
+		logger.Warning("Failed unmarshalling principal:", err)
+		return nil
+	}
+	cp.mspID = sID.Mspid
+	cp.idBytes = sID.IdBytes
 	return cp
 }
 

--- a/protoutil/txutils.go
+++ b/protoutil/txutils.go
@@ -208,10 +208,23 @@ func createTx(
 		}
 	}
 
-	// fill endorsements
-	endorsements := make([]*peer.Endorsement, len(resps))
-	for n, r := range resps {
-		endorsements[n] = r.Endorsement
+	// fill endorsements according to their uniqueness
+	endorsersUsed := make(map[string]struct{})
+	var endorsements []*peer.Endorsement
+	for _, r := range resps {
+		if r.Endorsement == nil {
+			continue
+		}
+		key := string(r.Endorsement.Endorser)
+		if _, used := endorsersUsed[key]; used {
+			continue
+		}
+		endorsements = append(endorsements, r.Endorsement)
+		endorsersUsed[key] = struct{}{}
+	}
+
+	if len(endorsements) == 0 {
+		return nil, errors.Errorf("no endorsements")
 	}
 
 	// create ChaincodeEndorsedAction


### PR DESCRIPTION
This commit contains the following two seemingly unrelated changes, each on its own preserving current Fabric behavior:

1. **Deduplicate endorsements in createTx**
This commit makes createTx de-duplicate endorsers according to their identity.
Meaning, when multiple but identical endorsements (same identity) are passed to
the createTx function, it returns a transaction with unique endorsements, and without repeated endorsers.
Since at validation, endorsers are anyway de-duplicated, this commit preserves current system behavior.

2. **Support identity based endorsement policy in discovery**
Currently, whenever a chaincode's endorsement policy contains an identity principal, discovery rejects the policy,
saying that it contains a principal it does not support. This commit simply makes discovery classify the principal.


**Making clients and gateways unaware of a threshold signature scheme**
This commit enables advanced use cases, in which case the endorsements collected for transaction
submission contain identical identities that represent a threshold or aggregation signature scheme.

In such a case, peers can be deployed with custom endorsement plugins and generate a threshold/aggregation signature,
but the flow of service discovery, the client, and peer gateway remains the same.

The endorsement policy can to be an OR over two mutually exclusive cases:
1. An AND over a set of organizational principals (such as Org1.Peer and Org2.Peer)
2. An OR over one or more identities (which can only be signed in collaboration among the peers)
Discovery will always return only combinations of the former kind since no peer can identify with an identity of the latter kind.

The flow will then be as follows: 
1. The client and the gateway interact as usual, and the gateway collects endorsements from several peers.
2. The peers, using the endorsement plugin, engage in a protocol at which end they all return the same endorsement.
3. The gateway submits the transaction (this time, with a single endorsement) to the orderer.
4. Upon transaction validation we validate a single endorsement instead of several.

By enabling threshold signatures, we can maintain security (multiple organizations execute the smart contract and sign over the execution results) without sacrificing performance (transaction ends up with having a single endorsement)

Change-Id: I9193187ae6b08791f8762a9d325442d156c4f828
Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>
