### PR TITLE
peer-chaincode-devmode.md - added missing quotation mark (') in commnd

### DIFF
--- a/docs/source/peer-chaincode-devmode.md
+++ b/docs/source/peer-chaincode-devmode.md
@@ -157,7 +157,7 @@ You can issue CLI commands to invoke and query the chaincode as needed to verify
 
 ```
 CORE_PEER_ADDRESS=127.0.0.1:7051 peer chaincode invoke -o 127.0.0.1:7050 -C ch1 -n mycc -c '{"Args":["init","a","100","b","200"]}' --isInit
-CORE_PEER_ADDRESS=127.0.0.1:7051 peer chaincode invoke -o 127.0.0.1:7050 -C ch1 -n mycc -c '{"Args":["invoke","a","b","10"]}
+CORE_PEER_ADDRESS=127.0.0.1:7051 peer chaincode invoke -o 127.0.0.1:7050 -C ch1 -n mycc -c '{"Args":["invoke","a","b","10"]}'
 CORE_PEER_ADDRESS=127.0.0.1:7051 peer chaincode invoke -o 127.0.0.1:7050 -C ch1 -n mycc -c '{"Args":["query","a"]}'
 ```
 


### PR DESCRIPTION
Signed-off-by: rajan-31 <rajankhade31@gmail.com>

#### Type of change

- Documentation update

#### Description

A quotation mark was missing at the end of the command.

`CORE_PEER_ADDRESS=127.0.0.1:7051 peer chaincode invoke -o 127.0.0.1:7050 -C ch1 -n mycc -c '{"Args":["invoke","a","b","10"]}
`