### PR TITLE
fix unittest failure (#3294)

### DIFF
--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -3053,7 +3053,8 @@ var _ = Describe("Chain", func() {
 
 					Eventually(c1.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(3))
 					Eventually(c3.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(1))
-					Expect(countSnapShotsForChain(c1)).Should(Equal(3))
+					countSnapShotsForc1 := func() int { return countSnapShotsForChain(c1) }
+					Eventually(countSnapShotsForc1, LongEventualTimeout).Should(Equal(3))
 					// No snapshot would be taken for node 3 after this orrderer request
 					addtional_snapshots_for_node3 := countSnapShotsForChain(c3) - snapshots_on_node3
 					Expect(addtional_snapshots_for_node3).Should(Equal(0))


### PR DESCRIPTION
Signed-off-by: Shivdeep Singh <Shivdeep.Singh@ibm.com>

#### Type of change

- Bug fix
- Test update

#### Description

Unittest __snapshot on accumlated bytes condition met__ in `orderer/consensus/etcdraft` was failing due to *Expect* conditions not met. Replaced *Expect* condition with *Eventually* which waits for some time to check for expected condition. 

#### Related issues
- [3294](https://github.com/hyperledger/fabric/issues/3294)