### PR TITLE
Improved gateway error for transient data failure

### DIFF
--- a/internal/pkg/gateway/api.go
+++ b/internal/pkg/gateway/api.go
@@ -334,9 +334,16 @@ func (gs *Server) planFromFirstEndorser(ctx context.Context, channel string, cha
 
 	// 4. If transient data is involved, then we need to ensure that discovery only returns orgs which own the collections involved.
 	// Do this by setting NoPrivateReads to false on each collection
+	originalInterest := &peer.ChaincodeInterest{}
+	var protectedCollections []string
 	if hasTransientData {
 		for _, call := range interest.GetChaincodes() {
-			call.NoPrivateReads = false
+			ccc := *call // shallow copy
+			originalInterest.Chaincodes = append(originalInterest.Chaincodes, &ccc)
+			if call.NoPrivateReads {
+				call.NoPrivateReads = false
+				protectedCollections = append(protectedCollections, call.CollectionNames...)
+			}
 		}
 	}
 
@@ -344,6 +351,13 @@ func (gs *Server) planFromFirstEndorser(ctx context.Context, channel string, cha
 	// The preferred discovery layout will contain the firstEndorser's Org.
 	plan, err = gs.registry.endorsementPlan(channel, interest, firstEndorser)
 	if err != nil {
+		if len(protectedCollections) > 0 {
+			// may have failed because of the cautious approach we are taking with transient data - check
+			_, err = gs.registry.endorsementPlan(channel, originalInterest, firstEndorser)
+			if err == nil {
+				return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("requires endorsement from organisation(s) that are not in the distribution policy of the private data collection(s): %v; retry specifying trusted endorsing organizations to protect transient data", protectedCollections))
+			}
+		}
 		return nil, status.Error(codes.FailedPrecondition, err.Error())
 	}
 


### PR DESCRIPTION
When transient data is passed to the gateway in a transaction submit, the gateway is more cautious about which orgs it will select to endorse.  It alters the ChaincodeInterest to only allow orgs that are in the distribution policy for the PDCs written to by the chaincode.
This commit doesn’t change the behaviour, but gives a more helpful error message if this layer of protection caused the submit to fail due to the lack of endorsing orgs.
This will help to diagnose issues such as #3328 which took a long time to resolve because of the generic error message.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
