### PR TITLE
scope snapshot trigger for non empty data block

### DIFF
--- a/orderer/consensus/etcdraft/chain.go
+++ b/orderer/consensus/etcdraft/chain.go
@@ -1139,7 +1139,7 @@ func (c *Chain) apply(ents []raftpb.Entry) {
 		}
 	}
 
-	if c.accDataSize >= c.sizeLimit {
+	if c.accDataSize >= c.sizeLimit && len(ents[position].Data) > 0 {
 		b := protoutil.UnmarshalBlockOrPanic(ents[position].Data)
 
 		select {


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description
Problem context: Integration test scenario https://github.com/hyperledger/fabric/blob/752853701709ce1d5d88db572cacf224ed0e4bd8/integration/raft/cft_test.go#L257 orderer crashes when it tried to trigger a snapshot after it catches up with the other orderer. Since it tries to take snapshot on the empty data block, it is failing.  More info: https://github.com/hyperledger/fabric/issues/3149

Change: Updated the condition to take snap shot when the data block is not empty. 

#### Related issues
#3149 

Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>
