### PR TITLE
Fix inconsistent behavior of GetBookmarkAndClose method in different statedb

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/commontests/test_common.go
+++ b/core/ledger/kvledger/txmgmt/statedb/commontests/test_common.go
@@ -913,6 +913,17 @@ func TestPaginatedRangeQuery(t *testing.T, dbProvider statedb.VersionedDBProvide
 	returnKeys = []string{"key1", "key10", "key11", "key12"}
 	_, err = executeRangeQuery(t, db, "ns1", "key1", "key15", int32(4), returnKeys)
 	require.NoError(t, err)
+
+	// Test the returned bookmark of range query when there are no more results in that range
+	returnKeys = []string{"key1", "key10", "key11"}
+	nextStartKey, err = executeRangeQuery(t, db, "ns1", "key1", "key15", int32(3), returnKeys)
+	require.NoError(t, err)
+
+	// NextStartKey is now passed in as startKey, and return the nextStartKey which should be empty string
+	returnKeys = []string{"key12", "key13", "key14"}
+	nextStartKey, err = executeRangeQuery(t, db, "ns1", nextStartKey, "key15", int32(3), returnKeys)
+	require.NoError(t, err)
+	require.Equal(t, "", nextStartKey)
 }
 
 // TestRangeQuerySpecialCharacters tests range queries for keys with special characters and/or non-English characters

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb.go
@@ -1098,6 +1098,9 @@ func (scanner *queryScanner) GetBookmarkAndClose() string {
 		retval = scanner.paginationInfo.bookmark
 	} else {
 		retval = scanner.queryDefinition.startKey
+		if retval == scanner.queryDefinition.endKey {
+			retval = ""
+		}
 	}
 	scanner.Close()
 	return retval

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
@@ -1690,7 +1690,7 @@ func testRangeQueryWithPageSize(
 			continue
 		}
 		nextStartKey := itr.GetBookmarkAndClose()
-		if nextStartKey == endKey {
+		if nextStartKey == "" {
 			break
 		}
 		itr, err = db.GetStateRangeScanIteratorWithPagination(ns, nextStartKey, endKey, int32(pageSize))

--- a/integration/ledger/marbles_test.go
+++ b/integration/ledger/marbles_test.go
@@ -124,10 +124,8 @@ var _ = Describe("all shim APIs for non-private data", func() {
 		bookmark = helper.assertQueryMarblesWithPagination(ccName, peer, expectedQueryResult,
 			"getMarblesByRangeWithPagination", "marble-1", "marble-6", "3", bookmark)
 
-		By("quering marbles by range with pagination size 3, 3rd call should return no marble")
-		expectedQueryResult = make([]*marbleQueryResult, 0)
-		helper.assertQueryMarblesWithPagination(ccName, peer, expectedQueryResult,
-			"getMarblesByRangeWithPagination", "marble-1", "marble-6", "3", bookmark)
+		By("after 2nd call, bookmark should be empty string")
+		Expect(bookmark).To(Equal(""))
 
 		By("quering marbles by search criteria with pagination size 10, 1st call")
 		bookmark = ""


### PR DESCRIPTION
<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

<!--- Describe your changes in detail, including motivation. -->
When there are no more results in paginated range query, statecouchdb return endKey
as bookmark in GetBookmarkAndClose method, but stateleveldb return empty string as bookmark.
This inconsistent behavior may cause different code logic when use bookmark in smart contract
with different statedb.
