### PR TITLE
  Prevent peer from failure on malformed proposal

### DIFF
--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -1967,6 +1967,54 @@ func TestNilArgs(t *testing.T) {
 	_, err = server.Evaluate(ctx, &pb.EvaluateRequest{ProposedTransaction: nil})
 	require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "failed to unpack transaction proposal: a signed proposal is required"))
 
+	_, err = server.Evaluate(ctx, &pb.EvaluateRequest{ProposedTransaction: &peer.SignedProposal{
+		ProposalBytes: protoutil.MarshalOrPanic(&peer.Proposal{
+			Header: protoutil.MarshalOrPanic(&cp.Header{}),
+			Payload: protoutil.MarshalOrPanic(&peer.ChaincodeActionPayload{
+				ChaincodeProposalPayload: protoutil.MarshalOrPanic(&peer.ChaincodeProposalPayload{
+					Input: nil,
+				}),
+			}),
+		}),
+	}})
+	require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "failed to unpack transaction proposal: no channel id provided"))
+
+	_, err = server.Evaluate(ctx, &pb.EvaluateRequest{ProposedTransaction: &peer.SignedProposal{
+		ProposalBytes: protoutil.MarshalOrPanic(&peer.Proposal{
+			Header: protoutil.MarshalOrPanic(&cp.Header{
+				ChannelHeader: protoutil.MarshalOrPanic(&cp.ChannelHeader{
+					ChannelId: "test",
+				}),
+			}),
+			Payload: protoutil.MarshalOrPanic(&peer.ChaincodeActionPayload{
+				ChaincodeProposalPayload: protoutil.MarshalOrPanic(&peer.ChaincodeProposalPayload{
+					Input: nil,
+				}),
+			}),
+		}),
+	}})
+	require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "failed to unpack transaction proposal: no chaincode spec is provided, channel id [test]"))
+
+	_, err = server.Evaluate(ctx, &pb.EvaluateRequest{ProposedTransaction: &peer.SignedProposal{
+		ProposalBytes: protoutil.MarshalOrPanic(&peer.Proposal{
+			Header: protoutil.MarshalOrPanic(&cp.Header{
+				ChannelHeader: protoutil.MarshalOrPanic(&cp.ChannelHeader{
+					ChannelId: "test",
+				}),
+			}),
+			Payload: protoutil.MarshalOrPanic(&peer.ChaincodeActionPayload{
+				ChaincodeProposalPayload: protoutil.MarshalOrPanic(&peer.ChaincodeProposalPayload{
+					Input: protoutil.MarshalOrPanic(&peer.ChaincodeSpec{
+						ChaincodeId: &peer.ChaincodeID{
+							Name: "",
+						},
+					}),
+				}),
+			}),
+		}),
+	}})
+	require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "failed to unpack transaction proposal: no chaincode name is provided, channel id [test]"))
+
 	_, err = server.Endorse(ctx, nil)
 	require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "an endorse request is required"))
 

--- a/internal/pkg/gateway/apiutils.go
+++ b/internal/pkg/gateway/apiutils.go
@@ -25,28 +25,44 @@ func getChannelAndChaincodeFromSignedProposal(signedProposal *peer.SignedProposa
 	if signedProposal == nil {
 		return "", "", false, fmt.Errorf("a signed proposal is required")
 	}
-	proposal, err := protoutil.UnmarshalProposal(signedProposal.ProposalBytes)
+	proposal, err := protoutil.UnmarshalProposal(signedProposal.GetProposalBytes())
 	if err != nil {
 		return "", "", false, err
 	}
-	header, err := protoutil.UnmarshalHeader(proposal.Header)
+	header, err := protoutil.UnmarshalHeader(proposal.GetHeader())
 	if err != nil {
 		return "", "", false, err
 	}
-	channelHeader, err := protoutil.UnmarshalChannelHeader(header.ChannelHeader)
+	channelHeader, err := protoutil.UnmarshalChannelHeader(header.GetChannelHeader())
 	if err != nil {
 		return "", "", false, err
 	}
-	payload, err := protoutil.UnmarshalChaincodeProposalPayload(proposal.Payload)
+	payload, err := protoutil.UnmarshalChaincodeProposalPayload(proposal.GetPayload())
 	if err != nil {
 		return "", "", false, err
 	}
-	spec, err := protoutil.UnmarshalChaincodeInvocationSpec(payload.Input)
+	spec, err := protoutil.UnmarshalChaincodeInvocationSpec(payload.GetInput())
 	if err != nil {
 		return "", "", false, err
 	}
 
-	return channelHeader.ChannelId, spec.ChaincodeSpec.ChaincodeId.Name, len(payload.TransientMap) > 0, nil
+	if len(channelHeader.GetChannelId()) == 0 {
+		return "", "", false, fmt.Errorf("no channel id provided")
+	}
+
+	if spec.GetChaincodeSpec() == nil {
+		return "", "", false, fmt.Errorf("no chaincode spec is provided, channel id [%s]", channelHeader.GetChannelId())
+	}
+
+	if spec.GetChaincodeSpec().GetChaincodeId() == nil {
+		return "", "", false, fmt.Errorf("no chaincode id is provided, channel id [%s]", channelHeader.GetChannelId())
+	}
+
+	if len(spec.GetChaincodeSpec().GetChaincodeId().GetName()) == 0 {
+		return "", "", false, fmt.Errorf("no chaincode name is provided, channel id [%s]", channelHeader.GetChannelId())
+	}
+
+	return channelHeader.GetChannelId(), spec.GetChaincodeSpec().GetChaincodeId().GetName(), len(payload.TransientMap) > 0, nil
 }
 
 func newRpcError(code codes.Code, message string, details ...proto.Message) error {


### PR DESCRIPTION
- Bug fix

While the new peer gateway service tries to extract channel and chaincode information from the signed proposal, it doesn't check the proposal fields for validity. Therefore malformed proposal might end up crashing peer service. This commit adds validation to the parameters extracted from the proposal.
