### PR TITLE
Fix channel config callback in gateway

### DIFF
--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -315,14 +315,14 @@ func (p *Peer) createChannel(
 		cryptoProvider: p.CryptoProvider,
 	}
 
-	callbacks := append(
-		p.configCallbacks,
+	callbacks := []channelconfig.BundleActor{
 		ordererSourceCallback,
 		gossipCallbackWrapper,
 		trustedRootsCallbackWrapper,
 		mspCallback,
 		channel.bundleUpdate,
-	)
+	}
+	callbacks = append(callbacks, p.configCallbacks...)
 
 	channel.bundleSource = channelconfig.NewBundleSource(
 		bundle,

--- a/internal/pkg/gateway/registry_test.go
+++ b/internal/pkg/gateway/registry_test.go
@@ -33,14 +33,7 @@ func TestOrdererCache(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, orderers, 1)
 
-	// add 2 more orderer nodes
-	test.discovery.ConfigReturns(buildConfig(t, []string{"orderer1", "orderer2", "orderer3"}), nil)
-	// the config is cached in the registry - so will still return the single orderer
-	orderers, err = test.server.registry.orderers(channelName)
-	require.NoError(t, err)
-	require.Len(t, orderers, 1)
-
-	// the config update callback is triggered, which will invalidate the cache
+	// trigger the config update callback, updating the orderers
 	bundle, err := createChannelConfigBundle()
 	require.NoError(t, err)
 	test.server.registry.configUpdate(bundle)
@@ -74,6 +67,7 @@ func buildConfig(t *testing.T, orderers []string) *dp.ConfigResult {
 func createChannelConfigBundle() (*channelconfig.Bundle, error) {
 	conf := genesisconfig.Load(genesisconfig.SampleDevModeSoloProfile, configtest.GetDevConfigDir())
 	conf.Capabilities = map[string]bool{"V2_0": true}
+	conf.Orderer.Organizations[0].OrdererEndpoints = []string{"orderer1", "orderer2", "orderer3"}
 
 	cg, err := encoder.NewChannelGroup(conf)
 	if err != nil {


### PR DESCRIPTION
Currently, the config update callback triggers a discovery call to get the updated channel orderers.
However, this relies on the discovery service having processed the config message before the gateway.  If it hasn’t, the gateway just gets the stale orderer config.
This commit changes the logic so the gateway extracts the orderer endpoints directly from the config bundle.

Resolves https://github.com/hyperledger/fabric-gateway/issues/318

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
