### PR TITLE
Bump CouchDB to 3.2.2 (#3369)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ BASE_VERSION = 2.4.3
 
 # 3rd party image version
 # These versions are also set in the runners in ./integration/runners/
-COUCHDB_VER ?= 3.1.1
+COUCHDB_VER ?= 3.2.2
 KAFKA_VER ?= 5.3.1
 ZOOKEEPER_VER ?= 5.3.1
 

--- a/docs/source/couchdb_as_state_database.rst
+++ b/docs/source/couchdb_as_state_database.rst
@@ -132,7 +132,7 @@ any JSON query with a sort. Indexes enable you to query data from chaincode when
 a large amount of data on your ledger. Indexes can be packaged alongside chaincode
 in a ``/META-INF/statedb/couchdb/indexes`` directory. Each index must be defined in
 its own text file with extension ``*.json`` with the index definition formatted in JSON
-following the `CouchDB index JSON syntax <http://docs.couchdb.org/en/3.1.1/api/database/find.html#db-index>`__.
+following the `CouchDB index JSON syntax <http://docs.couchdb.org/en/stable/api/database/find.html#db-index>`__.
 For example, to support the above marble query, a sample index on the ``docType`` and ``owner``
 fields is provided:
 
@@ -227,7 +227,7 @@ variables using Docker Compose scripting.
 For CouchDB installations outside of the docker images supplied with Fabric,
 the
 `local.ini file of that installation
-<http://docs.couchdb.org/en/3.1.1/config/intro.html#configuration-files>`__
+<http://docs.couchdb.org/en/stable/config/intro.html#configuration-files>`__
 must be edited to set the admin username and password.
 
 Docker compose scripts only set the username and password at the creation of

--- a/integration/nwo/runner/couchdb.go
+++ b/integration/nwo/runner/couchdb.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	CouchDBDefaultImage = "couchdb:3.1.1"
+	CouchDBDefaultImage = "couchdb:3.2.2"
 	CouchDBUsername     = "admin"
 	CouchDBPassword     = "adminpw"
 )


### PR DESCRIPTION
Update CouchDB to 3.2.2.
Update CouchDB doc refererences to 'stable' so that the links
don't point to outdated CouchDB versions.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>