### PR TITLE
Update deploy_chaincode.md `package` command docs

### DIFF
--- a/docs/source/deploy_chaincode.md
+++ b/docs/source/deploy_chaincode.md
@@ -247,7 +247,7 @@ To install the smart contract dependencies, run the following command from the `
 npm install
 ```
 
-If the command is successful, the JavaScript packages will be installed inside a `node_modules` folder.
+If the command is successful, the JavaScript packages will be installed inside a `node_modules` folder. Note that the `peer lifecycle chaincode package` command does not package your `node_modules` folder in the chaincode package. If you wish to bundle `node modules` in your chaincode package, you can do so manually. However, this will require you to use the [External Chaincode Launcher](https://hyperledger-fabric.readthedocs.io/en/release-2.2/cc_launcher.html) or [Chaincode as a Service](https://hyperledger-fabric.readthedocs.io/en/release-2.2/cc_service.html) functionality.
 
 Now that we that have our dependencies, we can create the chaincode package. Navigate back to our working directory in the `test-network` folder so that we can package the chaincode together with our other network artifacts.
 


### PR DESCRIPTION
Define the default behavior of `peer lifecycle chaincode package`, which does *not* include node_modules in the resulting tar.gz package for chaincode. The existing step of `npm install` and quote "If the command is successful, the JavaScript packages will be installed inside a `node_modules` folder. Now that we that have our dependencies, we can create the chaincode package." would lead a reader to believe that `node_modules` are included when they are not. 

Also added more detail about what chaincode services allow `node_modules` when packaged manually.

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix
- New feature
- Improvement (improvement to code, performance, etc)
- Test update
- Documentation update

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
