### PR TITLE
Use actual address of the deadMembers2Expire slice variable

### DIFF
--- a/gossip/discovery/discovery_impl.go
+++ b/gossip/discovery/discovery_impl.go
@@ -735,9 +735,9 @@ func (d *gossipDiscoveryImpl) expireDeadMembers(dead []common.PKIidType) {
 
 	d.lock.Unlock()
 
-	for _, member2Expire := range deadMembers2Expire {
-		d.logger.Warning("Closing connection to", member2Expire)
-		d.comm.CloseConn(&member2Expire)
+	for i := range deadMembers2Expire {
+		d.logger.Warning("Closing connection to", deadMembers2Expire[i])
+		d.comm.CloseConn(&deadMembers2Expire[i])
 	}
 }
 


### PR DESCRIPTION
Instead of passing the address of the for-loop variable, pass address of the 
actual slice element.

Signed-off-by: Artem Barger <artem@bargr.net>
