### PR TITLE
Use any peer to evaluate system chaincode transactions

### DIFF
--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -829,6 +829,7 @@ func serve(args []string) error {
 				aclProvider,
 				coreConfig.LocalMSPID,
 				coreConfig.GatewayOptions,
+				builtinSCCs,
 			)
 			gatewayprotos.RegisterGatewayServer(peerServer.Server(), gatewayServer)
 		} else {

--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -1837,6 +1837,7 @@ func TestNilArgs(t *testing.T) {
 		"msp1",
 		&comm.SecureOptions{},
 		config.GetOptions(viper.New()),
+		nil,
 	)
 	ctx := context.Background()
 
@@ -1979,7 +1980,7 @@ func prepareTest(t *testing.T, tt *testDef) *preparedTest {
 		Endpoint: "localhost:7051",
 	}
 
-	server := newServer(localEndorser, disc, mockFinder, mockPolicy, mockLedgerProvider, member, "msp1", &comm.SecureOptions{}, options)
+	server := newServer(localEndorser, disc, mockFinder, mockPolicy, mockLedgerProvider, member, "msp1", &comm.SecureOptions{}, options, nil)
 
 	dialer := &mocks.Dialer{}
 	dialer.Returns(nil, nil)


### PR DESCRIPTION
Cherry-pick of d0e209309ce412a66b7a20a6348327f1b2f6ee23 from main branch.

System chaincodes are not included in the installed chaincodes returned by service discovery. The Gateway service was relying on discovery results to find peers on which to evaluate transactions and so failed to evaluate system chaincode transaction functions. Now the Gateway service uses any network peer to evaluate transactions invoked on known built-in system chaincodes.

Also added a system test to confirm that the Gateway service can endorse system chaincode transaction functions.