### PR TITLE
Fix Orderer test flake #3149

### DIFF
--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -2981,6 +2981,84 @@ var _ = Describe("Chain", func() {
 					c1.opts.SnapshotCatchUpEntries = 1
 				})
 
+				It("take snapshot on accumlated bytes condition met", func() {
+					// change the SnapshotIntervalSize on the chains
+					c3.opts.SnapshotIntervalSize = 1
+					c3.opts.SnapshotCatchUpEntries = 1
+					c2.opts.SnapshotIntervalSize = 1
+					c2.opts.SnapshotCatchUpEntries = 1
+
+					countSnapShotsForChain := func(cn *chain) int {
+						files, err := ioutil.ReadDir(cn.opts.SnapDir)
+						Expect(err).NotTo(HaveOccurred())
+						return len(files)
+					}
+
+					Expect(countSnapShotsForChain(c1)).Should(Equal(0))
+					Expect(countSnapShotsForChain(c3)).Should(Equal(0))
+
+					By("order envelop on node 1 to accumulate bytes")
+					c1.cutter.CutNext = true
+					err := c1.Order(env, 0)
+					Expect(err).NotTo(HaveOccurred())
+
+					// all three nodes should take snapshots
+					network.exec(
+						func(c *chain) {
+							Eventually(func() int { return c.support.WriteBlockCallCount() }, LongEventualTimeout).Should(Equal(1))
+						})
+
+					// order data on all nodes except node 3, empty the raft message directed to node 3
+					// node 1 should take a snapshot but node 3 should not
+					snapshots_on_node3 := countSnapShotsForChain(c3)
+					step1 := c1.getStepFunc()
+
+					c1.setStepFunc(func(dest uint64, msg *orderer.ConsensusRequest) error {
+						stepMsg := &raftpb.Message{}
+						Expect(proto.Unmarshal(msg.Payload, stepMsg)).NotTo(HaveOccurred())
+						if dest == 3 && stepMsg.Type == raftpb.MsgApp && len(stepMsg.Entries) > 0 {
+							stepMsg.Entries = stepMsg.Entries[0:1]
+							stepMsg.Entries[0].Data = nil
+							msg.Payload = protoutil.MarshalOrPanic(stepMsg)
+						}
+						return step1(dest, msg)
+					})
+
+					err = c1.Order(env, 0)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(c1.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(2))
+					Eventually(c3.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(1))
+
+					// order data on all nodes except node 3, send raft raftpb.EntryConfChange message to node 3
+					// node 1 should take a snapshot but node 3 should not
+					c1.setStepFunc(func(dest uint64, msg *orderer.ConsensusRequest) error {
+						stepMsg := &raftpb.Message{}
+						Expect(proto.Unmarshal(msg.Payload, stepMsg)).NotTo(HaveOccurred())
+						if dest == 3 && stepMsg.Type == raftpb.MsgApp && len(stepMsg.Entries) > 0 {
+							stepMsg.Entries = stepMsg.Entries[0:1]
+							// change message type to raftpb.EntryConfChange
+							stepMsg.Entries[0].Type = raftpb.EntryConfChange
+							cc := &raftpb.ConfChange{NodeID: uint64(3), Type: raftpb.ConfChangeRemoveNode}
+							data, err := cc.Marshal()
+							Expect(err).NotTo(HaveOccurred())
+							stepMsg.Entries[0].Data = data
+							msg.Payload = protoutil.MarshalOrPanic(stepMsg)
+						}
+						return step1(dest, msg)
+					})
+
+					err = c1.Order(env, 0)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(c1.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(3))
+					Eventually(c3.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(1))
+					Expect(countSnapShotsForChain(c1)).Should(Equal(3))
+					// No snapshot would be taken for node 3 after this orrderer request
+					addtional_snapshots_for_node3 := countSnapShotsForChain(c3) - snapshots_on_node3
+					Expect(addtional_snapshots_for_node3).Should(Equal(0))
+				})
+
 				It("keeps running if some entries in memory are purged", func() {
 					// Scenario: snapshotting is enabled on node 1 and it purges memory storage
 					// per every snapshot. Cluster should be correctly functioning.


### PR DESCRIPTION
fix #3149  In case of accumulated bytes since last snapshot 
exceed limit while taking snapshot check whether the pb buffer
type is of raftpb.EntryNormal, since blocks are marshalled into 
pb buffers of raftpb.EntryNormal and not raftpb.EntryConfChange

Signed-off-by: Shivdeep Singh <Shivdeep.Singh@ibm.com>
