### PR TITLE
goimports updates to prepare for Go 1.17

### DIFF
--- a/bccsp/factory/nopkcs11.go
+++ b/bccsp/factory/nopkcs11.go
@@ -1,3 +1,4 @@
+//go:build !pkcs11
 // +build !pkcs11
 
 /*

--- a/bccsp/factory/nopkcs11_test.go
+++ b/bccsp/factory/nopkcs11_test.go
@@ -1,3 +1,4 @@
+//go:build !pkcs11
 // +build !pkcs11
 
 /*

--- a/bccsp/factory/pkcs11.go
+++ b/bccsp/factory/pkcs11.go
@@ -1,3 +1,4 @@
+//go:build pkcs11
 // +build pkcs11
 
 /*

--- a/bccsp/factory/pkcs11_test.go
+++ b/bccsp/factory/pkcs11_test.go
@@ -1,3 +1,4 @@
+//go:build pkcs11
 // +build pkcs11
 
 /*

--- a/bccsp/factory/pkcs11factory.go
+++ b/bccsp/factory/pkcs11factory.go
@@ -1,3 +1,4 @@
+//go:build pkcs11
 // +build pkcs11
 
 /*

--- a/bccsp/factory/pkcs11factory_test.go
+++ b/bccsp/factory/pkcs11factory_test.go
@@ -1,3 +1,4 @@
+//go:build pkcs11
 // +build pkcs11
 
 /*

--- a/bccsp/pkcs11/pkcs11_test.go
+++ b/bccsp/pkcs11/pkcs11_test.go
@@ -1,3 +1,4 @@
+//go:build pkcs11
 // +build pkcs11
 
 /*

--- a/core/handlers/library/noplugin_test.go
+++ b/core/handlers/library/noplugin_test.go
@@ -1,3 +1,4 @@
+//go:build noplugin
 // +build noplugin
 
 /*

--- a/core/handlers/library/plugin.go
+++ b/core/handlers/library/plugin.go
@@ -1,4 +1,5 @@
-//+build !noplugin,cgo
+//go:build !noplugin && cgo
+// +build !noplugin,cgo
 
 /*
  Copyright IBM Corp, SecureKey Technologies Inc. All Rights Reserved.

--- a/core/handlers/library/plugin_stub.go
+++ b/core/handlers/library/plugin_stub.go
@@ -1,4 +1,5 @@
-//+build noplugin !cgo
+//go:build noplugin || !cgo
+// +build noplugin !cgo
 
 /*
  Copyright IBM Corp All Rights Reserved.

--- a/core/handlers/library/race_test.go
+++ b/core/handlers/library/race_test.go
@@ -1,3 +1,4 @@
+//go:build race
 // +build race
 
 /*

--- a/integration/ledger/ledger_generate_test.go
+++ b/integration/ledger/ledger_generate_test.go
@@ -1,3 +1,4 @@
+//go:build generate
 // +build generate
 
 /*

--- a/internal/fileutil/syncdir.go
+++ b/internal/fileutil/syncdir.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/internal/peer/node/signals.go
+++ b/internal/peer/node/signals.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/internal/peer/node/signals_windows.go
+++ b/internal/peer/node/signals_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/orderer/common/server/signals.go
+++ b/orderer/common/server/signals.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/orderer/common/server/signals_windows.go
+++ b/orderer/common/server/signals_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*


### PR DESCRIPTION
Run goimports to make code compatible with Go 1.17.
The changes work with both Go 1.16 and Go 1.17, therefore it can be merged now.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
