### PR TITLE
Remove an unused config parameter from peer

### DIFF
--- a/core/deliverservice/config.go
+++ b/core/deliverservice/config.go
@@ -142,12 +142,6 @@ func (c *DeliverServiceConfig) loadDeliverServiceConfig() {
 	}
 
 	c.KeepaliveOptions = comm.DefaultKeepaliveOptions
-	if viper.IsSet("peer.keepalive.deliveryClient.interval") {
-		c.KeepaliveOptions.ClientInterval = viper.GetDuration("peer.keepalive.deliveryClient.interval")
-	}
-	if viper.IsSet("peer.keepalive.deliveryClient.timeout") {
-		c.KeepaliveOptions.ClientTimeout = viper.GetDuration("peer.keepalive.deliveryClient.timeout")
-	}
 
 	c.SecOpts = comm.SecureOptions{
 		UseTLS:            viper.GetBool("peer.tls.enabled"),

--- a/core/deliverservice/config_test.go
+++ b/core/deliverservice/config_test.go
@@ -86,8 +86,6 @@ func TestGlobalConfig(t *testing.T) {
 	viper.Set("peer.deliveryclient.reConnectBackoffThreshold", "25s")
 	viper.Set("peer.deliveryclient.reconnectTotalTimeThreshold", "20s")
 	viper.Set("peer.deliveryclient.connTimeout", "10s")
-	viper.Set("peer.keepalive.deliveryClient.interval", "5s")
-	viper.Set("peer.keepalive.deliveryClient.timeout", "2s")
 
 	coreConfig := deliverservice.GlobalConfig()
 
@@ -98,8 +96,8 @@ func TestGlobalConfig(t *testing.T) {
 		ReconnectTotalTimeThreshold: 20 * time.Second,
 		ConnectionTimeout:           10 * time.Second,
 		KeepaliveOptions: comm.KeepaliveOptions{
-			ClientInterval:    time.Second * 5,
-			ClientTimeout:     time.Second * 2,
+			ClientInterval:    time.Second * 60,
+			ClientTimeout:     time.Second * 20,
 			ServerInterval:    time.Hour * 2,
 			ServerTimeout:     time.Second * 20,
 			ServerMinInterval: time.Minute,

--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -79,10 +79,6 @@ type Config struct {
 	// hardware threads on the machine.
 	ValidatorPoolSize int
 
-	// ----- Peer Delivery Client Keepalive -----
-	// DeliveryClient Keepalive settings for communication with ordering nodes.
-	DeliverClientKeepaliveOptions comm.KeepaliveOptions
-
 	// ----- Profile -----
 	// TODO: create separate sub-struct for Profile config.
 
@@ -269,14 +265,6 @@ func (c *Config) load() error {
 	c.ValidatorPoolSize = viper.GetInt("peer.validatorPoolSize")
 	if c.ValidatorPoolSize <= 0 {
 		c.ValidatorPoolSize = runtime.NumCPU()
-	}
-
-	c.DeliverClientKeepaliveOptions = comm.DefaultKeepaliveOptions
-	if viper.IsSet("peer.keepalive.deliveryClient.interval") {
-		c.DeliverClientKeepaliveOptions.ClientInterval = viper.GetDuration("peer.keepalive.deliveryClient.interval")
-	}
-	if viper.IsSet("peer.keepalive.deliveryClient.timeout") {
-		c.DeliverClientKeepaliveOptions.ClientTimeout = viper.GetDuration("peer.keepalive.deliveryClient.timeout")
 	}
 
 	c.GatewayOptions = gatewayconfig.GetOptions(viper.GetViper())

--- a/core/peer/config_test.go
+++ b/core/peer/config_test.go
@@ -346,7 +346,6 @@ func TestGlobalConfig(t *testing.T) {
 		ChaincodeListenAddress:                "0.0.0.0:7052",
 		ChaincodeAddress:                      "0.0.0.0:7052",
 		ValidatorPoolSize:                     1,
-		DeliverClientKeepaliveOptions:         comm.DefaultKeepaliveOptions,
 
 		VMEndpoint:           "unix:///var/run/docker.sock",
 		VMDockerTLSEnabled:   false,
@@ -402,12 +401,11 @@ func TestGlobalConfigDefault(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedConfig := &Config{
-		AuthenticationTimeWindow:      15 * time.Minute,
-		PeerAddress:                   "localhost:8080",
-		ValidatorPoolSize:             runtime.NumCPU(),
-		VMNetworkMode:                 "host",
-		DeliverClientKeepaliveOptions: comm.DefaultKeepaliveOptions,
-		GatewayOptions:                config.GetOptions(viper.GetViper()),
+		AuthenticationTimeWindow: 15 * time.Minute,
+		PeerAddress:              "localhost:8080",
+		ValidatorPoolSize:        runtime.NumCPU(),
+		VMNetworkMode:            "host",
+		GatewayOptions:           config.GetOptions(viper.GetViper()),
 	}
 
 	require.Equal(t, expectedConfig, coreConfig)
@@ -438,11 +436,10 @@ func TestPropagateEnvironment(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedConfig := &Config{
-		AuthenticationTimeWindow:      15 * time.Minute,
-		PeerAddress:                   "localhost:8080",
-		ValidatorPoolSize:             runtime.NumCPU(),
-		VMNetworkMode:                 "host",
-		DeliverClientKeepaliveOptions: comm.DefaultKeepaliveOptions,
+		AuthenticationTimeWindow: 15 * time.Minute,
+		PeerAddress:              "localhost:8080",
+		ValidatorPoolSize:        runtime.NumCPU(),
+		VMNetworkMode:            "host",
 		ExternalBuilders: []ExternalBuilder{
 			{
 				Name:                 "testName",

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -79,16 +79,6 @@ peer:
             # Timeout is the duration the client waits for a response from
             # peer nodes before closing the connection
             timeout: 20s
-        # DeliveryClient keepalive settings for communication with ordering
-        # nodes.
-        deliveryClient:
-            # Interval is the time between pings to ordering nodes.  This must
-            # greater than or equal to the minInterval specified by ordering
-            # nodes.
-            interval: 60s
-            # Timeout is the duration the client waits for a response from
-            # ordering nodes before closing the connection
-            timeout: 20s
 
 
     # Gossip related configuration


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description
After the commit of 6c58b2, a config parameter 'DeliverClientKeepaliveOptions' is no longer used.