### PR TITLE
Gateway support for mutual TLS networks

### DIFF
--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -825,6 +825,7 @@ func serve(args []string) error {
 				serverEndorser,
 				discoveryService,
 				peerInstance,
+				&serverConfig.SecOpts,
 				aclProvider,
 				coreConfig.LocalMSPID,
 				coreConfig.GatewayOptions,

--- a/internal/pkg/gateway/endpoint.go
+++ b/internal/pkg/gateway/endpoint.go
@@ -51,6 +51,8 @@ type endpointFactory struct {
 	connectEndorser endorserConnector
 	connectOrderer  ordererConnector
 	dialer          dialer
+	clientCert      []byte
+	clientKey       []byte
 }
 
 func (ef *endpointFactory) newEndorser(pkiid common.PKIidType, address, mspid string, tlsRootCerts [][]byte) (*endorser, error) {
@@ -97,7 +99,9 @@ func (ef *endpointFactory) newConnection(address string, tlsRootCerts [][]byte) 
 		SecOpts: comm.SecureOptions{
 			UseTLS:            len(tlsRootCerts) > 0,
 			ServerRootCAs:     tlsRootCerts,
-			RequireClientCert: false,
+			RequireClientCert: true,
+			Certificate:       ef.clientCert,
+			Key:               ef.clientKey,
 		},
 		DialTimeout: ef.timeout,
 	}

--- a/internal/pkg/gateway/endpoint_test.go
+++ b/internal/pkg/gateway/endpoint_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric/common/crypto/tlsgen"
+	"github.com/hyperledger/fabric/gossip/common"
+	"github.com/hyperledger/fabric/internal/pkg/comm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMutualTLS(t *testing.T) {
+	ca, err := tlsgen.NewCA()
+	require.NoError(t, err, "failed to create CA")
+
+	serverPair, err := ca.NewServerCertKeyPair("127.0.0.1")
+	require.NoError(t, err, "failed to create server key pair")
+
+	clientPair, err := ca.NewClientCertKeyPair()
+	require.NoError(t, err, "failed to create client key pair")
+
+	rootTLSCert := ca.CertBytes()
+
+	server, err := comm.NewGRPCServer("127.0.0.1:0", comm.ServerConfig{
+		SecOpts: comm.SecureOptions{
+			UseTLS:            true,
+			RequireClientCert: true,
+			Certificate:       serverPair.Cert,
+			Key:               serverPair.Key,
+			ClientRootCAs:     [][]byte{rootTLSCert},
+		},
+	})
+	require.NoError(t, err)
+
+	go server.Start()
+	defer server.Stop()
+
+	factory := &endpointFactory{
+		timeout:    10 * time.Second,
+		clientCert: clientPair.Cert,
+		clientKey:  clientPair.Key,
+	}
+
+	endorser, err := factory.newEndorser(common.PKIidType{}, server.Address(), "msp1", [][]byte{rootTLSCert})
+	require.NoError(t, err, "failed to make mTLS connection to server")
+
+	err = endorser.closeConnection()
+	require.NoError(t, err, "failed to close connection")
+}

--- a/internal/pkg/gateway/gateway.go
+++ b/internal/pkg/gateway/gateway.go
@@ -12,7 +12,8 @@ import (
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/common/ledger"
 	"github.com/hyperledger/fabric/core/peer"
-	"github.com/hyperledger/fabric/gossip/common"
+	gdiscovery "github.com/hyperledger/fabric/gossip/discovery"
+	"github.com/hyperledger/fabric/internal/pkg/comm"
 	"github.com/hyperledger/fabric/internal/pkg/gateway/commit"
 	"github.com/hyperledger/fabric/internal/pkg/gateway/config"
 	"google.golang.org/grpc"
@@ -51,7 +52,7 @@ type LedgerProvider interface {
 }
 
 // CreateServer creates an embedded instance of the Gateway.
-func CreateServer(localEndorser peerproto.EndorserServer, discovery Discovery, peerInstance *peer.Peer, policy ACLChecker, localMSPID string, options config.Options) *Server {
+func CreateServer(localEndorser peerproto.EndorserServer, discovery Discovery, peerInstance *peer.Peer, secureOptions *comm.SecureOptions, policy ACLChecker, localMSPID string, options config.Options) *Server {
 	adapter := &peerAdapter{
 		Peer: peerInstance,
 	}
@@ -65,9 +66,9 @@ func CreateServer(localEndorser peerproto.EndorserServer, discovery Discovery, p
 		commit.NewFinder(adapter, notifier),
 		policy,
 		adapter,
-		peerInstance.GossipService.SelfMembershipInfo().PKIid,
-		peerInstance.GossipService.SelfMembershipInfo().Endpoint,
+		peerInstance.GossipService.SelfMembershipInfo(),
 		localMSPID,
+		secureOptions,
 		options,
 	)
 
@@ -76,13 +77,13 @@ func CreateServer(localEndorser peerproto.EndorserServer, discovery Discovery, p
 	return server
 }
 
-func newServer(localEndorser peerproto.EndorserClient, discovery Discovery, finder CommitFinder, policy ACLChecker, ledgerProvider LedgerProvider, localPKIID common.PKIidType, localEndpoint, localMSPID string, options config.Options) *Server {
+func newServer(localEndorser peerproto.EndorserClient, discovery Discovery, finder CommitFinder, policy ACLChecker, ledgerProvider LedgerProvider, localInfo gdiscovery.NetworkMember, localMSPID string, secureOptions *comm.SecureOptions, options config.Options) *Server {
 	return &Server{
 		registry: &registry{
-			localEndorser:      &endorser{client: localEndorser, endpointConfig: &endpointConfig{pkiid: localPKIID, address: localEndpoint, mspid: localMSPID}},
+			localEndorser:      &endorser{client: localEndorser, endpointConfig: &endpointConfig{pkiid: localInfo.PKIid, address: localInfo.Endpoint, mspid: localMSPID}},
 			discovery:          discovery,
 			logger:             logger,
-			endpointFactory:    &endpointFactory{timeout: options.DialTimeout},
+			endpointFactory:    &endpointFactory{timeout: options.DialTimeout, clientCert: secureOptions.Certificate, clientKey: secureOptions.Key},
 			remoteEndorsers:    map[string]*endorser{},
 			channelInitialized: map[string]bool{},
 		},


### PR DESCRIPTION
To support client authentication (mTLS), the gateway needs to pass the host peer’s client certificate when making connections to the other nodes in the network.
If client authentication is not enabled, then these certs will be ignored.

Resolves #3234 

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
