### PR TITLE
Delete historical versions of private data marked for purging (#3024)

### DIFF
--- a/core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util.go
+++ b/core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util.go
@@ -286,7 +286,7 @@ func (nsPvtRwSet *NsPvtRwSet) toProtoMsg() (*rwset.NsPvtReadWriteSet, error) {
 	var err error
 	var collPvtRwSetProtoMsg *rwset.CollectionPvtReadWriteSet
 	for _, collPvtRwSet := range nsPvtRwSet.CollPvtRwSets {
-		if collPvtRwSetProtoMsg, err = collPvtRwSet.toProtoMsg(); err != nil {
+		if collPvtRwSetProtoMsg, err = collPvtRwSet.ToProtoMsg(); err != nil {
 			return nil, err
 		}
 		protoMsg.CollectionPvtRwset = append(protoMsg.CollectionPvtRwset, collPvtRwSetProtoMsg)
@@ -307,7 +307,7 @@ func nsPvtRwSetFromProtoMsg(protoMsg *rwset.NsPvtReadWriteSet) (*NsPvtRwSet, err
 	return nsPvtRwSet, nil
 }
 
-func (collPvtRwSet *CollPvtRwSet) toProtoMsg() (*rwset.CollectionPvtReadWriteSet, error) {
+func (collPvtRwSet *CollPvtRwSet) ToProtoMsg() (*rwset.CollectionPvtReadWriteSet, error) {
 	var err error
 	protoMsg := &rwset.CollectionPvtReadWriteSet{CollectionName: collPvtRwSet.CollectionName}
 	if protoMsg.Rwset, err = proto.Marshal(collPvtRwSet.KvRwSet); err != nil {

--- a/core/ledger/pvtdatastorage/kv_encoding.go
+++ b/core/ledger/pvtdatastorage/kv_encoding.go
@@ -302,6 +302,18 @@ func encodePurgeMarkerKey(k *purgeMarkerKey) []byte {
 	return encKey
 }
 
+func rangeScanKeysForPurgeMarkers() ([]byte, []byte) {
+	return purgeMarkerKeyPrefix, []byte{purgeMarkerKeyPrefix[0] + 1}
+}
+
+// driveHashedIndexKeyRangeFromPurgeMarker returns the scan range for hashedIndexKeys for a key specified by the `purgeMarkerKey`.
+// The range covers all the hashedIndexKeys between block 0 and the height specified in the `purgeMarkerVal`
+func driveHashedIndexKeyRangeFromPurgeMarker(purgeMarkerKey, purgeMarkerVal []byte) ([]byte, []byte) {
+	startKey := append(hashedIndexKeyPrefix, purgeMarkerKey[1:]...)
+	endKey := append(startKey, purgeMarkerVal...)
+	return startKey, endKey
+}
+
 func encodePurgeMarkerVal(v *purgeMarkerVal) []byte {
 	return version.NewHeight(v.blkNum, v.txNum).ToBytes()
 }


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Description
This PR includes
  - Code for processing the purge marker in the background that deletes
  the historical versions of the private data and corresponding
  hashed-indexed-keys that qualifies for deletion
  - Modifies the transaction number match in the previously committed
   code for filtering the 'to be purged' data so as to have the same
   behavior as for the actually purged data.

#### Related issues
Closes #3024 