### PR TITLE
Update private data tests to use raft orderer

### DIFF
--- a/integration/nwo/standard_networks.go
+++ b/integration/nwo/standard_networks.go
@@ -227,6 +227,24 @@ func MinimalRaft() *Config {
 	return config
 }
 
+// Like FullSolo, FullEtcdRaft is a configuration with two organizations and two peers per org.
+func FullEtcdRaft() *Config {
+	config := FullSolo()
+
+	config.Consensus.Type = "etcdraft"
+	config.Profiles = []*Profile{{
+		Name:     "SampleDevModeEtcdRaft",
+		Orderers: []string{"orderer"},
+	}, {
+		Name:          "TwoOrgsChannel",
+		Consortium:    "SampleConsortium",
+		Organizations: []string{"Org1", "Org2"},
+	}}
+	config.SystemChannel.Profile = "SampleDevModeEtcdRaft"
+
+	return config
+}
+
 func ThreeOrgRaft() *Config {
 	config := BasicEtcdRaft()
 

--- a/integration/pvtdata/pvtdata_test.go
+++ b/integration/pvtdata/pvtdata_test.go
@@ -946,7 +946,7 @@ func initThreeOrgsSetup(removePeer1 bool) *nwo.Network {
 	client, err := docker.NewClientFromEnv()
 	Expect(err).NotTo(HaveOccurred())
 
-	config := nwo.FullSolo()
+	config := nwo.FullEtcdRaft()
 
 	// add org3 with one peer
 	config.Organizations = append(config.Organizations, &nwo.Organization{


### PR DESCRIPTION
#### Type of change

- Test update

#### Description

Update private data tests to use raft orderer since the solo orderer has been deprecated

