### PR TITLE
Reduce CPU&memory cost of collecting endorsements

### DIFF
--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -761,7 +761,14 @@ func TestEndorse(t *testing.T) {
 			},
 			localResponse: "different_response",
 			errCode:       codes.Aborted,
-			errString:     "failed to assemble transaction: ProposalResponsePayloads do not match (base64): 'EhQaEgjIARoNbW9ja19yZXNwb25zZQ==' vs 'EhkaFwjIARoSZGlmZmVyZW50X3Jlc3BvbnNl'",
+			errString:     "failed to collect enough transaction endorsements",
+			errDetails: []*pb.ErrorDetail{
+				{
+					Address: "peer2:9051",
+					MspId:   "msp2",
+					Message: "ProposalResponsePayloads do not match",
+				},
+			},
 		},
 		{
 			name: "discovery fails",
@@ -1777,7 +1784,7 @@ func TestNilArgs(t *testing.T) {
 	require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "the proposed transaction must contain a signed proposal"))
 
 	_, err = server.Endorse(ctx, &pb.EndorseRequest{ProposedTransaction: &peer.SignedProposal{ProposalBytes: []byte("jibberish")}})
-	require.ErrorContains(t, err, "rpc error: code = InvalidArgument desc = failed to unpack transaction proposal: error unmarshalling Proposal")
+	require.ErrorContains(t, err, "rpc error: code = InvalidArgument desc = error unmarshalling Proposal")
 
 	_, err = server.Submit(ctx, nil)
 	require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "a submit request is required"))

--- a/internal/pkg/gateway/apiutils.go
+++ b/internal/pkg/gateway/apiutils.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-protos-go/common"
 	gp "github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/protoutil"
@@ -57,11 +58,6 @@ func newRpcError(code codes.Code, message string, details ...proto.Message) erro
 	return st.Err()
 }
 
-func wrappedRpcError(err error, message string, details ...proto.Message) error {
-	statusErr := status.Convert(err)
-	return newRpcError(statusErr.Code(), message+": "+statusErr.Message(), details...)
-}
-
 func toRpcError(err error, unknownCode codes.Code) error {
 	errStatus := toRpcStatus(err)
 	if errStatus.Code() != codes.Unknown {
@@ -100,4 +96,32 @@ func getResultFromProposalResponsePayload(responsePayload *peer.ProposalResponse
 	}
 
 	return chaincodeAction.GetResponse().GetPayload(), nil
+}
+
+func prepareTransaction(header *common.Header, payload *peer.ChaincodeProposalPayload, action *peer.ChaincodeEndorsedAction) (*common.Envelope, error) {
+	cppNoTransient := &peer.ChaincodeProposalPayload{Input: payload.Input, TransientMap: nil}
+	cppBytes, err := protoutil.GetBytesChaincodeProposalPayload(cppNoTransient)
+	if err != nil {
+		return nil, err
+	}
+
+	cap := &peer.ChaincodeActionPayload{ChaincodeProposalPayload: cppBytes, Action: action}
+	capBytes, err := protoutil.GetBytesChaincodeActionPayload(cap)
+	if err != nil {
+		return nil, err
+	}
+
+	tx := &peer.Transaction{Actions: []*peer.TransactionAction{{Header: header.SignatureHeader, Payload: capBytes}}}
+	txBytes, err := protoutil.GetBytesTransaction(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	payl := &common.Payload{Header: header, Data: txBytes}
+	paylBytes, err := protoutil.GetBytesPayload(payl)
+	if err != nil {
+		return nil, err
+	}
+
+	return &common.Envelope{Payload: paylBytes}, nil
 }


### PR DESCRIPTION
Based on performance analysis of the gateway, the following changes are made in this commit:
1. Instead of collecting and holding copies of all proposal responses in order to reuse the protoutil.CreateTx() function, just store a single response payload and all of the signed endorsement objects.  Check that all payloads are bitwise idential and endorsers are unique at collection time.
2. Eliminate the duplicate unmarshalling that was occurring as a result of reusing protoutil.CreateTx

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
