### PR TITLE
Fix Ginkgo deprecation warning

### DIFF
--- a/integration/ports.go
+++ b/integration/ports.go
@@ -49,7 +49,7 @@ const (
 func (t TestPortRange) StartPortForNode() int {
 	const startEphemeral, endEphemeral = 32768, 60999
 
-	port := int(t) + portsPerNode*(ginkgo.GinkgoParallelNode()-1)
+	port := int(t) + portsPerNode*(ginkgo.GinkgoParallelProcess()-1)
 	if port >= startEphemeral-portsPerNode && port <= endEphemeral-portsPerNode {
 		fmt.Fprintf(os.Stderr, "WARNING: port %d is part of the default ephemeral port range on linux", port)
 	}


### PR DESCRIPTION
#### Type of change

- Test update

#### Description

Rename GinkgoParallelNode GinkgoParallelProcess as documented in the Ginkgo migration guide:

#### Additional details

See https://github.com/onsi/ginkgo/blob/ver2/docs/MIGRATING_TO_V2.md#renamed-ginkgoparallelnode

Signed-off-by: James Taylor <jamest@uk.ibm.com>
