### PR TITLE
[Release-2.2 BP FAB-2643]

### DIFF
--- a/core/chaincode/config_test.go
+++ b/core/chaincode/config_test.go
@@ -36,6 +36,7 @@ var _ = Describe("Config", func() {
 			viper.Set("chaincode.logging.format", "test-chaincode-logging-format")
 			viper.Set("chaincode.logging.level", "warning")
 			viper.Set("chaincode.logging.shim", "warning")
+			viper.Set("chaincode.system", `{"lscc": "true", "escc": "true", "vscc": "true", "cscc": "true", "somecc": "enabled"}`)
 
 			config := chaincode.GlobalConfig()
 			Expect(config.TLSEnabled).To(BeTrue())
@@ -46,6 +47,13 @@ var _ = Describe("Config", func() {
 			Expect(config.LogFormat).To(Equal("test-chaincode-logging-format"))
 			Expect(config.LogLevel).To(Equal("warn"))
 			Expect(config.ShimLogLevel).To(Equal("warn"))
+			Expect(config.SCCAllowlist).To(Equal(map[string]bool{
+				"somecc": true,
+				"lscc":   true,
+				"escc":   true,
+				"vscc":   true,
+				"cscc":   true,
+			}))
 		})
 
 		Context("when an invalid keepalive is configured", func() {

--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -22,6 +22,7 @@ package peer
 import (
 	"crypto/tls"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"net"
 	"path/filepath"
@@ -276,10 +277,11 @@ func (c *Config) load() error {
 
 	c.ChaincodePull = viper.GetBool("chaincode.pull")
 	var externalBuilders []ExternalBuilder
-	err = viper.UnmarshalKey("chaincode.externalBuilders", &externalBuilders)
-	if err != nil {
-		return err
+
+	if err := yaml.UnmarshalStrict([]byte(viper.GetString("chaincode.externalBuilders")), &externalBuilders); err != nil {
+		return errors.Wrap(err, "unmarshalling 'chaincode.externalBuilders' into yaml")
 	}
+
 	c.ExternalBuilders = externalBuilders
 	for builderIndex, builder := range c.ExternalBuilders {
 		if builder.Path == "" {

--- a/core/peer/config_test.go
+++ b/core/peer/config_test.go
@@ -455,6 +455,26 @@ func TestPropagateEnvironment(t *testing.T) {
 	assert.Equal(t, expectedConfig, coreConfig)
 }
 
+func TestExternalBuilderConfigAsEnvVar(t *testing.T) {
+	defer viper.Reset()
+	viper.Set("peer.address", "localhost:8080")
+	viper.Set("chaincode.externalBuilders", "[{name: relative, path: relative/plugin_dir, propagateEnvironment: [ENVVAR_NAME_TO_PROPAGATE_FROM_PEER, GOPROXY]}, {name: absolute, path: /absolute/plugin_dir}]")
+	coreConfig, err := GlobalConfig()
+	require.NoError(t, err)
+
+	require.Equal(t, []ExternalBuilder{
+		{
+			Path:                 "relative/plugin_dir",
+			Name:                 "relative",
+			PropagateEnvironment: []string{"ENVVAR_NAME_TO_PROPAGATE_FROM_PEER", "GOPROXY"},
+		},
+		{
+			Path: "/absolute/plugin_dir",
+			Name: "absolute",
+		},
+	}, coreConfig.ExternalBuilders)
+}
+
 func TestMissingExternalBuilderPath(t *testing.T) {
 	defer viper.Reset()
 	viper.Set("peer.address", "localhost:8080")

--- a/core/peer/config_test.go
+++ b/core/peer/config_test.go
@@ -308,16 +308,7 @@ func TestGlobalConfig(t *testing.T) {
 	viper.Set("metrics.statsd.prefix", "testPrefix")
 
 	viper.Set("chaincode.pull", false)
-	viper.Set("chaincode.externalBuilders", &[]ExternalBuilder{
-		{
-			Path: "relative/plugin_dir",
-			Name: "relative",
-		},
-		{
-			Path: "/absolute/plugin_dir",
-			Name: "absolute",
-		},
-	})
+	viper.Set("chaincode.externalBuilders", "[{name: relative, path: relative/plugin_dir}, {name: absolute, path: /absolute/plugin_dir}]")
 
 	coreConfig, err := GlobalConfig()
 	assert.NoError(t, err)
@@ -405,24 +396,7 @@ func TestGlobalConfigDefault(t *testing.T) {
 func TestPropagateEnvironment(t *testing.T) {
 	defer viper.Reset()
 	viper.Set("peer.address", "localhost:8080")
-	viper.Set("chaincode.externalBuilders", &[]ExternalBuilder{
-		{
-			Name:        "testName",
-			Environment: []string{"KEY=VALUE"},
-			Path:        "/testPath",
-		},
-		{
-			Name:                 "testName",
-			PropagateEnvironment: []string{"KEY=VALUE"},
-			Path:                 "/testPath",
-		},
-		{
-			Name:                 "testName",
-			Environment:          []string{"KEY=VALUE"},
-			PropagateEnvironment: []string{"KEY=VALUE2"},
-			Path:                 "/testPath",
-		},
-	})
+	viper.Set("chaincode.externalBuilders", "[{name: testName, environmentWhitelist: [KEY=VALUE], path: /testPath}, {name: testName, propagateEnvironment: [KEY=VALUE], path: /testPath}, {name: testName, environmentWhitelist: [KEY=VALUE], propagateEnvironment: [KEY=VALUE2], path: /testPath}]")
 	coreConfig, err := GlobalConfig()
 	assert.NoError(t, err)
 
@@ -478,11 +452,7 @@ func TestExternalBuilderConfigAsEnvVar(t *testing.T) {
 func TestMissingExternalBuilderPath(t *testing.T) {
 	defer viper.Reset()
 	viper.Set("peer.address", "localhost:8080")
-	viper.Set("chaincode.externalBuilders", &[]ExternalBuilder{
-		{
-			Name: "testName",
-		},
-	})
+	viper.Set("chaincode.externalBuilders", "[{name: testName}]")
 	_, err := GlobalConfig()
 	assert.EqualError(t, err, "invalid external builder configuration, path attribute missing in one or more builders")
 }
@@ -490,11 +460,7 @@ func TestMissingExternalBuilderPath(t *testing.T) {
 func TestMissingExternalBuilderName(t *testing.T) {
 	defer viper.Reset()
 	viper.Set("peer.address", "localhost:8080")
-	viper.Set("chaincode.externalBuilders", &[]ExternalBuilder{
-		{
-			Path: "relative/plugin_dir",
-		},
-	})
+	viper.Set("chaincode.externalBuilders", "[{path: relative/plugin_dir}]")
 	_, err := GlobalConfig()
 	assert.EqualError(t, err, "external builder at path relative/plugin_dir has no name attribute")
 }

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -602,6 +602,7 @@ chaincode:
     keepalive: 0
 
     # enabled system chaincodes
+    # To override this property via env variable use CORE_CHAINCODE_SYSTEM: {"xxx:": "enable"}
     system:
         _lifecycle: enable
         cscc: enable


### PR DESCRIPTION
This is a backport of pull request https://github.com/hyperledger/fabric/pull/2643

Because we can't upgrade viper to `v1.1.1` in which the bug of shadowing a key is fixed and hooks are introduced, I had to find a workaround to simplify the backport as more as possible. 

Also, I added a test and a short explanation for overriding the list of system chaincodes. The default approach with env var `CORE_CHAINCODE_SYSTEM_XXX: enabled` won't work due to a bug in viper in earlier versions. I agree that bumping it to v1.1.1 requires too many changes and might break the LTS release. 

updated a few related tests to use strings as viper config values instead of variables.