### PR TITLE
Update link to Toturial in Style Guide

### DIFF
--- a/docs/source/style_guide.md
+++ b/docs/source/style_guide.md
@@ -33,7 +33,7 @@ as starting points.
 
 **Tutorials should have a list of steps at the top.**
 
-A list of steps (with links to the corresponding sections) at the beginning of a tutorial helps users find particular steps they're interested in. For an example, check out [Use private data in Fabric](./private-data/private-data.html).
+A list of steps (with links to the corresponding sections) at the beginning of a tutorial helps users find particular steps they're interested in. For an example, check out [Using Private Data in Fabric](./private_data_tutorial.html).
 
 **"Fabric", "Hyperledger Fabric" or "HLF"?**
 


### PR DESCRIPTION
Signed-off-by: Alexander Zemtsov <a.zemtsov@gmail.com>

#### Type of change

Documentation update

#### Description

Style Guide describes how to write tutorials. And it has a link to the document which is supposed to be a tutorial example (./private-data/private-data.html). But it is not a tutorial. This commit updates the link. Now it aims to Using Private Data in Fabric tutorial.
