### PR TITLE
Randomize endorsement layouts

### DIFF
--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -573,7 +573,7 @@ func TestEndorse(t *testing.T) {
 			errString:     "failed to find any endorsing peers for org(s): msp4, msp5",
 		},
 		{
-			name: "endorse with multiple layouts - default choice first layout",
+			name: "endorse retry - localhost and peer3 fail - retry on peer1 and peer2",
 			plan: endorsementPlan{
 				"g1": {{endorser: localhostMock, height: 4}, {endorser: peer1Mock, height: 4}}, // msp1
 				"g2": {{endorser: peer2Mock, height: 3}, {endorser: peer3Mock, height: 4}},     // msp2
@@ -581,22 +581,6 @@ func TestEndorse(t *testing.T) {
 			},
 			layouts: []endorsementLayout{
 				{"g1": 1, "g2": 1},
-				{"g1": 1, "g3": 1},
-				{"g2": 1, "g3": 1},
-			},
-			expectedEndorsers: []string{"localhost:7051", "peer3:10051"},
-		},
-		{
-			name: "endorse retry - localhost and peer2 fail - retry on peer1 and peer2",
-			plan: endorsementPlan{
-				"g1": {{endorser: localhostMock, height: 4}, {endorser: peer1Mock, height: 4}}, // msp1
-				"g2": {{endorser: peer2Mock, height: 3}, {endorser: peer3Mock, height: 4}},     // msp2
-				"g3": {{endorser: peer4Mock, height: 5}},                                       // msp3
-			},
-			layouts: []endorsementLayout{
-				{"g1": 1, "g2": 1},
-				{"g1": 1, "g3": 1},
-				{"g2": 1, "g3": 1},
 			},
 			postSetup: func(t *testing.T, def *preparedTest) {
 				def.localEndorser.ProcessProposalReturns(nil, status.Error(codes.Aborted, "bad local endorser"))

--- a/internal/pkg/gateway/registry.go
+++ b/internal/pkg/gateway/registry.go
@@ -9,6 +9,7 @@ package gateway
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"sort"
 	"strings"
 	"sync"
@@ -139,6 +140,9 @@ layout:
 		}
 	}
 
+	// shuffle the layouts - keep the preferred ones first
+	rand.Shuffle(len(preferredLayouts), func(i, j int) { preferredLayouts[i], preferredLayouts[j] = preferredLayouts[j], preferredLayouts[i] })
+	rand.Shuffle(len(otherLayouts), func(i, j int) { otherLayouts[i], otherLayouts[j] = otherLayouts[j], otherLayouts[i] })
 	layouts := append(preferredLayouts, otherLayouts...)
 
 	if len(layouts) == 0 {


### PR DESCRIPTION
Cherry pick of https://github.com/hyperledger/fabric/commit/7c736c44b5b9d2ba4d64d148a8fca2be2bb59341 from main branch

For improved load balancing and fairer workload distribution across organizations, then gateway should randomize the endorsement layouts

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
