### PR TITLE
unittest update, fix unittest failed case for TestEcdsaPublicKey

### DIFF
--- a/bccsp/sw/ecdsa_test.go
+++ b/bccsp/sw/ecdsa_test.go
@@ -22,8 +22,8 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
-	"fmt"
 	"math/big"
+	"runtime"
 	"testing"
 
 	"github.com/hyperledger/fabric/bccsp/utils"
@@ -177,14 +177,14 @@ func TestEcdsaPublicKey(t *testing.T) {
 	invalidCurve := &elliptic.CurveParams{Name: "P-Invalid"}
 	invalidCurve.BitSize = 1024
 	k.pubKey = &ecdsa.PublicKey{Curve: invalidCurve, X: big.NewInt(1), Y: big.NewInt(1)}
-	defer func() {
-		if p := recover(); p != nil {
-			err = fmt.Errorf("internal error: %v", p)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "crypto/elliptic: attempted operation on invalid point")
-		}
-	}()
-	_, err = k.Bytes()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "Failed marshalling key [")
+
+	if runtime.Version() < "go1.19" {
+		_, err = k.Bytes()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Failed marshalling key [")
+	} else {
+		require.Panics(t, func() {
+			_, err = k.Bytes()
+		})
+	}
 }

--- a/bccsp/sw/ecdsa_test.go
+++ b/bccsp/sw/ecdsa_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -176,6 +177,13 @@ func TestEcdsaPublicKey(t *testing.T) {
 	invalidCurve := &elliptic.CurveParams{Name: "P-Invalid"}
 	invalidCurve.BitSize = 1024
 	k.pubKey = &ecdsa.PublicKey{Curve: invalidCurve, X: big.NewInt(1), Y: big.NewInt(1)}
+	defer func() {
+		if p := recover(); p != nil {
+			err = fmt.Errorf("internal error: %v", p)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "crypto/elliptic: attempted operation on invalid point")
+		}
+	}()
 	_, err = k.Bytes()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Failed marshalling key [")


### PR DESCRIPTION
#### Type of change
- Test update

#### Description
modify file: bccsp/sw/ecdsa_test.go
reason: with go version 1.19, `x509.MarshalPKIXPublicKey` -> `marshalPublicKey` -> `elliptic.Marshal` will panic if point not on curve because of function new function `panicIfNotOnCurve(curve, x, y)`

```go
func Marshal(curve Curve, x, y *big.Int) []byte {
	panicIfNotOnCurve(curve, x, y)
        // ...
}
```

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
