### PR TITLE
fix(security): Path Traversal Bug

### DIFF
--- a/vendor/github.com/docker/docker/pkg/archive/diff.go
+++ b/vendor/github.com/docker/docker/pkg/archive/diff.go
@@ -184,7 +184,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				if srcHdr == nil {
 					return 0, fmt.Errorf("Invalid aufs hardlink")
 				}
-				tmpFile, err := os.Open(filepath.Join(aufsTempdir, linkBasename))
+				tmpFile, err := os.Open(secure_file_path(filepath.Join(aufsTempdir, linkBasename)))
 				if err != nil {
 					return 0, err
 				}
@@ -196,7 +196,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				return 0, err
 			}
 
-			if err := createTarFile(path, dest, srcHdr, srcData, !options.NoLchown, nil, options.InUserNS); err != nil {
+			if err := createTarFile(secure_file_path(path), dest, srcHdr, srcData, !options.NoLchown, nil, options.InUserNS); err != nil {
 				return 0, err
 			}
 


### PR DESCRIPTION
Unsanitized input from open tar file flows into os.Open, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to open arbitrary files.

primary changes :
	1.updates to archive.go

Signed-off-by: Bhaskar <ram@hacker.ind.in>

- Bug fix
- Improvement (improvement to code, performance, etc)

#### Description

Unsanitized input from open tar file flows into os.Open, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to open arbitrary files.

## Data flow:
22 steps in 1 file
vendor/github.com/docker/docker/pkg/archive/diff.go