### PR TITLE
Reflectd Cross site Scripting (XSS)

### DIFF
--- a/internal/configtxlator/rest/protolator_handlers.go
+++ b/internal/configtxlator/rest/protolator_handlers.go
@@ -33,7 +33,8 @@ func Decode(w http.ResponseWriter, r *http.Request) {
 	msg, err := getMsgType(r)
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintln(w, err)
+		reader := strings.NewReader(err)
+  		io.Copy(w, reader)
 		return
 	}
 

--- a/internal/configtxlator/rest/protolator_handlers.go
+++ b/internal/configtxlator/rest/protolator_handlers.go
@@ -8,7 +8,9 @@ package rest
 
 import (
 	"bytes"
+	"io"
 	"fmt"
+	"strings"
 	"io/ioutil"
 	"net/http"
 	"reflect"


### PR DESCRIPTION
Unsanitized input from the request body `r.Body` flows into `fmt.Fprintln`. This may result in a Reflected Cross-Site Scripting attack (XSS).

Signed-off-by: Bhaskar Ram <bhaskarvilles@duck.com>
