### PR TITLE
Fix binary package creation

### DIFF
--- a/ci/scripts/create_binary_package.sh
+++ b/ci/scripts/create_binary_package.sh
@@ -6,11 +6,9 @@ set -euo pipefail
 
 make "release/${TARGET}"
 mkdir -p "release/${TARGET}/config"
-mkdir -p "release/${TARGET}/builders/ccaas"
 
 # cp not move otherwise this breaks your source tree
 cp sampleconfig/*yaml "release/${TARGET}/config"
-cp ccaas_builder/bin/${TARGET}/* "release/${TARGET}/builders/ccaas"
 
 cd "release/${TARGET}"
 if [ "$TARGET" == "windows-amd64" ]; then


### PR DESCRIPTION
create_binary_package.sh was broken due to builders/ccaas.
The `make "release/${TARGET}"` step creates the builders/ccaas directory, just like it creates the bin directory.
Therefore there is no need to later create this directory or cp the content since it already exists in the correct location.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
