### PR TITLE
Clarify paths in core.yaml

### DIFF
--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -313,6 +313,7 @@ peer:
     # Path on the file system where peer will store data (eg ledger). This
     # location must be access control protected to prevent unintended
     # modification that might corrupt the peer operations.
+    # The path may be relative to FABRIC_CFG_PATH or an absolute path.
     fileSystemPath: /var/hyperledger/production
 
     # BCCSP (Blockchain crypto provider): Select which crypto implementation or
@@ -342,6 +343,7 @@ peer:
             Security:
 
     # Path on the file system where peer will find MSP local configurations
+    # The path may be relative to FABRIC_CFG_PATH or an absolute path.
     mspConfigPath: msp
 
     # Identifier of the local MSP
@@ -587,6 +589,7 @@ chaincode:
     # builders in the order specified below.
     # If you don't need to fallback to the default Docker builder, also unconfigure vm.endpoint above.
     # To override this property via env variable use CORE_CHAINCODE_EXTERNALBUILDERS: [{name: x, path: dir1}, {name: y, path: dir2}]
+    # The path must be an absolute path.
     externalBuilders:
        - name: ccaas_builder
          path: /opt/hyperledger/ccaas_builder
@@ -722,6 +725,7 @@ ledger:
 
   snapshots:
     # Path on the file system where peer will store ledger snapshots
+    # The path must be an absolute path.
     rootDir: /var/hyperledger/production/snapshots
 
 ###############################################################################
@@ -739,6 +743,7 @@ operations:
         enabled: false
 
         # path to PEM encoded server certificate for the operations server
+        # The paths in this section may be relative to FABRIC_CFG_PATH or an absolute path.
         cert:
             file:
 


### PR DESCRIPTION
Clarify whether paths in core.yaml may be absolute or relative.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
