### PR TITLE
Updated dockerfile with new build arg

### DIFF
--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -27,6 +27,7 @@ FROM golang as peer
 ARG GO_TAGS
 RUN make peer GO_TAGS=${GO_TAGS}
 RUN make ccaasbuilder
+RUN export MARCH=$(go env GOOS)-$(go env GOARCH) && mkdir -p /tmp/ccaas_builder/bin/ && cp /go/src/github.com/hyperledger/fabric/release/${MARCH}/bin/ccaas_builder/bin/* /tmp/ccaas_builder/bin/
 
 FROM peer-base
 ENV FABRIC_CFG_PATH /etc/hyperledger/fabric
@@ -35,6 +36,6 @@ VOLUME /var/hyperledger
 COPY --from=peer /go/src/github.com/hyperledger/fabric/build/bin /usr/local/bin
 COPY --from=peer /go/src/github.com/hyperledger/fabric/sampleconfig/msp ${FABRIC_CFG_PATH}/msp
 COPY --from=peer /go/src/github.com/hyperledger/fabric/sampleconfig/core.yaml ${FABRIC_CFG_PATH}/core.yaml
-COPY --from=peer /go/src/github.com/hyperledger/fabric/release/linux-amd64/bin/ccaas_builder/bin/ /opt/hyperledger/ccaas_builder/bin/
+COPY --from=peer /tmp/ccaas_builder/bin/ /opt/hyperledger/ccaas_builder/bin/
 EXPOSE 7051
 CMD ["peer","node","start"]


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Updated multistage peer dockerfile with ccbuilder binaries location. It becomes 2 step process to copy the binaries Step 1. copy the files into temporary location, Step 2. copy the files into correction location into docker image

#### Related issues

#3337 


Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>