### PR TITLE
- Fix failure to generate all possible combinations

### DIFF
--- a/common/graph/choose.go
+++ b/common/graph/choose.go
@@ -67,9 +67,6 @@ func choose(n int, targetAmount int, i int, currentSubGroup []int, subGroups *or
 func concatInts(a []int, elements ...int) []int {
 	var res []int
 	res = append(res, a...)
-	for _, e := range elements {
-		res = append(res, e)
-	}
-
+	res = append(res, elements...)
 	return res
 }

--- a/common/graph/choose.go
+++ b/common/graph/choose.go
@@ -61,5 +61,5 @@ func choose(n int, targetAmount int, i int, currentSubGroup []int, subGroups *or
 	// We either pick the current element
 	choose(n, targetAmount, i+1, append(currentSubGroup, i), subGroups)
 	// Or don't pick it
-	choose(n, targetAmount, i+1, currentSubGroup, subGroups)
+	choose(n, targetAmount, i+1, append(make([]int, 0), currentSubGroup...), subGroups)
 }

--- a/common/graph/choose.go
+++ b/common/graph/choose.go
@@ -59,7 +59,17 @@ func choose(n int, targetAmount int, i int, currentSubGroup []int, subGroups *or
 		return
 	}
 	// We either pick the current element
-	choose(n, targetAmount, i+1, append(currentSubGroup, i), subGroups)
+	choose(n, targetAmount, i+1, concatInts(currentSubGroup, i), subGroups)
 	// Or don't pick it
-	choose(n, targetAmount, i+1, append(make([]int, 0), currentSubGroup...), subGroups)
+	choose(n, targetAmount, i+1, currentSubGroup, subGroups)
+}
+
+func concatInts(a []int, elements ...int) []int {
+	var res []int
+	res = append(res, a...)
+	for _, e := range elements {
+		res = append(res, e)
+	}
+
+	return res
 }

--- a/common/graph/choose_test.go
+++ b/common/graph/choose_test.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package graph
 
 import (
-	"reflect"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,7 +27,6 @@ func TestCombinationsExceed(t *testing.T) {
 }
 
 func TestChooseKoutOfN(t *testing.T) {
-	results := chooseKoutOfN(6, 4)
 	expectedSets := indiceSets{
 		&indiceSet{[]int{0, 1, 2, 3}},
 		&indiceSet{[]int{0, 1, 2, 4}},
@@ -45,14 +44,13 @@ func TestChooseKoutOfN(t *testing.T) {
 		&indiceSet{[]int{1, 3, 4, 5}},
 		&indiceSet{[]int{2, 3, 4, 5}},
 	}
-	for _, expected := range expectedSets {
-		matched := false
-		for _, result := range results {
-			if reflect.DeepEqual(expected.indices, result.indices) {
-				matched = true
-				break
-			}
-		}
-		require.True(t, matched)
+	require.Equal(t, indiceSetsToStrings(expectedSets), indiceSetsToStrings(chooseKoutOfN(6, 4)))
+}
+
+func indiceSetsToStrings(sets indiceSets) []string {
+	var res []string
+	for _, set := range sets {
+		res = append(res, fmt.Sprintf("%v", set.indices))
 	}
+	return res
 }

--- a/common/graph/choose_test.go
+++ b/common/graph/choose_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package graph
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,4 +24,35 @@ func TestCombinationsExceed(t *testing.T) {
 
 	// N < K returns false
 	require.False(t, CombinationsExceed(20, 30, 0))
+}
+
+func TestChooseKoutOfN(t *testing.T) {
+	results := chooseKoutOfN(6, 4)
+	expectedSets := indiceSets{
+		&indiceSet{[]int{0, 1, 2, 3}},
+		&indiceSet{[]int{0, 1, 2, 4}},
+		&indiceSet{[]int{0, 1, 2, 5}},
+		&indiceSet{[]int{0, 1, 3, 4}},
+		&indiceSet{[]int{0, 1, 3, 5}},
+		&indiceSet{[]int{0, 1, 4, 5}},
+		&indiceSet{[]int{0, 2, 3, 4}},
+		&indiceSet{[]int{0, 2, 3, 5}},
+		&indiceSet{[]int{0, 2, 4, 5}},
+		&indiceSet{[]int{0, 3, 4, 5}},
+		&indiceSet{[]int{1, 2, 3, 4}},
+		&indiceSet{[]int{1, 2, 3, 5}},
+		&indiceSet{[]int{1, 2, 4, 5}},
+		&indiceSet{[]int{1, 3, 4, 5}},
+		&indiceSet{[]int{2, 3, 4, 5}},
+	}
+	for _, expected := range expectedSets {
+		matched := false
+		for _, result := range results {
+			if reflect.DeepEqual(expected.indices, result.indices) {
+				matched = true
+				break
+			}
+		}
+		require.True(t, matched)
+	}
 }


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Bug happens when the endorsement policy is set to k-out-of-n where (n - k) > 1.
For example, when there are 6 organizations and the endorsement policy is set
to majority (i.e. 4-out-of-6). The combinations calculated by chooseKoutOfN()
in original code are as below.
	[0 1 2 5], [0 1 2 5], [0 1 2 5], [0 1 3 5],
	[0 1 3 5], [0 1 4 5], [0 2 3 5], [0 2 3 5],
	[0 2 4 5], [0 3 4 5], [1 2 3 5], [1 2 3 5],
	[1 2 4 5], [1 3 4 5], [2 3 4 5]

Obviously, the function fails to find out all the possible combinations. Some of
 the combinations are overrided by child's call. This bug would trigger below
error sometimes when the alive peers are not within the above combinations.

	[discovery] chaincodeQuery -> ERRO 13a Failed constructing descriptor for
	chaincode chaincodes:<name:"XXXX" > ,: no peer combination can satisfy the
	endorsement policy

To fix it, the last line of choose() should be changed to pass a copy of
"currentSubGroup" to the recursive call instead, i.e.

	choose(n, targetAmount, i+1, append(make([]int, 0), currentSubGroup...), subGroups)

After applying the fix, the resulting combinations generated should be corrected
as below.
	[0 1 2 3], [0 1 2 4], [0 1 2 5], [0 1 3 4],
	[0 1 3 5], [0 1 4 5], [0 2 3 4], [0 2 3 5],
	[0 2 4 5], [0 3 4 5], [1 2 3 4], [1 2 3 5],
	[1 2 4 5], [1 3 4 5], [2 3 4 5]
