### PR TITLE
Go 1.17 prep - ignore vendor directory in staticcheck

### DIFF
--- a/scripts/golinter.sh
+++ b/scripts/golinter.sh
@@ -69,8 +69,9 @@ if [ -n "$OUTPUT" ]; then
     exit 1
 fi
 
+# staticcheck Fabric source files - ignore issues in vendored dependency projects
 echo "Checking with staticcheck"
-OUTPUT="$(staticcheck ./... || true)"
+OUTPUT="$(staticcheck ./... | grep -v vendor/ || true)"
 if [ -n "$OUTPUT" ]; then
     echo "The following staticcheck issues were flagged"
     echo "$OUTPUT"


### PR DESCRIPTION
A few vendored dependencies have benign staticcheck errors
when using Go 1.17.

This commit simply filters out vendor directories in staticcheck output
since the intention of the linter is to check Fabric source only.

Note - it is not possible to filter the vendor directories as input to staticcheck,
as they will still show up when the Fabric package that uses them gets checked.
Have to filter the output instead.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
