### PR TITLE
Filter out purged data from private data store

### DIFF
--- a/core/ledger/pvtdatastorage/kv_encoding.go
+++ b/core/ledger/pvtdatastorage/kv_encoding.go
@@ -31,6 +31,8 @@ var (
 	bootKVHashesKeyPrefix            = []byte{9}
 	lastBlockInBootSnapshotKey       = []byte{'a'}
 	hashedIndexKeyPrefix             = []byte{'b'}
+	purgeMarkerKeyPrefix             = []byte{'c'}
+	purgeMarkerCollKeyPrefix         = []byte{'d'}
 
 	nilByte    = byte(0)
 	emptyValue = []byte{}
@@ -282,6 +284,31 @@ func encodeHashedIndexKey(k *hashedIndexKey) []byte {
 	encKey = append(encKey, nilByte)
 	encKey = append(encKey, k.pvtkeyHash...)
 	return append(encKey, version.NewHeight(k.blkNum, k.txNum).ToBytes()...)
+}
+
+func encodePurgeMarkerCollKey(k *purgeMarkerCollKey) []byte {
+	encKey := append(purgeMarkerCollKeyPrefix, []byte(k.ns)...)
+	encKey = append(encKey, nilByte)
+	encKey = append(encKey, []byte(k.coll)...)
+	return encKey
+}
+
+func encodePurgeMarkerKey(k *purgeMarkerKey) []byte {
+	encKey := append(purgeMarkerKeyPrefix, []byte(k.ns)...)
+	encKey = append(encKey, nilByte)
+	encKey = append(encKey, []byte(k.coll)...)
+	encKey = append(encKey, nilByte)
+	encKey = append(encKey, k.pvtkeyHash...)
+	return encKey
+}
+
+func encodePurgeMarkerVal(v *purgeMarkerVal) []byte {
+	return version.NewHeight(v.blkNum, v.txNum).ToBytes()
+}
+
+func decodePurgeMarkerVal(b []byte) (*version.Height, error) {
+	v, _, err := version.NewHeightFromBytes(b)
+	return v, err
 }
 
 func deriveDataKeyFromEncodedHashedIndexKey(encHashedIndexKey []byte) ([]byte, error) {

--- a/core/ledger/pvtdatastorage/retroactive_hashed_index.go
+++ b/core/ledger/pvtdatastorage/retroactive_hashed_index.go
@@ -101,7 +101,7 @@ func constructHashedIndexFor(ledgerID string, db *leveldbhelper.DBHandle) error 
 				return err
 			}
 
-			txPvtData, err := v11DecodeKV(k, v, nil)
+			txPvtData, err := v11DecodeKV(k, v)
 			if err != nil {
 				return err
 			}

--- a/core/ledger/pvtdatastorage/v11.go
+++ b/core/ledger/pvtdatastorage/v11.go
@@ -9,7 +9,6 @@ package pvtdatastorage
 import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset"
-	"github.com/hyperledger/fabric/common/ledger/util/leveldbhelper"
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 )
@@ -37,24 +36,7 @@ func v11DecodePvtRwSet(encodedBytes []byte) (*rwset.TxPvtReadWriteSet, error) {
 	return writeset, proto.Unmarshal(encodedBytes, writeset)
 }
 
-func v11RetrievePvtdata(itr *leveldbhelper.Iterator, filter ledger.PvtNsCollFilter) ([]*ledger.TxPvtData, error) {
-	var blkPvtData []*ledger.TxPvtData
-	txPvtData, err := v11DecodeKV(itr.Key(), itr.Value(), filter)
-	if err != nil {
-		return nil, err
-	}
-	blkPvtData = append(blkPvtData, txPvtData)
-	for itr.Next() {
-		pvtDatum, err := v11DecodeKV(itr.Key(), itr.Value(), filter)
-		if err != nil {
-			return nil, err
-		}
-		blkPvtData = append(blkPvtData, pvtDatum)
-	}
-	return blkPvtData, nil
-}
-
-func v11DecodeKV(k, v []byte, filter ledger.PvtNsCollFilter) (*ledger.TxPvtData, error) {
+func v11DecodeKV(k, v []byte) (*ledger.TxPvtData, error) {
 	bNum, tNum, err := v11DecodePK(k)
 	if err != nil {
 		return nil, err
@@ -64,38 +46,5 @@ func v11DecodeKV(k, v []byte, filter ledger.PvtNsCollFilter) (*ledger.TxPvtData,
 		return nil, err
 	}
 	logger.Debugf("Retrieved V11 private data write set for block [%d] tran [%d]", bNum, tNum)
-	filteredWSet := v11TrimPvtWSet(pvtWSet, filter)
-	return &ledger.TxPvtData{SeqInBlock: tNum, WriteSet: filteredWSet}, nil
-}
-
-func v11TrimPvtWSet(pvtWSet *rwset.TxPvtReadWriteSet, filter ledger.PvtNsCollFilter) *rwset.TxPvtReadWriteSet {
-	if filter == nil {
-		return pvtWSet
-	}
-
-	var filteredNsRwSet []*rwset.NsPvtReadWriteSet
-	for _, ns := range pvtWSet.NsPvtRwset {
-		var filteredCollRwSet []*rwset.CollectionPvtReadWriteSet
-		for _, coll := range ns.CollectionPvtRwset {
-			if filter.Has(ns.Namespace, coll.CollectionName) {
-				filteredCollRwSet = append(filteredCollRwSet, coll)
-			}
-		}
-		if filteredCollRwSet != nil {
-			filteredNsRwSet = append(filteredNsRwSet,
-				&rwset.NsPvtReadWriteSet{
-					Namespace:          ns.Namespace,
-					CollectionPvtRwset: filteredCollRwSet,
-				},
-			)
-		}
-	}
-	var filteredTxPvtRwSet *rwset.TxPvtReadWriteSet
-	if filteredNsRwSet != nil {
-		filteredTxPvtRwSet = &rwset.TxPvtReadWriteSet{
-			DataModel:  pvtWSet.GetDataModel(),
-			NsPvtRwset: filteredNsRwSet,
-		}
-	}
-	return filteredTxPvtRwSet
+	return &ledger.TxPvtData{SeqInBlock: tNum, WriteSet: pvtWSet}, nil
 }


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Description
This PR  introduces support for the purge marker(s) and filters the data marked for purging. In addition, this PR removes the 
unused code for V11 format as now we upgraded data format along with retroactively creating hashed index at peer start.

#### Related issues
Resolves #3028 

