### PR TITLE
Bump Alpine to 3.16 (release-2.2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@
 #   - unit-test - runs the go-test based unit tests
 #   - verify - runs unit tests for only the changed package tree
 
-ALPINE_VER ?= 3.14
+ALPINE_VER ?= 3.16
 BASE_VERSION = 2.2.5
 
 # 3rd party image version


### PR DESCRIPTION
Signed-off-by: David Enyeart <enyeart@us.ibm.com>
