### PR TITLE
Orderer V3: Kafka cleanup - msgprocessor

### DIFF
--- a/orderer/common/msgprocessor/maintenancefilter.go
+++ b/orderer/common/msgprocessor/maintenancefilter.go
@@ -47,7 +47,6 @@ func NewMaintenanceFilter(support MaintenanceFilterSupport, bccsp bccsp.BCCSP) *
 	}
 	mf.permittedTargetConsensusTypes["etcdraft"] = true
 	mf.permittedTargetConsensusTypes["solo"] = true
-	mf.permittedTargetConsensusTypes["kafka"] = true
 	return mf
 }
 
@@ -118,7 +117,7 @@ func (mf *MaintenanceFilter) inspect(configEnvelope *cb.ConfigEnvelope, ordererC
 	}
 
 	// ConsensusType.Type can only change in maintenance-mode, and only within the set of permitted types.
-	// Note: only kafka to etcdraft or solo to etcdraft transitions are actually supported.
+	// Note: only solo to etcdraft transitions are supported.
 	if ordererConfig.ConsensusType() != nextOrdererConfig.ConsensusType() {
 		if ordererConfig.ConsensusState() == orderer.ConsensusType_STATE_NORMAL {
 			return errors.Errorf("attempted to change consensus type from %s to %s, but current config ConsensusType.State is not in maintenance mode",


### PR DESCRIPTION

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: I0202428c2b5dc571460474efc6d60dbc4fc60273


#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description

Clean kafka references in the msgprocessor maintenancefilter.

#### Related issues

Epic: #3511 
Issue: #3513 
