### PR TITLE
Enhance gateway error logic

### DIFF
--- a/core/chaincode/handler.go
+++ b/core/chaincode/handler.go
@@ -91,6 +91,11 @@ type ApplicationConfigRetriever interface {
 	GetApplicationConfig(cid string) (channelconfig.Application, bool)
 }
 
+const (
+	ErrorExecutionTimeout = "timeout expired while executing transaction"
+	ErrorStreamTerminated = "chaincode stream terminated"
+)
+
 // Handler implements the peer side of the chaincode stream.
 type Handler struct {
 	// Keepalive specifies the interval at which keep-alive messages are sent.
@@ -1180,10 +1185,10 @@ func (h *Handler) Execute(txParams *ccprovider.TransactionParams, namespace stri
 		// response is sent to user or calling chaincode. ChaincodeMessage_ERROR
 		// are typically treated as error
 	case <-time.After(timeout):
-		err = errors.New("timeout expired while executing transaction")
+		err = errors.New(ErrorExecutionTimeout)
 		h.Metrics.ExecuteTimeouts.With("chaincode", h.chaincodeID).Add(1)
 	case <-h.streamDone():
-		err = errors.New("chaincode stream terminated")
+		err = errors.New(ErrorStreamTerminated)
 	}
 
 	return ccresp, err

--- a/internal/pkg/gateway/apiutils.go
+++ b/internal/pkg/gateway/apiutils.go
@@ -76,8 +76,8 @@ func toRpcError(err error, unknownCode codes.Code) error {
 	return status.Error(unknownCode, err.Error())
 }
 
-func errorDetail(e *endpointConfig, err error) *gp.ErrorDetail {
-	return &gp.ErrorDetail{Address: e.address, MspId: e.mspid, Message: err.Error()}
+func errorDetail(e *endpointConfig, msg string) *gp.ErrorDetail {
+	return &gp.ErrorDetail{Address: e.address, MspId: e.mspid, Message: msg}
 }
 
 func getResultFromProposalResponse(proposalResponse *peer.ProposalResponse) ([]byte, error) {

--- a/internal/pkg/gateway/endorsement.go
+++ b/internal/pkg/gateway/endorsement.go
@@ -123,9 +123,9 @@ func (p *plan) update(endorser *endorser, endorsement *peer.ProposalResponse) []
 	return nil
 }
 
-// Invoke retry if an endorsement fails for the given endorser.
+// Invoke nextPeerInGroup if an endorsement fails for the given endorser.
 // Returns the next endorser in the same group as given endorser with which to retry the proposal, or nil if there are no more.
-func (p *plan) retry(endorser *endorser) *endorser {
+func (p *plan) nextPeerInGroup(endorser *endorser) *endorser {
 	p.planLock.Lock()
 	defer p.planLock.Unlock()
 

--- a/internal/pkg/gateway/endorsement_test.go
+++ b/internal/pkg/gateway/endorsement_test.go
@@ -60,13 +60,13 @@ func TestSingleLayoutRetry(t *testing.T) {
 	response2 := &peer.ProposalResponse{Payload: []byte("p2")}
 	response3 := &peer.ProposalResponse{Payload: []byte("p3")}
 
-	retry := plan.retry(localhostMock)
+	retry := plan.nextPeerInGroup(localhostMock)
 	require.Equal(t, peer1Mock, retry)
 	endorsements := plan.update(retry, response1)
 	require.Nil(t, endorsements)
 	endorsements = plan.update(peer2Mock, response2)
 	require.Nil(t, endorsements)
-	retry = plan.retry(peer3Mock)
+	retry = plan.nextPeerInGroup(peer3Mock)
 	require.Equal(t, peer4Mock, retry)
 	endorsements = plan.update(retry, response3)
 	require.Len(t, endorsements, 3)
@@ -95,7 +95,7 @@ func TestMultiLayoutRetry(t *testing.T) {
 	response2 := &peer.ProposalResponse{Payload: []byte("p2")}
 
 	// localhost (g1) fails, returns peer1 to retry
-	retry := plan.retry(localhostMock)
+	retry := plan.nextPeerInGroup(localhostMock)
 	require.Equal(t, peer1Mock, retry)
 
 	// peer2 (g2) succeeds
@@ -103,7 +103,7 @@ func TestMultiLayoutRetry(t *testing.T) {
 	require.Nil(t, endorsements)
 
 	// peer1 (g1) also fails - returns nil, since no more peers in g1
-	retry = plan.retry(retry)
+	retry = plan.nextPeerInGroup(retry)
 	require.Nil(t, retry)
 
 	// get endorsers for next layout - should be layout 3 because second layout also required g1
@@ -143,11 +143,11 @@ func TestMultiLayoutFailures(t *testing.T) {
 	require.Nil(t, endorsements)
 
 	// peer2 (g2) fails - returns peer3 to retry
-	retry := plan.retry(peer2Mock)
+	retry := plan.nextPeerInGroup(peer2Mock)
 	require.Equal(t, peer3Mock, retry)
 
 	// peer4 (g3) also fails - returns nil, since no more peers in g3
-	g3retry := plan.retry(peer4Mock)
+	g3retry := plan.nextPeerInGroup(peer4Mock)
 	require.Nil(t, g3retry)
 
 	// retry g2 - succeeds
@@ -162,7 +162,7 @@ func TestMultiLayoutFailures(t *testing.T) {
 	require.Equal(t, peer1Mock, endorsers[0])
 
 	// this one fails too
-	retry = plan.retry(peer1Mock)
+	retry = plan.nextPeerInGroup(peer1Mock)
 	// no more in this group
 	require.Nil(t, retry)
 	endorsers = plan.endorsers()

--- a/internal/pkg/gateway/registry.go
+++ b/internal/pkg/gateway/registry.go
@@ -371,6 +371,9 @@ func (reg *registry) connectChannelPeers(channel string, force bool) error {
 	return nil
 }
 
+// removeEndorser closes the connection and removes from the registry, but if the next call to discovery returns that
+// peer in its plan, then it will attempt to reconnect and add it back. This could happen if the peer had gone down,
+// but the gossip has not notified the discovery service yet.
 func (reg *registry) removeEndorser(endorser *endorser) {
 	if endorser == reg.localEndorser {
 		// nothing to close


### PR DESCRIPTION
Add logic to determine the origin of the error returned by ProcessProposal, and whether the evaluate/endorse methods should close the connection to the peer and/or retry the proposal on another peer.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
