### PR TITLE
Remove a duplicate command line in the "Deploying a smart contract to a channel" doc

### DIFF
--- a/docs/source/deploy_chaincode.md
+++ b/docs/source/deploy_chaincode.md
@@ -619,7 +619,6 @@ We now need to install the chaincode package and approve the chaincode definitio
 ```
 export CORE_PEER_LOCALMSPID="Org2MSP"
 export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt
-export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt
 export CORE_PEER_MSPCONFIGPATH=${PWD}/organizations/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp
 export CORE_PEER_ADDRESS=localhost:9051
 ```


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

I noticed there were two lines of the same command exporting the same environment variable `CORE_PEER_TLS_ROOTCERT_FILE` in the section *Upgrading a smart contract* of the *Deploying a smart contract to a channel* doc when I was reading it. So I removed one of them.

#### Additional details

`nil`

#### Related issues

No related issues. Quite a small change.
