### PR TITLE
Create HashedIndex in Pvtdata Store retroactively

### DIFF
--- a/common/ledger/util/leveldbhelper/leveldb_helper_test.go
+++ b/common/ledger/util/leveldbhelper/leveldb_helper_test.go
@@ -25,7 +25,7 @@ func TestLevelDBHelperWriteWithoutOpen(t *testing.T) {
 			t.Fatalf("A panic is expected when writing to db before opening")
 		}
 	}()
-	db.Put([]byte("key"), []byte("value"), false)
+	require.NoError(t, db.Put([]byte("key"), []byte("value"), false))
 }
 
 func TestLevelDBHelperReadWithoutOpen(t *testing.T) {
@@ -37,7 +37,8 @@ func TestLevelDBHelperReadWithoutOpen(t *testing.T) {
 			t.Fatalf("A panic is expected when writing to db before opening")
 		}
 	}()
-	db.Get([]byte("key"))
+	_, err := db.Get([]byte("key"))
+	require.NoError(t, err)
 }
 
 func TestLevelDBHelper(t *testing.T) {
@@ -51,15 +52,15 @@ func TestLevelDBHelper(t *testing.T) {
 	IsEmpty, err := db.IsEmpty()
 	require.NoError(t, err)
 	require.True(t, IsEmpty)
-	db.Put([]byte("key1"), []byte("value1"), false)
-	db.Put([]byte("key2"), []byte("value2"), true)
-	db.Put([]byte("key3"), []byte("value3"), true)
+	require.NoError(t, db.Put([]byte("key1"), []byte("value1"), false))
+	require.NoError(t, db.Put([]byte("key2"), []byte("value2"), true))
+	require.NoError(t, db.Put([]byte("key3"), []byte("value3"), true))
 
 	val, _ := db.Get([]byte("key2"))
 	require.Equal(t, "value2", string(val))
 
-	db.Delete([]byte("key1"), false)
-	db.Delete([]byte("key2"), true)
+	require.NoError(t, db.Delete([]byte("key1"), false))
+	require.NoError(t, db.Delete([]byte("key2"), true))
 
 	val1, err1 := db.Get([]byte("key1"))
 	require.NoError(t, err1, "")
@@ -89,7 +90,7 @@ func TestLevelDBHelper(t *testing.T) {
 	batch.Put([]byte("key1"), []byte("value1"))
 	batch.Put([]byte("key2"), []byte("value2"))
 	batch.Delete([]byte("key3"))
-	db.WriteBatch(batch, true)
+	require.NoError(t, db.WriteBatch(batch, true))
 
 	val1, err1 = db.Get([]byte("key1"))
 	require.NoError(t, err1, "")

--- a/core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util.go
+++ b/core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util.go
@@ -299,7 +299,7 @@ func nsPvtRwSetFromProtoMsg(protoMsg *rwset.NsPvtReadWriteSet) (*NsPvtRwSet, err
 	for _, collPvtRwSetProtoMsg := range protoMsg.CollectionPvtRwset {
 		var err error
 		var collPvtRwSet *CollPvtRwSet
-		if collPvtRwSet, err = collPvtRwSetFromProtoMsg(collPvtRwSetProtoMsg); err != nil {
+		if collPvtRwSet, err = CollPvtRwSetFromProtoMsg(collPvtRwSetProtoMsg); err != nil {
 			return nil, err
 		}
 		nsPvtRwSet.CollPvtRwSets = append(nsPvtRwSet.CollPvtRwSets, collPvtRwSet)
@@ -316,7 +316,7 @@ func (collPvtRwSet *CollPvtRwSet) toProtoMsg() (*rwset.CollectionPvtReadWriteSet
 	return protoMsg, nil
 }
 
-func collPvtRwSetFromProtoMsg(protoMsg *rwset.CollectionPvtReadWriteSet) (*CollPvtRwSet, error) {
+func CollPvtRwSetFromProtoMsg(protoMsg *rwset.CollectionPvtReadWriteSet) (*CollPvtRwSet, error) {
 	collPvtRwSet := &CollPvtRwSet{CollectionName: protoMsg.CollectionName, KvRwSet: &kvrwset.KVRWSet{}}
 	if err := proto.Unmarshal(protoMsg.Rwset, collPvtRwSet.KvRwSet); err != nil {
 		return nil, err

--- a/core/ledger/pvtdatastorage/retroactive_hashed_index.go
+++ b/core/ledger/pvtdatastorage/retroactive_hashed_index.go
@@ -1,0 +1,176 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pvtdatastorage
+
+import (
+	"time"
+
+	"github.com/hyperledger/fabric-protos-go/ledger/rwset"
+	"github.com/hyperledger/fabric/common/ledger/util/leveldbhelper"
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
+	"github.com/hyperledger/fabric/core/ledger/util"
+	"github.com/pkg/errors"
+)
+
+const (
+	previousDataVersion = ""
+	currentDataVersion  = "2.5"
+	maxUpgradeBatchSize = 4 * 1024 * 1024 // 4 MB
+)
+
+func checkAndConstructHashedIndex(storePath string, ledgerIDs []string) error {
+	info, err := leveldbhelper.RetrieveDataFormatInfo(storePath)
+	if err != nil {
+		return err
+	}
+
+	if info.IsDBEmpty || info.FormatVerison == currentDataVersion {
+		return nil
+	}
+
+	if info.FormatVerison == previousDataVersion {
+		if err := constructHashedIndex(storePath, ledgerIDs); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	return errors.Errorf("unexpected data version - cannot upgrade data format for pvtdatastore from %s to %s", info.FormatVerison, currentDataVersion)
+}
+
+// constructHashedIndex creates the HashedIndex entries for the private data keys and at the end sets the
+// data format version to the current version (2.5)
+func constructHashedIndex(storePath string, ledgerIDs []string) error {
+	p, err := leveldbhelper.NewProvider(
+		&leveldbhelper.Conf{
+			DBPath:         storePath,
+			ExpectedFormat: previousDataVersion,
+		})
+	if err != nil {
+		return err
+	}
+
+	defer p.Close()
+
+	for _, l := range ledgerIDs {
+		db := p.GetDBHandle(l)
+		if err := constructHashedIndexFor(l, db); err != nil {
+			return err
+		}
+	}
+	return p.SetDataFormat(currentDataVersion)
+}
+
+// constructHashedIndexFor creates the HashedIndex entries for a given ledger.
+// In this function we also piggyback to upgrade any private data key from format V11 to V12
+func constructHashedIndexFor(ledgerID string, db *leveldbhelper.DBHandle) error {
+	startKey, endKey := entireDatakeyRange()
+	itr, err := db.GetIterator(startKey, endKey)
+	if err != nil {
+		return err
+	}
+	defer itr.Release()
+
+	batch := db.NewUpdateBatch()
+
+	initialTime := time.Now()
+	numEntriesCreated := 0
+	logger.Infow("Starting creation of HashedIndex entries retroactively", "ledgerID", ledgerID)
+	for itr.Next() {
+		k := itr.Key()
+		v := itr.Value()
+
+		// In pvtdatastore, we used to persist the data of entire transaction as a single KV in V11.
+		// Later, when we introduced BlockToLive, we started storing each collection data as a KV.
+		// Here we leverage this opportunity (when we create HashedIndexKeys retroactively) to convert
+		// the private data in V11 format, if any so in the next available opportunity,
+		// we will remove the code where we have to detect this difference while processing queries on pvtdatastore.
+		v11Fmt, err := v11Format(k)
+		if err != nil {
+			return err
+		}
+
+		if v11Fmt {
+			blockNum, _, err := v11DecodePK(k)
+			if err != nil {
+				return err
+			}
+
+			txPvtData, err := v11DecodeKV(k, v, nil)
+			if err != nil {
+				return err
+			}
+
+			dataEntries := prepareDataEntries(blockNum, []*ledger.TxPvtData{txPvtData})
+			for _, dataEntry := range dataEntries {
+				var dataKey, dataVal []byte
+				dataKey = encodeDataKey(dataEntry.key)
+				if dataVal, err = encodeDataValue(dataEntry.value); err != nil {
+					return err
+				}
+				batch.Put(dataKey, dataVal)
+				if err := addHashedIndexEntriesInto(batch, dataEntry.key, dataEntry.value); err != nil {
+					return err
+				}
+				numEntriesCreated++
+			}
+			batch.Delete(k)
+		} else {
+			dataKey, err := decodeDatakey(k)
+			if err != nil {
+				return err
+			}
+
+			dataVal, err := decodeDataValue(v)
+			if err != nil {
+				return err
+			}
+			if err := addHashedIndexEntriesInto(batch, dataKey, dataVal); err != nil {
+				return err
+			}
+			numEntriesCreated++
+		}
+
+		if batch.Size() >= maxUpgradeBatchSize {
+			if err := db.WriteBatch(batch, true); err != nil {
+				return err
+			}
+			if (time.Since(initialTime) / time.Second) > 5 {
+				initialTime = time.Now()
+				logger.Infow("Creating HashedIndex entries retroactively...", "total entries created", numEntriesCreated, "ledgerID", ledgerID)
+			}
+			batch.Reset()
+		}
+	}
+
+	if err := db.WriteBatch(batch, true); err != nil {
+		return err
+	}
+	logger.Infow("Creation of HashedIndex entries retroactively done", "total entries created", numEntriesCreated, "ledgerID", ledgerID)
+	return nil
+}
+
+func addHashedIndexEntriesInto(batch *leveldbhelper.UpdateBatch, dataKey *dataKey, dataValue *rwset.CollectionPvtReadWriteSet) error {
+	collPvtRWSet, err := rwsetutil.CollPvtRwSetFromProtoMsg(dataValue)
+	if err != nil {
+		return err
+	}
+	for _, kvWrite := range collPvtRWSet.KvRwSet.Writes {
+		k := encodeHashedIndexKey(
+			&hashedIndexKey{
+				ns:         dataKey.ns,
+				coll:       dataKey.coll,
+				pvtkeyHash: util.ComputeStringHash(kvWrite.Key),
+				blkNum:     dataKey.blkNum,
+				txNum:      dataKey.txNum,
+			},
+		)
+		batch.Put(k, []byte(kvWrite.Key))
+	}
+	return nil
+}

--- a/core/ledger/pvtdatastorage/retroactive_hashed_index_test.go
+++ b/core/ledger/pvtdatastorage/retroactive_hashed_index_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pvtdatastorage
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
+	"github.com/hyperledger/fabric/common/ledger/testutil"
+	"github.com/hyperledger/fabric/common/ledger/util/leveldbhelper"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
+	btltestutil "github.com/hyperledger/fabric/core/ledger/pvtdatapolicy/testutil"
+	"github.com/hyperledger/fabric/core/ledger/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstructHashedIndexAndUpgradeDataFmtRetroactively(t *testing.T) {
+	testWorkingDir, err := ioutil.TempDir("", "pdstore")
+	require.NoError(t, err)
+	defer os.RemoveAll(testWorkingDir)
+
+	require.NoError(t, testutil.CopyDir("testdata/v11_v12/ledgersData/pvtdataStore", testWorkingDir, false))
+	storePath := filepath.Join(testWorkingDir, "pvtdataStore")
+
+	require.NoError(t, checkAndConstructHashedIndex(storePath, []string{"ch1"}))
+
+	levelProvider, err := leveldbhelper.NewProvider(&leveldbhelper.Conf{
+		DBPath:         storePath,
+		ExpectedFormat: currentDataVersion,
+	})
+	require.NoError(t, err)
+
+	pvtdataConf := pvtDataConf()
+	pvtdataConf.StorePath = storePath
+	storeProvider := &Provider{
+		dbProvider: levelProvider,
+		pvtData:    pvtdataConf,
+	}
+	defer storeProvider.Close()
+
+	s, err := storeProvider.OpenStore("ch1")
+	require.NoError(t, err)
+	s.Init(btltestutil.SampleBTLPolicy(
+		map[[2]string]uint64{
+			{"marbles_private", "collectionMarbles"}:              0,
+			{"marbles_private", "collectionMarblePrivateDetails"}: 0,
+		},
+	))
+
+	t.Run("v11-data-got-upgraded-to-v12-fmt", func(t *testing.T) {
+		startKey, endKey := getDataKeysForRangeScanByBlockNum(10)
+		itr, err := s.db.GetIterator(startKey, endKey)
+		require.NoError(t, err)
+		defer itr.Release()
+		for itr.Next() {
+			dataKeyBytes := itr.Key()
+			v11Fmt, err := v11Format(dataKeyBytes)
+			require.NoError(t, err)
+			require.False(t, v11Fmt)
+		}
+	})
+
+	t.Run("upgraded-v11-data-can-be-retrieved", func(t *testing.T) {
+		pvtdata, err := s.GetPvtDataByBlockNum(10, nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(pvtdata))
+		require.Equal(t, uint64(0), pvtdata[0].SeqInBlock)
+		pvtWS, err := rwsetutil.TxPvtRwSetFromProtoMsg(pvtdata[0].WriteSet)
+		require.NoError(t, err)
+
+		require.Equal(t, &rwsetutil.TxPvtRwSet{
+			NsPvtRwSet: []*rwsetutil.NsPvtRwSet{
+				{
+					NameSpace: "marbles_private",
+					CollPvtRwSets: []*rwsetutil.CollPvtRwSet{
+						{
+							CollectionName: "collectionMarblePrivateDetails",
+							KvRwSet: &kvrwset.KVRWSet{
+								Writes: []*kvrwset.KVWrite{
+									{
+										Key:   "marble1",
+										Value: []byte(`{"docType":"marblePrivateDetails","name":"marble1","price":150}`),
+									},
+								},
+							},
+						},
+
+						{
+							CollectionName: "collectionMarbles",
+							KvRwSet: &kvrwset.KVRWSet{
+								Writes: []*kvrwset.KVWrite{
+									{
+										Key:   "marble1",
+										Value: []byte(`{"docType":"marble","name":"marble1","color":"blue","size":100,"owner":"tom"}`),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+			pvtWS,
+		)
+	})
+
+	t.Run("hashed-indexs-get-constructed", func(t *testing.T) {
+		expectedIndexEntries := []*hashedIndexKey{
+			{
+				ns:         "marbles_private",
+				coll:       "collectionMarblePrivateDetails",
+				pvtkeyHash: util.ComputeStringHash("marble1"),
+				blkNum:     10,
+				txNum:      0,
+			},
+			{
+				ns:         "marbles_private",
+				coll:       "collectionMarbles",
+				pvtkeyHash: util.ComputeStringHash("marble1"),
+				blkNum:     10,
+				txNum:      0,
+			},
+			{
+				ns:         "marbles_private",
+				coll:       "collectionMarblePrivateDetails",
+				pvtkeyHash: util.ComputeStringHash("marble2"),
+				blkNum:     14,
+				txNum:      0,
+			},
+			{
+				ns:         "marbles_private",
+				coll:       "collectionMarbles",
+				pvtkeyHash: util.ComputeStringHash("marble2"),
+				blkNum:     14,
+				txNum:      0,
+			},
+		}
+
+		for i, e := range expectedIndexEntries {
+			t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+				val, err := s.db.Get(encodeHashedIndexKey(e))
+				require.NoError(t, err)
+				require.Equal(t, e.pvtkeyHash, util.ComputeHash(val))
+			})
+		}
+	})
+
+	// keep this as last test as this closes the storeProvider
+	t.Run("hashed-indexs-construction-is-done-only-once", func(t *testing.T) {
+		storeProvider.Close()
+		err := constructHashedIndex(storePath, []string{"ch1"})
+		require.ErrorContains(t, err, "data format = [2.5], expected format = []")
+	})
+}

--- a/core/ledger/pvtdatastorage/store.go
+++ b/core/ledger/pvtdatastorage/store.go
@@ -114,6 +114,12 @@ type bootKVHashesKey struct {
 	coll   string
 }
 
+type hashedIndexKey struct {
+	ns, coll      string
+	pvtkeyHash    []byte
+	blkNum, txNum uint64
+}
+
 type storeEntries struct {
 	dataEntries             []*dataEntry
 	expiryEntries           []*expiryEntry


### PR DESCRIPTION

Signed-off-by: manish <manish.sethi@gmail.com>

- Add functions in the pvtdata store package that would be used for creating the HashedIndex in Pvtdata Store retroactively.
- We use this opportunity to upgrade the data format from V11 to V12, so we can simplify the reading code in the future releases.
- Small refactoring is included to simplify the usage of update batch.

#### Type of change
- New feature

#### Related issues
- [RFC](https://github.com/hyperledger/fabric-rfcs/blob/main/text/0000-private_data_purge.md)
- [Issue](https://github.com/hyperledger/fabric/issues/3022) 