### PR TITLE
Small typo fix in Ordering Service

### DIFF
--- a/docs/source/orderer/ordering_service.md
+++ b/docs/source/orderer/ordering_service.md
@@ -257,7 +257,7 @@ single organization. With Raft, each organization can have its own ordering
 nodes, participating in the ordering service, which leads to a more decentralized
 system.
 
-* Raft is supported natively, which means that users are required to get the requisite images and
+* Kafka is supported natively, which means that users are required to get the requisite images and
 learn how to use Kafka and ZooKeeper on their own. Likewise, support for
 Kafka-related issues is handled through [Apache](https://kafka.apache.org/), the
 open-source developer of Kafka, not Hyperledger Fabric. The Fabric Raft implementation,


### PR DESCRIPTION
Signed-off-by: Saniyat Al Ahmed <32844821+saniyat013@users.noreply.github.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Documentation update

#### Description

There was a small typo in the Ordering Service page of the documentation, in the Raft vs Kafka differences section.
The word "Raft" was used, while it will be "Kafka"

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->
