### PR TITLE
Orderer V3: Kafka orderer cleanup

### DIFF
--- a/orderer/common/msgprocessor/maintenancefilter.go
+++ b/orderer/common/msgprocessor/maintenancefilter.go
@@ -47,7 +47,6 @@ func NewMaintenanceFilter(support MaintenanceFilterSupport, bccsp bccsp.BCCSP) *
 	}
 	mf.permittedTargetConsensusTypes["etcdraft"] = true
 	mf.permittedTargetConsensusTypes["solo"] = true
-	mf.permittedTargetConsensusTypes["kafka"] = true
 	return mf
 }
 
@@ -118,7 +117,7 @@ func (mf *MaintenanceFilter) inspect(configEnvelope *cb.ConfigEnvelope, ordererC
 	}
 
 	// ConsensusType.Type can only change in maintenance-mode, and only within the set of permitted types.
-	// Note: only kafka to etcdraft or solo to etcdraft transitions are actually supported.
+	// Note: only solo to etcdraft transitions are supported.
 	if ordererConfig.ConsensusType() != nextOrdererConfig.ConsensusType() {
 		if ordererConfig.ConsensusState() == orderer.ConsensusType_STATE_NORMAL {
 			return errors.Errorf("attempted to change consensus type from %s to %s, but current config ConsensusType.State is not in maintenance mode",

--- a/orderer/common/multichannel/chainsupport.go
+++ b/orderer/common/multichannel/chainsupport.go
@@ -38,7 +38,7 @@ type ChainSupport struct {
 
 	// The registrar is not aware of the exact type that the Chain is, e.g. etcdraft, inactive, or follower.
 	// Therefore, we let each chain report its cluster relation and status through this interface. Non cluster
-	// type chains (solo, kafka) are assigned a static reporter.
+	// type chains (solo) are assigned a static reporter.
 	consensus.StatusReporter
 }
 
@@ -95,7 +95,7 @@ func newChainSupport(
 	}
 
 	cs.StatusReporter, ok = cs.Chain.(consensus.StatusReporter)
-	if !ok { // Non-cluster types: solo, kafka
+	if !ok { // Non-cluster types: solo
 		cs.StatusReporter = consensus.StaticStatusReporter{ConsensusRelation: types.ConsensusRelationOther, Status: types.StatusActive}
 	}
 

--- a/orderer/common/multichannel/registrar_test.go
+++ b/orderer/common/multichannel/registrar_test.go
@@ -1504,32 +1504,6 @@ func TestRegistrar_RemoveChannel(t *testing.T) {
 		os.RemoveAll(tmpdir)
 	}
 
-	t.Run("kafka system channel exists", func(t *testing.T) {
-		setup(t)
-		defer cleanup()
-
-		confSysKafka := genesisconfig.Load(genesisconfig.SampleInsecureKafkaProfile, configtest.GetDevConfigDir())
-		genesisBlockSysKafka := encoder.New(confSysKafka).GenesisBlockForChannel("kafka-sys-channel")
-		newLedger(ledgerFactory, "kafka-sys-channel", genesisBlockSysKafka)
-
-		kafkaConsenter := &mocks.Consenter{}
-		kafkaConsenter.HandleChainCalls(handleChain)
-		mockConsenters["kafka"] = kafkaConsenter
-
-		registrar := NewRegistrar(localconfig.TopLevel{}, ledgerFactory, mockCrypto(), &disabled.Provider{}, cryptoProvider, nil)
-		registrar.Initialize(mockConsenters)
-
-		t.Run("reject removal of app channel", func(t *testing.T) {
-			err := registrar.RemoveChannel("some-app-channel")
-			require.EqualError(t, err, "system channel exists")
-		})
-
-		t.Run("reject removal of kafka system channel", func(t *testing.T) {
-			err := registrar.RemoveChannel("kafka-sys-channel")
-			require.EqualError(t, err, "cannot remove kafka system channel: kafka-sys-channel")
-		})
-	})
-
 	t.Run("without a system channel failures", func(t *testing.T) {
 		setup(t)
 		defer cleanup()

--- a/orderer/common/multichannel/util_test.go
+++ b/orderer/common/multichannel/util_test.go
@@ -142,7 +142,7 @@ func makeConfigTxMig(chainID string, i int) *cb.Envelope {
 	gConf.Orderer.Capabilities = map[string]bool{
 		capabilities.OrdererV2_0: true,
 	}
-	gConf.Orderer.OrdererType = "kafka"
+	gConf.Orderer.OrdererType = "solo"
 	channelGroup, err := encoder.NewChannelGroup(gConf)
 	if err != nil {
 		return nil

--- a/orderer/common/types/channelinfo.go
+++ b/orderer/common/types/channelinfo.go
@@ -43,7 +43,7 @@ const (
 	// The orderer is NOT in the consenters set of the channel, and is just tracking (polling) the last config block
 	// of the channel in order to detect when it is added to the channel.
 	ConsensusRelationConfigTracker ConsensusRelation = "config-tracker"
-	// The orderer runs a non-cluster consensus type, solo or kafka.
+	// The orderer runs a non-cluster consensus type, i.e. solo.
 	ConsensusRelationOther ConsensusRelation = "other"
 )
 
@@ -74,11 +74,11 @@ type ChannelInfo struct {
 	URL string `json:"url"`
 	// Whether the orderer is a “consenter”, ”follower”, or "config-tracker" of
 	// the cluster for this channel.
-	// For non cluster consensus types (solo, kafka) it is "other".
+	// For non cluster consensus types (solo) it is "other".
 	// Possible values:  “consenter”, ”follower”, "config-tracker", "other".
 	ConsensusRelation ConsensusRelation `json:"consensusRelation"`
 	// Whether the orderer is ”onboarding”, ”active”, or "inactive", for this channel.
-	// For non cluster consensus types (solo, kafka) it is "active".
+	// For non cluster consensus types (solo) it is "active".
 	// Possible values:  “onboarding”, ”active”, "inactive".
 	Status Status `json:"status"`
 	// Current block height.

--- a/orderer/consensus/cluster_status.go
+++ b/orderer/consensus/cluster_status.go
@@ -13,7 +13,7 @@ import "github.com/hyperledger/fabric/orderer/common/types"
 // This information is used to generate the channelparticipation.ChannelInfo in response
 // to a "List" request on a particular channel.
 //
-// Not all chains must implement this, in particular non-cluster-type (solo, kafka) are
+// Not all chains must implement this, in particular non-cluster-type (solo) are
 // assigned a StaticStatusReporter at construction time.
 type StatusReporter interface {
 	// StatusReport provides the cluster relation and status.

--- a/orderer/consensus/consensus.go
+++ b/orderer/consensus/consensus.go
@@ -53,8 +53,8 @@ type MetadataValidator interface {
 // Note, that in order to allow flexibility in the implementation, it is the responsibility of the implementer
 // to take the ordered messages, send them through the blockcutter.Receiver supplied via HandleChain to cut blocks,
 // and ultimately write the ledger also supplied via HandleChain.  This design allows for two primary flows
-// 1. Messages are ordered into a stream, the stream is cut into blocks, the blocks are committed (solo, kafka)
-// 2. Messages are cut into blocks, the blocks are ordered, then the blocks are committed (sbft)
+// 1. Messages are ordered into a stream, the stream is cut into blocks, the blocks are committed (solo)
+// 2. Messages are cut into blocks, the blocks are ordered, then the blocks are committed (etcdraft)
 type Chain interface {
 	// Order accepts a message which has been processed at a given configSeq.
 	// If the configSeq advances, it is the responsibility of the consenter


### PR DESCRIPTION

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Clean the orderer package from kafka references.

#### Related issues

Epic: #3511 
Issue: #3513 
