### PR TITLE
Remove discovery.acl principal warning

### DIFF
--- a/discovery/support/acl/support.go
+++ b/discovery/support/acl/support.go
@@ -99,11 +99,7 @@ func (s *DiscoverySupport) SatisfiesPrincipal(channel string, rawIdentity []byte
 		logger.Warnw("failed deserializing identity", "error", err, "identity", protoutil.LogMessageForSerializedIdentity(rawIdentity))
 		return errors.Wrap(err, "failed deserializing identity")
 	}
-	err = identity.SatisfiesPrincipal(principal)
-	if err != nil {
-		logger.Warnw("identity does not satisfy principal", "error", err, "requiredPrincipal", principal, "identity", protoutil.LogMessageForSerializedIdentity(rawIdentity))
-	}
-	return err
+	return identity.SatisfiesPrincipal(principal)
 }
 
 // ChannelPolicyManagerGetter is a support interface


### PR DESCRIPTION
PR #3006 added warnings for principal check failures to assist with troubleshooting.
The discovery warning was too much however since even in normal scenarios
discovery endorser service checks the peer against the various channel principals.
This change reverts to the prior code without the warning.

Resolves https://github.com/hyperledger/fabric-gateway/issues/349.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>