### PR TITLE
Fix firewall warnings for integration tests on Mac

### DIFF
--- a/integration/nwo/template/core_template.go
+++ b/integration/nwo/template/core_template.go
@@ -16,7 +16,7 @@ peer:
   address: 127.0.0.1:{{ .PeerPort Peer "Listen" }}
   addressAutoDetect: true
   listenAddress: 127.0.0.1:{{ .PeerPort Peer "Listen" }}
-  chaincodeListenAddress: 0.0.0.0:{{ .PeerPort Peer "Chaincode" }}
+  chaincodeListenAddress: 127.0.0.1:{{ .PeerPort Peer "Chaincode" }}
   keepalive:
     minInterval: 60s
     client:


### PR DESCRIPTION
When running integration tests locally on MacOS, each test causes a number of popup boxes containing the text
‘Do you want the application “peer” to accept incoming network connections?”.
Although this can be ignored, each popup takes the (cursor) focus away from the current window, and so is annoying when trying to do anything else.
This is caused because each test is launching one or more peer instances which get compiled on demand and appears to the firewall as a new executable.
The fix for this is to ensure that all listen addresses are explicitly set as localhost.  In this case, the chaincodeListenAddress host can be set to 127.0.0.1 rather than 0.0.0.0

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
