### PR TITLE
Don't use EndorseResponse.Result field

### DIFF
--- a/integration/gateway/endorsing_orgs_test.go
+++ b/integration/gateway/endorsing_orgs_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/integration/nwo"
+	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/tedsuo/ifrit"
@@ -139,7 +140,11 @@ func submitCheckEndorsingOrgsTransaction(ctx context.Context, client gateway.Gat
 	endorseResponse, err := client.Endorse(ctx, endorseRequest)
 	Expect(err).NotTo(HaveOccurred())
 
-	result := endorseResponse.GetResult()
+	chaincodeAction, err := protoutil.GetActionFromEnvelopeMsg(endorseResponse.GetPreparedTransaction())
+	Expect(err).NotTo(HaveOccurred())
+
+	result := chaincodeAction.GetResponse()
+
 	expectedPayload := "Peer mspid OK"
 	Expect(string(result.Payload)).To(Equal(expectedPayload))
 	expectedResult := &peer.Response{

--- a/integration/gateway/gateway_discovery_test.go
+++ b/integration/gateway/gateway_discovery_test.go
@@ -236,7 +236,10 @@ var _ = Describe("GatewayService with endorser discovery", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(statusResponse.Result).To(Equal(peer.TxValidationCode_VALID))
 
-		return endorseResponse.Result
+		chaincodeAction, err := protoutil.GetActionFromEnvelopeMsg(endorseResponse.GetPreparedTransaction())
+		Expect(err).NotTo(HaveOccurred())
+
+		return chaincodeAction.GetResponse()
 	}
 
 	evaluateTransaction := func(
@@ -587,6 +590,6 @@ var _ = Describe("GatewayService with endorser discovery", func() {
 			[]string{org1Peer0.ID()},
 		)
 
-		Expect(result.Payload).To(Equal([]byte("abcd")))
+		Expect(result.GetPayload()).To(Equal([]byte("abcd")))
 	})
 })

--- a/integration/gateway/gateway_test.go
+++ b/integration/gateway/gateway_test.go
@@ -179,7 +179,10 @@ var _ = Describe("GatewayService", func() {
 		_, err = gatewayClient.Submit(ctx, submitRequest)
 		Expect(err).NotTo(HaveOccurred())
 
-		return endorseResponse.Result, transactionID
+		chaincodeAction, err := protoutil.GetActionFromEnvelopeMsg(endorseResponse.GetPreparedTransaction())
+		Expect(err).NotTo(HaveOccurred())
+
+		return chaincodeAction.GetResponse(), transactionID
 	}
 
 	commitStatus := func(transactionID string, identity func() ([]byte, error), sign func(msg []byte) ([]byte, error)) (*gateway.CommitStatusResponse, error) {

--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -838,11 +838,14 @@ func TestEndorse(t *testing.T) {
 
 			// test the assertions
 			require.NoError(t, err)
+
 			// assert the preparedTxn is the payload from the proposal response
-			require.Equal(t, []byte("mock_response"), response.Result.Payload, "Incorrect response")
+			chaincodeAction, err := protoutil.GetActionFromEnvelopeMsg(response.GetPreparedTransaction())
+			require.NoError(t, err)
+			require.Equal(t, []byte("mock_response"), chaincodeAction.GetResponse().GetPayload(), "Incorrect response")
 
 			// check the generated transaction envelope contains the correct endorsements
-			checkTransaction(t, tt.expectedEndorsers, response.PreparedTransaction)
+			checkTransaction(t, tt.expectedEndorsers, response.GetPreparedTransaction())
 
 			// check the correct endorsers (mocks) were called with the right parameters
 			checkEndorsers(t, tt.expectedEndorsers, test)


### PR DESCRIPTION
This duplicates information already held within the transaction envelope, and can cause failures on gRPC message size limit with large transaction results.
    
Also:
- nil out the ProposalResponse.Response.Payload field in EndorseResponse messages since, in the successful endorsement case, this is typically populated with a duplicate of the transaction result. This field is not required by the Fabric Gateway client and can cause gRPC message size limit failures.
- prefer the transaction result within the proposal response payload for EvaluateResponse messages since the Response.Payload in the proposal response is not required to be the transaction result and may instead contain metadata.

Contributes to hyperledger/fabric-gateway#316