### PR TITLE
Change membership documentation about public keys

### DIFF
--- a/docs/source/membership/membership.md
+++ b/docs/source/membership/membership.md
@@ -7,7 +7,7 @@ Note: this topic describes a network that does not use a "system channel", a cha
 Because Fabric is a permissioned network, blockchain participants need a way to prove their identity to the rest of the network in order to transact on the network. If you've read through the documentation on [Identity](../identity/identity.html)
 you've seen how a Public Key Infrastructure (PKI) can provide verifiable identities through a chain of trust. How is that chain of trust used by the blockchain network?
 
-Certificate Authorities issue identities by generating a public and private key which forms a key-pair that can be used to prove identity. Because a private key can never be shared publicly, a mechanism is required to enable that proof which is where the MSP comes in. For example, a peer uses its private key to digitally sign, or endorse, a transaction.  The MSP on the ordering service contains the peer's public key which is then used to verify that the signature attached to the transaction is valid. The private key is used to produce a signature on a transaction that only the corresponding public key, that is part of an MSP, can match. Thus, the MSP is the mechanism that allows that identity to be trusted and recognized by the rest of the network without ever revealing the member’s private key.
+Certificate Authorities issue identities by generating a public and private key which forms a key-pair that can be used to prove identity. This identity needs a way to be recognized by the network, which is where the MSP comes in. For example, a peer uses its private key to digitally sign, or endorse, a transaction. The MSP is used to check that the peer is allowed to endorse the transaction. The public key from the peer's certificate is then used to verify that the signature attached to the transaction is valid. Thus, the MSP is the mechanism that allows that identity to be trusted and recognized by the rest of the network.
 
 Recall from the credit card scenario in the Identity topic that the Certificate Authority is like a card provider — it dispenses many different types of verifiable identities. An MSP, on the other hand, determines which credit card providers are accepted at the store. In this way, the MSP turns an identity (the credit card) into a role (the ability to buy things at the store).
 
@@ -21,10 +21,9 @@ Consider a group of banks that operate a blockchain network. Each bank operates 
 
 Finally, consider if you want to join an _existing_ network, you need a way to turn your identity into something that is recognized by the network. The MSP is the mechanism that enables you to participate on a permissioned blockchain network. To transact on a Fabric network a member needs to:
 
-1. Have an identity issued by a CA that is trusted by the network.
-2. Become a member of an _organization_ that is recognized and approved by the network members. The MSP is how the identity is linked to the membership of an organization. Membership is achieved by adding the member's public key (also known as certificate, signing cert, or signcert) to the organization’s MSP.
-3. Add the MSP to a channel.
-4. Ensure the MSP is included in the [policy](../policies/policies.html) definitions on the network.
+1. Have an identity issued by a CA that is trusted by an organization. The organization MSP determines which CAs are trusted by the organization.
+2. Check that the organization MSP is added to the channel. This means that the organization is recognized and approved by the network members.
+3. Ensure the MSP is included in the [policy](../policies/policies.html) definitions on the network.
 
 ## What is an MSP?
 


### PR DESCRIPTION
#### Type of change
- Documentation update
#### Description
> a mechanism is required to enable that proof which is where the MSP comes in

Identity can be proven just by signing the transaction and verifying with the public key on the certificate, proving identity is not where the MSP comes in, this is more related to how CAs issue the key-pair.

> The private key is used to produce a signature on a transaction that only the corresponding public key, that is part of an MSP, can match.

The sentence does not say anything about whether this public key matches invalid signatures, it only says that given that particular signature, only that particular public key can match. It should go along the lines of "only a valid signature will work". The sentence has been removed as I have adapted the paragraph.

I do not have experience with Fabric; these changes are based off my reading of the documentation. Am I right to assume that the member's public keys do not need to be added to the organization's MSP in the current version? Please correct me if I am wrong. Thank you.