### PR TITLE
Clarify v2.x upgrade docs

### DIFF
--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -37,7 +37,7 @@ as there has been for previous releases.
 
 .. note:: It is a best practice to upgrade your SDK to the latest version as a
           part of a general upgrade of your network. While the SDK will always
-          be compatible with equivalent releases of Fabric and lower, it might
+          be compatible with equivalent releases of Fabric and higher, it might
           be necessary to upgrade to the latest SDK to leverage the latest Fabric
           features. Consult the documentation of the Fabric SDK you are using
           for information about how to upgrade.


### PR DESCRIPTION
Combine the v2.x to v2.x instructions in a single section.

For v1.x to v2.x, clarify which steps should occur prior to updating peers,
while updating peers, and after updating peers, by adding a section header for each.

Finally, clarify that existing chaincodes will automatically shift from old lifecycle framework
to new lifecycle framework upon the first install/approve/commit after enabling the
v2.x lifecycle (i.e., after updating the V2_0 application capability).

Signed-off-by: David Enyeart <enyeart@us.ibm.com>