### PR TITLE
Enable compilation on linux/arm64 platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,8 +357,8 @@ ccaasbuilder/%: ccaasbuilder-clean
 	$(eval GOOS = $(word 1,$(subst -, ,$(platform))))
 	$(eval GOARCH = $(word 2,$(subst -, ,$(platform))))
 	@mkdir -p ../release/$(strip $(platform))/builders/ccaas/bin
-	cd ccaas_builder && go test -v ./cmd/detect && GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o ../release/$(strip $(platform))/builders/ccaas/bin/ ./cmd/detect/
-	cd ccaas_builder && go test -v ./cmd/build && GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o ../release/$(strip $(platform))/builders/ccaas/bin/ ./cmd/build/
-	cd ccaas_builder && go test -v ./cmd/release && GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o ../release/$(strip $(platform))/builders/ccaas/bin/ ./cmd/release/
+	cd ccaas_builder && go test -v ./cmd/detect && GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false -o ../release/$(strip $(platform))/builders/ccaas/bin/ ./cmd/detect/
+	cd ccaas_builder && go test -v ./cmd/build && GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false -o ../release/$(strip $(platform))/builders/ccaas/bin/ ./cmd/build/
+	cd ccaas_builder && go test -v ./cmd/release && GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false -o ../release/$(strip $(platform))/builders/ccaas/bin/ ./cmd/release/
 
 ccaasbuilder: ccaasbuilder/$(MARCH)

--- a/docker-env.mk
+++ b/docker-env.mk
@@ -21,7 +21,7 @@ ifneq ($(NO_PROXY),)
 DOCKER_BUILD_FLAGS+=--build-arg 'NO_PROXY=$(NO_PROXY)'
 endif
 
-DBUILD = docker build --force-rm $(DOCKER_BUILD_FLAGS)
+DBUILD = docker build --force-rm --platform=linux/$(ARCH) $(DOCKER_BUILD_FLAGS)
 
 DOCKER_NS ?= hyperledger
 DOCKER_TAG=$(ARCH)-$(PROJECT_VERSION)

--- a/images/orderer/Dockerfile
+++ b/images/orderer/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR $GOPATH/src/github.com/hyperledger/fabric
 
 FROM golang as orderer
 ARG GO_TAGS
-RUN make orderer GO_TAGS=${GO_TAGS}
+RUN CGO_ENABLED=0 make orderer GO_TAGS=${GO_TAGS}
 
 FROM base
 ENV FABRIC_CFG_PATH /etc/hyperledger/fabric

--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -25,8 +25,12 @@ WORKDIR $GOPATH/src/github.com/hyperledger/fabric
 
 FROM golang as peer
 ARG GO_TAGS
-RUN make peer GO_TAGS=${GO_TAGS}
-RUN make ccaasbuilder
+RUN CGO_ENABLED=0 make peer GO_TAGS=${GO_TAGS}
+RUN CGO_ENABLED=0 make ccaasbuilder
+RUN \
+    export MARCH=$(go env GOOS)-$(go env GOARCH) && \
+    mkdir -p release/linux-platform && \
+    cp -r release/${MARCH}/builders release/linux-platform/.
 
 FROM peer-base
 ENV FABRIC_CFG_PATH /etc/hyperledger/fabric
@@ -35,6 +39,6 @@ VOLUME /var/hyperledger
 COPY --from=peer /go/src/github.com/hyperledger/fabric/build/bin /usr/local/bin
 COPY --from=peer /go/src/github.com/hyperledger/fabric/sampleconfig/msp ${FABRIC_CFG_PATH}/msp
 COPY --from=peer /go/src/github.com/hyperledger/fabric/sampleconfig/core.yaml ${FABRIC_CFG_PATH}/core.yaml
-COPY --from=peer /go/src/github.com/hyperledger/fabric/release/linux-amd64/builders/ccaas/bin/ /opt/hyperledger/ccaas_builder/bin/
+COPY --from=peer /go/src/github.com/hyperledger/fabric/release/linux-platform/builders/ccaas/bin/ /opt/hyperledger/ccaas_builder/bin/
 EXPOSE 7051
 CMD ["peer","node","start"]

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR $GOPATH/src/github.com/hyperledger/fabric
 
 FROM golang as tools
 ARG GO_TAGS
-RUN make tools GO_TAGS=${GO_TAGS}
+RUN CGO_ENABLED=0 make tools GO_TAGS=${GO_TAGS}
 
 FROM golang:${GO_VER}-alpine${ALPINE_VER}
 # git is required to support `go list -m`


### PR DESCRIPTION
    Enable compilation on linux/arm64 platforms

    While building the peer docker image, the location of the ccaasbuilder
    binaries were hard-coded into the Dockerfile, though the output directory
    is platform-dependent. Therefore this commit suggests two changes:

    1. Prepare binary locations based on the architecture and copy them into
       the temporal location hence it will become possible to generalize
       file location inside Dockerfile

    2. Suggest static binaries compilation to include all dependent
       libraries in compile time, it turns out there are the different sets of
       libraries between alpine:${ALPINE_VER} and
       golang:${GO_VER}-alpine${ALPINE_VER} docker images which cause peer
       to segfault on ARM64-based platforms.