### PR TITLE
add http proxy support to core/chaincode/platforms

### DIFF
--- a/core/chaincode/platforms/golang/platform.go
+++ b/core/chaincode/platforms/golang/platform.go
@@ -228,7 +228,7 @@ echo Done!
 
 func (p *Platform) DockerBuildOptions(path string) (util.DockerBuildOptions, error) {
 	env := []string{}
-	for _, key := range []string{"GOPROXY", "GOSUMDB"} {
+	for _, key := range []string{"GOPROXY", "GOSUMDB", "https_proxy", "http_proxy", "no_proxy", "HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY"} {
 		if val, ok := os.LookupEnv(key); ok {
 			env = append(env, fmt.Sprintf("%s=%s", key, val))
 			continue

--- a/core/chaincode/platforms/java/platform.go
+++ b/core/chaincode/platforms/java/platform.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 
@@ -130,8 +131,20 @@ func (p *Platform) GenerateDockerfile() (string, error) {
 }
 
 func (p *Platform) DockerBuildOptions(path string) (util.DockerBuildOptions, error) {
+	env := []string{}
+	for _, key := range []string{
+		"https_proxy", "http_proxy", "no_proxy", "HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY",
+		"JAVA_OPTS", "JAVA_TOOL_OPTIONS", "MAVEN_OPTS", "GRADLE_OPTS",
+	} {
+		if val, ok := os.LookupEnv(key); ok {
+			env = append(env, fmt.Sprintf("%s=%s", key, val))
+			continue
+		}
+	}
+
 	return util.DockerBuildOptions{
 		Image: util.GetDockerImageFromConfig("chaincode.java.runtime"),
 		Cmd:   "./build.sh",
+		Env:   env,
 	}, nil
 }

--- a/core/chaincode/platforms/node/platform.go
+++ b/core/chaincode/platforms/node/platform.go
@@ -183,8 +183,17 @@ fi
 `
 
 func (p *Platform) DockerBuildOptions(path string) (util.DockerBuildOptions, error) {
+	env := []string{}
+	for _, key := range []string{"https_proxy", "http_proxy", "no_proxy", "HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY"} {
+		if val, ok := os.LookupEnv(key); ok {
+			env = append(env, fmt.Sprintf("%s=%s", key, val))
+			continue
+		}
+	}
+
 	return util.DockerBuildOptions{
 		Image: util.GetDockerImageFromConfig("chaincode.node.runtime"),
 		Cmd:   buildScript,
+		Env:   env,
 	}, nil
 }

--- a/core/chaincode/platforms/node/platform_test.go
+++ b/core/chaincode/platforms/node/platform_test.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hyperledger/fabric/core/chaincode/platforms/util"
 	"github.com/hyperledger/fabric/core/config/configtest"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
@@ -140,14 +139,43 @@ fi
 `
 
 func TestGenerateBuildOptions(t *testing.T) {
-	opts, err := platform.DockerBuildOptions("pathname")
-	require.NoError(t, err)
+	t.Run("basic test", func(t *testing.T) {
+		opts, err := platform.DockerBuildOptions("pathname")
+		require.NoError(t, err)
 
-	expectedOpts := util.DockerBuildOptions{
-		Image: "hyperledger/fabric-nodeenv:latest",
-		Cmd:   expectedBuildScript,
-	}
-	require.Equal(t, expectedOpts, opts)
+		require.Equal(t, opts.Image, "hyperledger/fabric-nodeenv:latest")
+		require.Equal(t, opts.Cmd, expectedBuildScript)
+	})
+
+	t.Run("proxy test", func(t *testing.T) {
+		env := map[string]string{
+			"https_proxy": "the-httpsproxy",
+			"http_proxy":  "the-httpproxy",
+			"no_proxy":    "the-noproxy",
+			"HTTPS_PROXY": "THE-HTTPSPROXY",
+			"HTTP_PROXY":  "THE-HTTPPROXY",
+			"NO_PROXY":    "THE-NOPROXY",
+		}
+
+		for key, val := range env {
+			oldval, set := os.LookupEnv(key)
+			if set {
+				defer os.Setenv(key, oldval)
+			} else {
+				defer os.Unsetenv(key)
+			}
+			os.Setenv(key, val)
+		}
+
+		opts, err := platform.DockerBuildOptions("the-path")
+		require.NoError(t, err, "unexpected error from DockerBuildOptions")
+
+		require.Equal(t, opts.Image, "hyperledger/fabric-nodeenv:latest")
+		require.Equal(t, opts.Cmd, expectedBuildScript)
+		for key, val := range env {
+			require.Contains(t, opts.Env, fmt.Sprintf("%s=%s", key, val))
+		}
+	})
 }
 
 func makeCodePackage(pfiles []*packageFile) ([]byte, error) {

--- a/docs/source/dev-setup/devenv.rst
+++ b/docs/source/dev-setup/devenv.rst
@@ -204,5 +204,19 @@ If those commands completely successfully, you're ready to Go!
 
 If you plan to use the Hyperledger Fabric application SDKs then be sure to check out their prerequisites in the Node.js SDK `README <https://github.com/hyperledger/fabric-sdk-node#build-and-test>`__, Java SDK `README <https://github.com/hyperledger/fabric-gateway-java/blob/main/README.md>`__, and Go SDK `README <https://github.com/hyperledger/fabric-sdk-go/blob/main/README.md>`__.
 
+
+setup no_proxy environment variable when your devenv localted behind http proxy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Fabric test codes use some fake domains and hostnames (without domain).
+When your devenv is located behind http proxy, you need to add them in no_proxy environment variable as below to avoid test making the wrong judge.
+
+::
+
+    export no_proxy='localhost,127.0.0.1/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.local,.example.com,.host.com,host.com,.invalid,couchdb'
+
+Note that you may need to add your domain to no_proxy.
+
+
 .. Licensed under Creative Commons Attribution 4.0 International License
    https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
Signed-off-by: itaru2622 <itaru2622@gmail.com>

close #3066 

#### Type of change

- New feature

#### Description

add http proxy support to chaincode container build phase when fabric-peer container run with  "-e https_proxy=... " 
for details, refer #3066 

#### Additional details

when your devenv is located behind http proxy, additional no_proxy entries may be required to pass unit-test and integration-test.
the reasons is  described in #3066 and end of docs/sources/dev-setup/devenv.rst
