### PR TITLE
ExternalBuilder PropagateEnvironment fix

### DIFF
--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -294,7 +294,7 @@ func (c *Config) load() error {
 		if builder.Name == "" {
 			return fmt.Errorf("external builder at path %s has no name attribute", builder.Path)
 		}
-		if builder.Environment != nil && builder.PropagateEnvironment == nil {
+		if builder.Environment != nil && len(builder.PropagateEnvironment) == 0 {
 			c.ExternalBuilders[builderIndex].PropagateEnvironment = builder.Environment
 		}
 	}

--- a/core/peer/config_test.go
+++ b/core/peer/config_test.go
@@ -416,9 +416,10 @@ func TestPropagateEnvironment(t *testing.T) {
 	viper.Set("peer.address", "localhost:8080")
 	viper.Set("chaincode.externalBuilders", &[]ExternalBuilder{
 		{
-			Name:        "testName",
-			Environment: []string{"KEY=VALUE"},
-			Path:        "/testPath",
+			Name:                 "testName",
+			Environment:          []string{"KEY=VALUE"},
+			PropagateEnvironment: []string{},
+			Path:                 "/testPath",
 		},
 		{
 			Name:                 "testName",


### PR DESCRIPTION
While I was working on #3534 I realized that the master branch has also a potential issue with PropagateEnvorinment field.
A different implementation/version of the unmarshaller might set `builder.PropagateEnvironment` to nil or empty slice. In the last case PropagateEnvironment won't have a correct value. The fix is to use a bulletproof check `builder.PropagateEnvironment == nil` => `len(builder.PropagateEnvironment) == 0`