### PR TITLE
Fix gossip unit test flake

### DIFF
--- a/gossip/service/gossip_service_test.go
+++ b/gossip/service/gossip_service_test.go
@@ -50,7 +50,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const TIMEOUT = 45 * time.Second
+const TIMEOUT = 90 * time.Second
 
 func init() {
 	util.SetupTestLogging()
@@ -611,7 +611,9 @@ func (jmc *joinChanMsg) AnchorPeersOf(org api.OrgIdentityType) []api.AnchorPeer 
 }
 
 func waitForFullMembershipOrFailNow(t *testing.T, channel string, gossips []*gossipGRPC, peersNum int, timeout time.Duration, testPollInterval time.Duration) {
-	end := time.Now().Add(timeout)
+	logger.Warning("Waiting for", peersNum, "members")
+	start := time.Now()
+	end := start.Add(timeout)
 	var correctPeers int
 	for time.Now().Before(end) {
 		correctPeers = 0
@@ -621,6 +623,7 @@ func waitForFullMembershipOrFailNow(t *testing.T, channel string, gossips []*gos
 			}
 		}
 		if correctPeers == peersNum {
+			logger.Warning("Established full channel membership in", time.Since(start))
 			return
 		}
 		time.Sleep(testPollInterval)

--- a/gossip/service/integration_test.go
+++ b/gossip/service/integration_test.go
@@ -104,7 +104,7 @@ func TestLeaderYield(t *testing.T) {
 	// Add peers to the channel
 	addPeersToChannel(channelName, gossips, peerIndexes)
 	// Prime the membership view of the peers
-	waitForFullMembershipOrFailNow(t, channelName, gossips, n, time.Second*30, time.Millisecond*100)
+	waitForFullMembershipOrFailNow(t, channelName, gossips, n, TIMEOUT, time.Millisecond*100)
 
 	store := newTransientStore(t)
 	defer store.tearDown()


### PR DESCRIPTION
Increasing the timeout in the gossip service unit tests appears to reduce the occurence of the flake that we frequently observe.

This should be seen as a tactical fix while the underlying cause is investigated.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
