### PR TITLE
docs: Fix a tutorial for deploying a smart contract

### DIFF
--- a/docs/source/deploy_chaincode.md
+++ b/docs/source/deploy_chaincode.md
@@ -45,18 +45,10 @@ We can now use the Peer CLI to deploy the asset-transfer (basic) chaincode to th
 
 This step is not required but is extremely useful for troubleshooting chaincode. To monitor the logs of the smart contract, an administrator can view the aggregated output from a set of Docker containers using the `logspout` [tool](https://logdna.com/what-is-logspout/). The tool collects the output streams from different Docker containers into one place, making it easy to see what's happening from a single window. This can help administrators debug problems when they install smart contracts or developers when they invoke smart contracts. Because some containers are created purely for the purposes of starting a smart contract and only exist for a short time, it is helpful to collect all of the logs from your network.
 
-A script to install and configure Logspout, `monitordocker.sh`, is already included in the `commercial-paper` sample in the Fabric samples. We will use the same script in this tutorial as well. The Logspout tool will continuously stream logs to your terminal, so you will need to use a new terminal window. Open a new terminal and navigate to the `test-network` directory.
+A script to install and configure Logspout, `monitordocker.sh`, is already included in the `test-network` directory in the Fabric samples. The Logspout tool will continuously stream logs to your terminal, so you will need to use a new terminal window. Open a new terminal and navigate to the `test-network` directory.
 
 ```
 cd fabric-samples/test-network
-```
-
-You can run the `monitordocker.sh` script from any directory. For ease of use, we will copy the `monitordocker.sh` script from the `commercial-paper` sample to your working directory
-
-```
-cp ../commercial-paper/organization/digibank/configuration/cli/monitordocker.sh .
-# if you're not sure where it is
-find . -name monitordocker.sh
 ```
 
 You can then start Logspout by running the following command:


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

This PR fixes a tutorial to keep up with the latest samples.
`test-network` has the `monitordocker.sh` to monitor the
logs of the smart contract. Copying the script from
`commercial-paper` is not required.

Signed-off-by: Yuki Kondo <yuki.kondo.ob@hitachi.com>