### PR TITLE
Retire inactive maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,10 +9,7 @@ See [the documentation on Maintainers](https://hyperledger-fabric.readthedocs.io
 |------|--------|------|----------------------
 | Alessandro Sorniotti | [ale-linux][ale-linux] | aso | <ale.linux@sopit.net>
 | Andrew Coleman | [andrew-coleman][andrew-coleman] | andrew-coleman | <andrew_coleman@uk.ibm.com>
-| Artem Barger | [c0rwin][c0rwin] | c0rwin | <artem@bargr.net>
-| Senthilnathan Natarajan | [cendhu][cendhu] | Senthil1 | <cendhu@gmail.com>
 | Dave Enyeart | [denyeart][denyeart] | dave.enyeart | <enyeart@us.ibm.com>
-| Jay Guo | [guoger][guoger] | guoger | <guojiannan1101@gmail.com>
 | Manish Sethi | [manish-sethi][manish-sethi] | manish-sethi | <manish.sethi@gmail.com>
 | Yacov Manevich | [yacovm][yacovm] | yacovm | <yacovm@il.ibm.com>
 
@@ -20,11 +17,7 @@ See [the documentation on Maintainers](https://hyperledger-fabric.readthedocs.io
 
 | Name | GitHub | Chat | email
 |------|--------|------|----------------------
-| Chris Gabriel  | [denali49][denali49] | cmgabriel | <alaskadd@gmail.com>
-| Joe Alewine | [joealewine][joealewine] | joe-alewine | <joe.alewine@ibm.com>
 | Nikhil Gupta | [nikhil550][nikhil550] | nikhilgupta | <nikhilg550@gmail.com>
-| Anthony O'Dowd | [odowdaibm][odowdaibm] | odowdaibm | <a_o-dowd@uk.ibm.com>
-| Pam Andrejko | [pamandrejko][pamandrejko] | pandrejko | <pama@ibm.com>
 
 **Release Managers**
 
@@ -36,19 +29,26 @@ See [the documentation on Maintainers](https://hyperledger-fabric.readthedocs.io
 
 | Name | GitHub | Chat | email
 |------|--------|------|----------------------
+| Anthony O'Dowd | [odowdaibm][odowdaibm] | odowdaibm | <a_o-dowd@uk.ibm.com>
+| Artem Barger | [c0rwin][c0rwin] | c0rwin | <artem@bargr.net>
 | Binh Nguyen | [binhn][binhn] | binhn | <binh1010010110@gmail.com>
 | Brett Logan | [lindluni][lindluni] | BrettLogan | <development.brett@gmail.com>
 | Chris Ferris | [christo4ferris][christo4ferris] | cbf | <chris.ferris@gmail.com>
+| Chris Gabriel  | [denali49][denali49] | cmgabriel | <alaskadd@gmail.com>
 | Danny Cao | [caod123][caod123] | caod | <caoxiaohua@gmail.com>
 | Gabor Hosszu | [gabre][gabre] | hgabor | <gabor@digitalasset.com>
 | Gari Singh | [mastersingh24][mastersingh24] | mastersingh24 | <gari.r.singh@gmail.com>
 | Greg Haskins | [ghaskins][ghaskins] | ghaskins | <gregory.haskins@gmail.com>
 | Jason Yellick | [jyellick][jyellick] | jyellick | <jason-github@unaddressable.org>
+| Jay Guo | [guoger][guoger] | guoger | <guojiannan1101@gmail.com>
 | Jim Zhang | [jimthematrix][jimthematrix] | jimthematrix | <jim_the_matrix@hotmail.com>
+| Joe Alewine | [joealewine][joealewine] | joe-alewine | <joe.alewine@ibm.com>
 | Jonathan Levi | [hacera][hacera] |JonathanLevi | <jonathan@hacera.com>
 | Keith Smith | [smithbk][smithbk] | smithbk | <bksmith@us.ibm.com>
 | Kostas Christidis | [kchristidis][kchristidis] | kostas | <kostas@gmail.com>
 | Matthew Sykes | [sykesm][sykesm] | sykesm | <matthew.sykes@gmail.com>
+| Pam Andrejko | [pamandrejko][pamandrejko] | pandrejko | <pama@ibm.com>
+| Senthilnathan Natarajan | [cendhu][cendhu] | Senthil1 | <cendhu@gmail.com>
 | Sheehan Anderson | [srderson][srderson] | sheehan | <sranderson@gmail.com>
 | Srinivasan Muralidharan | [muralisrini][muralisrini] | muralisr | <srinivasan.muralidharan99@gmail.com>
 | Tamas Blummer | [tamasblummer][tamasblummer] | tamas | <tamas@digitalasset.com>


### PR DESCRIPTION
Signed-off-by: Ry Jones <ry@linux.com>

#### Type of change

- Documentation update

#### Description

Retiring inactive maintainers.

#### Additional details

#### Related issues