### PR TITLE
Handle empty policies when traversing the policy tree in discovery policy analysis

### DIFF
--- a/common/policies/inquire/inquire.go
+++ b/common/policies/inquire/inquire.go
@@ -62,6 +62,10 @@ func principalsOfTree(tree *graph.Tree, principals policies.PrincipalSet) polici
 			continue
 		}
 		pol := v.Data.(*common.SignaturePolicy)
+		if pol == nil {
+			logger.Warnf("Malformed policy, it is either not composed of signature policy envelopes or is missing some")
+			return nil
+		}
 		switch principalIndex := pol.Type.(type) {
 		case *common.SignaturePolicy_SignedBy:
 			if len(principals) <= int(principalIndex.SignedBy) {


### PR DESCRIPTION

Discovery policy analysis engine assumed that the inner policy passed to it is of the correct type and cannot be empty.
Added a nil check and a test.

Change-Id: Ia6eaf0211d8d9f4b7f2881547934dc32c725a458
Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>
