### PR TITLE
fix minor unreachable code caused by t.Fatal

### DIFF
--- a/core/common/ccpackage/ccpackage_test.go
+++ b/core/common/ccpackage/ccpackage_test.go
@@ -288,35 +288,30 @@ func TestMain(m *testing.M) {
 	// setup the MSP manager so that we can sign/verify
 	err := msptesttools.LoadMSPSetupForTesting()
 	if err != nil {
-		os.Exit(-1)
 		fmt.Printf("Could not initialize msp")
-		return
+		os.Exit(-1)
 	}
 
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	if err != nil {
 		fmt.Printf("Initialize cryptoProvider bccsp failed: %s", cryptoProvider)
 		os.Exit(-1)
-		return
 	}
 	localmsp = mspmgmt.GetLocalMSP(cryptoProvider)
 	if localmsp == nil {
-		os.Exit(-1)
 		fmt.Printf("Could not get msp")
-		return
+		os.Exit(-1)
 	}
 	signer, err = localmsp.GetDefaultSigningIdentity()
 	if err != nil {
-		os.Exit(-1)
 		fmt.Printf("Could not get signer")
-		return
+		os.Exit(-1)
 	}
 
 	signerSerialized, err = signer.Serialize()
 	if err != nil {
-		os.Exit(-1)
 		fmt.Printf("Could not serialize identity")
-		return
+		os.Exit(-1)
 	}
 
 	os.Exit(m.Run())

--- a/gossip/privdata/coordinator_test.go
+++ b/gossip/privdata/coordinator_test.go
@@ -607,14 +607,10 @@ func TestCoordinatorStoreInvalidBlock(t *testing.T) {
 			iterator, err := store.GetTxPvtRWSetByTxid(txn, nil)
 			if err != nil {
 				t.Fatalf("Failed iterating, got err %s", err)
-				iterator.Close()
-				return
 			}
 			res, err := iterator.Next()
 			if err != nil {
 				t.Fatalf("Failed iterating, got err %s", err)
-				iterator.Close()
-				return
 			}
 			require.Nil(t, res)
 			iterator.Close()
@@ -928,14 +924,10 @@ func TestCoordinatorToFilterOutPvtRWSetsWithWrongHash(t *testing.T) {
 			iterator, err := store.GetTxPvtRWSetByTxid(txn, nil)
 			if err != nil {
 				t.Fatalf("Failed iterating, got err %s", err)
-				iterator.Close()
-				return
 			}
 			res, err := iterator.Next()
 			if err != nil {
 				t.Fatalf("Failed iterating, got err %s", err)
-				iterator.Close()
-				return
 			}
 			require.Nil(t, res)
 			iterator.Close()
@@ -1433,14 +1425,10 @@ func TestProceedWithoutPrivateData(t *testing.T) {
 			iterator, err := store.GetTxPvtRWSetByTxid(txn, nil)
 			if err != nil {
 				t.Fatalf("Failed iterating, got err %s", err)
-				iterator.Close()
-				return
 			}
 			res, err := iterator.Next()
 			if err != nil {
 				t.Fatalf("Failed iterating, got err %s", err)
-				iterator.Close()
-				return
 			}
 			require.Nil(t, res)
 			iterator.Close()

--- a/gossip/state/state_test.go
+++ b/gossip/state/state_test.go
@@ -1767,9 +1767,8 @@ func waitUntilTrueOrTimeout(t *testing.T, predicate func() bool, timeout time.Du
 		t.Log("Done.")
 		break
 	case <-time.After(timeout):
-		t.Fatal("Timeout has expired")
 		close(ch)
-		break
+		t.Fatal("Timeout has expired")
 	}
 	t.Log("Stop waiting until timeout or true")
 }

--- a/protoutil/proputils_test.go
+++ b/protoutil/proputils_test.go
@@ -480,28 +480,24 @@ func TestMain(m *testing.M) {
 	// setup the MSP manager so that we can sign/verify
 	err := msptesttools.LoadMSPSetupForTesting()
 	if err != nil {
-		os.Exit(-1)
 		fmt.Printf("Could not initialize msp")
-		return
+		os.Exit(-1)
 	}
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	if err != nil {
-		os.Exit(-1)
 		fmt.Printf("Could not initialize cryptoProvider")
-		return
+		os.Exit(-1)
 	}
 	signer, err = mspmgmt.GetLocalMSP(cryptoProvider).GetDefaultSigningIdentity()
 	if err != nil {
-		os.Exit(-1)
 		fmt.Printf("Could not get signer")
-		return
+		os.Exit(-1)
 	}
 
 	signerSerialized, err = signer.Serialize()
 	if err != nil {
-		os.Exit(-1)
 		fmt.Printf("Could not serialize identity")
-		return
+		os.Exit(-1)
 	}
 
 	os.Exit(m.Run())


### PR DESCRIPTION
#### Type of change
- Test update


#### Description

`t.Fatal` or `os.Exit` will make the subsequent code unreachable.

https://pkg.go.dev/testing#T.Fatalf
> Fatalf is equivalent to Logf followed by FailNow.



#### Additional details

see https://go.dev/play/p/I6MX-QOTC9n for `t.Fatal` example:

```go
package main

import (
	"testing"
)

func TestLastIndex(t *testing.T) {
	t.Errorf("first line")
	t.Errorf("second line")
	t.Fatalf("t.Fatalf will cause exit")
	t.Fatalf("so this line cant reach")
}

/* output:
=== RUN   TestLastIndex
    prog.go:8: first line
    prog.go:9: second line
    prog.go:10: t.Fatalf will cause exit
--- FAIL: TestLastIndex (0.00s)
FAIL

Program exited.
*/

```

#### Related issues

#### Release Note