### PR TITLE
Documentation for peer.gossip.externalEndpoint

### DIFF
--- a/docs/source/deploypeer/peerchecklist.md
+++ b/docs/source/deploypeer/peerchecklist.md
@@ -131,7 +131,7 @@ gossip:
     endpoint:
 
     # This is an endpoint that is published to peers outside of the organization.
-    # If this isn't set, the peer will not be known to other organizations.
+    # If this isn't set, the peer will not be known to other organizations and will not be exposed via service discovery.
     externalEndpoint:
 
     # NOTE: orgLeader and useLeaderElection parameters are mutual exclusive.

--- a/docs/source/discovery-cli.md
+++ b/docs/source/discovery-cli.md
@@ -48,12 +48,11 @@ Commands:
 Configuring external endpoints
 ------------------------------
 
-Currently, to see peers in service discovery they need to have `EXTERNAL_ENDPOINT`
-to be configured for them. Otherwise, Fabric assumes the peer should not be
+For a peer to be exposed to service discovery, they need to have `peer.gossip.externalEndpoint`
+configured in `core.yaml`. Otherwise, Fabric assumes the peer should not be
 disclosed.
 
-To define these endpoints, you need to specify them in the `core.yaml` of the
-peer, replacing the sample endpoint below with the ones of your peer.
+The `core.yaml` value can also be overridden using an environment variable.
 
 ```
 CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer1.org1.example.com:8051

--- a/docs/source/discovery-overview.rst
+++ b/docs/source/discovery-overview.rst
@@ -42,7 +42,7 @@ The application is bootstrapped knowing about a group of peers which are
 trusted by the application developer/administrator to provide authentic responses
 to discovery queries. A good candidate peer to be used by the client application
 is one that is in the same organization. Note that in order for peers to be known
-to the discovery service, they must have an ``EXTERNAL_ENDPOINT`` defined. To see
+to the discovery service, they must have a ``peer.gossip.externalEndpoint`` defined. To see
 how to do this, check out our :doc:`discovery-cli` documentation.
 
 The application issues a configuration query to the discovery service and obtains

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -178,7 +178,7 @@ peer:
         # Message expiration factor for alive messages
         msgExpirationFactor: 20
         # This is an endpoint that is published to peers outside of the organization.
-        # If this isn't set, the peer will not be known to other organizations.
+        # If this isn't set, the peer will not be known to other organizations and will not be exposed via service discovery.
         externalEndpoint:
         # Leader election service configuration
         election:


### PR DESCRIPTION
Fix the reference to EXTERNAL_ENDPOINT and clarify externalEndpoint role in service discovery.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>