### PR TITLE
fix timeout ginkgo

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -30,4 +30,5 @@ for ((i = "$agent_number"; i <= "${#test_dirs[@]}"; )); do
 done
 
 printf "\nRunning the following test suites:\n\n%s\n\nStarting tests...\n\n" "$(echo "${dirs[@]}" | tr -s ' ' '\n')"
+
 ginkgo --keep-going --slow-spec-threshold 60s --timeout 24h "${dirs[@]}"

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -30,4 +30,4 @@ for ((i = "$agent_number"; i <= "${#test_dirs[@]}"; )); do
 done
 
 printf "\nRunning the following test suites:\n\n%s\n\nStarting tests...\n\n" "$(echo "${dirs[@]}" | tr -s ' ' '\n')"
-ginkgo --keep-going --slow-spec-threshold 60s "${dirs[@]}"
+ginkgo --keep-going --slow-spec-threshold 60s --timeout 24h "${dirs[@]}"


### PR DESCRIPTION
In the old ginkgo, the timeout by default is 24h

In the new ginkgo (v2) the timeout by default is 1h

1 hour is not enough to pass the integration tests

I suggest that you explicitly pass the timeout parameter equal to 24h, so that there is enough time to pass the integration tests 
