### PR TITLE
ledgerutil exits with a proper code

### DIFF
--- a/cmd/ledgerutil/main.go
+++ b/cmd/ledgerutil/main.go
@@ -53,14 +53,14 @@ func main() {
 			*outputDir, err = os.Getwd()
 			if err != nil {
 				fmt.Printf("%s%s\n", compareErrorMessage, err)
-				return
+				os.Exit(1)
 			}
 		}
 
 		count, outputDirPath, err := ledgerutil.Compare(*snapshotPath1, *snapshotPath2, *outputDir, *firstDiffs)
 		if err != nil {
 			fmt.Printf("%s%s\n", compareErrorMessage, err)
-			return
+			os.Exit(1)
 		}
 
 		fmt.Print("\nSuccessfully compared snapshots. ")
@@ -68,6 +68,7 @@ func main() {
 			fmt.Println("Both snapshot public state and private state hashes were the same. No results were generated.")
 		} else {
 			fmt.Printf("Results saved to %s. Total differences found: %d\n", outputDirPath, count)
+			os.Exit(2)
 		}
 	}
 }

--- a/cmd/ledgerutil/main_test.go
+++ b/cmd/ledgerutil/main_test.go
@@ -38,7 +38,11 @@ func TestArguments(t *testing.T) {
 		},
 		"one-snapshot": {
 			exitCode: 1,
-			args:     []string{"compare, snapshotDir1"},
+			args:     []string{"compare", "snapshotDir1"},
+		},
+		"invalid-snapshot-dirs": {
+			exitCode: 1,
+			args:     []string{"compare", "/non-existent/snapshot1", "/non-existent/snapshot2"},
 		},
 	}
 

--- a/docs/source/commands/ledgerutil.md
+++ b/docs/source/commands/ledgerutil.md
@@ -47,6 +47,14 @@ Args:
   <snapshotPath2>  Second ledger snapshot directory.
 ```
 
+## Exit Status
+
+### ledgerutil compare
+
+- `0` if the snapshots are identical
+- `2` if the snapshots are not identical
+- `1` if an error occurs
+
 ## Example Usage
 
 ### ledgerutil compare example

--- a/docs/wrappers/ledgerutil_postscript.md
+++ b/docs/wrappers/ledgerutil_postscript.md
@@ -1,3 +1,11 @@
+## Exit Status
+
+### ledgerutil compare
+
+- `0` if the snapshots are identical
+- `2` if the snapshots are not identical
+- `1` if an error occurs
+
 ## Example Usage
 
 ### ledgerutil compare example


### PR DESCRIPTION
This patch makes ledgerutil exit with a proper code when it fails.

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

The ledgerutil command exits with 0 (success) whether or not it succeeds in the comparison; it exits with 1 (failure) only when the parsing of the command line arguments are unsuccessful.

This patch makes it exit with 1 additionally when
- it fails in the comparison of snapshots
- it finds that the snapshots are different after the comparison