### PR TITLE
Use any peer to evaluate system chaincode transactions

### DIFF
--- a/integration/gateway/gateway_test.go
+++ b/integration/gateway/gateway_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/orderer"
 	"github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric-protos-go/peer/lifecycle"
 	"github.com/hyperledger/fabric/integration/nwo"
 	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/ginkgo"
@@ -266,6 +267,25 @@ var _ = Describe("GatewayService", func() {
 			Expect(response.Result.Payload).To(Equal(expectedResponse.Result.Payload))
 			Expect(proto.Equal(response, expectedResponse)).To(BeTrue(), "Expected\n\t%#v\nto proto.Equal\n\t%#v", response, expectedResponse)
 		})
+
+		It("should responsd with system chaincode result", func() {
+			proposedTransaction, transactionID := NewProposedTransaction(signingIdentity, "testchannel", "qscc", "GetChainInfo", nil, []byte("testchannel"))
+
+			request := &gateway.EvaluateRequest{
+				TransactionId:       transactionID,
+				ChannelId:           "testchannel",
+				ProposedTransaction: proposedTransaction,
+			}
+
+			response, err := gatewayClient.Evaluate(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+
+			status := common.Status(response.GetResult().GetStatus())
+			Expect(status).To(Equal(common.Status_SUCCESS))
+
+			blockchainInfo := new(common.BlockchainInfo)
+			Expect(proto.Unmarshal(response.GetResult().GetPayload(), blockchainInfo)).NotTo(HaveOccurred())
+		})
 	})
 
 	Describe("Submit", func() {
@@ -278,6 +298,29 @@ var _ = Describe("GatewayService", func() {
 			}
 			Expect(result.Payload).To(Equal(expectedResult.Payload))
 			Expect(proto.Equal(result, expectedResult)).To(BeTrue(), "Expected\n\t%#v\nto proto.Equal\n\t%#v", result, expectedResult)
+		})
+
+		It("should endorse a system chaincode transaction", func() {
+			arg, err := proto.Marshal(&lifecycle.QueryInstalledChaincodesArgs{})
+			Expect(err).NotTo(HaveOccurred())
+			adminSigner := network.PeerUserSigner(org1Peer0, "Admin")
+			proposedTransaction, transactionID := NewProposedTransaction(adminSigner, "testchannel", "_lifecycle", "QueryInstalledChaincodes", nil, arg)
+
+			request := &gateway.EndorseRequest{
+				TransactionId:          transactionID,
+				ChannelId:              "testchannel",
+				ProposedTransaction:    proposedTransaction,
+				EndorsingOrganizations: []string{adminSigner.MSPID}, // Only use peers for our admin ID org
+			}
+
+			response, err := gatewayClient.Endorse(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+
+			chaincodeAction, err := protoutil.GetActionFromEnvelopeMsg(response.GetPreparedTransaction())
+			Expect(err).NotTo(HaveOccurred())
+
+			queryResult := new(lifecycle.QueryInstalledChaincodesResult)
+			Expect(proto.Unmarshal(chaincodeAction.GetResponse().GetPayload(), queryResult)).NotTo(HaveOccurred())
 		})
 	})
 

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -829,6 +829,7 @@ func serve(args []string) error {
 				aclProvider,
 				coreConfig.LocalMSPID,
 				coreConfig.GatewayOptions,
+				builtinSCCs,
 			)
 			gatewayprotos.RegisterGatewayServer(peerServer.Server(), gatewayServer)
 		} else {

--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -1930,6 +1930,7 @@ func TestNilArgs(t *testing.T) {
 		"msp1",
 		&comm.SecureOptions{},
 		config.GetOptions(viper.New()),
+		nil,
 	)
 	ctx := context.Background()
 
@@ -2072,7 +2073,7 @@ func prepareTest(t *testing.T, tt *testDef) *preparedTest {
 		Endpoint: "localhost:7051",
 	}
 
-	server := newServer(localEndorser, disc, mockFinder, mockPolicy, mockLedgerProvider, member, "msp1", &comm.SecureOptions{}, options)
+	server := newServer(localEndorser, disc, mockFinder, mockPolicy, mockLedgerProvider, member, "msp1", &comm.SecureOptions{}, options, nil)
 
 	dialer := &mocks.Dialer{}
 	dialer.Returns(nil, nil)


### PR DESCRIPTION
System chaincodes are not included in the installed chaincodes returned by service discovery. The Gateway service was relying on discovery results to find peers on which to evaluate transactions and so failed to evaluate system chaincode transaction functions. Now the Gateway service uses any network peer to evaluate transactions invoked on known built-in system chaincodes.

Also added a system test to confirm that the Gateway service can endorse system chaincode transaction functions.

Closes hyperledger/fabric-gateway#434