### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/bccsp/sw/fileks_test.go
+++ b/bccsp/sw/fileks_test.go
@@ -22,9 +22,7 @@ import (
 func TestInvalidStoreKey(t *testing.T) {
 	t.Parallel()
 
-	tempDir, err := ioutil.TempDir("", "bccspks")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	ks, err := NewFileBasedKeyStore(nil, filepath.Join(tempDir, "bccspks"), false)
 	if err != nil {
@@ -58,9 +56,7 @@ func TestInvalidStoreKey(t *testing.T) {
 }
 
 func TestBigKeyFile(t *testing.T) {
-	ksPath, err := ioutil.TempDir("", "bccspks")
-	require.NoError(t, err)
-	defer os.RemoveAll(ksPath)
+	ksPath := t.TempDir()
 
 	ks, err := NewFileBasedKeyStore(nil, ksPath, false)
 	require.NoError(t, err)
@@ -97,9 +93,7 @@ func TestBigKeyFile(t *testing.T) {
 }
 
 func TestReInitKeyStore(t *testing.T) {
-	ksPath, err := ioutil.TempDir("", "bccspks")
-	require.NoError(t, err)
-	defer os.RemoveAll(ksPath)
+	ksPath := t.TempDir()
 
 	ks, err := NewFileBasedKeyStore(nil, ksPath, false)
 	require.NoError(t, err)

--- a/ccaas_builder/cmd/build/main_test.go
+++ b/ccaas_builder/cmd/build/main_test.go
@@ -7,15 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"testing"
 	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
 )
 
 func TestArguements(t *testing.T) {
@@ -61,9 +62,7 @@ func TestGoodPath(t *testing.T) {
 	gt.Expect(err).NotTo(HaveOccurred())
 	defer gexec.CleanupBuildArtifacts()
 
-	testPath, err := ioutil.TempDir("", "test-ccaas-build-")
-	gt.Expect(err).NotTo(HaveOccurred())
-	defer os.RemoveAll(testPath)
+	testPath := t.TempDir()
 
 	// create a basic structure of a chaincode
 	os.MkdirAll(path.Join(testPath, "in-builder-dir", "META-INF"), 0755)
@@ -121,9 +120,7 @@ func TestTemplating(t *testing.T) {
 	gt.Expect(err).NotTo(HaveOccurred())
 	defer gexec.CleanupBuildArtifacts()
 
-	testPath, err := ioutil.TempDir("", "test-ccaas-build-")
-	gt.Expect(err).NotTo(HaveOccurred())
-	defer os.RemoveAll(testPath)
+	testPath := t.TempDir()
 
 	// create a basic structure of the chaincode to use
 	os.MkdirAll(path.Join(testPath, "in-builder-dir", "META-INF"), 0755)
@@ -195,9 +192,7 @@ func TestTemplatingFailure(t *testing.T) {
 	gt.Expect(err).NotTo(HaveOccurred())
 	defer gexec.CleanupBuildArtifacts()
 
-	testPath, err := ioutil.TempDir("", "test-ccaas-build-")
-	gt.Expect(err).NotTo(HaveOccurred())
-	defer os.RemoveAll(testPath)
+	testPath := t.TempDir()
 
 	// create a basic structure of the chaincode to use
 	os.MkdirAll(path.Join(testPath, "in-builder-dir", "META-INF"), 0755)
@@ -249,9 +244,7 @@ func TestMissingConnection(t *testing.T) {
 	gt.Expect(err).NotTo(HaveOccurred())
 	defer gexec.CleanupBuildArtifacts()
 
-	testPath, err := ioutil.TempDir("", "test-ccaas-build-")
-	gt.Expect(err).NotTo(HaveOccurred())
-	defer os.RemoveAll(testPath)
+	testPath := t.TempDir()
 
 	// create a basic structure of a chaincode
 	os.MkdirAll(path.Join(testPath, "in-builder-dir", "META-INF"), 0755)
@@ -292,9 +285,7 @@ func TestMissingMetadata(t *testing.T) {
 	gt.Expect(err).NotTo(HaveOccurred())
 	defer gexec.CleanupBuildArtifacts()
 
-	testPath, err := ioutil.TempDir("", "test-ccaas-build-")
-	gt.Expect(err).NotTo(HaveOccurred())
-	defer os.RemoveAll(testPath)
+	testPath := t.TempDir()
 
 	// create a basic structure of a chaincode
 	os.MkdirAll(path.Join(testPath, "in-builder-dir", "META-INF"), 0755)

--- a/ccaas_builder/cmd/detect/main_test.go
+++ b/ccaas_builder/cmd/detect/main_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 
-	"io/ioutil"
-	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -61,9 +59,7 @@ func TestArugments(t *testing.T) {
 func TestMissingFile(t *testing.T) {
 	gt := NewWithT(t)
 
-	testPath, err := ioutil.TempDir("", "empty-test-dir")
-	gt.Expect(err).NotTo(HaveOccurred())
-	defer os.RemoveAll(testPath)
+	testPath := t.TempDir()
 
 	detectCmd, err := gexec.Build("github.com/hyperledger/fabric/ccaas_builder/cmd/detect")
 	gt.Expect(err).NotTo(HaveOccurred())

--- a/ccaas_builder/cmd/release/main_test.go
+++ b/ccaas_builder/cmd/release/main_test.go
@@ -7,15 +7,15 @@ SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"testing"
 	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
 )
 
 func TestArugments(t *testing.T) {
@@ -57,9 +57,7 @@ func TestGoodPath(t *testing.T) {
 	gt.Expect(err).NotTo(HaveOccurred())
 	defer gexec.CleanupBuildArtifacts()
 
-	testPath, err := ioutil.TempDir("", "test-ccaas-release-")
-	gt.Expect(err).NotTo(HaveOccurred())
-	defer os.RemoveAll(testPath)
+	testPath := t.TempDir()
 
 	os.MkdirAll(path.Join(testPath, "in-builder-dir"), 0755)
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -96,9 +94,7 @@ func TestMissingConnection(t *testing.T) {
 	gt.Expect(err).NotTo(HaveOccurred())
 	defer gexec.CleanupBuildArtifacts()
 
-	testPath, err := ioutil.TempDir("", "test-ccaas-release-")
-	gt.Expect(err).NotTo(HaveOccurred())
-	defer os.RemoveAll(testPath)
+	testPath := t.TempDir()
 
 	os.MkdirAll(path.Join(testPath, "in-builder-dir"), 0755)
 	gt.Expect(err).NotTo(HaveOccurred())

--- a/cmd/peer/main_test.go
+++ b/cmd/peer/main_test.go
@@ -8,9 +8,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -30,9 +28,7 @@ func TestPluginLoadingFailure(t *testing.T) {
 	parentDir, err := filepath.Abs("../..")
 	gt.Expect(err).NotTo(HaveOccurred())
 
-	tempDir, err := ioutil.TempDir("", "plugin-failure")
-	gt.Expect(err).NotTo(HaveOccurred())
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	peerListener, err := net.Listen("tcp", "localhost:0")
 	gt.Expect(err).NotTo(HaveOccurred())

--- a/common/ledger/blkstorage/blkstoragetest/blkstoragetest.go
+++ b/common/ledger/blkstorage/blkstoragetest/blkstoragetest.go
@@ -9,7 +9,6 @@ package blkstoragetest
 import (
 	"crypto/sha256"
 	"hash"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,8 +40,7 @@ var (
 func BootstrapBlockstoreFromSnapshot(t *testing.T, ledgerName string, blocks []*common.Block) (*blkstorage.BlockStore, func()) {
 	require.NotEqual(t, 0, len(blocks))
 
-	testDir, err := ioutil.TempDir("", ledgerName)
-	require.NoError(t, err)
+	testDir := t.TempDir()
 	snapshotDir := filepath.Join(testDir, "snapshot")
 	require.NoError(t, os.Mkdir(snapshotDir, 0o755))
 
@@ -76,7 +74,6 @@ func BootstrapBlockstoreFromSnapshot(t *testing.T, ledgerName string, blocks []*
 
 	cleanup := func() {
 		provider.Close()
-		os.RemoveAll(testDir)
 	}
 	return blockStore, cleanup
 }

--- a/common/ledger/blkstorage/block_stream_test.go
+++ b/common/ledger/blkstorage/block_stream_test.go
@@ -22,7 +22,7 @@ func TestBlockfileStream(t *testing.T) {
 }
 
 func testBlockfileStream(t *testing.T, numBlocks int) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	ledgerid := "testledger"
 	w := newTestBlockfileWrapper(env, ledgerid)
@@ -63,7 +63,7 @@ func TestBlockFileStreamUnexpectedEOF(t *testing.T) {
 }
 
 func testBlockFileStreamUnexpectedEOF(t *testing.T, numBlocks int, partialBlockBytes []byte) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	w := newTestBlockfileWrapper(env, "testLedger")
 	blockfileMgr := w.blockfileMgr
@@ -93,7 +93,7 @@ func TestBlockStream(t *testing.T) {
 
 func testBlockStream(t *testing.T, numFiles int) {
 	ledgerID := "testLedger"
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	w := newTestBlockfileWrapper(env, ledgerID)
 	defer w.close()

--- a/common/ledger/blkstorage/blockfile_helper_test.go
+++ b/common/ledger/blkstorage/blockfile_helper_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestConstructBlockfilesInfo(t *testing.T) {
 	ledgerid := "testLedger"
-	conf := NewConf(testPath(), 0)
+	conf := NewConf(t.TempDir(), 0)
 	blkStoreDir := conf.getLedgerBlockDir(ledgerid)
 	env := newTestEnv(t, conf)
 	require.NoError(t, os.MkdirAll(blkStoreDir, 0o755))
@@ -91,7 +91,7 @@ func TestConstructBlockfilesInfo(t *testing.T) {
 }
 
 func TestBinarySearchBlockFileNum(t *testing.T) {
-	blockStoreRootDir := testPath()
+	blockStoreRootDir := t.TempDir()
 	blocks := testutil.ConstructTestBlocks(t, 100)
 	maxFileSie := int(0.1 * float64(testutilEstimateTotalSizeOnDisk(t, blocks)))
 	env := newTestEnv(t, NewConf(blockStoreRootDir, maxFileSie))
@@ -117,9 +117,7 @@ func TestBinarySearchBlockFileNum(t *testing.T) {
 }
 
 func TestIsBootstrappedFromSnapshot(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "isbootstrappedfromsnapshot")
-	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	t.Run("no_bootstrapping_snapshot_info_file", func(t *testing.T) {
 		// create chains directory for the ledger without bootstrappingSnapshotInfoFile
@@ -146,9 +144,7 @@ func TestIsBootstrappedFromSnapshot(t *testing.T) {
 
 func TestGetLedgersBootstrappedFromSnapshot(t *testing.T) {
 	t.Run("no_bootstrapping_snapshot_info_file", func(t *testing.T) {
-		testDir, err := ioutil.TempDir("", "getledgersfromsnapshot_nosnapshot_info")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		// create chains directories for ledgers without bootstrappingSnapshotInfoFile
 		for i := 0; i < 5; i++ {
@@ -161,9 +157,7 @@ func TestGetLedgersBootstrappedFromSnapshot(t *testing.T) {
 	})
 
 	t.Run("with_bootstrapping_snapshot_info_file", func(t *testing.T) {
-		testDir, err := ioutil.TempDir("", "getledgersfromsnapshot_snapshot_info")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		// create chains directories for ledgers
 		// also create bootstrappingSnapshotInfoFile for ledger_0 and ledger_1

--- a/common/ledger/blkstorage/blockfile_mgr_test.go
+++ b/common/ledger/blkstorage/blockfile_mgr_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestBlockfileMgrBlockReadWrite(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, "testLedger")
 	defer blkfileMgrWrapper.close()
@@ -33,7 +33,7 @@ func TestBlockfileMgrBlockReadWrite(t *testing.T) {
 }
 
 func TestAddBlockWithWrongHash(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, "testLedger")
 	defer blkfileMgrWrapper.close()
@@ -64,7 +64,7 @@ func TestBlockfileMgrCrashDuringWriting(t *testing.T) {
 func testBlockfileMgrCrashDuringWriting(t *testing.T, numBlksBeforeSavingBlkfilesInfo int,
 	numBlksAfterSavingBlkfilesInfo int, numLastBlockBytes int, numPartialBytesToWrite int,
 	deleteBFInfo bool) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	ledgerid := "testLedger"
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, ledgerid)
@@ -128,7 +128,7 @@ func testBlockfileMgrCrashDuringWriting(t *testing.T, numBlksBeforeSavingBlkfile
 }
 
 func TestBlockfileMgrBlockIterator(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, "testLedger")
 	defer blkfileMgrWrapper.close()
@@ -156,7 +156,7 @@ func testBlockfileMgrBlockIterator(t *testing.T, blockfileMgr *blockfileMgr,
 }
 
 func TestBlockfileMgrBlockchainInfo(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, "testLedger")
 	defer blkfileMgrWrapper.close()
@@ -172,7 +172,7 @@ func TestBlockfileMgrBlockchainInfo(t *testing.T) {
 
 func TestTxIDExists(t *testing.T) {
 	t.Run("green-path", func(t *testing.T) {
-		env := newTestEnv(t, NewConf(testPath(), 0))
+		env := newTestEnv(t, NewConf(t.TempDir(), 0))
 		defer env.Cleanup()
 
 		blkStore, err := env.provider.Open("testLedger")
@@ -199,7 +199,7 @@ func TestTxIDExists(t *testing.T) {
 	})
 
 	t.Run("error-path", func(t *testing.T) {
-		env := newTestEnv(t, NewConf(testPath(), 0))
+		env := newTestEnv(t, NewConf(t.TempDir(), 0))
 		defer env.Cleanup()
 
 		blkStore, err := env.provider.Open("testLedger")
@@ -214,7 +214,7 @@ func TestTxIDExists(t *testing.T) {
 }
 
 func TestBlockfileMgrGetTxById(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, "testLedger")
 	defer blkfileMgrWrapper.close()
@@ -237,7 +237,7 @@ func TestBlockfileMgrGetTxById(t *testing.T) {
 // TestBlockfileMgrGetTxByIdDuplicateTxid tests that a transaction with an existing txid
 // (within same block or a different block) should not over-write the index by-txid (FAB-8557)
 func TestBlockfileMgrGetTxByIdDuplicateTxid(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	blkStore, err := env.provider.Open("testLedger")
 	require.NoError(env.t, err)
@@ -355,7 +355,7 @@ func TestBlockfileMgrGetTxByIdDuplicateTxid(t *testing.T) {
 }
 
 func TestBlockfileMgrGetTxByBlockNumTranNum(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, "testLedger")
 	defer blkfileMgrWrapper.close()
@@ -374,7 +374,7 @@ func TestBlockfileMgrGetTxByBlockNumTranNum(t *testing.T) {
 }
 
 func TestBlockfileMgrRestart(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	ledgerid := "testLedger"
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, ledgerid)
@@ -403,7 +403,7 @@ func TestBlockfileMgrFileRolling(t *testing.T) {
 	}
 
 	maxFileSie := int(0.75 * float64(size))
-	env := newTestEnv(t, NewConf(testPath(), maxFileSie))
+	env := newTestEnv(t, NewConf(t.TempDir(), maxFileSie))
 	defer env.Cleanup()
 	ledgerid := "testLedger"
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, ledgerid)
@@ -420,7 +420,7 @@ func TestBlockfileMgrFileRolling(t *testing.T) {
 }
 
 func TestBlockfileMgrGetBlockByTxID(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, "testLedger")
 	defer blkfileMgrWrapper.close()
@@ -451,7 +451,7 @@ func TestBlockfileMgrSimulateCrashAtFirstBlockInFile(t *testing.T) {
 
 func testBlockfileMgrSimulateCrashAtFirstBlockInFile(t *testing.T, deleteBlkfilesInfo bool) {
 	// open blockfileMgr and add 5 blocks
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, "testLedger")

--- a/common/ledger/blkstorage/blockfile_scan_test.go
+++ b/common/ledger/blkstorage/blockfile_scan_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestBlockFileScanSmallTxOnly(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	ledgerid := "testLedger"
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, ledgerid)
@@ -44,7 +44,7 @@ func TestBlockFileScanSmallTxOnly(t *testing.T) {
 }
 
 func TestBlockFileScanSmallTxLastTxIncomplete(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	ledgerid := "testLedger"
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, ledgerid)

--- a/common/ledger/blkstorage/blockindex_test.go
+++ b/common/ledger/blkstorage/blockindex_test.go
@@ -39,7 +39,7 @@ func TestBlockIndexSync(t *testing.T) {
 func testBlockIndexSync(t *testing.T, numBlocks int, numBlocksToIndex int, syncByRestart bool) {
 	testName := fmt.Sprintf("%v/%v/%v", numBlocks, numBlocksToIndex, syncByRestart)
 	t.Run(testName, func(t *testing.T) {
-		env := newTestEnv(t, NewConf(testPath(), 0))
+		env := newTestEnv(t, NewConf(t.TempDir(), 0))
 		defer env.Cleanup()
 		ledgerid := "testledger"
 		blkfileMgrWrapper := newTestBlockfileWrapper(env, ledgerid)
@@ -105,7 +105,7 @@ func testBlockIndexSelectiveIndexing(t *testing.T, indexItems []IndexableAttr) {
 		testName = testName + string(s)
 	}
 	t.Run(testName, func(t *testing.T) {
-		env := newTestEnvSelectiveIndexing(t, NewConf(testPath(), 0), indexItems, &disabled.Provider{})
+		env := newTestEnvSelectiveIndexing(t, NewConf(t.TempDir(), 0), indexItems, &disabled.Provider{})
 		defer env.Cleanup()
 		blkfileMgrWrapper := newTestBlockfileWrapper(env, "testledger")
 		defer blkfileMgrWrapper.close()
@@ -269,15 +269,14 @@ func TestTxIDKeyDecodingInvalidInputs(t *testing.T) {
 }
 
 func TestExportUniqueTxIDs(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	ledgerid := "testledger"
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, ledgerid)
 	defer blkfileMgrWrapper.close()
 	blkfileMgr := blkfileMgrWrapper.blockfileMgr
 
-	testSnapshotDir := testPath()
-	defer os.RemoveAll(testSnapshotDir)
+	testSnapshotDir := t.TempDir()
 
 	// empty store generates no output
 	fileHashes, err := blkfileMgr.index.exportUniqueTxIDs(testSnapshotDir, testNewHashFunc)
@@ -334,7 +333,7 @@ func TestExportUniqueTxIDs(t *testing.T) {
 }
 
 func TestExportUniqueTxIDsWhenTxIDsNotIndexed(t *testing.T) {
-	env := newTestEnvSelectiveIndexing(t, NewConf(testPath(), 0), []IndexableAttr{IndexableAttrBlockNum}, &disabled.Provider{})
+	env := newTestEnvSelectiveIndexing(t, NewConf(t.TempDir(), 0), []IndexableAttr{IndexableAttrBlockNum}, &disabled.Provider{})
 	defer env.Cleanup()
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, "testledger")
 	defer blkfileMgrWrapper.close()
@@ -342,14 +341,13 @@ func TestExportUniqueTxIDsWhenTxIDsNotIndexed(t *testing.T) {
 	blocks := testutil.ConstructTestBlocks(t, 5)
 	blkfileMgrWrapper.addBlocks(blocks)
 
-	testSnapshotDir := testPath()
-	defer os.RemoveAll(testSnapshotDir)
+	testSnapshotDir := t.TempDir()
 	_, err := blkfileMgrWrapper.blockfileMgr.index.exportUniqueTxIDs(testSnapshotDir, testNewHashFunc)
 	require.EqualError(t, err, "transaction IDs not maintained in index")
 }
 
 func TestExportUniqueTxIDsErrorCases(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	ledgerid := "testledger"
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, ledgerid)
@@ -360,8 +358,7 @@ func TestExportUniqueTxIDsErrorCases(t *testing.T) {
 	blockfileMgr := blkfileMgrWrapper.blockfileMgr
 	index := blockfileMgr.index
 
-	testSnapshotDir := testPath()
-	defer os.RemoveAll(testSnapshotDir)
+	testSnapshotDir := t.TempDir()
 
 	// error during data file creation
 	dataFilePath := filepath.Join(testSnapshotDir, snapshotDataFileName)

--- a/common/ledger/blkstorage/blocks_itr_test.go
+++ b/common/ledger/blkstorage/blocks_itr_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestBlocksItrBlockingNext(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, "testLedger")
 	defer blkfileMgrWrapper.close()
@@ -41,7 +41,7 @@ func TestBlocksItrBlockingNext(t *testing.T) {
 }
 
 func TestBlockItrClose(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, "testLedger")
 	defer blkfileMgrWrapper.close()
@@ -63,7 +63,7 @@ func TestBlockItrClose(t *testing.T) {
 }
 
 func TestRaceToDeadlock(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, "testLedger")
 	defer blkfileMgrWrapper.close()
@@ -96,7 +96,7 @@ func TestRaceToDeadlock(t *testing.T) {
 }
 
 func TestBlockItrCloseWithoutRetrieve(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, "testLedger")
 	defer blkfileMgrWrapper.close()
@@ -110,7 +110,7 @@ func TestBlockItrCloseWithoutRetrieve(t *testing.T) {
 }
 
 func TestCloseMultipleItrsWaitForFutureBlock(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 	blkfileMgrWrapper := newTestBlockfileWrapper(env, "testLedger")
 	defer blkfileMgrWrapper.close()

--- a/common/ledger/blkstorage/blockstore_provider_test.go
+++ b/common/ledger/blkstorage/blockstore_provider_test.go
@@ -8,7 +8,6 @@ package blkstorage
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hyperledger/fabric-protos-go/common"
@@ -34,8 +33,7 @@ func TestIndexConfig(t *testing.T) {
 }
 
 func TestMultipleBlockStores(t *testing.T) {
-	tempdir := testPath()
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	env := newTestEnv(t, NewConf(tempdir, 0))
 	provider := env.provider
@@ -162,7 +160,7 @@ func checkWithWrongInputs(t *testing.T, store *BlockStore, numBlocks int) {
 }
 
 func TestBlockStoreProvider(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 
 	provider := env.provider
@@ -195,7 +193,7 @@ func TestBlockStoreProvider(t *testing.T) {
 }
 
 func TestDrop(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 
 	provider := env.provider

--- a/common/ledger/blkstorage/blockstore_test.go
+++ b/common/ledger/blkstorage/blockstore_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestWrongBlockNumber(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 
 	provider := env.provider
@@ -32,7 +32,7 @@ func TestWrongBlockNumber(t *testing.T) {
 }
 
 func TestTxIDIndexErrorPropagations(t *testing.T) {
-	env := newTestEnv(t, NewConf(testPath(), 0))
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
 	defer env.Cleanup()
 
 	provider := env.provider

--- a/common/ledger/blkstorage/metrics_test.go
+++ b/common/ledger/blkstorage/metrics_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestStatsBlockchainHeight(t *testing.T) {
 	testMetricProvider := testutilConstructMetricProvider()
-	env := newTestEnvWithMetricsProvider(t, NewConf(testPath(), 0), testMetricProvider.fakeProvider)
+	env := newTestEnvWithMetricsProvider(t, NewConf(t.TempDir(), 0), testMetricProvider.fakeProvider)
 	defer env.Cleanup()
 
 	provider := env.provider
@@ -71,7 +71,7 @@ func TestStatsBlockchainHeight(t *testing.T) {
 
 func TestStatsBlockCommit(t *testing.T) {
 	testMetricProvider := testutilConstructMetricProvider()
-	env := newTestEnvWithMetricsProvider(t, NewConf(testPath(), 0), testMetricProvider.fakeProvider)
+	env := newTestEnvWithMetricsProvider(t, NewConf(t.TempDir(), 0), testMetricProvider.fakeProvider)
 	defer env.Cleanup()
 
 	provider := env.provider

--- a/common/ledger/blkstorage/pkg_test.go
+++ b/common/ledger/blkstorage/pkg_test.go
@@ -8,7 +8,6 @@ package blkstorage
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"testing"
@@ -26,14 +25,6 @@ import (
 func TestMain(m *testing.M) {
 	flogging.ActivateSpec("blkstorage=debug")
 	os.Exit(m.Run())
-}
-
-func testPath() string {
-	if path, err := ioutil.TempDir("", "blkstorage-"); err != nil {
-		panic(err)
-	} else {
-		return path
-	}
 }
 
 type testEnv struct {
@@ -65,12 +56,6 @@ func newTestEnvSelectiveIndexing(t testing.TB, conf *Conf, attrsToIndex []Indexa
 
 func (env *testEnv) Cleanup() {
 	env.provider.Close()
-	env.removeFSPath()
-}
-
-func (env *testEnv) removeFSPath() {
-	fsPath := env.provider.conf.blockStorageDir
-	os.RemoveAll(fsPath)
 }
 
 type testBlockfileMgrWrapper struct {

--- a/common/ledger/blkstorage/rollback_test.go
+++ b/common/ledger/blkstorage/rollback_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestRollback(t *testing.T) {
-	path := testPath()
+	path := t.TempDir()
 	blocks := testutil.ConstructTestBlocks(t, 50) // 50 blocks persisted in ~5 block files
 	blocksPerFile := 50 / 5
 	env := newTestEnv(t, NewConf(path, 0))
@@ -108,7 +108,7 @@ func TestRollback(t *testing.T) {
 // TestRollbackWithOnlyBlockIndexAttributes mimics the scenario when ledger is used for orderer
 // i.e., only block is index and transancations are not indexed
 func TestRollbackWithOnlyBlockIndexAttributes(t *testing.T) {
-	path := testPath()
+	path := t.TempDir()
 	blocks := testutil.ConstructTestBlocks(t, 50) // 50 blocks persisted in ~5 block files
 	blocksPerFile := 50 / 5
 	onlyBlockNumIndex := []IndexableAttr{
@@ -160,7 +160,7 @@ func TestRollbackWithOnlyBlockIndexAttributes(t *testing.T) {
 }
 
 func TestRollbackWithNoIndexDir(t *testing.T) {
-	path := testPath()
+	path := t.TempDir()
 	blocks := testutil.ConstructTestBlocks(t, 50)
 	blocksPerFile := 50 / 5
 	conf := NewConf(path, 0)
@@ -213,7 +213,7 @@ func TestRollbackWithNoIndexDir(t *testing.T) {
 }
 
 func TestValidateRollbackParams(t *testing.T) {
-	path := testPath()
+	path := t.TempDir()
 	env := newTestEnv(t, NewConf(path, 1024*24))
 	defer env.Cleanup()
 
@@ -236,7 +236,7 @@ func TestValidateRollbackParams(t *testing.T) {
 }
 
 func TestDuplicateTxIDDuringRollback(t *testing.T) {
-	path := testPath()
+	path := t.TempDir()
 	blocks := testutil.ConstructTestBlocks(t, 4)
 	maxFileSize := 1024 * 1024 * 4
 	env := newTestEnv(t, NewConf(path, maxFileSize))

--- a/common/ledger/blkstorage/snapshot_test.go
+++ b/common/ledger/blkstorage/snapshot_test.go
@@ -42,7 +42,7 @@ func TestImportFromSnapshot(t *testing.T) {
 	bootstrappedLedgerName := "bootstrappedLedger"
 
 	setup := func() {
-		testDir = testPath()
+		testDir = t.TempDir()
 		env = newTestEnv(t, NewConf(testDir, 0))
 		snapshotDir = filepath.Join(testDir, "snapshot")
 		require.NoError(t, os.Mkdir(snapshotDir, 0o755))
@@ -326,7 +326,7 @@ func TestImportFromSnapshot(t *testing.T) {
 }
 
 func TestBootstrapFromSnapshotErrorPaths(t *testing.T) {
-	testPath := testPath()
+	testPath := t.TempDir()
 	env := newTestEnv(t, NewConf(testPath, 0))
 	defer func() {
 		env.Cleanup()

--- a/common/ledger/blockledger/fileledger/impl_test.go
+++ b/common/ledger/blockledger/fileledger/impl_test.go
@@ -9,8 +9,6 @@ package fileledger
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	cb "github.com/hyperledger/fabric-protos-go/common"
@@ -40,8 +38,7 @@ type testEnv struct {
 }
 
 func initialize(t *testing.T) (*testEnv, *FileLedger) {
-	name, err := ioutil.TempDir("", "hyperledger_fabric")
-	require.NoError(t, err, "Error creating temp dir: %s", err)
+	name := t.TempDir()
 
 	p, err := New(name, &disabled.Provider{})
 	require.NoError(t, err)
@@ -54,10 +51,6 @@ func initialize(t *testing.T) (*testEnv, *FileLedger) {
 
 func (tev *testEnv) tearDown() {
 	tev.shutDown()
-	err := os.RemoveAll(tev.location)
-	if err != nil {
-		tev.t.Fatalf("Error tearing down env: %s", err)
-	}
 }
 
 func (tev *testEnv) shutDown() {

--- a/common/ledger/snapshot/file_test.go
+++ b/common/ledger/snapshot/file_test.go
@@ -26,8 +26,7 @@ var testNewHashFunc = func() (hash.Hash, error) {
 }
 
 func TestFileCreateAndRead(t *testing.T) {
-	testDir := testPath(t)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	// create file and encode some data
 	fileCreator, err := CreateFile(path.Join(testDir, "dataFile"), byte(5), testNewHashFunc)
@@ -99,8 +98,7 @@ func TestFileCreateAndRead(t *testing.T) {
 }
 
 func TestFileCreateAndLargeValue(t *testing.T) {
-	testDir := testPath(t)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	// create file and encode some data
 	fileWriter, err := CreateFile(path.Join(testDir, "dataFile"), byte(5), testNewHashFunc)
@@ -126,8 +124,7 @@ func TestFileCreateAndLargeValue(t *testing.T) {
 }
 
 func TestFileCreatorErrorPropagation(t *testing.T) {
-	testPath := testPath(t)
-	defer os.RemoveAll(testPath)
+	testPath := t.TempDir()
 
 	// error propagation from CreateFile function when file already exists
 	existingFilePath := path.Join(testPath, "an-existing-file")
@@ -167,8 +164,7 @@ func TestFileCreatorErrorPropagation(t *testing.T) {
 }
 
 func TestFileReaderErrorPropagation(t *testing.T) {
-	testPath := testPath(t)
-	defer os.RemoveAll(testPath)
+	testPath := t.TempDir()
 
 	// non-existent-file cuases an error
 	nonExistentFile := path.Join(testPath, "non-existent-file")
@@ -222,12 +218,6 @@ func computeSha256(t *testing.T, file string) []byte {
 	require.NoError(t, err)
 	sha := sha256.Sum256(data)
 	return sha[:]
-}
-
-func testPath(t *testing.T) string {
-	path, err := ioutil.TempDir("", "test-file-encoder-")
-	require.NoError(t, err)
-	return path
 }
 
 type errorCausingWriter struct {

--- a/core/chaincode/platforms/golang/list_test.go
+++ b/core/chaincode/platforms/golang/list_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package golang
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -109,8 +108,7 @@ func Test_listModuleInfo(t *testing.T) {
 }
 
 func Test_listModuleInfoFailure(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "module")
-	require.NoError(t, err, "failed to create temporary directory")
+	tempDir := t.TempDir()
 
 	cwd, err := os.Getwd()
 	require.NoError(t, err, "failed to get working directory")

--- a/core/chaincode/platforms/golang/platform_test.go
+++ b/core/chaincode/platforms/golang/platform_test.go
@@ -12,7 +12,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -96,9 +95,7 @@ func TestValidatePath(t *testing.T) {
 }
 
 func TestNormalizePath(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "normalize-path")
-	require.NoError(t, err, "failed to create temporary directory")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	tests := []struct {
 		path   string

--- a/core/chaincode/platforms/util/writer_test.go
+++ b/core/chaincode/platforms/util/writer_test.go
@@ -24,9 +24,7 @@ import (
 )
 
 func TestWriteFileToPackage(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "utiltest")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	buf := bytes.NewBuffer(nil)
 	gw := gzip.NewWriter(buf)
@@ -36,7 +34,7 @@ func TestWriteFileToPackage(t *testing.T) {
 	filename := "test.txt"
 	filecontent := "hello"
 	filePath := filepath.Join(tempDir, filename)
-	err = ioutil.WriteFile(filePath, bytes.NewBufferString(filecontent).Bytes(), 0o600)
+	err := ioutil.WriteFile(filePath, bytes.NewBufferString(filecontent).Bytes(), 0o600)
 	require.NoError(t, err, "Error creating file %s", filePath)
 
 	err = WriteFileToPackage(filePath, filename, tw)
@@ -169,14 +167,12 @@ func TestWriteFolderToTarPackage5(t *testing.T) {
 
 // Failure case 1: no files in directory
 func TestWriteFolderToTarPackageFailure1(t *testing.T) {
-	srcPath, err := ioutil.TempDir("", "utiltest")
-	require.NoError(t, err)
-	defer os.RemoveAll(srcPath)
+	srcPath := t.TempDir()
 
 	tw := tar.NewWriter(bytes.NewBuffer(nil))
 	defer tw.Close()
 
-	err = WriteFolderToTarPackage(tw, srcPath, []string{}, nil, nil)
+	err := WriteFolderToTarPackage(tw, srcPath, []string{}, nil, nil)
 	require.Contains(t, err.Error(), "no source files found")
 }
 
@@ -216,11 +212,9 @@ func Test_WriteFolderToTarPackageFailure4(t *testing.T) {
 		t.Skip("unable to chmod execute permission on windows directory")
 	}
 
-	tempDir, err := ioutil.TempDir("", "WriteFolderToTarPackageFailure4BadFileMode")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	testFile := filepath.Join(tempDir, "test.java")
-	err = ioutil.WriteFile(testFile, []byte("Content"), 0o644)
+	err := ioutil.WriteFile(testFile, []byte("Content"), 0o644)
 	require.NoError(t, err, "Error creating file", testFile)
 	err = os.Chmod(tempDir, 0o644)
 	require.NoError(t, err)

--- a/core/committer/txvalidator/v14/txvalidator_test.go
+++ b/core/committer/txvalidator/v14/txvalidator_test.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package txvalidator
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -107,7 +105,7 @@ func TestDetectTXIdDuplicates(t *testing.T) {
 }
 
 func TestBlockValidationDuplicateTXId(t *testing.T) {
-	ledgerMgr, cleanup := constructLedgerMgrWithTestDefaults(t, "txvalidator")
+	ledgerMgr, cleanup := constructLedgerMgrWithTestDefaults(t)
 	defer cleanup()
 
 	gb, _ := test.MakeGenesisBlock("TestLedger")
@@ -171,7 +169,7 @@ func TestBlockValidationDuplicateTXId(t *testing.T) {
 }
 
 func TestBlockValidation(t *testing.T) {
-	ledgerMgr, cleanup := constructLedgerMgrWithTestDefaults(t, "txvalidator")
+	ledgerMgr, cleanup := constructLedgerMgrWithTestDefaults(t)
 	defer cleanup()
 
 	gb, _ := test.MakeGenesisBlock("TestLedger")
@@ -184,7 +182,7 @@ func TestBlockValidation(t *testing.T) {
 }
 
 func TestParallelBlockValidation(t *testing.T) {
-	ledgerMgr, cleanup := constructLedgerMgrWithTestDefaults(t, "txvalidator")
+	ledgerMgr, cleanup := constructLedgerMgrWithTestDefaults(t)
 	defer cleanup()
 
 	gb, _ := test.MakeGenesisBlock("TestLedger")
@@ -197,7 +195,7 @@ func TestParallelBlockValidation(t *testing.T) {
 }
 
 func TestVeryLargeParallelBlockValidation(t *testing.T) {
-	ledgerMgr, cleanup := constructLedgerMgrWithTestDefaults(t, "txvalidator")
+	ledgerMgr, cleanup := constructLedgerMgrWithTestDefaults(t)
 	defer cleanup()
 
 	gb, _ := test.MakeGenesisBlock("TestLedger")
@@ -212,7 +210,7 @@ func TestVeryLargeParallelBlockValidation(t *testing.T) {
 }
 
 func TestTxValidationFailure_InvalidTxid(t *testing.T) {
-	ledgerMgr, cleanup := constructLedgerMgrWithTestDefaults(t, "txvalidator")
+	ledgerMgr, cleanup := constructLedgerMgrWithTestDefaults(t)
 	defer cleanup()
 
 	gb, _ := test.MakeGenesisBlock("TestLedger")
@@ -423,16 +421,12 @@ func TestInvalidTXsForUpgradeCC(t *testing.T) {
 	require.EqualValues(t, expectTxsFltr, txsfltr)
 }
 
-func constructLedgerMgrWithTestDefaults(t *testing.T, testDir string) (*ledgermgmt.LedgerMgr, func()) {
-	testDir, err := ioutil.TempDir("", testDir)
-	if err != nil {
-		t.Fatalf("Failed to create ledger directory: %s", err)
-	}
+func constructLedgerMgrWithTestDefaults(t *testing.T) (*ledgermgmt.LedgerMgr, func()) {
+	testDir := t.TempDir()
 	initializer := ledgermgmttest.NewInitializer(testDir)
 	ledgerMgr := ledgermgmt.NewLedgerMgr(initializer)
 	cleanup := func() {
 		ledgerMgr.Close()
-		os.RemoveAll(testDir)
 	}
 	return ledgerMgr, cleanup
 }

--- a/core/committer/txvalidator/v14/validator_test.go
+++ b/core/committer/txvalidator/v14/validator_test.go
@@ -9,7 +9,6 @@ package txvalidator_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -117,7 +116,7 @@ func setupLedgerAndValidatorWithCapabilities(t *testing.T, c *tmocks.Application
 }
 
 func setupLedgerAndValidatorExplicitWithMSP(t *testing.T, cpb *tmocks.ApplicationCapabilities, plugin validation.Plugin, mspMgr msp.MSPManager) (ledger.PeerLedger, txvalidator.Validator, func()) {
-	ledgerMgr, cleanup := constructLedgerMgrWithTestDefaults(t, "txvalidator")
+	ledgerMgr, cleanup := constructLedgerMgrWithTestDefaults(t)
 	gb, err := ctxt.MakeGenesisBlock("TestLedger")
 	require.NoError(t, err)
 	theLedger, err := ledgerMgr.CreateLedger("TestLedger", gb)
@@ -1631,7 +1630,7 @@ func (exec *mockQueryExecutor) GetPrivateDataMetadata(namespace, collection, key
 }
 
 func createCustomSupportAndLedger(t *testing.T) (*mocktxvalidator.Support, ledger.PeerLedger, func()) {
-	ledgerMgr, cleanup := constructLedgerMgrWithTestDefaults(t, "txvalidator")
+	ledgerMgr, cleanup := constructLedgerMgrWithTestDefaults(t)
 	gb, err := ctxt.MakeGenesisBlock("TestLedger")
 	require.NoError(t, err)
 	l, err := ledgerMgr.CreateLedger("TestLedger", gb)
@@ -1949,16 +1948,12 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func constructLedgerMgrWithTestDefaults(t *testing.T, testDir string) (*ledgermgmt.LedgerMgr, func()) {
-	testDir, err := ioutil.TempDir("", testDir)
-	if err != nil {
-		t.Fatalf("Failed to create ledger directory: %s", err)
-	}
+func constructLedgerMgrWithTestDefaults(t *testing.T) (*ledgermgmt.LedgerMgr, func()) {
+	testDir := t.TempDir()
 	initializer := ledgermgmttest.NewInitializer(testDir)
 	ledgerMgr := ledgermgmt.NewLedgerMgr(initializer)
 	cleanup := func() {
 		ledgerMgr.Close()
-		os.RemoveAll(testDir)
 	}
 	return ledgerMgr, cleanup
 }

--- a/core/common/ccprovider/ccinfocache_test.go
+++ b/core/common/ccprovider/ccinfocache_test.go
@@ -208,13 +208,11 @@ func TestGetInstalledChaincodesErrorPaths(t *testing.T) {
 	defer SetChaincodesPath(cip)
 
 	// Create a temp dir and remove it at the end
-	dir, err := ioutil.TempDir(os.TempDir(), "chaincodes")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Set the above created directory as the chaincode install path
 	SetChaincodesPath(dir)
-	err = ioutil.WriteFile(filepath.Join(dir, "idontexist.1.0"), []byte("test"), 0o777)
+	err := ioutil.WriteFile(filepath.Join(dir, "idontexist.1.0"), []byte("test"), 0o777)
 	require.NoError(t, err)
 	resp, err := GetInstalledChaincodes()
 	require.NoError(t, err)
@@ -228,11 +226,7 @@ func TestChaincodePackageExists(t *testing.T) {
 }
 
 func TestSetChaincodesPath(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "setchaincodes")
-	if err != nil {
-		require.Fail(t, err.Error(), "Unable to create temp dir")
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	t.Logf("created temp dir %s", dir)
 
 	// Get the existing chaincode install path value and set it

--- a/core/common/ccprovider/ccprovider_test.go
+++ b/core/common/ccprovider/ccprovider_test.go
@@ -29,10 +29,6 @@ func TestInstalledCCs(t *testing.T) {
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 
-	defer func() {
-		os.RemoveAll(tmpDir)
-	}()
-
 	testCases := []struct {
 		name              string
 		directory         string
@@ -112,9 +108,8 @@ func TestInstalledCCs(t *testing.T) {
 }
 
 func TestSetGetChaincodeInstallPath(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "ccprovider")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
+	ccprovider.SetChaincodesPath(tempDir)
 
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
@@ -136,8 +131,7 @@ func setupDirectoryStructure(t *testing.T) (string, map[string][]byte) {
 		"example04.1",   // Version doesn't contain the '.' delimiter
 	}
 	hashes := map[string][]byte{}
-	tmp, err := ioutil.TempDir("", "test-installed-cc")
-	require.NoError(t, err)
+	tmp := t.TempDir()
 	dir := path.Join(tmp, "empty")
 	require.NoError(t, os.Mkdir(dir, 0o755))
 	dir = path.Join(tmp, "nonempty")
@@ -147,7 +141,7 @@ func setupDirectoryStructure(t *testing.T) (string, map[string][]byte) {
 	dir = path.Join(tmp, "nopermissionforfiles")
 	require.NoError(t, os.Mkdir(dir, 0o755))
 	noPermissionFile := path.Join(tmp, "nopermissionforfiles", "nopermission.1")
-	_, err = os.Create(noPermissionFile)
+	_, err := os.Create(noPermissionFile)
 	require.NoError(t, err)
 	dir = path.Join(tmp, "nonempty")
 	require.NoError(t, os.Mkdir(path.Join(tmp, "nonempty", "directory"), 0o755))

--- a/core/common/ccprovider/cdspackage_test.go
+++ b/core/common/ccprovider/cdspackage_test.go
@@ -8,7 +8,6 @@ package ccprovider
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -18,11 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupccdir() string {
-	tempDir, err := ioutil.TempDir("/tmp", "ccprovidertest")
-	if err != nil {
-		panic(err)
-	}
+func setupccdir(t *testing.T) string {
+	tempDir := t.TempDir()
 	SetChaincodesPath(tempDir)
 	return tempDir
 }
@@ -50,8 +46,7 @@ func processCDS(cds *pb.ChaincodeDeploymentSpec, tofs bool) (*CDSPackage, []byte
 }
 
 func TestPutCDSCC(t *testing.T) {
-	ccdir := setupccdir()
-	defer os.RemoveAll(ccdir)
+	_ = setupccdir(t)
 
 	cds := &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{Type: 1, ChaincodeId: &pb.ChaincodeID{Name: "testcc", Version: "0"}, Input: &pb.ChaincodeInput{Args: [][]byte{[]byte("")}}}, CodePackage: []byte("code")}
 
@@ -68,8 +63,7 @@ func TestPutCDSCC(t *testing.T) {
 }
 
 func TestPutCDSErrorPaths(t *testing.T) {
-	ccdir := setupccdir()
-	defer os.RemoveAll(ccdir)
+	ccdir := setupccdir(t)
 
 	cds := &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{
 		Type: 1, ChaincodeId: &pb.ChaincodeID{Name: "testcc", Version: "0"},
@@ -148,8 +142,7 @@ func TestCDSGetCCPackage(t *testing.T) {
 
 // switch the chaincodes on the FS and validate
 func TestCDSSwitchChaincodes(t *testing.T) {
-	ccdir := setupccdir()
-	defer os.RemoveAll(ccdir)
+	_ = setupccdir(t)
 
 	// someone modified the code on the FS with "badcode"
 	cds := &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{Type: 1, ChaincodeId: &pb.ChaincodeID{Name: "testcc", Version: "0"}, Input: &pb.ChaincodeInput{Args: [][]byte{[]byte("")}}}, CodePackage: []byte("badcode")}

--- a/core/common/ccprovider/sigcdspackage_test.go
+++ b/core/common/ccprovider/sigcdspackage_test.go
@@ -47,8 +47,7 @@ func processSignedCDS(cds *pb.ChaincodeDeploymentSpec, policy *common.SignatureP
 }
 
 func TestPutSigCDSCC(t *testing.T) {
-	ccdir := setupccdir()
-	defer os.RemoveAll(ccdir)
+	_ = setupccdir(t)
 
 	cds := &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{Type: 1, ChaincodeId: &pb.ChaincodeID{Name: "testcc", Version: "0"}, Input: &pb.ChaincodeInput{Args: [][]byte{[]byte("")}}}, CodePackage: []byte("code")}
 
@@ -65,8 +64,7 @@ func TestPutSigCDSCC(t *testing.T) {
 }
 
 func TestPutSignedCDSErrorPaths(t *testing.T) {
-	ccdir := setupccdir()
-	defer os.RemoveAll(ccdir)
+	ccdir := setupccdir(t)
 
 	cds := &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{
 		Type: 1, ChaincodeId: &pb.ChaincodeID{Name: "testcc", Version: "0"},
@@ -162,8 +160,7 @@ func TestPutSignedCDSErrorPaths(t *testing.T) {
 }
 
 func TestGetCDSDataErrorPaths(t *testing.T) {
-	ccdir := setupccdir()
-	defer os.RemoveAll(ccdir)
+	_ = setupccdir(t)
 
 	cds := &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{
 		Type: 1, ChaincodeId: &pb.ChaincodeID{Name: "testcc", Version: "0"},
@@ -201,8 +198,7 @@ func TestGetCDSDataErrorPaths(t *testing.T) {
 }
 
 func TestInitFromBufferErrorPaths(t *testing.T) {
-	ccdir := setupccdir()
-	defer os.RemoveAll(ccdir)
+	_ = setupccdir(t)
 
 	cds := &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{
 		Type: 1, ChaincodeId: &pb.ChaincodeID{Name: "testcc", Version: "0"},
@@ -221,8 +217,7 @@ func TestInitFromBufferErrorPaths(t *testing.T) {
 }
 
 func TestValidateSignedCCErrorPaths(t *testing.T) {
-	ccdir := setupccdir()
-	defer os.RemoveAll(ccdir)
+	_ = setupccdir(t)
 
 	cds := &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{
 		Type: 1, ChaincodeId: &pb.ChaincodeID{Name: "testcc", Version: "0"},
@@ -331,8 +326,7 @@ func TestInvalidSigCDSGetCCPackage(t *testing.T) {
 
 // switch the chaincodes on the FS and validate
 func TestSignedCDSSwitchChaincodes(t *testing.T) {
-	ccdir := setupccdir()
-	defer os.RemoveAll(ccdir)
+	_ = setupccdir(t)
 
 	// someone modifyed the code on the FS with "badcode"
 	cds := &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{Type: 1, ChaincodeId: &pb.ChaincodeID{Name: "testcc", Version: "0"}, Input: &pb.ChaincodeInput{Args: [][]byte{[]byte("")}}}, CodePackage: []byte("badcode")}

--- a/core/endorser/plugin_endorser_test.go
+++ b/core/endorser/plugin_endorser_test.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package endorser_test
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -44,11 +42,7 @@ type testTransientStore struct {
 func newTransientStore(t *testing.T) *testTransientStore {
 	s := &testTransientStore{}
 	var err error
-	s.tempdir, err = ioutil.TempDir("", "ts")
-	if err != nil {
-		t.Fatalf("Failed to create test directory, got err %s", err)
-		return s
-	}
+	s.tempdir = t.TempDir()
 	s.storeProvider, err = transientstore.NewStoreProvider(s.tempdir)
 	if err != nil {
 		t.Fatalf("Failed to open store, got err %s", err)
@@ -64,7 +58,6 @@ func newTransientStore(t *testing.T) *testTransientStore {
 
 func (s *testTransientStore) tearDown() {
 	s.storeProvider.Close()
-	os.RemoveAll(s.tempdir)
 }
 
 func (s *testTransientStore) Persist(txid string, blockHeight uint64,

--- a/core/handlers/library/registry_plugin_test.go
+++ b/core/handlers/library/registry_plugin_test.go
@@ -8,8 +8,6 @@ package library
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -52,9 +50,7 @@ func TestLoadAuthPlugin(t *testing.T) {
 		t.Skip("plugins disabled")
 	}
 
-	testDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "Could not create temp directory for plugins")
-	defer os.Remove(testDir)
+	testDir := t.TempDir()
 
 	pluginPath := filepath.Join(testDir, "authplugin.so")
 	buildPlugin(t, pluginPath, authPluginPackage)
@@ -77,9 +73,7 @@ func TestLoadDecoratorPlugin(t *testing.T) {
 	testProposal := &peer.Proposal{Payload: []byte("test")}
 	testInput := &peer.ChaincodeInput{Args: [][]byte{[]byte("test")}}
 
-	testDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "Could not create temp directory for plugins")
-	defer os.Remove(testDir)
+	testDir := t.TempDir()
 
 	pluginPath := filepath.Join(testDir, "decoratorplugin.so")
 	buildPlugin(t, pluginPath, decoratorPluginPackage)
@@ -97,9 +91,7 @@ func TestEndorsementPlugin(t *testing.T) {
 		t.Skip("plugins disabled")
 	}
 
-	testDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "Could not create temp directory for plugins")
-	defer os.Remove(testDir)
+	testDir := t.TempDir()
 
 	pluginPath := filepath.Join(testDir, "endorsementplugin.so")
 	buildPlugin(t, pluginPath, endorsementTestPlugin)
@@ -122,9 +114,7 @@ func TestValidationPlugin(t *testing.T) {
 		t.Skip("plugins disabled")
 	}
 
-	testDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "Could not create temp directory for plugins")
-	defer os.Remove(testDir)
+	testDir := t.TempDir()
 
 	pluginPath := filepath.Join(testDir, "validationplugin.so")
 	buildPlugin(t, pluginPath, validationTestPlugin)
@@ -137,7 +127,7 @@ func TestValidationPlugin(t *testing.T) {
 	instance := factory.New()
 	require.NotNil(t, instance)
 	require.NoError(t, instance.Init())
-	err = instance.Validate(nil, "", 0, 0)
+	err := instance.Validate(nil, "", 0, 0)
 	require.NoError(t, err)
 }
 

--- a/core/ledger/confighistory/confighistorytest/confighistory_test.go
+++ b/core/ledger/confighistory/confighistorytest/confighistory_test.go
@@ -8,9 +8,7 @@ package confighistorytest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
-	"os"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -19,9 +17,7 @@ import (
 )
 
 func TestConfigHistory(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "confighitory-")
-	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	mgr, err := NewMgr(testDir)
 	require.NoError(t, err)

--- a/core/ledger/confighistory/mgr_test.go
+++ b/core/ledger/confighistory/mgr_test.go
@@ -35,11 +35,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestWithNoCollectionConfig(t *testing.T) {
-	dbPath, err := ioutil.TempDir("", "confighistory")
-	if err != nil {
-		t.Fatalf("Failed to create config history directory: %s", err)
-	}
-	defer os.RemoveAll(dbPath)
+	dbPath := t.TempDir()
 	mockCCInfoProvider := &mock.DeployedChaincodeInfoProvider{}
 	mgr, err := NewMgr(dbPath, mockCCInfoProvider)
 	require.NoError(t, err)
@@ -57,11 +53,7 @@ func TestWithNoCollectionConfig(t *testing.T) {
 }
 
 func TestWithEmptyCollectionConfig(t *testing.T) {
-	dbPath, err := ioutil.TempDir("", "confighistory")
-	if err != nil {
-		t.Fatalf("Failed to create config history directory: %s", err)
-	}
-	defer os.RemoveAll(dbPath)
+	dbPath := t.TempDir()
 	mockCCInfoProvider := &mock.DeployedChaincodeInfoProvider{}
 	mgr, err := NewMgr(dbPath, mockCCInfoProvider)
 	require.NoError(t, err)
@@ -83,11 +75,7 @@ func TestWithEmptyCollectionConfig(t *testing.T) {
 }
 
 func TestMgrQueries(t *testing.T) {
-	dbPath, err := ioutil.TempDir("", "confighistory")
-	if err != nil {
-		t.Fatalf("Failed to create config history directory: %s", err)
-	}
-	defer os.RemoveAll(dbPath)
+	dbPath := t.TempDir()
 	mockCCInfoProvider := &mock.DeployedChaincodeInfoProvider{}
 	mgr, err := NewMgr(dbPath, mockCCInfoProvider)
 	require.NoError(t, err)
@@ -133,9 +121,7 @@ func TestMgrQueries(t *testing.T) {
 }
 
 func TestDrop(t *testing.T) {
-	dbPath, err := ioutil.TempDir("", "confighistory")
-	require.NoError(t, err)
-	defer os.RemoveAll(dbPath)
+	dbPath := t.TempDir()
 	mockCCInfoProvider := &mock.DeployedChaincodeInfoProvider{}
 	mgr, err := NewMgr(dbPath, mockCCInfoProvider)
 	require.NoError(t, err)
@@ -183,11 +169,7 @@ func TestDrop(t *testing.T) {
 }
 
 func TestWithImplicitColls(t *testing.T) {
-	dbPath, err := ioutil.TempDir("", "confighistory")
-	if err != nil {
-		t.Fatalf("Failed to create config history directory: %s", err)
-	}
-	defer os.RemoveAll(dbPath)
+	dbPath := t.TempDir()
 	collConfigPackage := testutilCreateCollConfigPkg([]string{"Explicit-coll-1", "Explicit-coll-2"})
 	mockCCInfoProvider := &mock.DeployedChaincodeInfoProvider{}
 	mockCCInfoProvider.ImplicitCollectionsReturns(
@@ -252,30 +234,19 @@ func TestWithImplicitColls(t *testing.T) {
 type testEnvForSnapshot struct {
 	mgr             *Mgr
 	testSnapshotDir string
-	cleanup         func()
 }
 
 func newTestEnvForSnapshot(t *testing.T) *testEnvForSnapshot {
-	dbPath, err := ioutil.TempDir("", "confighistory")
-	require.NoError(t, err)
+	dbPath := t.TempDir()
 	mgr, err := NewMgr(dbPath, &mock.DeployedChaincodeInfoProvider{})
 	if err != nil {
-		os.RemoveAll(dbPath)
 		t.Fatalf("Failed to create new config history manager: %s", err)
 	}
 
-	testSnapshotDir, err := ioutil.TempDir("", "confighistorysnapshot")
-	if err != nil {
-		os.RemoveAll(dbPath)
-		t.Fatalf("Failed to create config history snapshot directory: %s", err)
-	}
+	testSnapshotDir := t.TempDir()
 	return &testEnvForSnapshot{
 		mgr:             mgr,
 		testSnapshotDir: testSnapshotDir,
-		cleanup: func() {
-			os.RemoveAll(dbPath)
-			os.RemoveAll(testSnapshotDir)
-		},
 	}
 }
 
@@ -374,7 +345,6 @@ func TestExportAndImportConfigHistory(t *testing.T) {
 
 	t.Run("confighistory is empty", func(t *testing.T) {
 		env := newTestEnvForSnapshot(t)
-		defer env.cleanup()
 		retriever := env.mgr.GetRetriever("ledger1")
 		fileHashes, err := retriever.ExportConfigHistory(env.testSnapshotDir, testNewHashFunc)
 		require.NoError(t, err)
@@ -387,7 +357,6 @@ func TestExportAndImportConfigHistory(t *testing.T) {
 	t.Run("export confighistory", func(t *testing.T) {
 		// setup ledger1 => export ledger1
 		env := newTestEnvForSnapshot(t)
-		defer env.cleanup()
 		storedKVs, _ := setupWithSampleData(env, "ledger1")
 		retriever := env.mgr.GetRetriever("ledger1")
 		fileHashes, err := retriever.ExportConfigHistory(env.testSnapshotDir, testNewHashFunc)
@@ -398,7 +367,6 @@ func TestExportAndImportConfigHistory(t *testing.T) {
 	t.Run("import confighistory and verify queries", func(t *testing.T) {
 		// setup ledger1 => export ledger1 => import into ledger2
 		env := newTestEnvForSnapshot(t)
-		defer env.cleanup()
 		_, ccConfigInfo := setupWithSampleData(env, "ledger1")
 		retriever := env.mgr.GetRetriever("ledger1")
 		_, err := retriever.ExportConfigHistory(env.testSnapshotDir, testNewHashFunc)
@@ -414,7 +382,6 @@ func TestExportAndImportConfigHistory(t *testing.T) {
 	t.Run("export from an imported confighistory", func(t *testing.T) {
 		// setup ledger1 => export ledger1 => import into ledger2 => export ledger2
 		env := newTestEnvForSnapshot(t)
-		defer env.cleanup()
 		storedKVs, _ := setupWithSampleData(env, "ledger1")
 		retriever := env.mgr.GetRetriever("ledger1")
 		_, err := retriever.ExportConfigHistory(env.testSnapshotDir, testNewHashFunc)
@@ -433,7 +400,6 @@ func TestExportAndImportConfigHistory(t *testing.T) {
 
 	t.Run("import confighistory with no data and metadata files", func(t *testing.T) {
 		env := newTestEnvForSnapshot(t)
-		defer env.cleanup()
 		require.NoFileExists(t, filepath.Join(env.testSnapshotDir, snapshotDataFileName))
 		require.NoFileExists(t, filepath.Join(env.testSnapshotDir, snapshotMetadataFileName))
 		err := env.mgr.ImportFromSnapshot("ledger1", env.testSnapshotDir)
@@ -442,7 +408,6 @@ func TestExportAndImportConfigHistory(t *testing.T) {
 
 	t.Run("import confighistory - ledger exists error", func(t *testing.T) {
 		env := newTestEnvForSnapshot(t)
-		defer env.cleanup()
 		setupWithSampleData(env, "ledger1")
 		dataFileWriter, err := snapshot.CreateFile(filepath.Join(env.testSnapshotDir, snapshotDataFileName), snapshotFileFormat, testNewHashFunc)
 		require.NoError(t, err)
@@ -454,7 +419,6 @@ func TestExportAndImportConfigHistory(t *testing.T) {
 
 	t.Run("import confighistory - EOF error", func(t *testing.T) {
 		env := newTestEnvForSnapshot(t)
-		defer env.cleanup()
 		dataFileWriter1, err := snapshot.CreateFile(filepath.Join(env.testSnapshotDir, snapshotMetadataFileName), snapshotFileFormat, testNewHashFunc)
 		require.NoError(t, err)
 		defer dataFileWriter1.Close()
@@ -479,7 +443,6 @@ func TestExportAndImportConfigHistory(t *testing.T) {
 
 	t.Run("import confighistory - leveldb iter error", func(t *testing.T) {
 		env := newTestEnvForSnapshot(t)
-		defer env.cleanup()
 		env.mgr.dbProvider.Close()
 		dataFileWriter, err := snapshot.CreateFile(filepath.Join(env.testSnapshotDir, snapshotDataFileName), snapshotFileFormat, testNewHashFunc)
 		require.NoError(t, err)
@@ -543,7 +506,6 @@ func verifyImportedConfigHistory(t *testing.T, retriever *Retriever, expectedCCC
 
 func TestExportConfigHistoryErrorCase(t *testing.T) {
 	env := newTestEnvForSnapshot(t)
-	defer env.cleanup()
 
 	db := env.mgr.dbProvider.getDB("ledger1")
 	cc1collConfigPackage := testutilCreateCollConfigPkg([]string{"Explicit-cc1-coll-1", "Explicit-cc1-coll-2"})

--- a/core/ledger/kvledger/benchmark/chainmgmt/sanity_test.go
+++ b/core/ledger/kvledger/benchmark/chainmgmt/sanity_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package chainmgmt
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -16,10 +15,8 @@ import (
 
 // TestChainMgmt is a basic sanity check test to catch any errors that could be caused by changes in the ledgermgmt or kvledger packages
 func TestChainMgmt(t *testing.T) {
-	dataDir, err := ioutil.TempDir("", "ledgerbenchmark_sanitycheck")
-	require.NoError(t, err)
+	dataDir := t.TempDir()
 	require.NoError(t, os.RemoveAll(dataDir))
-	defer os.RemoveAll(dataDir)
 
 	mgrConf := &ChainMgrConf{
 		DataDir:   dataDir,

--- a/core/ledger/kvledger/bookkeeping/test_exports.go
+++ b/core/ledger/kvledger/bookkeeping/test_exports.go
@@ -17,8 +17,6 @@ limitations under the License.
 package bookkeeping
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,8 +31,7 @@ type TestEnv struct {
 
 // NewTestEnv construct a TestEnv for testing
 func NewTestEnv(t testing.TB) *TestEnv {
-	dbPath, err := ioutil.TempDir("", "bookkeep")
-	require.NoError(t, err)
+	dbPath := t.TempDir()
 	provider, err := NewProvider(dbPath)
 	require.NoError(t, err)
 	return &TestEnv{t, provider, dbPath}
@@ -43,5 +40,4 @@ func NewTestEnv(t testing.TB) *TestEnv {
 // Cleanup cleansup the  store env after testing
 func (te *TestEnv) Cleanup() {
 	te.TestProvider.Close()
-	os.RemoveAll(te.dbPath)
 }

--- a/core/ledger/kvledger/channelinfo_provider_test.go
+++ b/core/ledger/kvledger/channelinfo_provider_test.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -30,9 +29,7 @@ import (
 
 func TestNamespacesAndCollections(t *testing.T) {
 	channelName := "testnamespacesandcollections"
-	basePath, err := ioutil.TempDir("", "testchannelinfoprovider")
-	require.NoError(t, err)
-	defer os.RemoveAll(basePath)
+	basePath := t.TempDir()
 	blkStoreProvider, blkStore := openBlockStorage(t, channelName, basePath)
 	defer blkStoreProvider.Close()
 
@@ -92,9 +89,7 @@ func TestNamespacesAndCollections(t *testing.T) {
 // TestGetAllMSPIDs verifies getAllMSPIDs by adding and removing organizations to the channel config.
 func TestGetAllMSPIDs(t *testing.T) {
 	channelName := "testgetallmspids"
-	basePath, err := ioutil.TempDir("", "testchannelinfoprovider")
-	require.NoError(t, err)
-	defer os.RemoveAll(basePath)
+	basePath := t.TempDir()
 
 	blkStoreProvider, blkStore := openBlockStorage(t, channelName, basePath)
 	defer blkStoreProvider.Close()
@@ -110,7 +105,7 @@ func TestGetAllMSPIDs(t *testing.T) {
 
 	// add genesis block and verify GetAllMSPIDs when the channel has only genesis block
 	// the genesis block is created for org "SampleOrg" with MSPID "SampleOrg"
-	configBlock, err = test.MakeGenesisBlock(channelName)
+	configBlock, err := test.MakeGenesisBlock(channelName)
 	require.NoError(t, err)
 	require.NoError(t, blkStore.AddBlock(configBlock))
 	verifyGetAllMSPIDs(t, channelInfoProvider, []string{"SampleOrg"})
@@ -170,9 +165,7 @@ func TestGetAllMSPIDs(t *testing.T) {
 
 func TestGetAllMSPIDs_NegativeTests(t *testing.T) {
 	channelName := "testgetallmspidsnegativetests"
-	basePath, err := ioutil.TempDir("", "testchannelinfoprovider_negativetests")
-	require.NoError(t, err)
-	defer os.RemoveAll(basePath)
+	basePath := t.TempDir()
 
 	blkStoreProvider, blkStore := openBlockStorage(t, channelName, basePath)
 	defer blkStoreProvider.Close()
@@ -183,7 +176,7 @@ func TestGetAllMSPIDs_NegativeTests(t *testing.T) {
 	lastConfigBlockNum := uint64(0)
 
 	// add genesis block
-	configBlock, err = test.MakeGenesisBlock(channelName)
+	configBlock, err := test.MakeGenesisBlock(channelName)
 	require.NoError(t, err)
 	require.NoError(t, blkStore.AddBlock(configBlock))
 

--- a/core/ledger/kvledger/delete_partial_ledgers_test.go
+++ b/core/ledger/kvledger/delete_partial_ledgers_test.go
@@ -15,9 +15,8 @@ import (
 )
 
 func TestDeleteUnderDeletionLedger(t *testing.T) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	conf.HistoryDBConfig.Enabled = true
-	defer cleanup()
 
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
@@ -40,9 +39,8 @@ func TestDeleteUnderDeletionLedger(t *testing.T) {
 }
 
 func TestDeletePartialLedgers(t *testing.T) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	conf.HistoryDBConfig.Enabled = true
-	defer cleanup()
 
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
@@ -65,9 +63,8 @@ func TestDeletePartialLedgers(t *testing.T) {
 }
 
 func TestNewProviderDeletesPartialLedgers(t *testing.T) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	conf.HistoryDBConfig.Enabled = true
-	defer cleanup()
 
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 

--- a/core/ledger/kvledger/hashcheck_pvtdata_test.go
+++ b/core/ledger/kvledger/hashcheck_pvtdata_test.go
@@ -21,8 +21,7 @@ import (
 )
 
 func TestConstructValidInvalidBlocksPvtData(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 
 	nsCollBtlConfs := []*nsCollBtlConfig{
 		{
@@ -93,8 +92,7 @@ func TestConstructValidInvalidBlocksPvtData(t *testing.T) {
 
 	// generate snapshot at block-2
 	require.NoError(t, kvledger.generateSnapshot())
-	freshConf, cleanup := testConfig(t)
-	defer cleanup()
+	freshConf := testConfig(t)
 
 	freshProvider := testutilNewProviderWithCollectionConfig(
 		t,

--- a/core/ledger/kvledger/history/pkg_test.go
+++ b/core/ledger/kvledger/history/pkg_test.go
@@ -8,8 +8,6 @@ package history
 
 import (
 	"crypto/sha256"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/hyperledger/fabric/common/ledger/blkstorage"
@@ -50,10 +48,7 @@ func newTestHistoryEnv(t *testing.T) *levelDBLockBasedHistoryEnv {
 	testDB := testDBEnv.GetDBHandle(testLedgerID)
 	testBookkeepingEnv := bookkeeping.NewTestEnv(t)
 
-	testHistoryDBPath, err := ioutil.TempDir("", "historyldb")
-	if err != nil {
-		t.Fatalf("Failed to create history database directory: %s", err)
-	}
+	testHistoryDBPath := t.TempDir()
 
 	txmgrInitializer := &txmgr.Initializer{
 		LedgerID:            testLedgerID,
@@ -91,7 +86,6 @@ func (env *levelDBLockBasedHistoryEnv) cleanup() {
 	env.testBookkeepingEnv.Cleanup()
 	// clean up history
 	env.testHistoryDBProvider.Close()
-	os.RemoveAll(env.testHistoryDBPath)
 }
 
 /////// testBlockStoreEnv//////
@@ -103,10 +97,7 @@ type testBlockStoreEnv struct {
 }
 
 func newBlockStorageTestEnv(t testing.TB) *testBlockStoreEnv {
-	testPath, err := ioutil.TempDir("", "historyleveldb-")
-	if err != nil {
-		panic(err)
-	}
+	testPath := t.TempDir()
 	conf := blkstorage.NewConf(testPath, 0)
 
 	attrsToIndex := []blkstorage.IndexableAttr{
@@ -124,10 +115,4 @@ func newBlockStorageTestEnv(t testing.TB) *testBlockStoreEnv {
 
 func (env *testBlockStoreEnv) cleanup() {
 	env.provider.Close()
-	env.removeFSPath()
-}
-
-func (env *testBlockStoreEnv) removeFSPath() {
-	fsPath := env.blockStorageDir
-	os.RemoveAll(fsPath)
 }

--- a/core/ledger/kvledger/kv_ledger_provider_test.go
+++ b/core/ledger/kvledger/kv_ledger_provider_test.go
@@ -8,7 +8,6 @@ package kvledger
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -54,9 +53,8 @@ func TestLedgerProvider(t *testing.T) {
 }
 
 func testLedgerProvider(t *testing.T, enableHistoryDB bool) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	conf.HistoryDBConfig.Enabled = enableHistoryDB
-	defer cleanup()
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	numLedgers := 10
 	existingLedgerIDs, err := provider.List()
@@ -120,8 +118,7 @@ func testLedgerProvider(t *testing.T, enableHistoryDB bool) {
 }
 
 func TestGetLedger(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 
 	inputTestData := map[string]msgs.Status{
@@ -155,8 +152,7 @@ func TestGetLedger(t *testing.T) {
 }
 
 func TestLedgerMetataDataUnmarshalError(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
 
@@ -176,8 +172,7 @@ func TestLedgerMetataDataUnmarshalError(t *testing.T) {
 }
 
 func TestNewProviderIdStoreFormatError(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 
 	require.NoError(t, testutil.Unzip("tests/testdata/v11/sample_ledgers/ledgersData.zip", conf.RootFSPath, false))
 
@@ -193,8 +188,7 @@ func TestNewProviderIdStoreFormatError(t *testing.T) {
 }
 
 func TestUpgradeIDStoreFormatDBError(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	provider.Close()
 
@@ -204,8 +198,7 @@ func TestUpgradeIDStoreFormatDBError(t *testing.T) {
 }
 
 func TestCheckUpgradeEligibilityV1x(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	dbPath := LedgerProviderPath(conf.RootFSPath)
 	db := leveldbhelper.CreateDB(&leveldbhelper.Conf{DBPath: dbPath})
 	idStore := &idStore{db, dbPath}
@@ -222,8 +215,7 @@ func TestCheckUpgradeEligibilityV1x(t *testing.T) {
 }
 
 func TestCheckUpgradeEligibilityCurrentVersion(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	dbPath := LedgerProviderPath(conf.RootFSPath)
 	db := leveldbhelper.CreateDB(&leveldbhelper.Conf{DBPath: dbPath})
 	idStore := &idStore{db, dbPath}
@@ -239,8 +231,7 @@ func TestCheckUpgradeEligibilityCurrentVersion(t *testing.T) {
 }
 
 func TestCheckUpgradeEligibilityBadFormat(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	dbPath := LedgerProviderPath(conf.RootFSPath)
 	db := leveldbhelper.CreateDB(&leveldbhelper.Conf{DBPath: dbPath})
 	idStore := &idStore{db, dbPath}
@@ -261,8 +252,7 @@ func TestCheckUpgradeEligibilityBadFormat(t *testing.T) {
 }
 
 func TestCheckUpgradeEligibilityEmptyDB(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	dbPath := LedgerProviderPath(conf.RootFSPath)
 	db := leveldbhelper.CreateDB(&leveldbhelper.Conf{DBPath: dbPath})
 	idStore := &idStore{db, dbPath}
@@ -305,9 +295,8 @@ func TestDeletionOfUnderConstructionLedgersAtStart(t *testing.T) {
 }
 
 func testDeletionOfUnderConstructionLedgersAtStart(t *testing.T, enableHistoryDB, mimicCrashAfterLedgerCreation bool) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	conf.HistoryDBConfig.Enabled = enableHistoryDB
-	defer cleanup()
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	idStore := provider.idStore
 	ledgerID := "testLedger"
@@ -348,8 +337,7 @@ func testDeletionOfUnderConstructionLedgersAtStart(t *testing.T, enableHistoryDB
 }
 
 func TestLedgerCreationFailure(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	ledgerID := "testLedger"
 	defer func() {
@@ -366,8 +354,7 @@ func TestLedgerCreationFailure(t *testing.T) {
 }
 
 func TestLedgerCreationFailureDuringLedgerDeletion(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	ledgerID := "testLedger"
 	defer func() {
@@ -386,8 +373,7 @@ func TestLedgerCreationFailureDuringLedgerDeletion(t *testing.T) {
 }
 
 func TestMultipleLedgerBasicRW(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider1 := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider1.Close()
 
@@ -435,9 +421,7 @@ func TestMultipleLedgerBasicRW(t *testing.T) {
 
 func TestLedgerBackup(t *testing.T) {
 	ledgerid := "TestLedger"
-	basePath, err := ioutil.TempDir("", "kvledger")
-	require.NoError(t, err, "Failed to create ledger directory")
-	defer os.RemoveAll(basePath)
+	basePath := t.TempDir()
 	originalPath := filepath.Join(basePath, "kvledger1")
 	restorePath := filepath.Join(basePath, "kvledger2")
 
@@ -515,7 +499,7 @@ func TestLedgerBackup(t *testing.T) {
 	provider = testutilNewProvider(restoreConf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
 
-	_, err = provider.CreateFromGenesisBlock(gb)
+	_, err := provider.CreateFromGenesisBlock(gb)
 	require.EqualError(t, err, "ledger [TestLedger] already exists with state [ACTIVE]")
 
 	lgr, err = provider.Open(ledgerid)
@@ -597,9 +581,8 @@ func constructTestLedger(t *testing.T, provider *Provider, sequenceID int) strin
 	return ledgerID
 }
 
-func testConfig(t *testing.T) (conf *ledger.Config, cleanup func()) {
-	path, err := ioutil.TempDir("", "kvledger")
-	require.NoError(t, err, "Failed to create test ledger directory")
+func testConfig(t *testing.T) (conf *ledger.Config) {
+	path := t.TempDir()
 	conf = &ledger.Config{
 		RootFSPath:    path,
 		StateDBConfig: &ledger.StateDBConfig{},
@@ -616,11 +599,8 @@ func testConfig(t *testing.T) (conf *ledger.Config, cleanup func()) {
 			RootDir: filepath.Join(path, "snapshots"),
 		},
 	}
-	cleanup = func() {
-		os.RemoveAll(path)
-	}
 
-	return conf, cleanup
+	return conf
 }
 
 func testutilNewProvider(conf *ledger.Config, t *testing.T, ccInfoProvider *mock.DeployedChaincodeInfoProvider) *Provider {

--- a/core/ledger/kvledger/kv_ledger_test.go
+++ b/core/ledger/kvledger/kv_ledger_test.go
@@ -63,8 +63,7 @@ func TestKVLedgerNilHistoryDBProvider(t *testing.T) {
 
 func TestKVLedgerBlockStorage(t *testing.T) {
 	t.Run("green-path", func(t *testing.T) {
-		conf, cleanup := testConfig(t)
-		defer cleanup()
+		conf := testConfig(t)
 		provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 		defer provider.Close()
 
@@ -161,8 +160,7 @@ func TestKVLedgerBlockStorage(t *testing.T) {
 	})
 
 	t.Run("error-path", func(t *testing.T) {
-		conf, cleanup := testConfig(t)
-		defer cleanup()
+		conf := testConfig(t)
 		provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 		defer provider.Close()
 
@@ -179,8 +177,7 @@ func TestKVLedgerBlockStorage(t *testing.T) {
 }
 
 func TestAddCommitHash(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
 
@@ -232,8 +229,7 @@ func TestAddCommitHash(t *testing.T) {
 
 func TestKVLedgerBlockStorageWithPvtdata(t *testing.T) {
 	t.Skip()
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
 
@@ -298,8 +294,7 @@ func TestKVLedgerBlockStorageWithPvtdata(t *testing.T) {
 }
 
 func TestKVLedgerDBRecovery(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	nsCollBtlConfs := []*nsCollBtlConfig{
 		{
 			namespace: "ns",
@@ -517,8 +512,7 @@ func TestKVLedgerDBRecovery(t *testing.T) {
 }
 
 func TestLedgerWithCouchDbEnabledWithBinaryAndJSONData(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
 	bg, gb := testutil.NewBlockGenerator(t, "testLedger", false)
@@ -629,8 +623,7 @@ func TestLedgerWithCouchDbEnabledWithBinaryAndJSONData(t *testing.T) {
 }
 
 func TestPvtDataAPIs(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
 
@@ -715,8 +708,7 @@ func TestPvtDataAPIs(t *testing.T) {
 }
 
 func TestCrashAfterPvtdataStoreCommit(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	ccInfoProvider := &mock.DeployedChaincodeInfoProvider{}
 	ccInfoProvider.CollectionInfoReturns(&peer.StaticCollectionConfig{BlockToLive: 0}, nil)
 	provider := testutilNewProvider(conf, t, ccInfoProvider)
@@ -816,8 +808,7 @@ func testVerifyPvtData(t *testing.T, lgr ledger.PeerLedger, blockNum uint64, exp
 }
 
 func TestPvtStoreAheadOfBlockStore(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	ccInfoProvider := &mock.DeployedChaincodeInfoProvider{}
 	ccInfoProvider.CollectionInfoReturns(&peer.StaticCollectionConfig{BlockToLive: 0}, nil)
 	provider := testutilNewProvider(conf, t, ccInfoProvider)
@@ -915,8 +906,7 @@ func TestPvtStoreAheadOfBlockStore(t *testing.T) {
 }
 
 func TestCommitToPvtAndBlockstoreError(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	ccInfoProvider := &mock.DeployedChaincodeInfoProvider{}
 	ccInfoProvider.CollectionInfoReturns(&peer.StaticCollectionConfig{BlockToLive: 0}, nil)
 	provider1 := testutilNewProvider(conf, t, ccInfoProvider)
@@ -968,7 +958,7 @@ func TestCollectionConfigHistoryRetriever(t *testing.T) {
 
 	init := func() {
 		var err error
-		conf, cleanupFunc := testConfig(t)
+		conf := testConfig(t)
 		mockDeployedCCInfoProvider = &mock.DeployedChaincodeInfoProvider{}
 		provider = testutilNewProvider(conf, t, mockDeployedCCInfoProvider)
 		ledgerID := "testLedger"
@@ -978,7 +968,6 @@ func TestCollectionConfigHistoryRetriever(t *testing.T) {
 		cleanup = func() {
 			lgr.Close()
 			provider.Close()
-			cleanupFunc()
 		}
 	}
 
@@ -1228,8 +1217,7 @@ func TestCommitNotifications(t *testing.T) {
 }
 
 func TestCommitNotificationsOnBlockCommit(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
 

--- a/core/ledger/kvledger/metrics_test.go
+++ b/core/ledger/kvledger/metrics_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 func TestStatsBlockCommit(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	testMetricProvider := testutilConstructMetricProvider()
 
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())

--- a/core/ledger/kvledger/pause_resume_test.go
+++ b/core/ledger/kvledger/pause_resume_test.go
@@ -17,9 +17,8 @@ import (
 )
 
 func TestPauseAndResume(t *testing.T) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	conf.HistoryDBConfig.Enabled = false
-	defer cleanup()
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 
 	numLedgers := 10
@@ -73,9 +72,8 @@ func TestPauseAndResume(t *testing.T) {
 }
 
 func TestPauseAndResumeErrors(t *testing.T) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	conf.HistoryDBConfig.Enabled = false
-	defer cleanup()
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 
 	ledgerID := constructTestLedgerID(0)

--- a/core/ledger/kvledger/rebuild_dbs_test.go
+++ b/core/ledger/kvledger/rebuild_dbs_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestRebuildDBs(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 
 	numLedgers := 3

--- a/core/ledger/kvledger/rwset_backward_compatibility_test.go
+++ b/core/ledger/kvledger/rwset_backward_compatibility_test.go
@@ -39,8 +39,7 @@ func TestBackwardCompatibilityRWSetV21(t *testing.T) {
 // }
 
 func testGenerateSampleRWSet(t *testing.T) []byte {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
 

--- a/core/ledger/kvledger/snapshot_mgmt_test.go
+++ b/core/ledger/kvledger/snapshot_mgmt_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 func TestSnapshotRequestBookKeeper(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
 
@@ -87,8 +86,7 @@ func TestSnapshotRequestBookKeeper(t *testing.T) {
 }
 
 func TestSnapshotRequestBookKeeperErrorPaths(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
 
@@ -119,8 +117,7 @@ func TestSnapshotRequestBookKeeperErrorPaths(t *testing.T) {
 }
 
 func TestSnapshotRequests(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
 
@@ -231,8 +228,7 @@ func TestSnapshotRequests(t *testing.T) {
 }
 
 func TestSnapshotMgmtConcurrency(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
 
@@ -263,8 +259,7 @@ func TestSnapshotMgmtConcurrency(t *testing.T) {
 }
 
 func TestSnapshotMgrShutdown(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
 
@@ -300,8 +295,7 @@ func TestSnapshotMgrShutdown(t *testing.T) {
 }
 
 func TestSnapshotRequestsErrorPaths(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 
 	// create a ledger with genesis block

--- a/core/ledger/kvledger/snapshot_test.go
+++ b/core/ledger/kvledger/snapshot_test.go
@@ -40,8 +40,7 @@ import (
 )
 
 func TestSnapshotGenerationAndNewLedgerCreation(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	snapshotRootDir := conf.SnapshotsConfig.RootDir
 	nsCollBtlConfs := []*nsCollBtlConfig{
 		{
@@ -210,9 +209,8 @@ func TestSnapshotGenerationAndNewLedgerCreation(t *testing.T) {
 }
 
 func TestSnapshotDBTypeCouchDB(t *testing.T) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	fmt.Printf("snapshotRootDir %s\n", conf.SnapshotsConfig.RootDir)
-	defer cleanup()
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
 
@@ -240,8 +238,7 @@ func TestSnapshotDBTypeCouchDB(t *testing.T) {
 
 func TestSnapshotCouchDBIndexCreation(t *testing.T) {
 	setup := func() (string, *ledger.CouchDBConfig, *Provider) {
-		conf, cleanup := testConfig(t)
-		t.Cleanup(cleanup)
+		conf := testConfig(t)
 
 		snapshotRootDir := conf.SnapshotsConfig.RootDir
 		provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
@@ -280,8 +277,7 @@ func TestSnapshotCouchDBIndexCreation(t *testing.T) {
 			RedoLogPath:         filepath.Join(conf.RootFSPath, "couchdbRedoLogs"),
 		}
 
-		destConf, destCleanup := testConfig(t)
-		t.Cleanup(destCleanup)
+		destConf := testConfig(t)
 		destConf.StateDBConfig = &ledger.StateDBConfig{
 			StateDatabase: ledger.CouchDB,
 			CouchDB:       couchDBConfig,
@@ -455,8 +451,7 @@ func TestSnapshotDirPaths(t *testing.T) {
 }
 
 func TestSnapshotDirPathsCreation(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer func() {
 		provider.Close()
@@ -509,16 +504,14 @@ func TestSnapshotsDirInitializingErrors(t *testing.T) {
 	}
 
 	t.Run("invalid-path", func(t *testing.T) {
-		conf, cleanup := testConfig(t)
-		defer cleanup()
+		conf := testConfig(t)
 		conf.SnapshotsConfig.RootDir = "./a-relative-path"
 		err := initKVLedgerProvider(conf)
 		require.EqualError(t, err, "invalid path: ./a-relative-path. The path for the snapshot dir is expected to be an absolute path")
 	})
 
 	t.Run("snapshots final dir creation returns error", func(t *testing.T) {
-		conf, cleanup := testConfig(t)
-		defer cleanup()
+		conf := testConfig(t)
 
 		completedSnapshotsPath := CompletedSnapshotsPath(conf.SnapshotsConfig.RootDir)
 		require.NoError(t, os.MkdirAll(filepath.Dir(completedSnapshotsPath), 0o755))
@@ -530,8 +523,7 @@ func TestSnapshotsDirInitializingErrors(t *testing.T) {
 }
 
 func TestGenerateSnapshotErrors(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer func() {
 		provider.Close()
@@ -626,7 +618,7 @@ func testCreateLedgerFromSnapshotErrorPaths(t *testing.T, originalSnapshotDir st
 	var additionalMetadataFile string
 
 	init := func(t *testing.T) {
-		conf, cleanupFunc := testConfig(t)
+		conf := testConfig(t)
 		// make a copy of originalSnapshotDir
 		snapshotDirForTest = filepath.Join(conf.RootFSPath, "snapshot")
 		require.NoError(t, os.MkdirAll(snapshotDirForTest, 0o700))
@@ -650,7 +642,6 @@ func testCreateLedgerFromSnapshotErrorPaths(t *testing.T, originalSnapshotDir st
 		provider = testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 		cleanup = func() {
 			provider.Close()
-			cleanupFunc()
 		}
 	}
 
@@ -922,8 +913,7 @@ func verifySnapshotOutput(
 }
 
 func testCreateLedgerFromSnapshot(t *testing.T, snapshotDir string, expectedChannelID string) *kvLedger {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 	p := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	destLedger, channelID, err := p.CreateFromSnapshot(snapshotDir)
 	require.NoError(t, err)
@@ -1008,8 +998,7 @@ func addDummyEntryInCollectionConfigHistory(
 }
 
 func TestMostRecentCollectionConfigFetcher(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 
 	ledgerID := "test-ledger"
 	chaincodeName := "test-chaincode"

--- a/core/ledger/kvledger/state_listener_test.go
+++ b/core/ledger/kvledger/state_listener_test.go
@@ -20,8 +20,7 @@ import (
 )
 
 func TestStateListener(t *testing.T) {
-	conf, cleanup := testConfig(t)
-	defer cleanup()
+	conf := testConfig(t)
 
 	// create a listener and register it to listen to state change in a namespace
 	channelid := "testLedger"

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/snapshot_test.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/snapshot_test.go
@@ -162,11 +162,7 @@ func testSnapshotWithSampleData(t *testing.T, env TestEnv,
 	require.NoError(t, err)
 
 	// export snapshot files from statedb
-	snapshotDirSrcDB, err := ioutil.TempDir("", "testsnapshot")
-	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(snapshotDirSrcDB)
-	}()
+	snapshotDirSrcDB := t.TempDir()
 
 	// verify exported snapshot files
 	filesAndHashesSrcDB, err := sourceDB.ExportPubStateAndPvtStateHashes(snapshotDirSrcDB, testNewHashFunc)
@@ -189,11 +185,7 @@ func testSnapshotWithSampleData(t *testing.T, env TestEnv,
 		publicState, pvtStateHashes, pvtState)
 
 	// export snapshot from the destination db
-	snapshotDirDestDB, err := ioutil.TempDir("", "testsnapshot")
-	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(snapshotDirDestDB)
-	}()
+	snapshotDirDestDB := t.TempDir()
 	filesAndHashesDestDB, err := destinationDB.ExportPubStateAndPvtStateHashes(snapshotDirDestDB, testNewHashFunc)
 	require.NoError(t, err)
 	require.Equal(t, filesAndHashesSrcDB, filesAndHashesDestDB)
@@ -304,11 +296,7 @@ func TestSnapshotImportMetadtaHintImport(t *testing.T) {
 	require.NoError(t, err)
 
 	// export snapshot files from statedb
-	snapshotDir, err := ioutil.TempDir("", "testsnapshot")
-	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(snapshotDir)
-	}()
+	snapshotDir := t.TempDir()
 	_, err = sourceDB.ExportPubStateAndPvtStateHashes(snapshotDir, testNewHashFunc)
 	require.NoError(t, err)
 
@@ -333,9 +321,7 @@ func sha256ForFileForTest(t *testing.T, file string) []byte {
 }
 
 func TestSnapshotReaderNextFunction(t *testing.T) {
-	testdir, err := ioutil.TempDir("", "testsnapshot-WriterReader-")
-	require.NoError(t, err)
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 
 	w, err := NewSnapshotWriter(testdir, "datafile", "metadatafile", testNewHashFunc)
 	require.NoError(t, err)
@@ -390,9 +376,7 @@ func TestMetadataCursor(t *testing.T) {
 }
 
 func TestLoadMetadata(t *testing.T) {
-	testdir, err := ioutil.TempDir("", "testsnapshot-metadata-")
-	require.NoError(t, err)
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 
 	metadata := []*metadataRow{}
 	for i := 1; i <= 100; i++ {
@@ -433,11 +417,9 @@ func TestSnapshotExportErrorPropagation(t *testing.T) {
 		updateBatch.PubUpdates.Put("ns1", "key1", []byte("value1"), version.NewHeight(1, 1))
 		updateBatch.HashUpdates.Put("ns1", "coll1", []byte("key1"), []byte("value1"), version.NewHeight(1, 1))
 		require.NoError(t, db.ApplyPrivacyAwareUpdates(updateBatch, version.NewHeight(1, 1)))
-		snapshotDir, err = ioutil.TempDir("", "testsnapshot")
-		require.NoError(t, err)
+		snapshotDir = t.TempDir()
 		cleanup = func() {
 			dbEnv.Cleanup()
-			os.RemoveAll(snapshotDir)
 		}
 	}
 
@@ -499,7 +481,6 @@ func TestSnapshotImportErrorPropagation(t *testing.T) {
 	var dbEnv *LevelDBTestEnv
 	var snapshotDir string
 	var cleanup func()
-	var err error
 
 	init := func() {
 		dbEnv = &LevelDBTestEnv{}
@@ -509,13 +490,11 @@ func TestSnapshotImportErrorPropagation(t *testing.T) {
 		updateBatch.PubUpdates.PutValAndMetadata("ns1", "key1", []byte("value1"), []byte("metadata"), version.NewHeight(1, 1))
 		updateBatch.HashUpdates.Put("ns1", "coll1", []byte("key1"), []byte("value1"), version.NewHeight(1, 1))
 		require.NoError(t, db.ApplyPrivacyAwareUpdates(updateBatch, version.NewHeight(1, 1)))
-		snapshotDir, err = ioutil.TempDir("", "testsnapshot")
-		require.NoError(t, err)
+		snapshotDir = t.TempDir()
 		_, err := db.ExportPubStateAndPvtStateHashes(snapshotDir, testNewHashFunc)
 		require.NoError(t, err)
 		cleanup = func() {
 			dbEnv.Cleanup()
-			os.RemoveAll(snapshotDir)
 		}
 	}
 
@@ -702,24 +681,20 @@ func testSnapshotImportPvtdataHashesConsumer(t *testing.T, dbEnv TestEnv) {
 	var snapshotDir string
 
 	init := func() {
-		var err error
 		dbEnv.Init(t)
-		snapshotDir, err = ioutil.TempDir("", "testsnapshot")
+		snapshotDir = t.TempDir()
 
 		t.Cleanup(func() {
 			dbEnv.Cleanup()
-			os.RemoveAll(snapshotDir)
 		})
 
-		require.NoError(t, err)
 		db := dbEnv.GetDBHandle(generateLedgerID(t))
 		updateBatch := NewUpdateBatch()
 		updateBatch.PubUpdates.Put("ns-1", "key-1", []byte("value-1"), version.NewHeight(1, 1))
 		updateBatch.HashUpdates.Put("ns-1", "coll-1", []byte("key-hash-1"), []byte("value-hash-1"), version.NewHeight(1, 1))
 		require.NoError(t, db.ApplyPrivacyAwareUpdates(updateBatch, version.NewHeight(1, 1)))
-		snapshotDir, err = ioutil.TempDir("", "testsnapshot")
-		require.NoError(t, err)
-		_, err = db.ExportPubStateAndPvtStateHashes(snapshotDir, testNewHashFunc)
+		snapshotDir = t.TempDir()
+		_, err := db.ExportPubStateAndPvtStateHashes(snapshotDir, testNewHashFunc)
 		require.NoError(t, err)
 	}
 

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/test_exports.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/test_exports.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package privacyenabledstate
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -48,10 +46,7 @@ type LevelDBTestEnv struct {
 
 // Init implements corresponding function from interface TestEnv
 func (env *LevelDBTestEnv) Init(t testing.TB) {
-	dbPath, err := ioutil.TempDir("", "cstestenv")
-	if err != nil {
-		t.Fatalf("Failed to create level db storage directory: %s", err)
-	}
+	dbPath := t.TempDir()
 	env.bookkeeperTestEnv = bookkeeping.NewTestEnv(t)
 	dbProvider, err := NewDBProvider(
 		env.bookkeeperTestEnv.TestProvider,
@@ -100,7 +95,6 @@ func (env *LevelDBTestEnv) GetName() string {
 func (env *LevelDBTestEnv) Cleanup() {
 	env.provider.Close()
 	env.bookkeeperTestEnv.Cleanup()
-	os.RemoveAll(env.dbPath)
 }
 
 ///////////// CouchDB Environment //////////////
@@ -133,10 +127,7 @@ func (env *CouchDBTestEnv) StopExternalResource() {
 
 // Init implements corresponding function from interface TestEnv
 func (env *CouchDBTestEnv) Init(t testing.TB) {
-	redoPath, err := ioutil.TempDir("", "pestate")
-	if err != nil {
-		t.Fatalf("Failed to create redo log directory: %s", err)
-	}
+	redoPath := t.TempDir()
 
 	env.t = t
 	env.StartExternalResource()
@@ -195,7 +186,6 @@ func (env *CouchDBTestEnv) Cleanup() {
 	if env.provider != nil {
 		require.NoError(env.t, statecouchdb.DropApplicationDBs(env.couchDBConfig))
 	}
-	os.RemoveAll(env.redoPath)
 	env.bookkeeperTestEnv.Cleanup()
 	env.provider.Close()
 }

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/redolog_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/redolog_test.go
@@ -9,7 +9,6 @@ package statecouchdb
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -151,15 +150,11 @@ func TestCouchdbRedoLogger(t *testing.T) {
 }
 
 func redologTestSetup(t *testing.T) (p *redoLoggerProvider, cleanup func()) {
-	dbPath, err := ioutil.TempDir("", "redolog")
-	if err != nil {
-		t.Fatalf("Failed to create redo log directory: %s", err)
-	}
-	p, err = newRedoLoggerProvider(dbPath)
+	dbPath := t.TempDir()
+	p, err := newRedoLoggerProvider(dbPath)
 	require.NoError(t, err)
 	cleanup = func() {
 		p.close()
-		require.NoError(t, os.RemoveAll(dbPath))
 	}
 	return
 }

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/statecouchdb_test.go
@@ -9,7 +9,6 @@ package statecouchdb
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -46,10 +45,7 @@ func (env *testVDBEnv) init(t *testing.T, sysNamespaces []string) {
 		env.couchDBEnv = couchDBEnv
 	}
 
-	redoPath, err := ioutil.TempDir("", "cvdbenv")
-	if err != nil {
-		t.Fatalf("Failed to create redo log directory: %s", err)
-	}
+	redoPath := t.TempDir()
 	config := &ledger.CouchDBConfig{
 		Address:             env.couchDBEnv.couchAddress,
 		Username:            "admin",
@@ -91,7 +87,6 @@ func (env *testVDBEnv) cleanup() {
 		env.DBProvider.Close()
 	}
 	env.couchDBEnv.cleanup(env.config)
-	require.NoError(env.t, os.RemoveAll(env.config.RedoLogPath))
 }
 
 // testVDBEnv provides a couch db for testing
@@ -1119,9 +1114,7 @@ func TestFormatCheck(t *testing.T) {
 }
 
 func testFormatCheck(t *testing.T, dataFormat string, dataExists bool, expectedErr *dataformat.ErrFormatMismatch, expectedFormat string, vdbEnv *testVDBEnv) {
-	redoPath, err := ioutil.TempDir("", "redoPath")
-	require.NoError(t, err)
-	defer os.RemoveAll(redoPath)
+	redoPath := t.TempDir()
 	config := &ledger.CouchDBConfig{
 		Address:             vdbEnv.couchDBEnv.couchAddress,
 		Username:            "admin",

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb_test_export.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/stateleveldb_test_export.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package stateleveldb
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,10 +22,7 @@ type TestVDBEnv struct {
 // NewTestVDBEnv instantiates and new level db backed TestVDB
 func NewTestVDBEnv(t testing.TB) *TestVDBEnv {
 	t.Logf("Creating new TestVDBEnv")
-	dbPath, err := ioutil.TempDir("", "statelvldb")
-	if err != nil {
-		t.Fatalf("Failed to create leveldb directory: %s", err)
-	}
+	dbPath := t.TempDir()
 	dbProvider, err := NewVersionedDBProvider(dbPath)
 	require.NoError(t, err)
 	return &TestVDBEnv{t, dbProvider, dbPath}
@@ -37,5 +32,4 @@ func NewTestVDBEnv(t testing.TB) *TestVDBEnv {
 func (env *TestVDBEnv) Cleanup() {
 	env.t.Logf("Cleaningup TestVDBEnv")
 	env.DBProvider.Close()
-	os.RemoveAll(env.dbPath)
 }

--- a/core/ledger/kvledger/unjoin_channel_test.go
+++ b/core/ledger/kvledger/unjoin_channel_test.go
@@ -15,9 +15,8 @@ import (
 )
 
 func TestUnjoinChannel(t *testing.T) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	conf.HistoryDBConfig.Enabled = true
-	defer cleanup()
 
 	ledgerID := "ledger_unjoin"
 
@@ -56,9 +55,8 @@ func TestUnjoinChannel(t *testing.T) {
 
 // Unjoining an unjoined channel is an error.
 func TestUnjoinUnjoinedChannelErrors(t *testing.T) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	conf.HistoryDBConfig.Enabled = false
-	defer cleanup()
 
 	ledgerID := "ledger_unjoin_unjoined"
 
@@ -84,9 +82,8 @@ func TestUnjoinUnjoinedChannelErrors(t *testing.T) {
 }
 
 func TestUnjoinWithRunningPeerErrors(t *testing.T) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	conf.HistoryDBConfig.Enabled = false
-	defer cleanup()
 
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	defer provider.Close()
@@ -102,9 +99,8 @@ func TestUnjoinWithRunningPeerErrors(t *testing.T) {
 }
 
 func TestUnjoinWithMissingChannelErrors(t *testing.T) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	conf.HistoryDBConfig.Enabled = false
-	defer cleanup()
 
 	// fail if channel does not exist
 	require.EqualError(t, UnjoinChannel(conf, "__invalid_channel"),
@@ -112,9 +108,8 @@ func TestUnjoinWithMissingChannelErrors(t *testing.T) {
 }
 
 func TestUnjoinChannelWithInvalidMetadataErrors(t *testing.T) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	conf.HistoryDBConfig.Enabled = false
-	defer cleanup()
 
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 

--- a/core/ledger/kvledger/upgrade_dbs_test.go
+++ b/core/ledger/kvledger/upgrade_dbs_test.go
@@ -18,9 +18,8 @@ import (
 )
 
 func TestUpgradeWrongFormat(t *testing.T) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	conf.HistoryDBConfig.Enabled = false
-	defer cleanup()
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 
 	// change format to a wrong value to test upgradeFormat error path
@@ -49,9 +48,8 @@ func TestUpgradeWrongFormat(t *testing.T) {
 }
 
 func TestUpgradeAlreadyUptodateFormat(t *testing.T) {
-	conf, cleanup := testConfig(t)
+	conf := testConfig(t)
 	conf.HistoryDBConfig.Enabled = false
-	defer cleanup()
 	provider := testutilNewProvider(conf, t, &mock.DeployedChaincodeInfoProvider{})
 	provider.Close()
 

--- a/core/ledger/ledgermgmt/ledger_mgmt_test.go
+++ b/core/ledger/ledgermgmt/ledger_mgmt_test.go
@@ -8,7 +8,6 @@ package ledgermgmt
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +27,7 @@ import (
 )
 
 func TestLedgerMgmt(t *testing.T) {
-	initializer, ledgerMgr, cleanup := setup(t, "ledgermgmt")
+	initializer, ledgerMgr, cleanup := setup(t)
 	defer cleanup()
 
 	numLedgers := 10
@@ -75,14 +74,14 @@ func TestLedgerMgmt(t *testing.T) {
 // TestCreateLedgerFromSnapshot first creates a ledger using a genesis block and generates a snapshot.
 // After it, it tests creating ledger from the snapshot.
 func TestCreateLedgerFromSnapshot(t *testing.T) {
-	initializer, lgrMgr, cleanup := setup(t, "createledgerfromsnapshot")
+	initializer, lgrMgr, cleanup := setup(t)
 	defer cleanup()
 
 	channelID := "testcreatefromsnapshot"
 	snapshotDir, gb := generateSnapshot(t, lgrMgr, initializer, channelID)
 
 	t.Run("create_ledger_from_snapshot_internal", func(t *testing.T) {
-		_, ledgerMgr, cleanup := setup(t, "createledgerfromsnapshot_internal")
+		_, ledgerMgr, cleanup := setup(t)
 		defer cleanup()
 
 		l, _, err := ledgerMgr.createFromSnapshot(snapshotDir)
@@ -99,7 +98,7 @@ func TestCreateLedgerFromSnapshot(t *testing.T) {
 	})
 
 	t.Run("create_ledger_from_snapshot_async", func(t *testing.T) {
-		_, ledgerMgr, cleanup := setup(t, "createledgerfromsnapshot_async")
+		_, ledgerMgr, cleanup := setup(t)
 		defer cleanup()
 
 		callbackCounter := 0
@@ -127,9 +126,7 @@ func TestCreateLedgerFromSnapshot(t *testing.T) {
 	})
 
 	t.Run("create_ledger_from_nonexist_or_empty_dir_returns_error", func(t *testing.T) {
-		testDir, err := ioutil.TempDir("", "invalidsnapshotdir")
-		require.NoError(t, err)
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 
 		nonExistDir := filepath.Join(testDir, "nonexistdir")
 		require.EqualError(t, lgrMgr.CreateLedgerFromSnapshot(nonExistDir, nil),
@@ -140,7 +137,7 @@ func TestCreateLedgerFromSnapshot(t *testing.T) {
 	})
 
 	t.Run("callback_func_is_not_called_if_create_ledger_from_snapshot_failed", func(t *testing.T) {
-		initializer, ledgerMgr, cleanup := setup(t, "callbackfuncisnotcalled")
+		initializer, ledgerMgr, cleanup := setup(t)
 		defer cleanup()
 
 		// copy snapshotDir to a new dir and remove a metadata file so that kvledger.CreateFromSnapshot will fail
@@ -171,7 +168,7 @@ func TestCreateLedgerFromSnapshot(t *testing.T) {
 }
 
 func TestConcurrentCreateLedgerFromGB(t *testing.T) {
-	_, ledgerMgr, cleanup := setup(t, "concurrentcreateledgerfromgb")
+	_, ledgerMgr, cleanup := setup(t)
 	defer cleanup()
 
 	var err error
@@ -200,7 +197,7 @@ func TestConcurrentCreateLedgerFromGB(t *testing.T) {
 }
 
 func TestConcurrentCreateLedgerFromSnapshot(t *testing.T) {
-	initializer, ledgerMgr, cleanup := setup(t, "concurrentcreateledgerfromsnapshot")
+	initializer, ledgerMgr, cleanup := setup(t)
 	defer cleanup()
 
 	// generate 2 snapshots for 2 channels
@@ -212,7 +209,7 @@ func TestConcurrentCreateLedgerFromSnapshot(t *testing.T) {
 	ledgerMgr.Close()
 
 	// create a new ledger mgr to import snapshot
-	_, ledgerMgr2, cleanup2 := setup(t, "concurrentcreateledgerfromsnapshot2")
+	_, ledgerMgr2, cleanup2 := setup(t)
 	defer cleanup2()
 
 	// use a channel to keep the callback func waiting so that we can test concurrent CreateLedger/CreateLedgerBySnapshot calls
@@ -265,7 +262,7 @@ func TestConcurrentCreateLedgerFromSnapshot(t *testing.T) {
 }
 
 func TestChaincodeInfoProvider(t *testing.T) {
-	_, ledgerMgr, cleanup := setup(t, "chaincodeinfoprovider")
+	_, ledgerMgr, cleanup := setup(t)
 	defer cleanup()
 
 	gb, _ := test.MakeGenesisBlock("ledger1")
@@ -298,15 +295,13 @@ func TestChaincodeInfoProvider(t *testing.T) {
 	require.Equal(t, constructTestCCInfo("cc1", "cc1", "cc1"), ccInfo)
 }
 
-func setup(t *testing.T, basename string) (*Initializer, *LedgerMgr, func()) {
-	testDir, err := ioutil.TempDir("", basename)
-	require.NoError(t, err)
+func setup(t *testing.T) (*Initializer, *LedgerMgr, func()) {
+	testDir := t.TempDir()
 	initializer, err := constructDefaultInitializer(testDir)
 	require.NoError(t, err)
 	ledgerMgr := NewLedgerMgr(initializer)
 	cleanup := func() {
 		ledgerMgr.Close()
-		os.Remove(testDir)
 	}
 	return initializer, ledgerMgr, cleanup
 }

--- a/core/ledger/ledgermgmt/ledgermgmttest/ledgermgmttest.go
+++ b/core/ledger/ledgermgmt/ledgermgmttest/ledgermgmttest.go
@@ -8,8 +8,6 @@ package ledgermgmttest
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -63,9 +61,7 @@ func NewInitializer(testLedgerDir string) *ledgermgmt.Initializer {
 // the snapshot directory. It is intended to be used for creating a ledger by snapshot for testing purpose.
 func CreateSnapshotWithGenesisBlock(t *testing.T, testDir string, ledgerID string, configTxProcessor ledger.CustomTxProcessor) string {
 	// use a tmpdir to create the ledger for ledgerID so that we can create the snapshot
-	tmpDir, err := ioutil.TempDir("", "createsnapshotwithgenesisblock")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	initializer := NewInitializer(tmpDir)
 	initializer.CustomTxProcessors = map[common.HeaderType]ledger.CustomTxProcessor{

--- a/core/ledger/pvtdatastorage/retroactive_hashed_index_test.go
+++ b/core/ledger/pvtdatastorage/retroactive_hashed_index_test.go
@@ -8,8 +8,6 @@ package pvtdatastorage
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -29,9 +27,7 @@ import (
 // a pvtdata from peer v1.1. Block 11 - 13 has not pvt data. Block 14 has pvt data from peer v1.2
 
 func TestConstructHashedIndexAndUpgradeDataFmtRetroactively(t *testing.T) {
-	testWorkingDir, err := ioutil.TempDir("", "pdstore")
-	require.NoError(t, err)
-	defer os.RemoveAll(testWorkingDir)
+	testWorkingDir := t.TempDir()
 
 	require.NoError(t, testutil.CopyDir("testdata/v11_v12/ledgersData/pvtdataStore", testWorkingDir, false))
 	storePath := filepath.Join(testWorkingDir, "pvtdataStore")

--- a/core/ledger/pvtdatastorage/snapshot_data_importer_test.go
+++ b/core/ledger/pvtdatastorage/snapshot_data_importer_test.go
@@ -8,9 +8,7 @@ package pvtdatastorage
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
-	"os"
 	"path"
 	"testing"
 
@@ -42,8 +40,7 @@ func TestSnapshotImporter(t *testing.T) {
 	}()
 
 	setup := func() (*SnapshotDataImporter, *confighistorytest.Mgr, *dbEntriesVerifier) {
-		testDir := testDir(t)
-		t.Cleanup(func() { os.RemoveAll(testDir) })
+		testDir := t.TempDir()
 		dbProvider, err := leveldbhelper.NewProvider(&leveldbhelper.Conf{DBPath: testDir})
 		require.NoError(t, err)
 		t.Cleanup(func() { dbProvider.Close() })
@@ -422,8 +419,7 @@ func TestSnapshotImporterErrorPropagation(t *testing.T) {
 	myMSPID := "myOrg"
 
 	setup := func() (*SnapshotDataImporter, *confighistorytest.Mgr) {
-		testDir := testDir(t)
-		t.Cleanup(func() { os.RemoveAll(testDir) })
+		testDir := t.TempDir()
 		dbProvider, err := leveldbhelper.NewProvider(&leveldbhelper.Conf{DBPath: testDir})
 		require.NoError(t, err)
 		t.Cleanup(func() { dbProvider.Close() })
@@ -580,8 +576,7 @@ func TestSnapshotImporterErrorPropagation(t *testing.T) {
 }
 
 func TestEligibilityAndBTLCacheLoadData(t *testing.T) {
-	testDir := testDir(t)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	configHistoryMgr, err := confighistorytest.NewMgr(testDir)
 	require.NoError(t, err)
@@ -812,8 +807,7 @@ func (e eligibilityVal) sameAs(p *peer.CollectionPolicyConfig) bool {
 
 func TestDBUpdates(t *testing.T) {
 	setup := func() *leveldbhelper.Provider {
-		testDir := testDir(t)
-		t.Cleanup(func() { os.RemoveAll(testDir) })
+		testDir := t.TempDir()
 
 		p, err := leveldbhelper.NewProvider(&leveldbhelper.Conf{DBPath: testDir})
 		require.NoError(t, err)
@@ -976,12 +970,6 @@ func (v *dbEntriesVerifier) verifyNoExpiryEntries() {
 	require.NoError(v.t, iter.Error())
 }
 
-func testDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "snapshot-data-importer-")
-	require.NoError(t, err)
-	return dir
-}
-
 func TestSnapshotRowsSorter(t *testing.T) {
 	testCases := []struct {
 		inputRows         []*snapshotRow
@@ -1095,9 +1083,7 @@ func TestSnapshotRowsSorter(t *testing.T) {
 
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("testcase-%d", i), func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "snapshot-row-sorter-")
-			require.NoError(t, err)
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			sorter, err := newSnapshotRowsSorter(dir)
 			require.NoError(t, err)
@@ -1134,9 +1120,7 @@ func TestSnapshotRowsSorter(t *testing.T) {
 }
 
 func TestSnapshotRowsSorterCleanup(t *testing.T) {
-	dir, err := ioutil.TempDir("", "snapshot-row-sorter-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	sorter, err := newSnapshotRowsSorter(dir)
 	require.NoError(t, err)

--- a/core/ledger/pvtdatastorage/store_created_from_snapshot_test.go
+++ b/core/ledger/pvtdatastorage/store_created_from_snapshot_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package pvtdatastorage
 
 import (
-	"os"
 	"path"
 	"testing"
 
@@ -27,10 +26,9 @@ func TestPvtdataStoreCreatedFromSnapshot(t *testing.T) {
 	}
 
 	setup := func(snapshotData []*snapshotData) *Store {
-		testDir := testDir(t)
+		testDir := t.TempDir()
 		conf := pvtDataConf()
 		conf.StorePath = testDir
-		t.Cleanup(func() { os.RemoveAll(testDir) })
 
 		p, err := NewProvider(conf)
 		require.NoError(t, err)
@@ -310,10 +308,9 @@ func TestPvtdataStoreCreatedFromSnapshot(t *testing.T) {
 }
 
 func TestStoreCreationErrorPath(t *testing.T) {
-	testDir := testDir(t)
+	testDir := t.TempDir()
 	conf := pvtDataConf()
 	conf.StorePath = testDir
-	defer os.RemoveAll(testDir)
 
 	p, err := NewProvider(conf)
 	require.NoError(t, err)

--- a/core/ledger/pvtdatastorage/store_test.go
+++ b/core/ledger/pvtdatastorage/store_test.go
@@ -8,7 +8,6 @@ package pvtdatastorage
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -181,8 +180,7 @@ func TestStoreIteratorError(t *testing.T) {
 	})
 
 	t.Run("processCollElgEvents", func(t *testing.T) {
-		storeDir, err := ioutil.TempDir("", "pdstore")
-		require.NoError(t, err)
+		storeDir := t.TempDir()
 		s := &Store{}
 		dbProvider, err := leveldbhelper.NewProvider(&leveldbhelper.Conf{DBPath: storeDir})
 		require.NoError(t, err)

--- a/core/ledger/pvtdatastorage/test_exports.go
+++ b/core/ledger/pvtdatastorage/test_exports.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package pvtdatastorage
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -45,11 +43,7 @@ func NewTestStoreEnv(
 	ledgerid string,
 	btlPolicy pvtdatapolicy.BTLPolicy,
 	conf *PrivateDataConfig) *StoreEnv {
-	storeDir, err := ioutil.TempDir("", "pdstore")
-	if err != nil {
-		t.Fatalf("Failed to create private data storage directory: %s", err)
-	}
-	conf.StorePath = storeDir
+	conf.StorePath = t.TempDir()
 	testStoreProvider, err := NewProvider(conf)
 	require.NoError(t, err)
 	testStore, err := testStoreProvider.OpenStore(ledgerid)
@@ -72,8 +66,4 @@ func (env *StoreEnv) CloseAndReopen() {
 // Cleanup cleansup the  store env after testing
 func (env *StoreEnv) Cleanup() {
 	env.TestStoreProvider.Close()
-	env.TestStore.db.Close()
-	if err := os.RemoveAll(env.conf.StorePath); err != nil {
-		env.t.Errorf("error while removing path %s, %v", env.conf.StorePath, err)
-	}
 }

--- a/core/ledger/snapshotgrpc/snapshot_service_test.go
+++ b/core/ledger/snapshotgrpc/snapshot_service_test.go
@@ -9,7 +9,6 @@ package snapshotgrpc
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"testing"
 
 	"github.com/hyperledger/fabric-protos-go/common"
@@ -34,8 +33,7 @@ type aclProvider interface {
 }
 
 func TestSnapshot(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "snapshotgrpc")
-	require.NoError(t, err)
+	testDir := t.TempDir()
 
 	ledgerID := "testsnapshot"
 	ledgermgmtInitializer := ledgermgmttest.NewInitializer(testDir)

--- a/core/peer/config_test.go
+++ b/core/peer/config_test.go
@@ -96,9 +96,7 @@ func TestPeerAddress(t *testing.T) {
 }
 
 func TestGetServerConfig(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "peer-clientcert")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	// good config without TLS
 	viper.Set("peer.tls.enabled", false)
@@ -180,9 +178,7 @@ func TestGetServerConfig(t *testing.T) {
 }
 
 func TestGetClientCertificate(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "peer-clientcert")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	ca, err := tlsgen.NewCA()
 	require.NoError(t, err)

--- a/core/peer/configtx_test.go
+++ b/core/peer/configtx_test.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package peer
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -29,8 +27,7 @@ import (
 func TestConfigTxCreateLedger(t *testing.T) {
 	helper := newTestHelper(t)
 	channelID := "testchain1"
-	tempdir, err := ioutil.TempDir("", "peer-test")
-	require.NoError(t, err, "failed to create temporary directory")
+	tempdir := t.TempDir()
 
 	ledgerMgr, err := constructLedgerMgrWithTestDefaults(tempdir)
 	if err != nil {
@@ -39,7 +36,6 @@ func TestConfigTxCreateLedger(t *testing.T) {
 
 	defer func() {
 		ledgerMgr.Close()
-		os.RemoveAll(tempdir)
 	}()
 
 	chanConf := helper.sampleChannelConfig(1, true)
@@ -72,8 +68,7 @@ func TestConfigTxErrorScenarios(t *testing.T) {
 func TestConfigTxUpdateChanConfig(t *testing.T) {
 	helper := newTestHelper(t)
 	channelID := "testchain1"
-	tempdir, err := ioutil.TempDir("", "peer-test")
-	require.NoError(t, err, "failed to create temporary directory")
+	tempdir := t.TempDir()
 
 	ledgerMgr, err := constructLedgerMgrWithTestDefaults(tempdir)
 	if err != nil {
@@ -82,7 +77,6 @@ func TestConfigTxUpdateChanConfig(t *testing.T) {
 
 	defer func() {
 		ledgerMgr.Close()
-		os.RemoveAll(tempdir)
 	}()
 
 	chanConf := helper.sampleChannelConfig(1, true)
@@ -115,8 +109,7 @@ func TestConfigTxUpdateChanConfig(t *testing.T) {
 func TestGenesisBlockCreateLedger(t *testing.T) {
 	b, err := configtxtest.MakeGenesisBlock("testchain")
 	require.NoError(t, err)
-	tempdir, err := ioutil.TempDir("", "peer-test")
-	require.NoError(t, err, "failed to create temporary directory")
+	tempdir := t.TempDir()
 
 	ledgerMgr, err := constructLedgerMgrWithTestDefaults(tempdir)
 	if err != nil {
@@ -125,7 +118,6 @@ func TestGenesisBlockCreateLedger(t *testing.T) {
 
 	defer func() {
 		ledgerMgr.Close()
-		os.RemoveAll(tempdir)
 	}()
 
 	lgr, err := ledgerMgr.CreateLedger("testchain", b)

--- a/core/peer/peer_test.go
+++ b/core/peer/peer_test.go
@@ -8,7 +8,6 @@ package peer
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -52,8 +51,7 @@ func TestMain(m *testing.M) {
 }
 
 func NewTestPeer(t *testing.T) (*Peer, func()) {
-	tempdir, err := ioutil.TempDir("", "peer-test")
-	require.NoError(t, err, "failed to create temporary directory")
+	tempdir := t.TempDir()
 
 	// Initialize gossip service
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
@@ -111,7 +109,6 @@ func NewTestPeer(t *testing.T) (*Peer, func()) {
 
 	cleanup := func() {
 		ledgerMgr.Close()
-		os.RemoveAll(tempdir)
 	}
 	return peerInstance, cleanup
 }
@@ -237,12 +234,10 @@ func TestCreateChannelBySnapshot(t *testing.T) {
 	testChannelID := "createchannelbysnapshot"
 
 	// create a temp dir to store snapshot
-	tempdir, err := ioutil.TempDir("", testChannelID)
-	require.NoError(t, err)
-	defer os.Remove(tempdir)
+	tempdir := t.TempDir()
 
 	snapshotDir := ledgermgmttest.CreateSnapshotWithGenesisBlock(t, tempdir, testChannelID, &ConfigTxProcessor{})
-	err = peerInstance.CreateChannelFromSnapshot(snapshotDir, &ledgermocks.DeployedChaincodeInfoProvider{}, nil, nil)
+	err := peerInstance.CreateChannelFromSnapshot(snapshotDir, &ledgermocks.DeployedChaincodeInfoProvider{}, nil, nil)
 	require.NoError(t, err)
 
 	expectedStatus := &pb.JoinBySnapshotStatus{InProgress: true, BootstrappingSnapshotDir: snapshotDir}

--- a/core/scc/cscc/configure_test.go
+++ b/core/scc/cscc/configure_test.go
@@ -8,7 +8,6 @@ package cscc
 
 import (
 	"errors"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -236,9 +235,7 @@ func TestConfigerInvokeJoinChainWrongParams(t *testing.T) {
 }
 
 func TestConfigerInvokeJoinChainCorrectParams(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "cscc_test")
-	require.NoError(t, err, "error in creating test dir")
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	ledgerInitializer := ledgermgmttest.NewInitializer(testDir)
 	ledgerInitializer.CustomTxProcessors = map[cb.HeaderType]ledger.CustomTxProcessor{
@@ -351,9 +348,7 @@ func TestConfigerInvokeJoinChainCorrectParams(t *testing.T) {
 }
 
 func TestConfigerInvokeJoinChainBySnapshot(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "cscc_test_bysnapshot")
-	require.NoError(t, err, "error in creating test dir")
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	ledgerInitializer := ledgermgmttest.NewInitializer(testDir)
 	ledgerInitializer.CustomTxProcessors = map[cb.HeaderType]ledger.CustomTxProcessor{
@@ -437,9 +432,7 @@ func TestConfigerInvokeJoinChainBySnapshot(t *testing.T) {
 }
 
 func TestConfigerInvokeGetChannelConfig(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "cscc_test_GetChannelConfig")
-	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	ledgerInitializer := ledgermgmttest.NewInitializer(testDir)
 	ledgerInitializer.CustomTxProcessors = map[cb.HeaderType]ledger.CustomTxProcessor{

--- a/core/scc/lscc/lscc_test.go
+++ b/core/scc/lscc/lscc_test.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -150,9 +149,7 @@ func getMSPManager(cid string) msp.MSPManager { return mspmgmt.GetManagerForChai
 // TestInstall tests the install function with various inputs
 func TestInstall(t *testing.T) {
 	// Initialize ledgermgmt that inturn initializes internal components (such as cceventmgmt on which this test depends)
-	tempdir, err := ioutil.TempDir("", "lscc-test")
-	require.NoError(t, err, "failed to create temporary directory")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	initializer := ledgermgmttest.NewInitializer(tempdir)
 

--- a/core/scc/qscc/query_test.go
+++ b/core/scc/qscc/query_test.go
@@ -8,7 +8,6 @@ package qscc
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -31,14 +30,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupTestLedger(chainid string, path string) (*shimtest.MockStub, *peer.Peer, func(), error) {
+func setupTestLedger(t *testing.T, chainid string, path string) (*shimtest.MockStub, *peer.Peer, func(), error) {
 	mockAclProvider.Reset()
 
 	viper.Set("peer.fileSystemPath", path)
-	testDir, err := ioutil.TempDir("", "qscc_test")
-	if err != nil {
-		return nil, nil, nil, err
-	}
+	testDir := t.TempDir()
 
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	if err != nil {
@@ -51,7 +47,6 @@ func setupTestLedger(chainid string, path string) (*shimtest.MockStub, *peer.Pee
 
 	cleanup := func() {
 		ledgerMgr.Close()
-		os.RemoveAll(testDir)
 	}
 	peerInstance := &peer.Peer{
 		LedgerMgr:      ledgerMgr,
@@ -89,18 +84,11 @@ func resetProvider(res, chainid string, prop *peer2.SignedProposal, retErr error
 	return prop
 }
 
-func tempDir(t *testing.T, stem string) string {
-	path, err := ioutil.TempDir("", "qscc-"+stem)
-	require.NoError(t, err)
-	return path
-}
-
 func TestQueryGetChainInfo(t *testing.T) {
 	chainid := "mytestchainid1"
-	path := tempDir(t, "test1")
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
-	stub, _, cleanup, err := setupTestLedger(chainid, path)
+	stub, _, cleanup, err := setupTestLedger(t, chainid, path)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -122,10 +110,9 @@ func TestQueryGetChainInfo(t *testing.T) {
 
 func TestQueryGetTransactionByID(t *testing.T) {
 	chainid := "mytestchainid2"
-	path := tempDir(t, "test2")
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
-	stub, _, cleanup, err := setupTestLedger(chainid, path)
+	stub, _, cleanup, err := setupTestLedger(t, chainid, path)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -148,10 +135,9 @@ func TestQueryGetTransactionByID(t *testing.T) {
 
 func TestQueryGetBlockByNumber(t *testing.T) {
 	chainid := "mytestchainid3"
-	path := tempDir(t, "test3")
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
-	stub, _, cleanup, err := setupTestLedger(chainid, path)
+	stub, _, cleanup, err := setupTestLedger(t, chainid, path)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -176,10 +162,9 @@ func TestQueryGetBlockByNumber(t *testing.T) {
 
 func TestQueryGetBlockByHash(t *testing.T) {
 	chainid := "mytestchainid4"
-	path := tempDir(t, "test4")
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
-	stub, _, cleanup, err := setupTestLedger(chainid, path)
+	stub, _, cleanup, err := setupTestLedger(t, chainid, path)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -197,10 +182,9 @@ func TestQueryGetBlockByHash(t *testing.T) {
 
 func TestQueryGetBlockByTxID(t *testing.T) {
 	chainid := "mytestchainid5"
-	path := tempDir(t, "test5")
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
-	stub, _, cleanup, err := setupTestLedger(chainid, path)
+	stub, _, cleanup, err := setupTestLedger(t, chainid, path)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -251,10 +235,9 @@ func TestFailingCC2CC(t *testing.T) {
 
 func TestFailingAccessControl(t *testing.T) {
 	chainid := "mytestchainid6"
-	path := tempDir(t, "test6")
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
-	_, p, cleanup, err := setupTestLedger(chainid, path)
+	_, p, cleanup, err := setupTestLedger(t, chainid, path)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -372,10 +355,9 @@ func TestFailingAccessControl(t *testing.T) {
 
 func TestQueryNonexistentFunction(t *testing.T) {
 	chainid := "mytestchainid7"
-	path := tempDir(t, "test7")
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
-	stub, _, cleanup, err := setupTestLedger(chainid, path)
+	stub, _, cleanup, err := setupTestLedger(t, chainid, path)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -391,10 +373,9 @@ func TestQueryNonexistentFunction(t *testing.T) {
 // that contains two transactions
 func TestQueryGeneratedBlock(t *testing.T) {
 	chainid := "mytestchainid8"
-	path := tempDir(t, "test8")
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
-	stub, p, cleanup, err := setupTestLedger(chainid, path)
+	stub, p, cleanup, err := setupTestLedger(t, chainid, path)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/core/testutil/config.go
+++ b/core/testutil/config.go
@@ -9,8 +9,8 @@ package testutil
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"strings"
+	"testing"
 
 	"github.com/hyperledger/fabric/bccsp/factory"
 	"github.com/hyperledger/fabric/core/config/configtest"
@@ -19,7 +19,7 @@ import (
 )
 
 // SetupTestConfig setup the config during test execution
-func SetupTestConfig() {
+func SetupTestConfig(t *testing.T) {
 	flag.Parse()
 
 	// Now set the configuration file
@@ -42,10 +42,7 @@ func SetupTestConfig() {
 		bccspConfig = nil
 	}
 
-	tmpKeyStore, err := ioutil.TempDir("/tmp", "msp-keystore")
-	if err != nil {
-		panic(fmt.Errorf("Could not create temporary directory: %s\n", tmpKeyStore))
-	}
+	tmpKeyStore := t.TempDir()
 
 	msp.SetupBCCSPKeystoreConfig(bccspConfig, tmpKeyStore)
 

--- a/core/transientstore/store_test.go
+++ b/core/transientstore/store_test.go
@@ -43,12 +43,10 @@ type testEnv struct {
 	store         *Store
 	tempdir       string
 	storedir      string
-	cleanup       func()
 }
 
 func initTestEnv(t *testing.T) *testEnv {
-	tempdir, err := ioutil.TempDir("", "ts")
-	require.NoErrorf(t, err, "failed to create test directory [%s]", tempdir)
+	tempdir := t.TempDir()
 
 	storedir := filepath.Join(tempdir, "transientstore")
 	storeProvider, err := NewStoreProvider(storedir)
@@ -64,9 +62,6 @@ func initTestEnv(t *testing.T) *testEnv {
 		store:         store,
 		tempdir:       tempdir,
 		storedir:      storedir,
-		cleanup: func() {
-			require.NoError(t, os.RemoveAll(tempdir))
-		},
 	}
 }
 
@@ -117,7 +112,6 @@ func TestRWSetKeyCodingEncoding(t *testing.T) {
 
 func TestTransientStorePersistAndRetrieve(t *testing.T) {
 	env := initTestEnv(t)
-	defer env.cleanup()
 	testStore := env.store
 	require := require.New(t)
 	txid := "txid-1"
@@ -169,7 +163,6 @@ func TestTransientStorePersistAndRetrieve(t *testing.T) {
 
 func TestTransientStorePersistAndRetrieveBothOldAndNewProto(t *testing.T) {
 	env := initTestEnv(t)
-	defer env.cleanup()
 	testStore := env.store
 	require := require.New(t)
 	txid := "txid-1"
@@ -226,7 +219,6 @@ func TestTransientStorePersistAndRetrieveBothOldAndNewProto(t *testing.T) {
 
 func TestTransientStorePurgeByTxids(t *testing.T) {
 	env := initTestEnv(t)
-	defer env.cleanup()
 	testStore := env.store
 	require := require.New(t)
 
@@ -390,7 +382,6 @@ func TestTransientStorePurgeByTxids(t *testing.T) {
 
 func TestTransientStorePurgeBelowHeight(t *testing.T) {
 	env := initTestEnv(t)
-	defer env.cleanup()
 	testStore := env.store
 	require := require.New(t)
 
@@ -506,7 +497,6 @@ func TestTransientStorePurgeBelowHeight(t *testing.T) {
 
 func TestTransientStoreRetrievalWithFilter(t *testing.T) {
 	env := initTestEnv(t)
-	defer env.cleanup()
 	testStore := env.store
 
 	samplePvtSimResWithConfig := samplePvtDataWithConfigInfo(t)
@@ -716,7 +706,6 @@ func (s *Store) persistOldProto(txid string, blockHeight uint64,
 
 func TestIteratorErrorCases(t *testing.T) {
 	env := initTestEnv(t)
-	defer env.cleanup()
 	testStore := env.store
 	env.storeProvider.Close()
 
@@ -735,7 +724,6 @@ func TestIteratorErrorCases(t *testing.T) {
 
 func TestDeleteTransientStore(t *testing.T) {
 	env := initTestEnv(t)
-	defer env.cleanup()
 
 	ledgerID := "test-deleted-tx-count"
 	store, err := env.storeProvider.OpenStore(ledgerID)
@@ -776,7 +764,6 @@ func TestDeleteTransientStore(t *testing.T) {
 
 func TestDeleteMissingTransientStoreIsOK(t *testing.T) {
 	env := initTestEnv(t)
-	defer env.cleanup()
 
 	sp := env.storeProvider.(*storeProvider)
 	require.NoError(t, sp.deleteStore("_not_a_valid_store"))

--- a/gossip/privdata/coordinator_test.go
+++ b/gossip/privdata/coordinator_test.go
@@ -11,8 +11,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -161,11 +159,7 @@ type testTransientStore struct {
 func newTransientStore(t *testing.T) *testTransientStore {
 	s := &testTransientStore{}
 	var err error
-	s.tempdir, err = ioutil.TempDir("", "ts")
-	if err != nil {
-		t.Fatalf("Failed to create test directory, got err %s", err)
-		return s
-	}
+	s.tempdir = t.TempDir()
 	s.storeProvider, err = transientstore.NewStoreProvider(s.tempdir)
 	if err != nil {
 		t.Fatalf("Failed to open store, got err %s", err)
@@ -181,7 +175,6 @@ func newTransientStore(t *testing.T) *testTransientStore {
 
 func (s *testTransientStore) tearDown() {
 	s.storeProvider.Close()
-	os.RemoveAll(s.tempdir)
 }
 
 func (s *testTransientStore) Persist(txid string, blockHeight uint64,

--- a/gossip/privdata/pull_test.go
+++ b/gossip/privdata/pull_test.go
@@ -9,8 +9,6 @@ package privdata
 import (
 	"bytes"
 	"crypto/rand"
-	"io/ioutil"
-	"os"
 	"sync"
 	"testing"
 
@@ -1068,11 +1066,7 @@ func TestPullerIntegratedWithDataRetreiver(t *testing.T) {
 	p2 := gn.newPuller("p2", policyStore, factoryMock, membership(peerData{"p1", uint64(1)})...)
 
 	committer := &mocks.Committer{}
-	tempdir, err := ioutil.TempDir("", "ts")
-	if err != nil {
-		t.Fatalf("Failed to create test directory, got err %s", err)
-		return
-	}
+	tempdir := t.TempDir()
 	storeProvider, err := transientstore.NewStoreProvider(tempdir)
 	if err != nil {
 		t.Fatalf("Failed to open store, got err %s", err)
@@ -1084,7 +1078,6 @@ func TestPullerIntegratedWithDataRetreiver(t *testing.T) {
 		return
 	}
 	defer storeProvider.Close()
-	defer os.RemoveAll(tempdir)
 	result := []*ledger.TxPvtData{
 		{
 			WriteSet: &rwset.TxPvtReadWriteSet{

--- a/gossip/privdata/pvtdataprovider_test.go
+++ b/gossip/privdata/pvtdataprovider_test.go
@@ -8,8 +8,6 @@ package privdata
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -923,15 +921,13 @@ func TestRetryFetchFromPeer(t *testing.T) {
 	ns1c1 := collectionPvtdataInfoFromTemplate("ns1", "c1", identity.GetMSPIdentifier(), ts.hash, endorser, signature)
 	ns1c2 := collectionPvtdataInfoFromTemplate("ns1", "c2", identity.GetMSPIdentifier(), ts.hash, endorser, signature)
 
-	tempdir, err := ioutil.TempDir("", "ts")
-	require.NoError(t, err, fmt.Sprintf("Failed to create test directory, got err %s", err))
+	tempdir := t.TempDir()
 	storeProvider, err := transientstore.NewStoreProvider(tempdir)
 	require.NoError(t, err, fmt.Sprintf("Failed to create store provider, got err %s", err))
 	store, err := storeProvider.OpenStore(ts.channelID)
 	require.NoError(t, err, fmt.Sprintf("Failed to open store, got err %s", err))
 
 	defer storeProvider.Close()
-	defer os.RemoveAll(tempdir)
 
 	storePvtdataOfInvalidTx := true
 	skipPullingInvalidTransactions := false
@@ -1018,15 +1014,13 @@ func TestSkipPullingAllInvalidTransactions(t *testing.T) {
 	ns1c1 := collectionPvtdataInfoFromTemplate("ns1", "c1", identity.GetMSPIdentifier(), ts.hash, endorser, signature)
 	ns1c2 := collectionPvtdataInfoFromTemplate("ns1", "c2", identity.GetMSPIdentifier(), ts.hash, endorser, signature)
 
-	tempdir, err := ioutil.TempDir("", "ts")
-	require.NoError(t, err, fmt.Sprintf("Failed to create test directory, got err %s", err))
+	tempdir := t.TempDir()
 	storeProvider, err := transientstore.NewStoreProvider(tempdir)
 	require.NoError(t, err, fmt.Sprintf("Failed to create store provider, got err %s", err))
 	store, err := storeProvider.OpenStore(ts.channelID)
 	require.NoError(t, err, fmt.Sprintf("Failed to open store, got err %s", err))
 
 	defer storeProvider.Close()
-	defer os.RemoveAll(tempdir)
 
 	storePvtdataOfInvalidTx := true
 	skipPullingInvalidTransactions := true
@@ -1119,15 +1113,13 @@ func TestRetrievedPvtdataPurgeBelowHeight(t *testing.T) {
 
 	ns1c1 := collectionPvtdataInfoFromTemplate("ns1", "c1", identity.GetMSPIdentifier(), ts.hash, endorser, signature)
 
-	tempdir, err := ioutil.TempDir("", "ts")
-	require.NoError(t, err, fmt.Sprintf("Failed to create test directory, got err %s", err))
+	tempdir := t.TempDir()
 	storeProvider, err := transientstore.NewStoreProvider(tempdir)
 	require.NoError(t, err, fmt.Sprintf("Failed to create store provider, got err %s", err))
 	store, err := storeProvider.OpenStore(ts.channelID)
 	require.NoError(t, err, fmt.Sprintf("Failed to open store, got err %s", err))
 
 	defer storeProvider.Close()
-	defer os.RemoveAll(tempdir)
 
 	// set up store with 9 existing private data write sets
 	for i := 0; i < 9; i++ {
@@ -1260,14 +1252,12 @@ func testRetrievePvtdataSuccess(t *testing.T,
 	expectedBlockPvtdata *ledger.BlockPvtdata) {
 	fmt.Println("\n" + scenario)
 
-	tempdir, err := ioutil.TempDir("", "ts")
-	require.NoError(t, err, fmt.Sprintf("Failed to create test directory, got err %s", err))
+	tempdir := t.TempDir()
 	storeProvider, err := transientstore.NewStoreProvider(tempdir)
 	require.NoError(t, err, fmt.Sprintf("Failed to create store provider, got err %s", err))
 	store, err := storeProvider.OpenStore(ts.channelID)
 	require.NoError(t, err, fmt.Sprintf("Failed to open store, got err %s", err))
 	defer storeProvider.Close()
-	defer os.RemoveAll(tempdir)
 
 	pdp := setupPrivateDataProvider(t, ts, testConfig,
 		storePvtdataOfInvalidTx, skipPullingInvalidTransactions, store,
@@ -1298,14 +1288,12 @@ func testRetrievePvtdataFailure(t *testing.T,
 	expectedErr string) {
 	fmt.Println("\n" + scenario)
 
-	tempdir, err := ioutil.TempDir("", "ts")
-	require.NoError(t, err, fmt.Sprintf("Failed to create test directory, got err %s", err))
+	tempdir := t.TempDir()
 	storeProvider, err := transientstore.NewStoreProvider(tempdir)
 	require.NoError(t, err, fmt.Sprintf("Failed to create store provider, got err %s", err))
 	store, err := storeProvider.OpenStore(ts.channelID)
 	require.NoError(t, err, fmt.Sprintf("Failed to open store, got err %s", err))
 	defer storeProvider.Close()
-	defer os.RemoveAll(tempdir)
 
 	pdp := setupPrivateDataProvider(t, ts, testConfig,
 		storePvtdataOfInvalidTx, skipPullingInvalidTransactions, store,

--- a/gossip/service/gossip_service_test.go
+++ b/gossip/service/gossip_service_test.go
@@ -9,9 +9,7 @@ package service
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -71,11 +69,7 @@ type testTransientStore struct {
 func newTransientStore(t *testing.T) *testTransientStore {
 	s := &testTransientStore{}
 	var err error
-	s.tempdir, err = ioutil.TempDir("", "ts")
-	if err != nil {
-		t.Fatalf("Failed to create test directory, got err %s", err)
-		return s
-	}
+	s.tempdir = t.TempDir()
 	s.storeProvider, err = transientstore.NewStoreProvider(s.tempdir)
 	if err != nil {
 		t.Fatalf("Failed to open store, got err %s", err)
@@ -91,7 +85,6 @@ func newTransientStore(t *testing.T) *testTransientStore {
 
 func (s *testTransientStore) tearDown() {
 	s.storeProvider.Close()
-	os.RemoveAll(s.tempdir)
 }
 
 func (s *testTransientStore) Persist(txid string, blockHeight uint64,

--- a/internal/cryptogen/ca/ca_test.go
+++ b/internal/cryptogen/ca/ca_test.go
@@ -36,11 +36,7 @@ const (
 )
 
 func TestLoadCertificateECDSA(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "ca-test")
-	if err != nil {
-		t.Fatalf("Failed to create test directory: %s", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	// generate private key
 	certDir, err := ioutil.TempDir(testDir, "certs")
@@ -88,12 +84,10 @@ func TestLoadCertificateECDSA(t *testing.T) {
 }
 
 func TestLoadCertificateECDSA_wrongEncoding(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "wrongEncoding")
-	require.NoError(t, err, "failed to create test directory")
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	filename := filepath.Join(testDir, "wrong_encoding.pem")
-	err = ioutil.WriteFile(filename, []byte("wrong_encoding"), 0o644) // Wrong encoded cert
+	err := ioutil.WriteFile(filename, []byte("wrong_encoding"), 0o644) // Wrong encoded cert
 	require.NoErrorf(t, err, "failed to create file %s", filename)
 
 	_, err = ca.LoadCertificateECDSA(testDir)
@@ -102,13 +96,11 @@ func TestLoadCertificateECDSA_wrongEncoding(t *testing.T) {
 }
 
 func TestLoadCertificateECDSA_empty_DER_cert(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "ca-test")
-	require.NoError(t, err, "failed to create test directory")
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	filename := filepath.Join(testDir, "empty.pem")
 	empty_cert := "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"
-	err = ioutil.WriteFile(filename, []byte(empty_cert), 0o644)
+	err := ioutil.WriteFile(filename, []byte(empty_cert), 0o644)
 	require.NoErrorf(t, err, "failed to create file %s", filename)
 
 	cert, err := ca.LoadCertificateECDSA(testDir)
@@ -118,11 +110,7 @@ func TestLoadCertificateECDSA_empty_DER_cert(t *testing.T) {
 }
 
 func TestNewCA(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "ca-test")
-	if err != nil {
-		t.Fatalf("Failed to create test directory: %s", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	caDir := filepath.Join(testDir, "ca")
 	rootCA, err := ca.NewCA(
@@ -163,11 +151,7 @@ func TestNewCA(t *testing.T) {
 }
 
 func TestGenerateSignCertificate(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "ca-test")
-	if err != nil {
-		t.Fatalf("Failed to create test directory: %s", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	// generate private key
 	certDir, err := ioutil.TempDir(testDir, "certs")

--- a/internal/cryptogen/csp/csp_test.go
+++ b/internal/cryptogen/csp/csp_test.go
@@ -25,11 +25,7 @@ import (
 )
 
 func TestLoadPrivateKey(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "csp-test")
-	if err != nil {
-		t.Fatalf("Failed to create test directory: %s", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 	priv, err := csp.GeneratePrivateKey(testDir)
 	if err != nil {
 		t.Fatalf("Failed to generate private key: %s", err)
@@ -44,11 +40,7 @@ func TestLoadPrivateKey(t *testing.T) {
 }
 
 func TestLoadPrivateKey_BadPEM(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "csp-test")
-	if err != nil {
-		t.Fatalf("Failed to create test directory: %s", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	badPEMFile := filepath.Join(testDir, "badpem_sk")
 
@@ -107,11 +99,7 @@ func TestLoadPrivateKey_BadPEM(t *testing.T) {
 }
 
 func TestGeneratePrivateKey(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "csp-test")
-	if err != nil {
-		t.Fatalf("Failed to create test directory: %s", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	expectedFile := filepath.Join(testDir, "priv_sk")
 	priv, err := csp.GeneratePrivateKey(testDir)

--- a/internal/fileutil/fileutil_test.go
+++ b/internal/fileutil/fileutil_test.go
@@ -25,8 +25,7 @@ func TestFileExists(t *testing.T) {
 	})
 
 	t.Run("dir-path", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		exists, size, err := FileExists(testPath)
 		require.EqualError(t, err, fmt.Sprintf("the supplied path [%s] is a dir", testPath))
@@ -35,8 +34,7 @@ func TestFileExists(t *testing.T) {
 	})
 
 	t.Run("empty-file", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		file := filepath.Join(testPath, "empty-file")
 		f, err := os.Create(file)
@@ -50,8 +48,7 @@ func TestFileExists(t *testing.T) {
 	})
 
 	t.Run("file-with-content", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		file := filepath.Join(testPath, "empty-file")
 		contents := []byte("some random contents")
@@ -65,8 +62,7 @@ func TestFileExists(t *testing.T) {
 
 func TestDirExists(t *testing.T) {
 	t.Run("non-existent-path", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		exists, err := DirExists(filepath.Join(testPath, "non-existent-path"))
 		require.NoError(t, err)
@@ -74,8 +70,7 @@ func TestDirExists(t *testing.T) {
 	})
 
 	t.Run("dir-exists", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		exists, err := DirExists(testPath)
 		require.NoError(t, err)
@@ -83,8 +78,7 @@ func TestDirExists(t *testing.T) {
 	})
 
 	t.Run("file-exists", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		file := filepath.Join(testPath, "empty-file")
 		f, err := os.Create(file)
@@ -99,8 +93,7 @@ func TestDirExists(t *testing.T) {
 
 func TestDirEmpty(t *testing.T) {
 	t.Run("non-existent-dir", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		dir := filepath.Join(testPath, "non-existent-dir")
 		_, err := DirEmpty(dir)
@@ -108,8 +101,7 @@ func TestDirEmpty(t *testing.T) {
 	})
 
 	t.Run("empty-dir", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		dir := filepath.Join(testPath, "empty-dir")
 		require.NoError(t, os.MkdirAll(dir, 0o755))
@@ -119,8 +111,7 @@ func TestDirEmpty(t *testing.T) {
 	})
 
 	t.Run("dir-has-file", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		dir := filepath.Join(testPath, "non-empty-dir")
 		require.NoError(t, os.MkdirAll(dir, 0o755))
@@ -132,8 +123,7 @@ func TestDirEmpty(t *testing.T) {
 	})
 
 	t.Run("dir-has-subdir", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		dir := filepath.Join(testPath, "non-empty-dir")
 		subdir := filepath.Join(testPath, "non-empty-dir", "some-random-dir")
@@ -146,8 +136,7 @@ func TestDirEmpty(t *testing.T) {
 
 func TestCreateDirIfMissing(t *testing.T) {
 	t.Run("non-existent-dir", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		dir := filepath.Join(testPath, "non-existent-dir")
 		empty, err := CreateDirIfMissing(dir)
@@ -156,8 +145,7 @@ func TestCreateDirIfMissing(t *testing.T) {
 	})
 
 	t.Run("existing-dir", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		dir := filepath.Join(testPath, "empty-dir")
 		require.NoError(t, os.MkdirAll(dir, 0o755))
@@ -173,8 +161,7 @@ func TestCreateDirIfMissing(t *testing.T) {
 	})
 
 	t.Run("cannot-create-dir", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		path := filepath.Join(testPath, "some-random-file")
 		require.NoError(t, ioutil.WriteFile(path, []byte("some-random-text"), 0o644))
@@ -186,8 +173,7 @@ func TestCreateDirIfMissing(t *testing.T) {
 
 func TestListSubdirs(t *testing.T) {
 	t.Run("only-subdirs", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		childFolders := []string{".childFolder1", "childFolder2", "childFolder3"}
 		for _, folder := range childFolders {
@@ -199,8 +185,7 @@ func TestListSubdirs(t *testing.T) {
 	})
 
 	t.Run("only-file", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		require.NoError(t, ioutil.WriteFile(filepath.Join(testPath, "some-random-file"), []byte("random-text"), 0o644))
 		subFolders, err := ListSubdirs(testPath)
@@ -209,8 +194,7 @@ func TestListSubdirs(t *testing.T) {
 	})
 
 	t.Run("empty-dir", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		subFolders, err := ListSubdirs(testPath)
 		require.NoError(t, err)
@@ -218,8 +202,7 @@ func TestListSubdirs(t *testing.T) {
 	})
 
 	t.Run("non-existent-dir", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		dir := filepath.Join(testPath, "non-existent-dir")
 		_, err := ListSubdirs(dir)
@@ -229,8 +212,7 @@ func TestListSubdirs(t *testing.T) {
 
 func TestCreateAndSyncFileAtomically(t *testing.T) {
 	t.Run("green-path", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		content := []byte("some random content")
 		err := CreateAndSyncFileAtomically(testPath, "tmpFile", "finalFile", content, 0o644)
@@ -242,8 +224,7 @@ func TestCreateAndSyncFileAtomically(t *testing.T) {
 	})
 
 	t.Run("dir-doesnot-exist", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		content := []byte("some random content")
 		dir := filepath.Join(testPath, "non-exitent-dir")
@@ -253,8 +234,7 @@ func TestCreateAndSyncFileAtomically(t *testing.T) {
 	})
 
 	t.Run("tmp-file-already-exists", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		content := []byte("some random content")
 		tmpFile := filepath.Join(testPath, "tmpFile")
@@ -265,8 +245,7 @@ func TestCreateAndSyncFileAtomically(t *testing.T) {
 	})
 
 	t.Run("final-file-already-exists", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		content := []byte("some random content")
 		finalFile := filepath.Join(testPath, "finalFile")
@@ -280,8 +259,7 @@ func TestCreateAndSyncFileAtomically(t *testing.T) {
 	})
 
 	t.Run("rename-returns-error", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		content := []byte("some random content")
 		tmpFile := filepath.Join(testPath, "tmpFile")
@@ -294,8 +272,7 @@ func TestCreateAndSyncFileAtomically(t *testing.T) {
 
 func TestSyncDir(t *testing.T) {
 	t.Run("green-path", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		require.NoError(t, SyncDir(testPath))
 		require.NoError(t, SyncParentDir(testPath))
@@ -308,8 +285,7 @@ func TestSyncDir(t *testing.T) {
 
 func TestRemoveContents(t *testing.T) {
 	t.Run("non-empty-dir", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		// create files and a non-empty subdir under testPath to test RemoveContents
 		require.NoError(t, CreateAndSyncFile(filepath.Join(testPath, "file1"), []byte("test-removecontents"), 0o644))
@@ -324,8 +300,7 @@ func TestRemoveContents(t *testing.T) {
 	})
 
 	t.Run("empty-dir", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 
 		require.NoError(t, RemoveContents(testPath))
 		empty, err := DirEmpty(testPath)
@@ -334,14 +309,7 @@ func TestRemoveContents(t *testing.T) {
 	})
 
 	t.Run("non-existent-dir", func(t *testing.T) {
-		testPath := testPath(t)
-		defer os.RemoveAll(testPath)
+		testPath := t.TempDir()
 		require.NoError(t, RemoveContents(filepath.Join(testPath, "non-existent-dir")))
 	})
-}
-
-func testPath(t *testing.T) string {
-	path, err := ioutil.TempDir("", "fileutiltest-")
-	require.NoError(t, err)
-	return path
 }

--- a/internal/ledgerutil/compare/compare_test.go
+++ b/internal/ledgerutil/compare/compare_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"hash"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -597,18 +596,12 @@ func TestCompare(t *testing.T) {
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			// Create temporary directories for the sample snapshots and comparison results
-			snapshotDir1, err := ioutil.TempDir("", "sample-snapshot-dir1")
-			require.NoError(t, err)
-			defer os.RemoveAll(snapshotDir1)
-			snapshotDir2, err := ioutil.TempDir("", "sample-snapshot-dir2")
-			require.NoError(t, err)
-			defer os.RemoveAll(snapshotDir2)
-			resultsDir, err := ioutil.TempDir("", "results")
-			require.NoError(t, err)
-			defer os.RemoveAll(resultsDir)
+			snapshotDir1 := t.TempDir()
+			snapshotDir2 := t.TempDir()
+			resultsDir := t.TempDir()
 
 			// Populate temporary directories with sample snapshot data
-			err = createSnapshot(snapshotDir1, testCase.inputTestRecords1, testCase.inputTestPvtRecords1, testCase.inputSignableMetadata1)
+			err := createSnapshot(snapshotDir1, testCase.inputTestRecords1, testCase.inputTestPvtRecords1, testCase.inputSignableMetadata1)
 			require.NoError(t, err)
 			err = createSnapshot(snapshotDir2, testCase.inputTestRecords2, testCase.inputTestPvtRecords2, testCase.inputSignableMetadata2)
 			require.NoError(t, err)
@@ -834,9 +827,7 @@ func TestJSONArrayFileWriter(t *testing.T) {
 	}`
 
 	// Create temporary directory for output
-	resultDir, err := ioutil.TempDir("", "result")
-	require.NoError(t, err)
-	defer os.RemoveAll(resultDir)
+	resultDir := t.TempDir()
 	// Create the output file
 	jsonResultFile, err := newJSONFileWriter(filepath.Join(resultDir, "result.json"), "testchannel")
 	require.NoError(t, err)

--- a/internal/ledgerutil/identifytxs/identifytxs_test.go
+++ b/internal/ledgerutil/identifytxs/identifytxs_test.go
@@ -8,7 +8,6 @@ package identifytxs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -143,20 +142,16 @@ func TestIdentifyTxs(t *testing.T) {
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			// Temporary directory for identifytxs results
-			outputDir, err := ioutil.TempDir("", "result")
-			require.NoError(t, err)
-			defer os.RemoveAll(outputDir)
+			outputDir := t.TempDir()
 			// Temporary directory for file system
 			var fsDir string
+			var err error
 			if testCase.expectedOutputType == "empty-bs-error" {
-				fsDir, err = ioutil.TempDir("", "sample_prod_empty")
-				require.NoError(t, err)
+				fsDir = t.TempDir()
 				err = os.MkdirAll(filepath.Join(fsDir, "ledgersData", "chains"), 0o700)
 				require.NoError(t, err)
 			} else {
-				fsDir, err = ioutil.TempDir("", "fs-copy")
-				require.NoError(t, err)
-				defer os.RemoveAll(fsDir)
+				fsDir = t.TempDir()
 				err = testutil.CopyDir(testCase.sampleFileSystemPath, fsDir, false)
 				require.NoError(t, err)
 			}

--- a/internal/ledgerutil/jsonrw/json_read_write_test.go
+++ b/internal/ledgerutil/jsonrw/json_read_write_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package jsonrw
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -78,7 +77,7 @@ type sampleObject struct {
 }
 
 func TestLoadRecords(t *testing.T) {
-	fp, err := createTestJSONInput(inputJSON)
+	fp, err := createTestJSONInput(t, inputJSON)
 	require.NoError(t, err)
 
 	expectedDiffRec1 := models.DiffRecord{
@@ -131,12 +130,9 @@ func TestLoadRecords(t *testing.T) {
 }
 
 // Turns input string into json file, returns filepath
-func createTestJSONInput(input string) (string, error) {
+func createTestJSONInput(t *testing.T, input string) (string, error) {
 	// Temp directory and file for input json
-	inputDir, err := ioutil.TempDir("", "input")
-	if err != nil {
-		return "", err
-	}
+	inputDir := t.TempDir()
 	fp := filepath.Join(inputDir, "testInput.json")
 	f, err := os.Create(fp)
 	if err != nil {
@@ -153,8 +149,7 @@ func createTestJSONInput(input string) (string, error) {
 
 func TestJSONFileWriter(t *testing.T) {
 	// Temp directory and file for output json
-	outputDir, err := ioutil.TempDir("", "output")
-	require.NoError(t, err)
+	outputDir := t.TempDir()
 	fp := filepath.Join(outputDir, "testOutput.json")
 	// New JSONFileWriter
 	jsonFileWriter, err := NewJSONFileWriter(fp)

--- a/internal/ledgerutil/jsonrw/json_test_utils_test.go
+++ b/internal/ledgerutil/jsonrw/json_test_utils_test.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package jsonrw
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,11 +32,6 @@ func TestOutputFileToString(t *testing.T) {
 
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			// Temporary directory
-			outputDir, err := ioutil.TempDir("", "result")
-			require.NoError(t, err)
-			defer os.RemoveAll(outputDir)
-
 			actual, err := OutputFileToString(testCase.filename, testCase.path)
 			require.NoError(t, err)
 			require.Equal(t, testCase.expected, actual)

--- a/internal/peer/chaincode/install_test.go
+++ b/internal/peer/chaincode/install_test.go
@@ -51,16 +51,10 @@ func initInstallTest(t *testing.T, fsPath string, ec pb.EndorserClient, mockResp
 	return cmd, mockCF
 }
 
-func cleanupInstallTest(fsPath string) {
-	os.RemoveAll(fsPath)
-}
-
 func TestInstallBadVersion(t *testing.T) {
-	fsPath, err := ioutil.TempDir("", "installbadversion")
-	require.NoError(t, err)
+	fsPath := t.TempDir()
 
 	cmd, _ := initInstallTest(t, fsPath, nil, nil)
-	defer cleanupInstallTest(fsPath)
 
 	args := []string{"-n", "mychaincode", "-p", "github.com/hyperledger/fabric/internal/peer/chaincode/testdata/src/chaincodes/noop"}
 	cmd.SetArgs(args)
@@ -71,11 +65,9 @@ func TestInstallBadVersion(t *testing.T) {
 }
 
 func TestInstallNonExistentCC(t *testing.T) {
-	fsPath, err := ioutil.TempDir("", "install-nonexistentcc")
-	require.NoError(t, err)
+	fsPath := t.TempDir()
 
 	cmd, _ := initInstallTest(t, fsPath, nil, nil)
-	defer cleanupInstallTest(fsPath)
 
 	args := []string{"-n", "badmychaincode", "-p", "github.com/hyperledger/fabric/internal/peer/chaincode/testdata/src/chaincodes/bad_mychaincode", "-v", "testversion"}
 	cmd.SetArgs(args)
@@ -90,8 +82,7 @@ func TestInstallNonExistentCC(t *testing.T) {
 }
 
 func TestInstallFromPackage(t *testing.T) {
-	pdir := newTempDir()
-	defer os.RemoveAll(pdir)
+	pdir := t.TempDir()
 
 	ccpackfile := pdir + "/ccpack.file"
 	err := createSignedCDSPackage(t, []string{"-n", "somecc", "-p", "some/go/package", "-v", "0", ccpackfile}, false)
@@ -99,10 +90,9 @@ func TestInstallFromPackage(t *testing.T) {
 		t.Fatalf("could not create package :%v", err)
 	}
 
-	fsPath := "/tmp/installtest"
+	fsPath := t.TempDir()
 
 	cmd, mockCF := initInstallTest(t, fsPath, nil, nil)
-	defer cleanupInstallTest(fsPath)
 
 	mockResponse := &pb.ProposalResponse{
 		Response:    &pb.Response{Status: 200},
@@ -120,8 +110,7 @@ func TestInstallFromPackage(t *testing.T) {
 }
 
 func TestInstallFromBadPackage(t *testing.T) {
-	pdir := newTempDir()
-	defer os.RemoveAll(pdir)
+	pdir := t.TempDir()
 
 	ccpackfile := pdir + "/ccpack.file"
 	err := ioutil.WriteFile(ccpackfile, []byte("really bad CC package"), 0o700)
@@ -129,10 +118,9 @@ func TestInstallFromBadPackage(t *testing.T) {
 		t.Fatalf("could not create package :%v", err)
 	}
 
-	fsPath := "/tmp/installtest"
+	fsPath := t.TempDir()
 
 	cmd, _ := initInstallTest(t, fsPath, nil, nil)
-	defer cleanupInstallTest(fsPath)
 
 	args := []string{ccpackfile}
 	cmd.SetArgs(args)
@@ -145,10 +133,8 @@ func TestInstallFromBadPackage(t *testing.T) {
 func installCC(t *testing.T) error {
 	defer viper.Reset()
 
-	fsPath, err := ioutil.TempDir("", "installLegacyEx02")
-	require.NoError(t, err)
+	fsPath := t.TempDir()
 	cmd, _ := initInstallTest(t, fsPath, nil, nil)
-	defer cleanupInstallTest(fsPath)
 
 	args := []string{"-n", "mychaincode", "-p", "github.com/hyperledger/fabric/internal/peer/chaincode/testdata/src/chaincodes/noop", "-v", "anotherversion"}
 	cmd.SetArgs(args)

--- a/internal/peer/chaincode/package_test.go
+++ b/internal/peer/chaincode/package_test.go
@@ -31,14 +31,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func newTempDir() string {
-	tempDir, err := ioutil.TempDir("/tmp", "packagetest-")
-	if err != nil {
-		panic(err)
-	}
-	return tempDir
-}
-
 func mockCDSFactory(spec *pb.ChaincodeSpec) (*pb.ChaincodeDeploymentSpec, error) {
 	return &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec, CodePackage: []byte("somecode")}, nil
 }
@@ -67,8 +59,7 @@ func extractSignedCCDepSpec(env *pcommon.Envelope) (*pcommon.ChannelHeader, *pb.
 // TestCDSPackage tests generation of the old ChaincodeDeploymentSpec install
 // which we will presumably continue to support at least for a bit
 func TestCDSPackage(t *testing.T) {
-	pdir := newTempDir()
-	defer os.RemoveAll(pdir)
+	pdir := t.TempDir()
 
 	ccpackfile := pdir + "/ccpack.file"
 	err := createSignedCDSPackage(t, []string{"-n", "somecc", "-p", "some/go/package", "-v", "0", ccpackfile}, false)
@@ -122,8 +113,7 @@ func mockChaincodeCmdFactoryForTest(sign bool) (*ChaincodeCmdFactory, error) {
 // TestSignedCDSPackage generates the new envelope encapsulating
 // CDS, policy
 func TestSignedCDSPackage(t *testing.T) {
-	pdir := newTempDir()
-	defer os.RemoveAll(pdir)
+	pdir := t.TempDir()
 
 	ccpackfile := pdir + "/ccpack.file"
 	err := createSignedCDSPackage(t, []string{"-n", "somecc", "-p", "some/go/package", "-v", "0", "-s", ccpackfile}, false)
@@ -155,8 +145,7 @@ func TestSignedCDSPackage(t *testing.T) {
 // TestSignedCDSPackageWithSignature generates the new envelope encapsulating
 // CDS, policy and signs the package with local MSP
 func TestSignedCDSPackageWithSignature(t *testing.T) {
-	pdir := newTempDir()
-	defer os.RemoveAll(pdir)
+	pdir := t.TempDir()
 
 	ccpackfile := pdir + "/ccpack.file"
 	err := createSignedCDSPackage(t, []string{"-n", "somecc", "-p", "some/go/package", "-v", "0", "-s", "-S", ccpackfile}, true)
@@ -185,8 +174,7 @@ func TestSignedCDSPackageWithSignature(t *testing.T) {
 }
 
 func TestNoOwnerToSign(t *testing.T) {
-	pdir := newTempDir()
-	defer os.RemoveAll(pdir)
+	pdir := t.TempDir()
 
 	ccpackfile := pdir + "/ccpack.file"
 	// note "-S" requires signer but we are passing fase
@@ -198,8 +186,7 @@ func TestNoOwnerToSign(t *testing.T) {
 }
 
 func TestInvalidPolicy(t *testing.T) {
-	pdir := newTempDir()
-	defer os.RemoveAll(pdir)
+	pdir := t.TempDir()
 
 	ccpackfile := pdir + "/ccpack.file"
 	err := createSignedCDSPackage(t, []string{"-n", "somecc", "-p", "some/go/package", "-v", "0", "-s", "-i", "AND('a bad policy')", ccpackfile}, false)

--- a/internal/peer/chaincode/signpackage_test.go
+++ b/internal/peer/chaincode/signpackage_test.go
@@ -9,7 +9,6 @@ package chaincode
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -45,8 +44,7 @@ func signExistingPackage(env *pcommon.Envelope, infile, outfile string, cryptoPr
 func TestSignExistingPackage(t *testing.T) {
 	resetFlags()
 	defer resetFlags()
-	pdir := newTempDir()
-	defer os.RemoveAll(pdir)
+	pdir := t.TempDir()
 
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
@@ -103,8 +101,7 @@ func TestSignExistingPackage(t *testing.T) {
 func TestFailSignUnsignedPackage(t *testing.T) {
 	resetFlags()
 	defer resetFlags()
-	pdir := newTempDir()
-	defer os.RemoveAll(pdir)
+	pdir := t.TempDir()
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 

--- a/internal/peer/channel/create_test.go
+++ b/internal/peer/channel/create_test.go
@@ -213,11 +213,7 @@ func TestCreateChainWithOutputBlock(t *testing.T) {
 	cmd := createCmd(mockCF)
 	AddFlags(cmd)
 
-	tempDir, err := ioutil.TempDir("", "create-output")
-	if err != nil {
-		t.Fatalf("failed to create temporary directory")
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	outputBlockPath := filepath.Join(tempDir, "output.block")
 	args := []string{"-c", mockchain, "-o", "localhost:7050", "--outputBlock", outputBlockPath}
@@ -457,11 +453,7 @@ func TestCreateChainFromTx(t *testing.T) {
 	defer cleanup()
 
 	mockchannel := "mockchannel"
-	dir, err := ioutil.TempDir("", "createtestfromtx-")
-	if err != nil {
-		t.Fatalf("couldn't create temp dir")
-	}
-	defer os.RemoveAll(dir) // clean up
+	dir := t.TempDir()
 
 	// this could be created by the create command
 	defer os.Remove(mockchannel + ".block")
@@ -520,12 +512,7 @@ func TestCreateChainInvalidTx(t *testing.T) {
 
 	mockchannel := "mockchannel"
 
-	dir, err := ioutil.TempDir("", "createinvaltest-")
-	if err != nil {
-		t.Fatalf("couldn't create temp dir")
-	}
-
-	defer os.RemoveAll(dir) // clean up
+	dir := t.TempDir()
 
 	// this is created by create command
 	defer os.Remove(mockchannel + ".block")
@@ -595,9 +582,7 @@ func TestCreateChainNilCF(t *testing.T) {
 	defer cleanup()
 
 	mockchannel := "mockchannel"
-	dir, err := ioutil.TempDir("", "createinvaltest-")
-	require.NoError(t, err, "Couldn't create temp dir")
-	defer os.RemoveAll(dir) // clean up
+	dir := t.TempDir()
 
 	// this is created by create command
 	defer os.Remove(mockchannel + ".block")
@@ -609,7 +594,7 @@ func TestCreateChainNilCF(t *testing.T) {
 	AddFlags(cmd)
 	args := []string{"-c", mockchannel, "-f", file, "-o", "localhost:7050"}
 	cmd.SetArgs(args)
-	err = cmd.Execute()
+	err := cmd.Execute()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to create deliver client")
 

--- a/internal/peer/channel/fetch_test.go
+++ b/internal/peer/channel/fetch_test.go
@@ -8,7 +8,6 @@ package channel
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,11 +43,7 @@ func TestFetch(t *testing.T) {
 		DeliverClient:    getMockDeliverClient(mockchain),
 	}
 
-	tempDir, err := ioutil.TempDir("", "fetch-output")
-	if err != nil {
-		t.Fatalf("failed to create temporary directory")
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	cmd := fetchCmd(mockCF)
 	AddFlags(cmd)

--- a/internal/peer/channel/join_test.go
+++ b/internal/peer/channel/join_test.go
@@ -38,12 +38,10 @@ func TestJoin(t *testing.T) {
 	InitMSP()
 	resetFlags()
 
-	dir, err := ioutil.TempDir("/tmp", "jointest")
-	require.NoError(t, err, "Could not create the directory %s", dir)
+	dir := t.TempDir()
 	mockblockfile := filepath.Join(dir, "mockjointest.block")
-	err = ioutil.WriteFile(mockblockfile, []byte(""), 0o644)
+	err := ioutil.WriteFile(mockblockfile, []byte(""), 0o644)
 	require.NoError(t, err, "Could not write to the file %s", mockblockfile)
-	defer os.RemoveAll(dir)
 	signer, err := common.GetDefaultSigner()
 	require.NoError(t, err, "Get default signer error: %v", err)
 
@@ -149,17 +147,15 @@ func TestJoinNilCF(t *testing.T) {
 	InitMSP()
 	resetFlags()
 
-	dir, err := ioutil.TempDir("/tmp", "jointest")
-	require.NoError(t, err, "Could not create the directory %s", dir)
+	dir := t.TempDir()
 	mockblockfile := filepath.Join(dir, "mockjointest.block")
-	defer os.RemoveAll(dir)
 	viper.Set("peer.client.connTimeout", 10*time.Millisecond)
 	cmd := joinCmd(nil)
 	AddFlags(cmd)
 	args := []string{"-b", mockblockfile}
 	cmd.SetArgs(args)
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "endorser client failed to connect to")
 }

--- a/internal/peer/channel/signconfigtx_test.go
+++ b/internal/peer/channel/signconfigtx_test.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package channel
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,14 +19,10 @@ func TestSignConfigtx(t *testing.T) {
 	InitMSP()
 	resetFlags()
 
-	dir, err := ioutil.TempDir("/tmp", "signconfigtxtest-")
-	if err != nil {
-		t.Fatalf("couldn't create temp dir")
-	}
-	defer os.RemoveAll(dir) // clean up
+	dir := t.TempDir()
 
 	configtxFile := filepath.Join(dir, mockChannel)
-	if _, err = createTxFile(configtxFile, cb.HeaderType_CONFIG_UPDATE, mockChannel); err != nil {
+	if _, err := createTxFile(configtxFile, cb.HeaderType_CONFIG_UPDATE, mockChannel); err != nil {
 		t.Fatalf("couldn't create tx file")
 	}
 

--- a/internal/peer/channel/update_test.go
+++ b/internal/peer/channel/update_test.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package channel
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -23,14 +21,10 @@ func TestUpdateChannel(t *testing.T) {
 	InitMSP()
 	resetFlags()
 
-	dir, err := ioutil.TempDir("/tmp", "createinvaltest-")
-	if err != nil {
-		t.Fatalf("couldn't create temp dir")
-	}
-	defer os.RemoveAll(dir) // clean up
+	dir := t.TempDir()
 
 	configtxFile := filepath.Join(dir, mockChannel)
-	if _, err = createTxFile(configtxFile, cb.HeaderType_CONFIG_UPDATE, mockChannel); err != nil {
+	if _, err := createTxFile(configtxFile, cb.HeaderType_CONFIG_UPDATE, mockChannel); err != nil {
 		t.Fatalf("couldn't create tx file")
 	}
 
@@ -109,14 +103,10 @@ func TestUpdateChannelMissingChannelID(t *testing.T) {
 	InitMSP()
 	resetFlags()
 
-	dir, err := ioutil.TempDir("/tmp", "createinvaltest-")
-	if err != nil {
-		t.Fatalf("couldn't create temp dir")
-	}
-	defer os.RemoveAll(dir) // clean up
+	dir := t.TempDir()
 
 	configtxFile := filepath.Join(dir, mockChannel)
-	if _, err = createTxFile(configtxFile, cb.HeaderType_CONFIG_UPDATE, mockChannel); err != nil {
+	if _, err := createTxFile(configtxFile, cb.HeaderType_CONFIG_UPDATE, mockChannel); err != nil {
 		t.Fatalf("couldn't create tx file")
 	}
 

--- a/internal/peer/common/common_test.go
+++ b/internal/peer/common/common_test.go
@@ -355,9 +355,7 @@ func TestGetOrdererEndpointFromConfigTx(t *testing.T) {
 }
 
 func TestConfigFromEnv(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "peer-clientcert")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	// peer client config
 	address, clientConfig, err := common.ConfigFromEnv("peer")

--- a/internal/peer/common/ordererclient_test.go
+++ b/internal/peer/common/ordererclient_test.go
@@ -23,10 +23,9 @@ import (
 
 func initOrdererTestEnv(t *testing.T) (cleanup func()) {
 	t.Helper()
-	cfgPath, err := ioutil.TempDir("", "ordererTestEnv")
-	require.NoError(t, err)
+	cfgPath := t.TempDir()
 	certsDir := filepath.Join(cfgPath, "certs")
-	err = os.Mkdir(certsDir, 0o755)
+	err := os.Mkdir(certsDir, 0o755)
 	require.NoError(t, err)
 
 	configFile, err := os.Create(filepath.Join(cfgPath, "test.yaml"))
@@ -103,7 +102,6 @@ QjUeWEu3crkxMvjq4vYh3LaDREuhRANCAAR+FujNKcGQW/CEpMU6Yp45ye2cbOwJ
 	return func() {
 		err := os.Unsetenv("FABRIC_CFG_PATH")
 		require.NoError(t, err)
-		defer os.RemoveAll(cfgPath)
 		viper.Reset()
 	}
 }

--- a/internal/peer/common/peerclient_test.go
+++ b/internal/peer/common/peerclient_test.go
@@ -25,10 +25,9 @@ import (
 
 func initPeerTestEnv(t *testing.T) (cfgPath string, cleanup func()) {
 	t.Helper()
-	cfgPath, err := ioutil.TempDir("", "peerTestEnv")
-	require.NoError(t, err)
+	cfgPath = t.TempDir()
 	certsDir := filepath.Join(cfgPath, "certs")
-	err = os.Mkdir(certsDir, 0o755)
+	err := os.Mkdir(certsDir, 0o755)
 	require.NoError(t, err)
 
 	configFile, err := os.Create(filepath.Join(cfgPath, "test.yaml"))
@@ -105,7 +104,6 @@ QjUeWEu3crkxMvjq4vYh3LaDREuhRANCAAR+FujNKcGQW/CEpMU6Yp45ye2cbOwJ
 	return cfgPath, func() {
 		err := os.Unsetenv("FABRIC_CFG_PATH")
 		require.NoError(t, err)
-		defer os.RemoveAll(cfgPath)
 		viper.Reset()
 	}
 }

--- a/internal/peer/node/start_test.go
+++ b/internal/peer/node/start_test.go
@@ -8,8 +8,6 @@ package node
 
 import (
 	"bytes"
-	"io/ioutil"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -30,9 +28,7 @@ func TestStartCmd(t *testing.T) {
 	defer viper.Reset()
 	g := NewGomegaWithT(t)
 
-	tempDir, err := ioutil.TempDir("", "startcmd")
-	g.Expect(err).NotTo(HaveOccurred())
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	viper.Set("peer.address", "localhost:6051")
 	viper.Set("peer.listenAddress", "0.0.0.0:6051")
@@ -155,7 +151,7 @@ func TestComputeChaincodeEndpoint(t *testing.T) {
 }
 
 func TestGetDockerHostConfig(t *testing.T) {
-	testutil.SetupTestConfig()
+	testutil.SetupTestConfig(t)
 	hostConfig := getDockerHostConfig()
 	require.NotNil(t, hostConfig)
 	require.Equal(t, "host", hostConfig.NetworkMode)

--- a/msp/configbuilder_test.go
+++ b/msp/configbuilder_test.go
@@ -106,12 +106,10 @@ func TestGetPemMaterialFromDirWithFile(t *testing.T) {
 
 func TestGetPemMaterialFromDirWithSymlinks(t *testing.T) {
 	mspDir := configtest.GetDevMspDir()
-	tempDir, err := ioutil.TempDir("", "fabric-msp-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	dirSymlinkName := filepath.Join(tempDir, "..data")
-	err = os.Symlink(filepath.Join(mspDir, "signcerts"), dirSymlinkName)
+	err := os.Symlink(filepath.Join(mspDir, "signcerts"), dirSymlinkName)
 	require.NoError(t, err)
 
 	fileSymlinkTarget := filepath.Join("..data", "peer.pem")

--- a/orderer/common/bootstrap/file/bootstrap_test.go
+++ b/orderer/common/bootstrap/file/bootstrap_test.go
@@ -22,9 +22,7 @@ const (
 )
 
 func TestGenesisBlock(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "unittest")
-	require.NoErrorf(t, err, "generate temporary test dir")
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	testFile := path.Join(testDir, file)
 
@@ -117,12 +115,10 @@ func TestReplaceGenesisBlockFile(t *testing.T) {
 	}
 	marshalledBlock, _ := proto.Marshal(block)
 
-	testDir, err := ioutil.TempDir("", "unittest")
-	require.NoErrorf(t, err, "generate temporary test dir")
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	testFile := path.Join(testDir, file)
-	err = ioutil.WriteFile(testFile, marshalledBlock, 0o644)
+	err := ioutil.WriteFile(testFile, marshalledBlock, 0o644)
 	require.NoErrorf(t, err, "generate temporary test file: %s", file)
 
 	testFileBak := path.Join(testDir, fileBak)

--- a/orderer/common/follower/block_puller_test.go
+++ b/orderer/common/follower/block_puller_test.go
@@ -9,7 +9,6 @@ package follower_test
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"sync/atomic"
 	"testing"
@@ -181,9 +180,7 @@ func TestBlockPullerFactory_VerifyBlockSequence(t *testing.T) {
 }
 
 func generateJoinBlock(t *testing.T, tlsCA tlsgen.CA, channelID string, number uint64) *cb.Block {
-	tmpdir, err := ioutil.TempDir("", "block-puller-test-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	confAppRaft := genesisconfig.Load(genesisconfig.SampleDevModeEtcdRaftProfile, configtest.GetDevConfigDir())
 	confAppRaft.Consortiums = nil

--- a/orderer/common/localconfig/config_test.go
+++ b/orderer/common/localconfig/config_test.go
@@ -5,7 +5,6 @@ package localconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,12 +82,7 @@ func TestLoadMissingConfigFile(t *testing.T) {
 }
 
 func TestLoadMalformedConfigFile(t *testing.T) {
-	name, err := ioutil.TempDir("", "hyperledger_fabric")
-	require.Nil(t, err, "Error creating temp dir: %s", err)
-	defer func() {
-		err = os.RemoveAll(name)
-		require.Nil(t, os.RemoveAll(name), "Error removing temp dir: %s", err)
-	}()
+	name := t.TempDir()
 
 	// Create a malformed orderer.yaml file in temp dir
 	f, err := os.OpenFile(filepath.Join(name, "orderer.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
@@ -188,12 +182,7 @@ func TestClusterDefaults(t *testing.T) {
 }
 
 func TestConsensusConfig(t *testing.T) {
-	name, err := ioutil.TempDir("", "hyperledger_fabric")
-	require.Nil(t, err, "Error creating temp dir: %s", err)
-	defer func() {
-		err = os.RemoveAll(name)
-		require.Nil(t, os.RemoveAll(name), "Error removing temp dir: %s", err)
-	}()
+	name := t.TempDir()
 
 	content := `---
 Consensus:

--- a/orderer/common/multichannel/blockwriter_test.go
+++ b/orderer/common/multichannel/blockwriter_test.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package multichannel
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -70,9 +68,7 @@ func TestCreateBlock(t *testing.T) {
 }
 
 func TestBlockSignature(t *testing.T) {
-	dir, err := ioutil.TempDir("", "file-ledger")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	rlf, err := fileledger.New(dir, &disabled.Provider{})
 	require.NoError(t, err)
@@ -209,9 +205,7 @@ func TestGoodWriteConfig(t *testing.T) {
 	confSys := genesisconfig.Load(genesisconfig.SampleInsecureSoloProfile, configtest.GetDevConfigDir())
 	genesisBlockSys := encoder.New(confSys).GenesisBlock()
 
-	tmpdir, err := ioutil.TempDir("", "file-ledger")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	_, l := newLedgerAndFactory(tmpdir, "testchannelid", genesisBlockSys)
 
@@ -256,9 +250,7 @@ func TestWriteConfigSynchronously(t *testing.T) {
 	confSys := genesisconfig.Load(genesisconfig.SampleInsecureSoloProfile, configtest.GetDevConfigDir())
 	genesisBlockSys := encoder.New(confSys).GenesisBlock()
 
-	tmpdir, err := ioutil.TempDir("", "file-ledger")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	_, l := newLedgerAndFactory(tmpdir, "testchannelid", genesisBlockSys)
 
@@ -300,9 +292,7 @@ func TestMigrationWriteConfig(t *testing.T) {
 	confSys := genesisconfig.Load(genesisconfig.SampleInsecureSoloProfile, configtest.GetDevConfigDir())
 	genesisBlockSys := encoder.New(confSys).GenesisBlock()
 
-	tmpdir, err := ioutil.TempDir("", "file-ledger")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	_, l := newLedgerAndFactory(tmpdir, "testchannelid", genesisBlockSys)
 
@@ -348,9 +338,7 @@ func TestRaceWriteConfig(t *testing.T) {
 	confSys := genesisconfig.Load(genesisconfig.SampleInsecureSoloProfile, configtest.GetDevConfigDir())
 	genesisBlockSys := encoder.New(confSys).GenesisBlock()
 
-	tmpdir, err := ioutil.TempDir("", "file-ledger")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	_, l := newLedgerAndFactory(tmpdir, "testchannelid", genesisBlockSys)
 
@@ -411,9 +399,7 @@ func TestRaceWriteBlocks(t *testing.T) {
 	confSys := genesisconfig.Load(genesisconfig.SampleInsecureSoloProfile, configtest.GetDevConfigDir())
 	genesisBlockSys := encoder.New(confSys).GenesisBlock()
 
-	tmpdir, err := ioutil.TempDir("", "file-ledger")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	_, l := newLedgerAndFactory(tmpdir, "testchannelid", genesisBlockSys)
 

--- a/orderer/common/multichannel/registrar_test.go
+++ b/orderer/common/multichannel/registrar_test.go
@@ -146,9 +146,7 @@ func TestConfigTx(t *testing.T) {
 	// Tests for a normal channel which contains 3 config transactions and other
 	// normal transactions to make sure the right one returned
 	t.Run("GetConfigTx - ok", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		_, rl := newLedgerAndFactory(tmpdir, "testchannelid", genesisBlockSys)
 		for i := 0; i < 5; i++ {
@@ -181,9 +179,7 @@ func TestNewRegistrar(t *testing.T) {
 
 	// This test checks to make sure the orderer can come up if it cannot find any chains
 	t.Run("No chains", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		lf, err := fileledger.New(tmpdir, &disabled.Provider{})
 		require.NoError(t, err)
@@ -205,9 +201,7 @@ func TestNewRegistrar(t *testing.T) {
 
 	// This test checks to make sure that the orderer refuses to come up if there are multiple system channels
 	t.Run("Multiple system chains - failure", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		lf, err := fileledger.New(tmpdir, &disabled.Provider{})
 		require.NoError(t, err)
@@ -231,9 +225,7 @@ func TestNewRegistrar(t *testing.T) {
 
 	// This test essentially brings the entire system up and is ultimately what main.go will replicate
 	t.Run("Correct flow with system channel", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		lf, rl := newLedgerAndFactory(tmpdir, "testchannelid", genesisBlockSys)
 
@@ -307,9 +299,7 @@ func TestRegistrar_Initialize(t *testing.T) {
 	confAppRaft := genesisconfig.Load(genesisconfig.SampleDevModeEtcdRaftProfile, configtest.GetDevConfigDir())
 	confAppRaft.Consortiums = nil
 	confAppRaft.Consortium = ""
-	certDir, err := ioutil.TempDir("", "registrar_test-")
-	require.NoError(t, err)
-	defer os.RemoveAll(certDir)
+	certDir := t.TempDir()
 	generateCertificates(t, confAppRaft, tlsCA, certDir)
 	bootstrapper, err := encoder.NewBootstrapper(confAppRaft)
 	require.NoError(t, err, "cannot create bootstrapper")
@@ -329,9 +319,7 @@ func TestRegistrar_Initialize(t *testing.T) {
 
 	// This test essentially brings the entire system up and is ultimately what main.go will replicate
 	t.Run("Correct flow with system channel - etcdraft.Chain", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		lf, _ := newLedgerAndFactory(tmpdir, "my-sys-channel", genesisBlockSysRaft)
 
@@ -365,9 +353,7 @@ func TestRegistrar_Initialize(t *testing.T) {
 
 	t.Run("Correct flow without system channel - etcdraft.Chain", func(t *testing.T) {
 		// TODO
-		tmpdir, err := ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		lf, _ := newLedgerAndFactory(tmpdir, "my-raft-channel", genesisBlockAppRaft)
 
@@ -404,9 +390,7 @@ func TestRegistrar_Initialize(t *testing.T) {
 
 	t.Run("Correct flow without system channel - follower.Chain", func(t *testing.T) {
 		// TODO
-		tmpdir, err := ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		lf, _ := newLedgerAndFactory(tmpdir, "my-raft-channel", genesisBlockAppRaft)
 
@@ -444,9 +428,7 @@ func TestRegistrar_Initialize(t *testing.T) {
 
 	t.Run("Correct flow without system channel - follower.Chain with join block", func(t *testing.T) {
 		// TODO
-		tmpdir, err := ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		config.FileLedger = localconfig.FileLedger{Location: tmpdir}
 
@@ -500,9 +482,7 @@ func TestNewRegistrarWithFileRepo(t *testing.T) {
 	consenters := map[string]consensus.Consenter{"etcdraft": consenter}
 
 	t.Run("Correct flow with valid file repo dir, one existing channel, two joinblocks", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		tlsCA, err := tlsgen.NewCA()
 		require.NoError(t, err)
@@ -598,9 +578,7 @@ func TestCreateChain(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Create chain", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		lf, _ := newLedgerAndFactory(tmpdir, "testchannelid", genesisBlockSys)
 
@@ -663,9 +641,7 @@ func TestCreateChain(t *testing.T) {
 	})
 
 	t.Run("chain of type etcdraft.Chain is already created", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		lf, _ := newLedgerAndFactory(tmpdir, "testchannelid", genesisBlockSys)
 
@@ -696,9 +672,7 @@ func TestCreateChain(t *testing.T) {
 		expectedLastConfigSeq := uint64(1)
 		newChainID := "test-new-chain"
 
-		tmpdir, err := ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		lf, rl := newLedgerAndFactory(tmpdir, "testchannelid", genesisBlockSys)
 
@@ -853,9 +827,7 @@ func TestBroadcastChannelSupport(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Rejection", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		ledgerFactory, _ := newLedgerAndFactory(tmpdir, "testchannelid", genesisBlockSys)
 		consenter := &mocks.Consenter{}
@@ -870,9 +842,7 @@ func TestBroadcastChannelSupport(t *testing.T) {
 	})
 
 	t.Run("No system channel", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		ledgerFactory, _ := newLedgerAndFactory(tmpdir, "", nil)
 		consenter := &mocks.Consenter{}
@@ -910,8 +880,7 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 
 	setup := func(t *testing.T) {
 		var err error
-		tmpdir, err = ioutil.TempDir("", "registrar_test-")
-		require.NoError(t, err)
+		tmpdir = t.TempDir()
 
 		tlsCA, err = tlsgen.NewCA()
 		require.NoError(t, err)
@@ -969,7 +938,6 @@ func TestRegistrar_JoinChannel(t *testing.T) {
 
 	cleanup := func() {
 		ledgerFactory.Close()
-		os.RemoveAll(tmpdir)
 	}
 
 	t.Run("Reject join when removal is occurring", func(t *testing.T) {
@@ -1443,8 +1411,7 @@ func TestRegistrar_RemoveChannel(t *testing.T) {
 
 	setup := func(t *testing.T) {
 		var err error
-		tmpdir, err = ioutil.TempDir("", "remove-channel")
-		require.NoError(t, err)
+		tmpdir = t.TempDir()
 
 		tlsCA, err = tlsgen.NewCA()
 		require.NoError(t, err)
@@ -1501,7 +1468,6 @@ func TestRegistrar_RemoveChannel(t *testing.T) {
 
 	cleanup := func() {
 		ledgerFactory.Close()
-		os.RemoveAll(tmpdir)
 	}
 
 	t.Run("without a system channel failures", func(t *testing.T) {
@@ -1797,9 +1763,7 @@ func createLedgerAndChain(t *testing.T, r *Registrar, lf blockledger.Factory, b 
 
 func TestRegistrar_ConfigBlockOrPanic(t *testing.T) {
 	t.Run("Panics when ledger is empty", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "file-ledger")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		_, l := newLedgerAndFactory(tmpdir, "testchannelid", nil)
 
@@ -1812,9 +1776,7 @@ func TestRegistrar_ConfigBlockOrPanic(t *testing.T) {
 		block := protoutil.NewBlock(0, nil)
 		block.Metadata.Metadata[cb.BlockMetadataIndex_SIGNATURES] = []byte("bad metadata")
 
-		tmpdir, err := ioutil.TempDir("", "file-ledger")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		_, l := newLedgerAndFactory(tmpdir, "testchannelid", block)
 
@@ -1831,9 +1793,7 @@ func TestRegistrar_ConfigBlockOrPanic(t *testing.T) {
 			}),
 		})
 
-		tmpdir, err := ioutil.TempDir("", "file-ledger")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		_, l := newLedgerAndFactory(tmpdir, "testchannelid", block)
 
@@ -1846,9 +1806,7 @@ func TestRegistrar_ConfigBlockOrPanic(t *testing.T) {
 		confSys := genesisconfig.Load(genesisconfig.SampleInsecureSoloProfile, configtest.GetDevConfigDir())
 		genesisBlockSys := encoder.New(confSys).GenesisBlock()
 
-		tmpdir, err := ioutil.TempDir("", "file-ledger")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		_, l := newLedgerAndFactory(tmpdir, "testchannelid", genesisBlockSys)
 

--- a/orderer/common/server/attestationserver_test.go
+++ b/orderer/common/server/attestationserver_test.go
@@ -8,8 +8,6 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -225,9 +223,7 @@ func Test_attestationserver_BlockAttestations(t *testing.T) {
 		cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 		require.NoError(t, err)
 
-		tmpdir, err := ioutil.TempDir("", "attestation_test-")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		lf, _ := newLedgerAndFactory(tmpdir, "testchannelid", genesisBlockSys)
 

--- a/orderer/common/server/etcdraft_test.go
+++ b/orderer/common/server/etcdraft_test.go
@@ -43,9 +43,7 @@ func TestSpawnEtcdRaft(t *testing.T) {
 
 	defer gexec.CleanupBuildArtifacts()
 
-	tempSharedDir, err := ioutil.TempDir("", "etcdraft-test")
-	gt.Expect(err).NotTo(HaveOccurred())
-	defer os.RemoveAll(tempSharedDir)
+	tempSharedDir := t.TempDir()
 
 	copyYamlFiles(gt, "testdata", tempSharedDir)
 

--- a/orderer/common/server/server_test.go
+++ b/orderer/common/server/server_test.go
@@ -78,11 +78,7 @@ func (mds *mockDeliverSrv) Send(br *ab.DeliverResponse) error {
 }
 
 func testMsgTrace(handler func(dir string, msg *cb.Envelope) recvr, t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestMsgTrace")
-	if err != nil {
-		t.Fatalf("Could not create temp dir")
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	msg := &cb.Envelope{Payload: []byte("somedata")}
 

--- a/orderer/consensus/etcdraft/storage_test.go
+++ b/orderer/consensus/etcdraft/storage_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package etcdraft
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -37,8 +36,7 @@ var (
 func setup(t *testing.T) {
 	logger = flogging.NewFabricLogger(zap.NewExample())
 	ram = raft.NewMemoryStorage()
-	dataDir, err = ioutil.TempDir("", "etcdraft-")
-	require.NoError(t, err)
+	dataDir = t.TempDir()
 	walDir, snapDir = path.Join(dataDir, "wal"), path.Join(dataDir, "snapshot")
 	store, err = CreateStorage(logger, walDir, snapDir, ram)
 	require.NoError(t, err)
@@ -46,8 +44,6 @@ func setup(t *testing.T) {
 
 func clean(t *testing.T) {
 	err = store.Close()
-	require.NoError(t, err)
-	err = os.RemoveAll(dataDir)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
#### Type of change

- Test update

#### Description

A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

#### Additional details


#### Related issues
