### PR TITLE
doc - add new gateway to key concepts

### DIFF
--- a/docs/source/key_concepts.rst
+++ b/docs/source/key_concepts.rst
@@ -15,6 +15,7 @@ Key Concepts
    orderer/ordering_service.md
    smartcontract/smartcontract.md
    chaincode_lifecycle.md
+   gateway.md
    private-data/private-data.md
    capabilities_concept.md
    security_model.md


### PR DESCRIPTION
Signed-off-by: Josh Horton <joshh@us.ibm.com>

#### Type of change

- Documentation update

#### Description

New Fabric Gateway service page needed a link in Key Concepts page / list
(gateway.md)

#### Additional details

Add to go here near the bottom (logical sequential) - https://hyperledger-fabric.readthedocs.io/en/latest/key_concepts.html

