### PR TITLE
Update fabric go module to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hyperledger/fabric
+module github.com/hyperledger/fabric/v2
 
 go 1.14
 


### PR DESCRIPTION
Although Fabric is not intended to be used as a go module that other
projects import, some projects use Go tooling to download repositories
and this does not work for Fabric v2.x since Fabric's go module is
not defined as a v2 module. This change marks Fabric's go module
as v2 so that Fabric v2.x versions can be downloaded with Go tooling.

Fixes #2929

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
