### PR TITLE
Update the Makefile target for release/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,7 @@ release-all: check-go-version $(RELEASE_PLATFORMS:%=release/%)
 .PHONY: $(RELEASE_PLATFORMS:%=release/%)
 $(RELEASE_PLATFORMS:%=release/%): GO_LDFLAGS = $(METADATA_VAR:%=-X $(PKGNAME)/common/metadata.%)
 $(RELEASE_PLATFORMS:%=release/%): release/%: $(foreach exe,$(RELEASE_EXES),release/%/bin/$(exe))
+$(RELEASE_PLATFORMS:%=release/%): ccaasbuilder 
 
 # explicit targets for all platform executables
 $(foreach platform, $(RELEASE_PLATFORMS), $(RELEASE_EXES:%=release/$(platform)/bin/%)):


### PR DESCRIPTION
Updating the release/xxx target to include the cc builders in the tgz
The dist/xxx target was originally updated, but the actual publishing from the fabric-interop test doesn't use this target.