### PR TITLE
replace arm64 with amd64 for installation scripts

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -9,7 +9,7 @@
 VERSION=2.4.1
 # if ca version not passed in, default to latest released version
 CA_VERSION=1.5.2
-ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m | sed 's/x86_64/amd64/g')")
+ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m | uname -m | sed -E -e 's/x86_64|arm64/amd64/g')")
 MARCH=$(uname -m)
 
 printHelp() {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -9,7 +9,7 @@
 VERSION=2.4.1
 # if ca version not passed in, default to latest released version
 CA_VERSION=1.5.2
-ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m | uname -m | sed -E -e 's/x86_64|arm64/amd64/g')")
+ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m |sed 's/x86_64/amd64/g')" |sed 's/darwin-arm64/darwin-amd64/g')
 MARCH=$(uname -m)
 
 printHelp() {

--- a/scripts/install-fabric.sh
+++ b/scripts/install-fabric.sh
@@ -26,7 +26,7 @@ _arg_comp=('' )
 _arg_fabric_version="2.4.1"
 _arg_ca_version="1.5.2"
 
-ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m | uname -m | sed -E -e 's/x86_64|arm64/amd64/g')")
+ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m |sed 's/x86_64/amd64/g')" |sed 's/darwin-arm64/darwin-amd64/g')
 MARCH=$(uname -m)
 
 die()

--- a/scripts/install-fabric.sh
+++ b/scripts/install-fabric.sh
@@ -26,7 +26,7 @@ _arg_comp=('' )
 _arg_fabric_version="2.4.1"
 _arg_ca_version="1.5.2"
 
-ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m | sed 's/x86_64/amd64/g')")
+ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m | uname -m | sed -E -e 's/x86_64|arm64/amd64/g')")
 MARCH=$(uname -m)
 
 die()


### PR DESCRIPTION
Signed-off-by: Rohan Shrothrium <shrothriumrohan@gmail.com>

While using the new mac books which has an arm64 infrastructure, the installation and bootstrap script fails as there is no specific binaries for arm64. I downloaded the amd64 binaries and fabric images and they work as expected on the new M1 architecture.

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
This PR incorporates changes to download the amd64 binaries and images for an arm64 architecture.