### PR TITLE
Unfreeze active nodes metrics once a consenter is evicted

### DIFF
--- a/orderer/consensus/etcdraft/chain.go
+++ b/orderer/consensus/etcdraft/chain.go
@@ -469,6 +469,9 @@ func (c *Chain) halt() {
 		// StatusReport.
 		c.consensusRelation = types.ConsensusRelationConfigTracker
 	}
+
+	// active nodes metric shouldn't be frozen once a channel is stopped.
+	c.Metrics.ActiveNodes.Set(float64(0))
 }
 
 func (c *Chain) isRunning() error {

--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -1431,6 +1431,7 @@ var _ = Describe("Chain", func() {
 				c1.clock.Increment(interval)
 				return c2.fakeFields.fakeActiveNodes.SetCallCount()
 			}, LongEventualTimeout).Should(Equal(2))
+			Expect(c1.fakeFields.fakeActiveNodes.SetArgsForCall(1)).To(Equal(float64(2)))
 			Expect(c2.fakeFields.fakeActiveNodes.SetArgsForCall(1)).To(Equal(float64(2)))
 
 			By("Configuring cluster to remove node")
@@ -1459,6 +1460,8 @@ var _ = Describe("Chain", func() {
 			c2.cutter.CutNext = true
 			Expect(c2.Order(env, 0)).To(Succeed())
 			Eventually(c2.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(1))
+			Expect(c1.fakeFields.fakeActiveNodes.SetArgsForCall(2)).To(Equal(float64(0))) // was halted
+			Expect(c2.fakeFields.fakeActiveNodes.SetArgsForCall(1)).To(Equal(float64(2)))
 		})
 
 		It("remove leader by reconfiguring cluster, but Halt before eviction", func() {
@@ -1469,6 +1472,7 @@ var _ = Describe("Chain", func() {
 				c1.clock.Increment(interval)
 				return c2.fakeFields.fakeActiveNodes.SetCallCount()
 			}, LongEventualTimeout).Should(Equal(2))
+			Expect(c1.fakeFields.fakeActiveNodes.SetArgsForCall(1)).To(Equal(float64(2)))
 			Expect(c2.fakeFields.fakeActiveNodes.SetArgsForCall(1)).To(Equal(float64(2)))
 
 			By("Configuring cluster to remove node")
@@ -1499,6 +1503,10 @@ var _ = Describe("Chain", func() {
 			).Should(Equal(orderer_types.StatusInactive))
 			cRel, _ := c1.StatusReport()
 			Expect(cRel).To(Equal(orderer_types.ConsensusRelationConsenter))
+
+			// active nodes metric hasn't changed because c.halt() wasn't called
+			Expect(c1.fakeFields.fakeActiveNodes.SetArgsForCall(1)).To(Equal(float64(2)))
+			Expect(c2.fakeFields.fakeActiveNodes.SetArgsForCall(1)).To(Equal(float64(2)))
 		})
 
 		It("can remove leader by reconfiguring cluster even if leadership transfer fails", func() {


### PR DESCRIPTION
Fixed active nodes metrics for etcdraft when a node is evicted. Instead of being frozen we set it to 0 once halt is called. Tests.