### PR TITLE
Add read version to the example in read-write set

### DIFF
--- a/docs/source/readwrite.rst
+++ b/docs/source/readwrite.rst
@@ -121,10 +121,10 @@ each of these transactions.
 
     World state: (k1,1,v1), (k2,1,v2), (k3,1,v3), (k4,1,v4), (k5,1,v5)
     T1 -> Write(k1, v1'), Write(k2, v2')
-    T2 -> Read(k1), Write(k3, v3')
+    T2 -> Read(k1,1), Write(k3, v3')
     T3 -> Write(k2, v2'')
-    T4 -> Write(k2, v2'''), read(k2)
-    T5 -> Write(k6, v6'), read(k5)
+    T4 -> Write(k2, v2'''), read(k2,1)
+    T5 -> Write(k6, v6'), read(k5,1)
 
 Now, assume that these transactions are ordered in the sequence of
 T1,..,T5 (could be contained in a single block or different blocks)
@@ -133,18 +133,18 @@ T1,..,T5 (could be contained in a single block or different blocks)
    Further, the tuple of keys ``k1`` and ``k2`` in the world state are
    updated to ``(k1,2,v1'), (k2,2,v2')``
 
-2. ``T2`` fails validation because it reads a key, ``k1``, which was
-   modified by a preceding transaction - ``T1``
+2. ``T2`` fails validation because it reads key ``k1`` of version 1 but ``k1``
+   in the world state has progressed to version 2
 
-3. ``T3`` passes the validation because it does not perform a read.
-   Further the tuple of the key, ``k2``, in the world state is updated
-   to ``(k2,3,v2'')``
+3. ``T3`` passes the validation because it does not perform a read.  Further 
+   the tuple of the key, ``k2``, in the world state is updated to 
+   ``(k2,3,v2'')``
 
-4. ``T4`` fails the validation because it reads a key, ``k2``, which was
-   modified by a preceding transaction ``T1``
+4. ``T4`` fails the validation because it reads key ``k2`` of version 1 but
+   ``k2`` in the world state has progressed to version 3
 
-5. ``T5`` passes validation because it reads a key, ``k5``, which was
-   not modified by any of the preceding transactions
+5. ``T5`` passes validation because it reads a key, ``k5``, which is still on
+   version 1
 
 **Note**: Transactions with multiple read-write sets are not yet supported.
 


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description


Per discussion, we want to add read version to the example in read-write set so that

1. the read version described in the earlier description appears in this example.
2. show readers clearly that a transaction is rejected due to read version mismatch.

#### Related issues

Fixes #3015 

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
