### PR TITLE
Fix regex in install-fabric script

### DIFF
--- a/scripts/install-fabric.sh
+++ b/scripts/install-fabric.sh
@@ -275,21 +275,21 @@ fi
 
 # Process samples first then the binaries. So if the fabric-samples dir is present
 # the binaries will go there
-if [[ "${_arg_comp[@]}" =~ ^s(amples)? ]]; then
+if [[ "${_arg_comp[@]}" =~ (^| |,)s(amples)? ]]; then
         echo
         echo "Clone hyperledger/fabric-samples repo"
         echo
         cloneSamplesRepo
 fi
 
-if [[ "${_arg_comp[@]}" =~ ^b(inary)? ]]; then
+if [[ "${_arg_comp[@]}" =~ (^| |,)b(inary)? ]]; then
         echo
         echo "Pull Hyperledger Fabric binaries"
         echo
         pullBinaries
 fi
 
-if [[ "${_arg_comp[@]}" =~ ^p(odman)? ]]; then
+if [[ "${_arg_comp[@]}" =~ (^| |,)p(odman)? ]]; then
         echo
         echo "Pull Hyperledger Fabric podman images"
         echo
@@ -297,7 +297,7 @@ if [[ "${_arg_comp[@]}" =~ ^p(odman)? ]]; then
         pullImages
 fi
 
-if [[ "${_arg_comp[@]}" =~ ^d(ocker)? ]]; then
+if [[ "${_arg_comp[@]}" =~ (^| |,)d(ocker)? ]]; then
         echo
         echo "Pull Hyperledger Fabric docker images"
         echo


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
Running `./install-farbic.sh` or `./install-fabric.sh samples binary docker` should clone the samples, download the binaries, and download docker images, but it only clones the samples. The regex only took the first argument, so they are changed to take all arguments.

Signed-off-by: Youngeon Lee <youngl@bu.edu>
