### PR TITLE
Enable more parallel jobs in github actions

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -56,7 +56,7 @@ jobs:
         name: Checkout Fabric Code
       - run: ci/scripts/setup_hsm.sh
         name: Install SoftHSM
-      - run: make integration-test INTEGRATION_TEST_SUITE="configtx gossip raft"
+      - run: make integration-test INTEGRATION_TEST_SUITE="raft"
         name: Run Integration Tests 1
   integration-tests-2:
     name: Integration Tests 2
@@ -71,7 +71,7 @@ jobs:
         name: Checkout Fabric Code
       - run: ci/scripts/setup_hsm.sh
         name: Install SoftHSM
-      - run: make integration-test INTEGRATION_TEST_SUITE="idemix devmode nwo pvtdata"
+      - run: make integration-test INTEGRATION_TEST_SUITE="pvtdata"
         name: Run Integration Tests 2
   integration-tests-3:
     name: Integration Tests 3
@@ -86,7 +86,7 @@ jobs:
         name: Checkout Fabric Code
       - run: ci/scripts/setup_hsm.sh
         name: Install SoftHSM
-      - run: make integration-test INTEGRATION_TEST_SUITE="configtxlator pkcs11 pluggable sbe msp discovery"
+      - run: make integration-test INTEGRATION_TEST_SUITE="ledger"
         name: Run Integration Tests 3
   integration-tests-4:
     name: Integration Tests 4
@@ -101,7 +101,7 @@ jobs:
         name: Checkout Fabric Code
       - run: ci/scripts/setup_hsm.sh
         name: Install SoftHSM
-      - run: make integration-test INTEGRATION_TEST_SUITE="e2e ledger"
+      - run: make integration-test INTEGRATION_TEST_SUITE="lifecycle"
         name: Run Integration Tests 4
   integration-tests-5:
     name: Integration Tests 5
@@ -116,5 +116,50 @@ jobs:
         name: Checkout Fabric Code
       - run: ci/scripts/setup_hsm.sh
         name: Install SoftHSM
-      - run: make integration-test INTEGRATION_TEST_SUITE="gateway lifecycle"
+      - run: make integration-test INTEGRATION_TEST_SUITE="e2e"
         name: Run Integration Tests 5
+  integration-tests-6:
+    name: Integration Tests 6
+    needs: basic-checks
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/setup-go@v3
+        name: Install Go
+        with:
+          go-version: ${{ env.GO_VER }}
+      - uses: actions/checkout@v3
+        name: Checkout Fabric Code
+      - run: ci/scripts/setup_hsm.sh
+        name: Install SoftHSM
+      - run: make integration-test INTEGRATION_TEST_SUITE="gateway idemix pkcs11 configtx configtxlator"
+        name: Run Integration Tests 6
+  integration-tests-7:
+    name: Integration Tests 7
+    needs: basic-checks
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/setup-go@v3
+        name: Install Go
+        with:
+          go-version: ${{ env.GO_VER }}
+      - uses: actions/checkout@v3
+        name: Checkout Fabric Code
+      - run: ci/scripts/setup_hsm.sh
+        name: Install SoftHSM
+      - run: make integration-test INTEGRATION_TEST_SUITE="sbe nwo msp"
+        name: Run Integration Tests 7
+  integration-tests-8:
+    name: Integration Tests 8
+    needs: basic-checks
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/setup-go@v3
+        name: Install Go
+        with:
+          go-version: ${{ env.GO_VER }}
+      - uses: actions/checkout@v3
+        name: Checkout Fabric Code
+      - run: ci/scripts/setup_hsm.sh
+        name: Install SoftHSM
+      - run: make integration-test INTEGRATION_TEST_SUITE="discovery gossip devmode pluggable"
+        name: Run Integration Tests 8


### PR DESCRIPTION
Since GitHub actions allows for up to 20 free parallel jobs, this PR assigns some more jobs to the integration tests allowing the longer running tests to run in their own container.  This shaves a few more minutes off the total CI run time.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
