### PR TITLE
Insecure TLS Configuration

### DIFF
--- a/common/fabhttp/server_test.go
+++ b/common/fabhttp/server_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Server", func() {
 	When("trying to connect with an old TLS version", func() {
 		BeforeEach(func() {
 			tlsOpts := []func(config *tls.Config){func(config *tls.Config) {
-				config.MaxVersion = tls.VersionTLS11
+				config.MaxVersion = tls.VersionTLS12
 				config.ClientAuth = tls.RequireAndVerifyClientCert
 			}}
 


### PR DESCRIPTION
Insecure TLS Configuration

Signed-off-by: Bhaskar <ram@hacker.ind.in>

#### Type of change

Insecure TLS configuration is found to be in use. MaxVersion is set to a deprecated SSL/TLS version