### PR TITLE
Orderer v3: remove kafka from shared config

### DIFF
--- a/common/channelconfig/api.go
+++ b/common/channelconfig/api.go
@@ -109,11 +109,6 @@ type Orderer interface {
 	// MaxChannelsCount returns the maximum count of channels to allow for an ordering network
 	MaxChannelsCount() uint64
 
-	// KafkaBrokers returns the addresses (IP:port notation) of a set of "bootstrap"
-	// Kafka brokers, i.e. this is not necessarily the entire set of Kafka brokers
-	// used for ordering
-	KafkaBrokers() []string
-
 	Consenters() []*cb.Consenter
 
 	// Organizations returns the organizations for the ordering service

--- a/common/channelconfig/orderer_test.go
+++ b/common/channelconfig/orderer_test.go
@@ -41,11 +41,3 @@ func TestBatchTimeout(t *testing.T) {
 	oc = &OrdererConfig{protos: &OrdererProtos{BatchTimeout: &ab.BatchTimeout{Timeout: "0s"}}}
 	require.Error(t, oc.validateBatchTimeout(), "Zero batch timeout")
 }
-
-func TestKafkaBrokers(t *testing.T) {
-	oc := &OrdererConfig{protos: &OrdererProtos{KafkaBrokers: &ab.KafkaBrokers{Brokers: []string{"127.0.0.1:9092", "foo.bar:9092"}}}}
-	require.NoError(t, oc.validateKafkaBrokers(), "Valid kafka brokers")
-
-	oc = &OrdererConfig{protos: &OrdererProtos{KafkaBrokers: &ab.KafkaBrokers{Brokers: []string{"127.0.0.1", "foo.bar", "127.0.0.1:-1", "localhost:65536", "foo.bar.:9092", ".127.0.0.1:9092", "-foo.bar:9092"}}}}
-	require.Error(t, oc.validateKafkaBrokers(), "Invalid kafka brokers")
-}

--- a/common/channelconfig/util.go
+++ b/common/channelconfig/util.go
@@ -153,17 +153,6 @@ func ChannelRestrictionsValue(maxChannelCount uint64) *StandardConfigValue {
 	}
 }
 
-// KafkaBrokersValue returns the config definition for the addresses of the ordering service's Kafka brokers.
-// It is a value for the /Channel/Orderer group.
-func KafkaBrokersValue(brokers []string) *StandardConfigValue {
-	return &StandardConfigValue{
-		key: KafkaBrokersKey,
-		value: &ab.KafkaBrokers{
-			Brokers: brokers,
-		},
-	}
-}
-
 // MSPValue returns the config definition for an MSP.
 // It is a value for the /Channel/Orderer/*, /Channel/Application/*, and /Channel/Consortiums/*/*/* groups.
 func MSPValue(mspDef *mspprotos.MSPConfig) *StandardConfigValue {

--- a/common/channelconfig/util_test.go
+++ b/common/channelconfig/util_test.go
@@ -46,7 +46,6 @@ func TestUtilsBasic(t *testing.T) {
 	basicTest(t, BatchSizeValue(1, 2, 3))
 	basicTest(t, BatchTimeoutValue("1s"))
 	basicTest(t, ChannelRestrictionsValue(7))
-	basicTest(t, KafkaBrokersValue([]string{"foo:1", "bar:2"}))
 	basicTest(t, MSPValue(&mspprotos.MSPConfig{}))
 	basicTest(t, CapabilitiesValue(map[string]bool{"foo": true, "bar": false}))
 	basicTest(t, AnchorPeersValue([]*pb.AnchorPeer{{}, {}}))

--- a/discovery/support/config/testdata/configtx.yaml
+++ b/discovery/support/config/testdata/configtx.yaml
@@ -240,8 +240,8 @@ Application: &ApplicationDefaults
 Orderer: &OrdererDefaults
 
     # Orderer Type: The orderer implementation to start
-    # Available types are "solo" and "kafka"
-    OrdererType: kafka
+    # Available types are "solo" and "etcdraft"
+    OrdererType: solo
 
     Addresses:
         - orderer.example.com:7050
@@ -263,16 +263,6 @@ Orderer: &OrdererDefaults
         # the serialized messages in a batch. A message larger than the preferred
         # max bytes will result in a batch larger than preferred max bytes.
         PreferredMaxBytes: 512 KB
-
-    Kafka:
-        # Brokers: A list of Kafka brokers to which the orderer connects. Edit
-        # this list to identify the brokers of the ordering service.
-        # NOTE: Use IP:port notation.
-        Brokers:
-            - kafka0:9092
-            - kafka1:9092
-            - kafka2:9092
-            - kafka3:9092
 
     # Organizations is the list of orgs which are defined as participants on
     # the orderer side of the network

--- a/docs/source/configtx.rst
+++ b/docs/source/configtx.rst
@@ -311,7 +311,6 @@ with different names.
                     "ConsensusType":orderer.ConsensusType,
                     "BatchSize":orderer.BatchSize,
                     "BatchTimeout":orderer.BatchTimeout,
-                    "KafkaBrokers":orderer.KafkaBrokers,
                 },
             },
             "Consortiums":&ConfigGroup{

--- a/internal/configtxgen/encoder/encoder.go
+++ b/internal/configtxgen/encoder/encoder.go
@@ -39,8 +39,6 @@ var logger = flogging.MustGetLogger("common.tools.configtxgen.encoder")
 const (
 	// ConsensusTypeSolo identifies the solo consensus implementation.
 	ConsensusTypeSolo = "solo"
-	// ConsensusTypeKafka identifies the Kafka-based consensus implementation.
-	ConsensusTypeKafka = "kafka"
 	// ConsensusTypeEtcdRaft identifies the Raft-based consensus implementation.
 	ConsensusTypeEtcdRaft = "etcdraft"
 	// ConsensusTypeBFT identifies the BFT-based consensus implementation.
@@ -205,8 +203,6 @@ func NewOrdererGroup(conf *genesisconfig.Orderer) (*cb.ConfigGroup, error) {
 
 	switch conf.OrdererType {
 	case ConsensusTypeSolo:
-	case ConsensusTypeKafka:
-		addValue(ordererGroup, channelconfig.KafkaBrokersValue(conf.Kafka.Brokers), channelconfig.AdminsPolicyKey)
 	case ConsensusTypeEtcdRaft:
 		if consensusMetadata, err = channelconfig.MarshalEtcdRaftMetadata(conf.EtcdRaft); err != nil {
 			return nil, errors.Errorf("cannot marshal metadata for orderer type %s: %s", ConsensusTypeEtcdRaft, err)

--- a/internal/configtxgen/encoder/encoder_test.go
+++ b/internal/configtxgen/encoder/encoder_test.go
@@ -8,6 +8,7 @@ package encoder_test
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -387,19 +388,6 @@ var _ = Describe("Encoder", func() {
 			It("wraps and returns the error", func() {
 				_, err := encoder.NewOrdererGroup(conf)
 				Expect(err).To(MatchError("error adding policies to orderer group: invalid implicit meta policy rule 'garbage': expected two space separated tokens, but got 1"))
-			})
-		})
-
-		Context("when the consensus type is Kafka", func() {
-			BeforeEach(func() {
-				conf.OrdererType = "kafka"
-			})
-
-			It("adds the kafka brokers key", func() {
-				cg, err := encoder.NewOrdererGroup(conf)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(len(cg.Values)).To(Equal(6))
-				Expect(cg.Values["KafkaBrokers"]).NotTo(BeNil())
 			})
 		})
 
@@ -1124,8 +1112,9 @@ var _ = Describe("Encoder", func() {
 				sysChannelConf = &genesisconfig.Profile{
 					Policies: CreateStandardPolicies(),
 					Orderer: &genesisconfig.Orderer{
-						OrdererType: "kafka",
-						Policies:    CreateStandardOrdererPolicies(),
+						OrdererType:  "solo",
+						BatchTimeout: time.Hour,
+						Policies:     CreateStandardOrdererPolicies(),
 					},
 					Consortiums: map[string]*genesisconfig.Consortium{
 						"SampleConsortium": {
@@ -1167,7 +1156,7 @@ var _ = Describe("Encoder", func() {
 				Expect(configUpdate.WriteSet.Groups["Application"].Groups["Org1"].Version).To(Equal(uint64(1)))
 				Expect(configUpdate.WriteSet.Groups["Application"].Groups["Org1"].Values["AnchorPeers"]).NotTo(BeNil())
 				Expect(configUpdate.WriteSet.Groups["Application"].Groups["Org2"].Version).To(Equal(uint64(0)))
-				Expect(configUpdate.WriteSet.Groups["Orderer"].Values["ConsensusType"].Version).To(Equal(uint64(1)))
+				Expect(configUpdate.WriteSet.Groups["Orderer"].Values["BatchTimeout"].Version).To(Equal(uint64(1)))
 			})
 
 			Context("when the system channel config is bad", func() {
@@ -1285,7 +1274,7 @@ var _ = Describe("Encoder", func() {
 				sysChannelGroup, err = encoder.NewChannelGroup(&genesisconfig.Profile{
 					Policies: CreateStandardPolicies(),
 					Orderer: &genesisconfig.Orderer{
-						OrdererType: "kafka",
+						OrdererType: "solo",
 						Policies:    CreateStandardOrdererPolicies(),
 					},
 					Consortiums: map[string]*genesisconfig.Consortium{

--- a/internal/configtxgen/encoder/integration_test.go
+++ b/internal/configtxgen/encoder/integration_test.go
@@ -67,8 +67,5 @@ var _ = Describe("Integration", func() {
 		Entry("Sample Insecure Solo Profile", genesisconfig.SampleInsecureSoloProfile),
 		Entry("Sample Single MSP Solo Profile", genesisconfig.SampleSingleMSPSoloProfile),
 		Entry("Sample DevMode Solo Profile", genesisconfig.SampleDevModeSoloProfile),
-		Entry("Sample Insecure Kafka Profile", genesisconfig.SampleInsecureKafkaProfile),
-		Entry("Sample Single MSP Kafka Profile", genesisconfig.SampleSingleMSPKafkaProfile),
-		Entry("Sample DevMode Kafka Profile", genesisconfig.SampleDevModeKafkaProfile),
 	)
 })

--- a/internal/peer/gossip/mocks/channel.go
+++ b/internal/peer/gossip/mocks/channel.go
@@ -4,7 +4,6 @@ package mocks
 import (
 	"sync"
 
-	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/common/channelconfig"
 )
 
@@ -49,16 +48,6 @@ type Channel struct {
 	ordererAddressesReturnsOnCall map[int]struct {
 		result1 []string
 	}
-	OrderersStub        func() []*common.Consenter
-	orderersMutex       sync.RWMutex
-	orderersArgsForCall []struct {
-	}
-	orderersReturns struct {
-		result1 []*common.Consenter
-	}
-	orderersReturnsOnCall map[int]struct {
-		result1 []*common.Consenter
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -68,16 +57,15 @@ func (fake *Channel) BlockDataHashingStructureWidth() uint32 {
 	ret, specificReturn := fake.blockDataHashingStructureWidthReturnsOnCall[len(fake.blockDataHashingStructureWidthArgsForCall)]
 	fake.blockDataHashingStructureWidthArgsForCall = append(fake.blockDataHashingStructureWidthArgsForCall, struct {
 	}{})
-	stub := fake.BlockDataHashingStructureWidthStub
-	fakeReturns := fake.blockDataHashingStructureWidthReturns
 	fake.recordInvocation("BlockDataHashingStructureWidth", []interface{}{})
 	fake.blockDataHashingStructureWidthMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.BlockDataHashingStructureWidthStub != nil {
+		return fake.BlockDataHashingStructureWidthStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.blockDataHashingStructureWidthReturns
 	return fakeReturns.result1
 }
 
@@ -121,16 +109,15 @@ func (fake *Channel) Capabilities() channelconfig.ChannelCapabilities {
 	ret, specificReturn := fake.capabilitiesReturnsOnCall[len(fake.capabilitiesArgsForCall)]
 	fake.capabilitiesArgsForCall = append(fake.capabilitiesArgsForCall, struct {
 	}{})
-	stub := fake.CapabilitiesStub
-	fakeReturns := fake.capabilitiesReturns
 	fake.recordInvocation("Capabilities", []interface{}{})
 	fake.capabilitiesMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.CapabilitiesStub != nil {
+		return fake.CapabilitiesStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.capabilitiesReturns
 	return fakeReturns.result1
 }
 
@@ -174,16 +161,15 @@ func (fake *Channel) HashingAlgorithm() func(input []byte) []byte {
 	ret, specificReturn := fake.hashingAlgorithmReturnsOnCall[len(fake.hashingAlgorithmArgsForCall)]
 	fake.hashingAlgorithmArgsForCall = append(fake.hashingAlgorithmArgsForCall, struct {
 	}{})
-	stub := fake.HashingAlgorithmStub
-	fakeReturns := fake.hashingAlgorithmReturns
 	fake.recordInvocation("HashingAlgorithm", []interface{}{})
 	fake.hashingAlgorithmMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.HashingAlgorithmStub != nil {
+		return fake.HashingAlgorithmStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.hashingAlgorithmReturns
 	return fakeReturns.result1
 }
 
@@ -227,16 +213,15 @@ func (fake *Channel) OrdererAddresses() []string {
 	ret, specificReturn := fake.ordererAddressesReturnsOnCall[len(fake.ordererAddressesArgsForCall)]
 	fake.ordererAddressesArgsForCall = append(fake.ordererAddressesArgsForCall, struct {
 	}{})
-	stub := fake.OrdererAddressesStub
-	fakeReturns := fake.ordererAddressesReturns
 	fake.recordInvocation("OrdererAddresses", []interface{}{})
 	fake.ordererAddressesMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.OrdererAddressesStub != nil {
+		return fake.OrdererAddressesStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.ordererAddressesReturns
 	return fakeReturns.result1
 }
 
@@ -275,59 +260,6 @@ func (fake *Channel) OrdererAddressesReturnsOnCall(i int, result1 []string) {
 	}{result1}
 }
 
-func (fake *Channel) Orderers() []*common.Consenter {
-	fake.orderersMutex.Lock()
-	ret, specificReturn := fake.orderersReturnsOnCall[len(fake.orderersArgsForCall)]
-	fake.orderersArgsForCall = append(fake.orderersArgsForCall, struct {
-	}{})
-	stub := fake.OrderersStub
-	fakeReturns := fake.orderersReturns
-	fake.recordInvocation("Orderers", []interface{}{})
-	fake.orderersMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *Channel) OrderersCallCount() int {
-	fake.orderersMutex.RLock()
-	defer fake.orderersMutex.RUnlock()
-	return len(fake.orderersArgsForCall)
-}
-
-func (fake *Channel) OrderersCalls(stub func() []*common.Consenter) {
-	fake.orderersMutex.Lock()
-	defer fake.orderersMutex.Unlock()
-	fake.OrderersStub = stub
-}
-
-func (fake *Channel) OrderersReturns(result1 []*common.Consenter) {
-	fake.orderersMutex.Lock()
-	defer fake.orderersMutex.Unlock()
-	fake.OrderersStub = nil
-	fake.orderersReturns = struct {
-		result1 []*common.Consenter
-	}{result1}
-}
-
-func (fake *Channel) OrderersReturnsOnCall(i int, result1 []*common.Consenter) {
-	fake.orderersMutex.Lock()
-	defer fake.orderersMutex.Unlock()
-	fake.OrderersStub = nil
-	if fake.orderersReturnsOnCall == nil {
-		fake.orderersReturnsOnCall = make(map[int]struct {
-			result1 []*common.Consenter
-		})
-	}
-	fake.orderersReturnsOnCall[i] = struct {
-		result1 []*common.Consenter
-	}{result1}
-}
-
 func (fake *Channel) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -339,8 +271,6 @@ func (fake *Channel) Invocations() map[string][][]interface{} {
 	defer fake.hashingAlgorithmMutex.RUnlock()
 	fake.ordererAddressesMutex.RLock()
 	defer fake.ordererAddressesMutex.RUnlock()
-	fake.orderersMutex.RLock()
-	defer fake.orderersMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/internal/peer/gossip/mocks/channel_capabilities.go
+++ b/internal/peer/gossip/mocks/channel_capabilities.go
@@ -67,16 +67,15 @@ func (fake *ChannelCapabilities) ConsensusTypeBFT() bool {
 	ret, specificReturn := fake.consensusTypeBFTReturnsOnCall[len(fake.consensusTypeBFTArgsForCall)]
 	fake.consensusTypeBFTArgsForCall = append(fake.consensusTypeBFTArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusTypeBFTStub
-	fakeReturns := fake.consensusTypeBFTReturns
 	fake.recordInvocation("ConsensusTypeBFT", []interface{}{})
 	fake.consensusTypeBFTMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusTypeBFTStub != nil {
+		return fake.ConsensusTypeBFTStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusTypeBFTReturns
 	return fakeReturns.result1
 }
 
@@ -120,16 +119,15 @@ func (fake *ChannelCapabilities) ConsensusTypeMigration() bool {
 	ret, specificReturn := fake.consensusTypeMigrationReturnsOnCall[len(fake.consensusTypeMigrationArgsForCall)]
 	fake.consensusTypeMigrationArgsForCall = append(fake.consensusTypeMigrationArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusTypeMigrationStub
-	fakeReturns := fake.consensusTypeMigrationReturns
 	fake.recordInvocation("ConsensusTypeMigration", []interface{}{})
 	fake.consensusTypeMigrationMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusTypeMigrationStub != nil {
+		return fake.ConsensusTypeMigrationStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusTypeMigrationReturns
 	return fakeReturns.result1
 }
 
@@ -173,16 +171,15 @@ func (fake *ChannelCapabilities) MSPVersion() msp.MSPVersion {
 	ret, specificReturn := fake.mSPVersionReturnsOnCall[len(fake.mSPVersionArgsForCall)]
 	fake.mSPVersionArgsForCall = append(fake.mSPVersionArgsForCall, struct {
 	}{})
-	stub := fake.MSPVersionStub
-	fakeReturns := fake.mSPVersionReturns
 	fake.recordInvocation("MSPVersion", []interface{}{})
 	fake.mSPVersionMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.MSPVersionStub != nil {
+		return fake.MSPVersionStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.mSPVersionReturns
 	return fakeReturns.result1
 }
 
@@ -226,16 +223,15 @@ func (fake *ChannelCapabilities) OrgSpecificOrdererEndpoints() bool {
 	ret, specificReturn := fake.orgSpecificOrdererEndpointsReturnsOnCall[len(fake.orgSpecificOrdererEndpointsArgsForCall)]
 	fake.orgSpecificOrdererEndpointsArgsForCall = append(fake.orgSpecificOrdererEndpointsArgsForCall, struct {
 	}{})
-	stub := fake.OrgSpecificOrdererEndpointsStub
-	fakeReturns := fake.orgSpecificOrdererEndpointsReturns
 	fake.recordInvocation("OrgSpecificOrdererEndpoints", []interface{}{})
 	fake.orgSpecificOrdererEndpointsMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.OrgSpecificOrdererEndpointsStub != nil {
+		return fake.OrgSpecificOrdererEndpointsStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.orgSpecificOrdererEndpointsReturns
 	return fakeReturns.result1
 }
 
@@ -279,16 +275,15 @@ func (fake *ChannelCapabilities) Supported() error {
 	ret, specificReturn := fake.supportedReturnsOnCall[len(fake.supportedArgsForCall)]
 	fake.supportedArgsForCall = append(fake.supportedArgsForCall, struct {
 	}{})
-	stub := fake.SupportedStub
-	fakeReturns := fake.supportedReturns
 	fake.recordInvocation("Supported", []interface{}{})
 	fake.supportedMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.SupportedStub != nil {
+		return fake.SupportedStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.supportedReturns
 	return fakeReturns.result1
 }
 

--- a/internal/peer/gossip/mocks/orderer.go
+++ b/internal/peer/gossip/mocks/orderer.go
@@ -81,16 +81,6 @@ type Orderer struct {
 	consentersReturnsOnCall map[int]struct {
 		result1 []*common.Consenter
 	}
-	KafkaBrokersStub        func() []string
-	kafkaBrokersMutex       sync.RWMutex
-	kafkaBrokersArgsForCall []struct {
-	}
-	kafkaBrokersReturns struct {
-		result1 []string
-	}
-	kafkaBrokersReturnsOnCall map[int]struct {
-		result1 []string
-	}
 	MaxChannelsCountStub        func() uint64
 	maxChannelsCountMutex       sync.RWMutex
 	maxChannelsCountArgsForCall []struct {
@@ -120,16 +110,15 @@ func (fake *Orderer) BatchSize() *orderer.BatchSize {
 	ret, specificReturn := fake.batchSizeReturnsOnCall[len(fake.batchSizeArgsForCall)]
 	fake.batchSizeArgsForCall = append(fake.batchSizeArgsForCall, struct {
 	}{})
-	stub := fake.BatchSizeStub
-	fakeReturns := fake.batchSizeReturns
 	fake.recordInvocation("BatchSize", []interface{}{})
 	fake.batchSizeMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.BatchSizeStub != nil {
+		return fake.BatchSizeStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.batchSizeReturns
 	return fakeReturns.result1
 }
 
@@ -173,16 +162,15 @@ func (fake *Orderer) BatchTimeout() time.Duration {
 	ret, specificReturn := fake.batchTimeoutReturnsOnCall[len(fake.batchTimeoutArgsForCall)]
 	fake.batchTimeoutArgsForCall = append(fake.batchTimeoutArgsForCall, struct {
 	}{})
-	stub := fake.BatchTimeoutStub
-	fakeReturns := fake.batchTimeoutReturns
 	fake.recordInvocation("BatchTimeout", []interface{}{})
 	fake.batchTimeoutMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.BatchTimeoutStub != nil {
+		return fake.BatchTimeoutStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.batchTimeoutReturns
 	return fakeReturns.result1
 }
 
@@ -226,16 +214,15 @@ func (fake *Orderer) Capabilities() channelconfig.OrdererCapabilities {
 	ret, specificReturn := fake.capabilitiesReturnsOnCall[len(fake.capabilitiesArgsForCall)]
 	fake.capabilitiesArgsForCall = append(fake.capabilitiesArgsForCall, struct {
 	}{})
-	stub := fake.CapabilitiesStub
-	fakeReturns := fake.capabilitiesReturns
 	fake.recordInvocation("Capabilities", []interface{}{})
 	fake.capabilitiesMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.CapabilitiesStub != nil {
+		return fake.CapabilitiesStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.capabilitiesReturns
 	return fakeReturns.result1
 }
 
@@ -279,16 +266,15 @@ func (fake *Orderer) ConsensusMetadata() []byte {
 	ret, specificReturn := fake.consensusMetadataReturnsOnCall[len(fake.consensusMetadataArgsForCall)]
 	fake.consensusMetadataArgsForCall = append(fake.consensusMetadataArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusMetadataStub
-	fakeReturns := fake.consensusMetadataReturns
 	fake.recordInvocation("ConsensusMetadata", []interface{}{})
 	fake.consensusMetadataMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusMetadataStub != nil {
+		return fake.ConsensusMetadataStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusMetadataReturns
 	return fakeReturns.result1
 }
 
@@ -332,16 +318,15 @@ func (fake *Orderer) ConsensusState() orderer.ConsensusType_State {
 	ret, specificReturn := fake.consensusStateReturnsOnCall[len(fake.consensusStateArgsForCall)]
 	fake.consensusStateArgsForCall = append(fake.consensusStateArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusStateStub
-	fakeReturns := fake.consensusStateReturns
 	fake.recordInvocation("ConsensusState", []interface{}{})
 	fake.consensusStateMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusStateStub != nil {
+		return fake.ConsensusStateStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusStateReturns
 	return fakeReturns.result1
 }
 
@@ -385,16 +370,15 @@ func (fake *Orderer) ConsensusType() string {
 	ret, specificReturn := fake.consensusTypeReturnsOnCall[len(fake.consensusTypeArgsForCall)]
 	fake.consensusTypeArgsForCall = append(fake.consensusTypeArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusTypeStub
-	fakeReturns := fake.consensusTypeReturns
 	fake.recordInvocation("ConsensusType", []interface{}{})
 	fake.consensusTypeMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusTypeStub != nil {
+		return fake.ConsensusTypeStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusTypeReturns
 	return fakeReturns.result1
 }
 
@@ -438,16 +422,15 @@ func (fake *Orderer) Consenters() []*common.Consenter {
 	ret, specificReturn := fake.consentersReturnsOnCall[len(fake.consentersArgsForCall)]
 	fake.consentersArgsForCall = append(fake.consentersArgsForCall, struct {
 	}{})
-	stub := fake.ConsentersStub
-	fakeReturns := fake.consentersReturns
 	fake.recordInvocation("Consenters", []interface{}{})
 	fake.consentersMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsentersStub != nil {
+		return fake.ConsentersStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consentersReturns
 	return fakeReturns.result1
 }
 
@@ -486,74 +469,20 @@ func (fake *Orderer) ConsentersReturnsOnCall(i int, result1 []*common.Consenter)
 	}{result1}
 }
 
-func (fake *Orderer) KafkaBrokers() []string {
-	fake.kafkaBrokersMutex.Lock()
-	ret, specificReturn := fake.kafkaBrokersReturnsOnCall[len(fake.kafkaBrokersArgsForCall)]
-	fake.kafkaBrokersArgsForCall = append(fake.kafkaBrokersArgsForCall, struct {
-	}{})
-	stub := fake.KafkaBrokersStub
-	fakeReturns := fake.kafkaBrokersReturns
-	fake.recordInvocation("KafkaBrokers", []interface{}{})
-	fake.kafkaBrokersMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *Orderer) KafkaBrokersCallCount() int {
-	fake.kafkaBrokersMutex.RLock()
-	defer fake.kafkaBrokersMutex.RUnlock()
-	return len(fake.kafkaBrokersArgsForCall)
-}
-
-func (fake *Orderer) KafkaBrokersCalls(stub func() []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = stub
-}
-
-func (fake *Orderer) KafkaBrokersReturns(result1 []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = nil
-	fake.kafkaBrokersReturns = struct {
-		result1 []string
-	}{result1}
-}
-
-func (fake *Orderer) KafkaBrokersReturnsOnCall(i int, result1 []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = nil
-	if fake.kafkaBrokersReturnsOnCall == nil {
-		fake.kafkaBrokersReturnsOnCall = make(map[int]struct {
-			result1 []string
-		})
-	}
-	fake.kafkaBrokersReturnsOnCall[i] = struct {
-		result1 []string
-	}{result1}
-}
-
 func (fake *Orderer) MaxChannelsCount() uint64 {
 	fake.maxChannelsCountMutex.Lock()
 	ret, specificReturn := fake.maxChannelsCountReturnsOnCall[len(fake.maxChannelsCountArgsForCall)]
 	fake.maxChannelsCountArgsForCall = append(fake.maxChannelsCountArgsForCall, struct {
 	}{})
-	stub := fake.MaxChannelsCountStub
-	fakeReturns := fake.maxChannelsCountReturns
 	fake.recordInvocation("MaxChannelsCount", []interface{}{})
 	fake.maxChannelsCountMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.MaxChannelsCountStub != nil {
+		return fake.MaxChannelsCountStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.maxChannelsCountReturns
 	return fakeReturns.result1
 }
 
@@ -597,16 +526,15 @@ func (fake *Orderer) Organizations() map[string]channelconfig.OrdererOrg {
 	ret, specificReturn := fake.organizationsReturnsOnCall[len(fake.organizationsArgsForCall)]
 	fake.organizationsArgsForCall = append(fake.organizationsArgsForCall, struct {
 	}{})
-	stub := fake.OrganizationsStub
-	fakeReturns := fake.organizationsReturns
 	fake.recordInvocation("Organizations", []interface{}{})
 	fake.organizationsMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.OrganizationsStub != nil {
+		return fake.OrganizationsStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.organizationsReturns
 	return fakeReturns.result1
 }
 
@@ -662,8 +590,6 @@ func (fake *Orderer) Invocations() map[string][][]interface{} {
 	defer fake.consensusTypeMutex.RUnlock()
 	fake.consentersMutex.RLock()
 	defer fake.consentersMutex.RUnlock()
-	fake.kafkaBrokersMutex.RLock()
-	defer fake.kafkaBrokersMutex.RUnlock()
 	fake.maxChannelsCountMutex.RLock()
 	defer fake.maxChannelsCountMutex.RUnlock()
 	fake.organizationsMutex.RLock()

--- a/internal/peer/gossip/mocks/resources.go
+++ b/internal/peer/gossip/mocks/resources.go
@@ -107,16 +107,15 @@ func (fake *Resources) ApplicationConfig() (channelconfig.Application, bool) {
 	ret, specificReturn := fake.applicationConfigReturnsOnCall[len(fake.applicationConfigArgsForCall)]
 	fake.applicationConfigArgsForCall = append(fake.applicationConfigArgsForCall, struct {
 	}{})
-	stub := fake.ApplicationConfigStub
-	fakeReturns := fake.applicationConfigReturns
 	fake.recordInvocation("ApplicationConfig", []interface{}{})
 	fake.applicationConfigMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ApplicationConfigStub != nil {
+		return fake.ApplicationConfigStub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.applicationConfigReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -163,16 +162,15 @@ func (fake *Resources) ChannelConfig() channelconfig.Channel {
 	ret, specificReturn := fake.channelConfigReturnsOnCall[len(fake.channelConfigArgsForCall)]
 	fake.channelConfigArgsForCall = append(fake.channelConfigArgsForCall, struct {
 	}{})
-	stub := fake.ChannelConfigStub
-	fakeReturns := fake.channelConfigReturns
 	fake.recordInvocation("ChannelConfig", []interface{}{})
 	fake.channelConfigMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ChannelConfigStub != nil {
+		return fake.ChannelConfigStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.channelConfigReturns
 	return fakeReturns.result1
 }
 
@@ -216,16 +214,15 @@ func (fake *Resources) ConfigtxValidator() configtx.Validator {
 	ret, specificReturn := fake.configtxValidatorReturnsOnCall[len(fake.configtxValidatorArgsForCall)]
 	fake.configtxValidatorArgsForCall = append(fake.configtxValidatorArgsForCall, struct {
 	}{})
-	stub := fake.ConfigtxValidatorStub
-	fakeReturns := fake.configtxValidatorReturns
 	fake.recordInvocation("ConfigtxValidator", []interface{}{})
 	fake.configtxValidatorMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConfigtxValidatorStub != nil {
+		return fake.ConfigtxValidatorStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.configtxValidatorReturns
 	return fakeReturns.result1
 }
 
@@ -269,16 +266,15 @@ func (fake *Resources) ConsortiumsConfig() (channelconfig.Consortiums, bool) {
 	ret, specificReturn := fake.consortiumsConfigReturnsOnCall[len(fake.consortiumsConfigArgsForCall)]
 	fake.consortiumsConfigArgsForCall = append(fake.consortiumsConfigArgsForCall, struct {
 	}{})
-	stub := fake.ConsortiumsConfigStub
-	fakeReturns := fake.consortiumsConfigReturns
 	fake.recordInvocation("ConsortiumsConfig", []interface{}{})
 	fake.consortiumsConfigMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsortiumsConfigStub != nil {
+		return fake.ConsortiumsConfigStub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.consortiumsConfigReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -325,16 +321,15 @@ func (fake *Resources) MSPManager() msp.MSPManager {
 	ret, specificReturn := fake.mSPManagerReturnsOnCall[len(fake.mSPManagerArgsForCall)]
 	fake.mSPManagerArgsForCall = append(fake.mSPManagerArgsForCall, struct {
 	}{})
-	stub := fake.MSPManagerStub
-	fakeReturns := fake.mSPManagerReturns
 	fake.recordInvocation("MSPManager", []interface{}{})
 	fake.mSPManagerMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.MSPManagerStub != nil {
+		return fake.MSPManagerStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.mSPManagerReturns
 	return fakeReturns.result1
 }
 
@@ -378,16 +373,15 @@ func (fake *Resources) OrdererConfig() (channelconfig.Orderer, bool) {
 	ret, specificReturn := fake.ordererConfigReturnsOnCall[len(fake.ordererConfigArgsForCall)]
 	fake.ordererConfigArgsForCall = append(fake.ordererConfigArgsForCall, struct {
 	}{})
-	stub := fake.OrdererConfigStub
-	fakeReturns := fake.ordererConfigReturns
 	fake.recordInvocation("OrdererConfig", []interface{}{})
 	fake.ordererConfigMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.OrdererConfigStub != nil {
+		return fake.OrdererConfigStub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.ordererConfigReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -434,16 +428,15 @@ func (fake *Resources) PolicyManager() policies.Manager {
 	ret, specificReturn := fake.policyManagerReturnsOnCall[len(fake.policyManagerArgsForCall)]
 	fake.policyManagerArgsForCall = append(fake.policyManagerArgsForCall, struct {
 	}{})
-	stub := fake.PolicyManagerStub
-	fakeReturns := fake.policyManagerReturns
 	fake.recordInvocation("PolicyManager", []interface{}{})
 	fake.policyManagerMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.PolicyManagerStub != nil {
+		return fake.PolicyManagerStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.policyManagerReturns
 	return fakeReturns.result1
 }
 
@@ -488,16 +481,15 @@ func (fake *Resources) ValidateNew(arg1 channelconfig.Resources) error {
 	fake.validateNewArgsForCall = append(fake.validateNewArgsForCall, struct {
 		arg1 channelconfig.Resources
 	}{arg1})
-	stub := fake.ValidateNewStub
-	fakeReturns := fake.validateNewReturns
 	fake.recordInvocation("ValidateNew", []interface{}{arg1})
 	fake.validateNewMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.ValidateNewStub != nil {
+		return fake.ValidateNewStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.validateNewReturns
 	return fakeReturns.result1
 }
 

--- a/orderer/common/blockcutter/mock/orderer_config.go
+++ b/orderer/common/blockcutter/mock/orderer_config.go
@@ -81,16 +81,6 @@ type OrdererConfig struct {
 	consentersReturnsOnCall map[int]struct {
 		result1 []*common.Consenter
 	}
-	KafkaBrokersStub        func() []string
-	kafkaBrokersMutex       sync.RWMutex
-	kafkaBrokersArgsForCall []struct {
-	}
-	kafkaBrokersReturns struct {
-		result1 []string
-	}
-	kafkaBrokersReturnsOnCall map[int]struct {
-		result1 []string
-	}
 	MaxChannelsCountStub        func() uint64
 	maxChannelsCountMutex       sync.RWMutex
 	maxChannelsCountArgsForCall []struct {
@@ -120,16 +110,15 @@ func (fake *OrdererConfig) BatchSize() *orderer.BatchSize {
 	ret, specificReturn := fake.batchSizeReturnsOnCall[len(fake.batchSizeArgsForCall)]
 	fake.batchSizeArgsForCall = append(fake.batchSizeArgsForCall, struct {
 	}{})
-	stub := fake.BatchSizeStub
-	fakeReturns := fake.batchSizeReturns
 	fake.recordInvocation("BatchSize", []interface{}{})
 	fake.batchSizeMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.BatchSizeStub != nil {
+		return fake.BatchSizeStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.batchSizeReturns
 	return fakeReturns.result1
 }
 
@@ -173,16 +162,15 @@ func (fake *OrdererConfig) BatchTimeout() time.Duration {
 	ret, specificReturn := fake.batchTimeoutReturnsOnCall[len(fake.batchTimeoutArgsForCall)]
 	fake.batchTimeoutArgsForCall = append(fake.batchTimeoutArgsForCall, struct {
 	}{})
-	stub := fake.BatchTimeoutStub
-	fakeReturns := fake.batchTimeoutReturns
 	fake.recordInvocation("BatchTimeout", []interface{}{})
 	fake.batchTimeoutMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.BatchTimeoutStub != nil {
+		return fake.BatchTimeoutStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.batchTimeoutReturns
 	return fakeReturns.result1
 }
 
@@ -226,16 +214,15 @@ func (fake *OrdererConfig) Capabilities() channelconfig.OrdererCapabilities {
 	ret, specificReturn := fake.capabilitiesReturnsOnCall[len(fake.capabilitiesArgsForCall)]
 	fake.capabilitiesArgsForCall = append(fake.capabilitiesArgsForCall, struct {
 	}{})
-	stub := fake.CapabilitiesStub
-	fakeReturns := fake.capabilitiesReturns
 	fake.recordInvocation("Capabilities", []interface{}{})
 	fake.capabilitiesMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.CapabilitiesStub != nil {
+		return fake.CapabilitiesStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.capabilitiesReturns
 	return fakeReturns.result1
 }
 
@@ -279,16 +266,15 @@ func (fake *OrdererConfig) ConsensusMetadata() []byte {
 	ret, specificReturn := fake.consensusMetadataReturnsOnCall[len(fake.consensusMetadataArgsForCall)]
 	fake.consensusMetadataArgsForCall = append(fake.consensusMetadataArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusMetadataStub
-	fakeReturns := fake.consensusMetadataReturns
 	fake.recordInvocation("ConsensusMetadata", []interface{}{})
 	fake.consensusMetadataMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusMetadataStub != nil {
+		return fake.ConsensusMetadataStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusMetadataReturns
 	return fakeReturns.result1
 }
 
@@ -332,16 +318,15 @@ func (fake *OrdererConfig) ConsensusState() orderer.ConsensusType_State {
 	ret, specificReturn := fake.consensusStateReturnsOnCall[len(fake.consensusStateArgsForCall)]
 	fake.consensusStateArgsForCall = append(fake.consensusStateArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusStateStub
-	fakeReturns := fake.consensusStateReturns
 	fake.recordInvocation("ConsensusState", []interface{}{})
 	fake.consensusStateMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusStateStub != nil {
+		return fake.ConsensusStateStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusStateReturns
 	return fakeReturns.result1
 }
 
@@ -385,16 +370,15 @@ func (fake *OrdererConfig) ConsensusType() string {
 	ret, specificReturn := fake.consensusTypeReturnsOnCall[len(fake.consensusTypeArgsForCall)]
 	fake.consensusTypeArgsForCall = append(fake.consensusTypeArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusTypeStub
-	fakeReturns := fake.consensusTypeReturns
 	fake.recordInvocation("ConsensusType", []interface{}{})
 	fake.consensusTypeMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusTypeStub != nil {
+		return fake.ConsensusTypeStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusTypeReturns
 	return fakeReturns.result1
 }
 
@@ -438,16 +422,15 @@ func (fake *OrdererConfig) Consenters() []*common.Consenter {
 	ret, specificReturn := fake.consentersReturnsOnCall[len(fake.consentersArgsForCall)]
 	fake.consentersArgsForCall = append(fake.consentersArgsForCall, struct {
 	}{})
-	stub := fake.ConsentersStub
-	fakeReturns := fake.consentersReturns
 	fake.recordInvocation("Consenters", []interface{}{})
 	fake.consentersMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsentersStub != nil {
+		return fake.ConsentersStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consentersReturns
 	return fakeReturns.result1
 }
 
@@ -486,74 +469,20 @@ func (fake *OrdererConfig) ConsentersReturnsOnCall(i int, result1 []*common.Cons
 	}{result1}
 }
 
-func (fake *OrdererConfig) KafkaBrokers() []string {
-	fake.kafkaBrokersMutex.Lock()
-	ret, specificReturn := fake.kafkaBrokersReturnsOnCall[len(fake.kafkaBrokersArgsForCall)]
-	fake.kafkaBrokersArgsForCall = append(fake.kafkaBrokersArgsForCall, struct {
-	}{})
-	stub := fake.KafkaBrokersStub
-	fakeReturns := fake.kafkaBrokersReturns
-	fake.recordInvocation("KafkaBrokers", []interface{}{})
-	fake.kafkaBrokersMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *OrdererConfig) KafkaBrokersCallCount() int {
-	fake.kafkaBrokersMutex.RLock()
-	defer fake.kafkaBrokersMutex.RUnlock()
-	return len(fake.kafkaBrokersArgsForCall)
-}
-
-func (fake *OrdererConfig) KafkaBrokersCalls(stub func() []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = stub
-}
-
-func (fake *OrdererConfig) KafkaBrokersReturns(result1 []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = nil
-	fake.kafkaBrokersReturns = struct {
-		result1 []string
-	}{result1}
-}
-
-func (fake *OrdererConfig) KafkaBrokersReturnsOnCall(i int, result1 []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = nil
-	if fake.kafkaBrokersReturnsOnCall == nil {
-		fake.kafkaBrokersReturnsOnCall = make(map[int]struct {
-			result1 []string
-		})
-	}
-	fake.kafkaBrokersReturnsOnCall[i] = struct {
-		result1 []string
-	}{result1}
-}
-
 func (fake *OrdererConfig) MaxChannelsCount() uint64 {
 	fake.maxChannelsCountMutex.Lock()
 	ret, specificReturn := fake.maxChannelsCountReturnsOnCall[len(fake.maxChannelsCountArgsForCall)]
 	fake.maxChannelsCountArgsForCall = append(fake.maxChannelsCountArgsForCall, struct {
 	}{})
-	stub := fake.MaxChannelsCountStub
-	fakeReturns := fake.maxChannelsCountReturns
 	fake.recordInvocation("MaxChannelsCount", []interface{}{})
 	fake.maxChannelsCountMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.MaxChannelsCountStub != nil {
+		return fake.MaxChannelsCountStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.maxChannelsCountReturns
 	return fakeReturns.result1
 }
 
@@ -597,16 +526,15 @@ func (fake *OrdererConfig) Organizations() map[string]channelconfig.OrdererOrg {
 	ret, specificReturn := fake.organizationsReturnsOnCall[len(fake.organizationsArgsForCall)]
 	fake.organizationsArgsForCall = append(fake.organizationsArgsForCall, struct {
 	}{})
-	stub := fake.OrganizationsStub
-	fakeReturns := fake.organizationsReturns
 	fake.recordInvocation("Organizations", []interface{}{})
 	fake.organizationsMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.OrganizationsStub != nil {
+		return fake.OrganizationsStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.organizationsReturns
 	return fakeReturns.result1
 }
 
@@ -662,8 +590,6 @@ func (fake *OrdererConfig) Invocations() map[string][][]interface{} {
 	defer fake.consensusTypeMutex.RUnlock()
 	fake.consentersMutex.RLock()
 	defer fake.consentersMutex.RUnlock()
-	fake.kafkaBrokersMutex.RLock()
-	defer fake.kafkaBrokersMutex.RUnlock()
 	fake.maxChannelsCountMutex.RLock()
 	defer fake.maxChannelsCountMutex.RUnlock()
 	fake.organizationsMutex.RLock()

--- a/orderer/common/msgprocessor/mocks/channel_config.go
+++ b/orderer/common/msgprocessor/mocks/channel_config.go
@@ -4,7 +4,6 @@ package mocks
 import (
 	"sync"
 
-	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/common/channelconfig"
 )
 
@@ -48,16 +47,6 @@ type ChannelConfig struct {
 	}
 	ordererAddressesReturnsOnCall map[int]struct {
 		result1 []string
-	}
-	OrderersStub        func() []*common.Consenter
-	orderersMutex       sync.RWMutex
-	orderersArgsForCall []struct {
-	}
-	orderersReturns struct {
-		result1 []*common.Consenter
-	}
-	orderersReturnsOnCall map[int]struct {
-		result1 []*common.Consenter
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -271,58 +260,6 @@ func (fake *ChannelConfig) OrdererAddressesReturnsOnCall(i int, result1 []string
 	}{result1}
 }
 
-func (fake *ChannelConfig) Orderers() []*common.Consenter {
-	fake.orderersMutex.Lock()
-	ret, specificReturn := fake.orderersReturnsOnCall[len(fake.orderersArgsForCall)]
-	fake.orderersArgsForCall = append(fake.orderersArgsForCall, struct {
-	}{})
-	fake.recordInvocation("Orderers", []interface{}{})
-	fake.orderersMutex.Unlock()
-	if fake.OrderersStub != nil {
-		return fake.OrderersStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.orderersReturns
-	return fakeReturns.result1
-}
-
-func (fake *ChannelConfig) OrderersCallCount() int {
-	fake.orderersMutex.RLock()
-	defer fake.orderersMutex.RUnlock()
-	return len(fake.orderersArgsForCall)
-}
-
-func (fake *ChannelConfig) OrderersCalls(stub func() []*common.Consenter) {
-	fake.orderersMutex.Lock()
-	defer fake.orderersMutex.Unlock()
-	fake.OrderersStub = stub
-}
-
-func (fake *ChannelConfig) OrderersReturns(result1 []*common.Consenter) {
-	fake.orderersMutex.Lock()
-	defer fake.orderersMutex.Unlock()
-	fake.OrderersStub = nil
-	fake.orderersReturns = struct {
-		result1 []*common.Consenter
-	}{result1}
-}
-
-func (fake *ChannelConfig) OrderersReturnsOnCall(i int, result1 []*common.Consenter) {
-	fake.orderersMutex.Lock()
-	defer fake.orderersMutex.Unlock()
-	fake.OrderersStub = nil
-	if fake.orderersReturnsOnCall == nil {
-		fake.orderersReturnsOnCall = make(map[int]struct {
-			result1 []*common.Consenter
-		})
-	}
-	fake.orderersReturnsOnCall[i] = struct {
-		result1 []*common.Consenter
-	}{result1}
-}
-
 func (fake *ChannelConfig) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -334,8 +271,6 @@ func (fake *ChannelConfig) Invocations() map[string][][]interface{} {
 	defer fake.hashingAlgorithmMutex.RUnlock()
 	fake.ordererAddressesMutex.RLock()
 	defer fake.ordererAddressesMutex.RUnlock()
-	fake.orderersMutex.RLock()
-	defer fake.orderersMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/orderer/common/msgprocessor/mocks/orderer_config.go
+++ b/orderer/common/msgprocessor/mocks/orderer_config.go
@@ -81,16 +81,6 @@ type OrdererConfig struct {
 	consentersReturnsOnCall map[int]struct {
 		result1 []*common.Consenter
 	}
-	KafkaBrokersStub        func() []string
-	kafkaBrokersMutex       sync.RWMutex
-	kafkaBrokersArgsForCall []struct {
-	}
-	kafkaBrokersReturns struct {
-		result1 []string
-	}
-	kafkaBrokersReturnsOnCall map[int]struct {
-		result1 []string
-	}
 	MaxChannelsCountStub        func() uint64
 	maxChannelsCountMutex       sync.RWMutex
 	maxChannelsCountArgsForCall []struct {
@@ -120,16 +110,15 @@ func (fake *OrdererConfig) BatchSize() *orderer.BatchSize {
 	ret, specificReturn := fake.batchSizeReturnsOnCall[len(fake.batchSizeArgsForCall)]
 	fake.batchSizeArgsForCall = append(fake.batchSizeArgsForCall, struct {
 	}{})
-	stub := fake.BatchSizeStub
-	fakeReturns := fake.batchSizeReturns
 	fake.recordInvocation("BatchSize", []interface{}{})
 	fake.batchSizeMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.BatchSizeStub != nil {
+		return fake.BatchSizeStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.batchSizeReturns
 	return fakeReturns.result1
 }
 
@@ -173,16 +162,15 @@ func (fake *OrdererConfig) BatchTimeout() time.Duration {
 	ret, specificReturn := fake.batchTimeoutReturnsOnCall[len(fake.batchTimeoutArgsForCall)]
 	fake.batchTimeoutArgsForCall = append(fake.batchTimeoutArgsForCall, struct {
 	}{})
-	stub := fake.BatchTimeoutStub
-	fakeReturns := fake.batchTimeoutReturns
 	fake.recordInvocation("BatchTimeout", []interface{}{})
 	fake.batchTimeoutMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.BatchTimeoutStub != nil {
+		return fake.BatchTimeoutStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.batchTimeoutReturns
 	return fakeReturns.result1
 }
 
@@ -226,16 +214,15 @@ func (fake *OrdererConfig) Capabilities() channelconfig.OrdererCapabilities {
 	ret, specificReturn := fake.capabilitiesReturnsOnCall[len(fake.capabilitiesArgsForCall)]
 	fake.capabilitiesArgsForCall = append(fake.capabilitiesArgsForCall, struct {
 	}{})
-	stub := fake.CapabilitiesStub
-	fakeReturns := fake.capabilitiesReturns
 	fake.recordInvocation("Capabilities", []interface{}{})
 	fake.capabilitiesMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.CapabilitiesStub != nil {
+		return fake.CapabilitiesStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.capabilitiesReturns
 	return fakeReturns.result1
 }
 
@@ -279,16 +266,15 @@ func (fake *OrdererConfig) ConsensusMetadata() []byte {
 	ret, specificReturn := fake.consensusMetadataReturnsOnCall[len(fake.consensusMetadataArgsForCall)]
 	fake.consensusMetadataArgsForCall = append(fake.consensusMetadataArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusMetadataStub
-	fakeReturns := fake.consensusMetadataReturns
 	fake.recordInvocation("ConsensusMetadata", []interface{}{})
 	fake.consensusMetadataMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusMetadataStub != nil {
+		return fake.ConsensusMetadataStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusMetadataReturns
 	return fakeReturns.result1
 }
 
@@ -332,16 +318,15 @@ func (fake *OrdererConfig) ConsensusState() orderer.ConsensusType_State {
 	ret, specificReturn := fake.consensusStateReturnsOnCall[len(fake.consensusStateArgsForCall)]
 	fake.consensusStateArgsForCall = append(fake.consensusStateArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusStateStub
-	fakeReturns := fake.consensusStateReturns
 	fake.recordInvocation("ConsensusState", []interface{}{})
 	fake.consensusStateMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusStateStub != nil {
+		return fake.ConsensusStateStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusStateReturns
 	return fakeReturns.result1
 }
 
@@ -385,16 +370,15 @@ func (fake *OrdererConfig) ConsensusType() string {
 	ret, specificReturn := fake.consensusTypeReturnsOnCall[len(fake.consensusTypeArgsForCall)]
 	fake.consensusTypeArgsForCall = append(fake.consensusTypeArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusTypeStub
-	fakeReturns := fake.consensusTypeReturns
 	fake.recordInvocation("ConsensusType", []interface{}{})
 	fake.consensusTypeMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusTypeStub != nil {
+		return fake.ConsensusTypeStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusTypeReturns
 	return fakeReturns.result1
 }
 
@@ -438,16 +422,15 @@ func (fake *OrdererConfig) Consenters() []*common.Consenter {
 	ret, specificReturn := fake.consentersReturnsOnCall[len(fake.consentersArgsForCall)]
 	fake.consentersArgsForCall = append(fake.consentersArgsForCall, struct {
 	}{})
-	stub := fake.ConsentersStub
-	fakeReturns := fake.consentersReturns
 	fake.recordInvocation("Consenters", []interface{}{})
 	fake.consentersMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsentersStub != nil {
+		return fake.ConsentersStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consentersReturns
 	return fakeReturns.result1
 }
 
@@ -486,74 +469,20 @@ func (fake *OrdererConfig) ConsentersReturnsOnCall(i int, result1 []*common.Cons
 	}{result1}
 }
 
-func (fake *OrdererConfig) KafkaBrokers() []string {
-	fake.kafkaBrokersMutex.Lock()
-	ret, specificReturn := fake.kafkaBrokersReturnsOnCall[len(fake.kafkaBrokersArgsForCall)]
-	fake.kafkaBrokersArgsForCall = append(fake.kafkaBrokersArgsForCall, struct {
-	}{})
-	stub := fake.KafkaBrokersStub
-	fakeReturns := fake.kafkaBrokersReturns
-	fake.recordInvocation("KafkaBrokers", []interface{}{})
-	fake.kafkaBrokersMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *OrdererConfig) KafkaBrokersCallCount() int {
-	fake.kafkaBrokersMutex.RLock()
-	defer fake.kafkaBrokersMutex.RUnlock()
-	return len(fake.kafkaBrokersArgsForCall)
-}
-
-func (fake *OrdererConfig) KafkaBrokersCalls(stub func() []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = stub
-}
-
-func (fake *OrdererConfig) KafkaBrokersReturns(result1 []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = nil
-	fake.kafkaBrokersReturns = struct {
-		result1 []string
-	}{result1}
-}
-
-func (fake *OrdererConfig) KafkaBrokersReturnsOnCall(i int, result1 []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = nil
-	if fake.kafkaBrokersReturnsOnCall == nil {
-		fake.kafkaBrokersReturnsOnCall = make(map[int]struct {
-			result1 []string
-		})
-	}
-	fake.kafkaBrokersReturnsOnCall[i] = struct {
-		result1 []string
-	}{result1}
-}
-
 func (fake *OrdererConfig) MaxChannelsCount() uint64 {
 	fake.maxChannelsCountMutex.Lock()
 	ret, specificReturn := fake.maxChannelsCountReturnsOnCall[len(fake.maxChannelsCountArgsForCall)]
 	fake.maxChannelsCountArgsForCall = append(fake.maxChannelsCountArgsForCall, struct {
 	}{})
-	stub := fake.MaxChannelsCountStub
-	fakeReturns := fake.maxChannelsCountReturns
 	fake.recordInvocation("MaxChannelsCount", []interface{}{})
 	fake.maxChannelsCountMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.MaxChannelsCountStub != nil {
+		return fake.MaxChannelsCountStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.maxChannelsCountReturns
 	return fakeReturns.result1
 }
 
@@ -597,16 +526,15 @@ func (fake *OrdererConfig) Organizations() map[string]channelconfig.OrdererOrg {
 	ret, specificReturn := fake.organizationsReturnsOnCall[len(fake.organizationsArgsForCall)]
 	fake.organizationsArgsForCall = append(fake.organizationsArgsForCall, struct {
 	}{})
-	stub := fake.OrganizationsStub
-	fakeReturns := fake.organizationsReturns
 	fake.recordInvocation("Organizations", []interface{}{})
 	fake.organizationsMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.OrganizationsStub != nil {
+		return fake.OrganizationsStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.organizationsReturns
 	return fakeReturns.result1
 }
 
@@ -662,8 +590,6 @@ func (fake *OrdererConfig) Invocations() map[string][][]interface{} {
 	defer fake.consensusTypeMutex.RUnlock()
 	fake.consentersMutex.RLock()
 	defer fake.consentersMutex.RUnlock()
-	fake.kafkaBrokersMutex.RLock()
-	defer fake.kafkaBrokersMutex.RUnlock()
 	fake.maxChannelsCountMutex.RLock()
 	defer fake.maxChannelsCountMutex.RUnlock()
 	fake.organizationsMutex.RLock()

--- a/orderer/common/multichannel/mocks/orderer_config.go
+++ b/orderer/common/multichannel/mocks/orderer_config.go
@@ -81,16 +81,6 @@ type OrdererConfig struct {
 	consentersReturnsOnCall map[int]struct {
 		result1 []*common.Consenter
 	}
-	KafkaBrokersStub        func() []string
-	kafkaBrokersMutex       sync.RWMutex
-	kafkaBrokersArgsForCall []struct {
-	}
-	kafkaBrokersReturns struct {
-		result1 []string
-	}
-	kafkaBrokersReturnsOnCall map[int]struct {
-		result1 []string
-	}
 	MaxChannelsCountStub        func() uint64
 	maxChannelsCountMutex       sync.RWMutex
 	maxChannelsCountArgsForCall []struct {
@@ -120,16 +110,15 @@ func (fake *OrdererConfig) BatchSize() *orderer.BatchSize {
 	ret, specificReturn := fake.batchSizeReturnsOnCall[len(fake.batchSizeArgsForCall)]
 	fake.batchSizeArgsForCall = append(fake.batchSizeArgsForCall, struct {
 	}{})
-	stub := fake.BatchSizeStub
-	fakeReturns := fake.batchSizeReturns
 	fake.recordInvocation("BatchSize", []interface{}{})
 	fake.batchSizeMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.BatchSizeStub != nil {
+		return fake.BatchSizeStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.batchSizeReturns
 	return fakeReturns.result1
 }
 
@@ -173,16 +162,15 @@ func (fake *OrdererConfig) BatchTimeout() time.Duration {
 	ret, specificReturn := fake.batchTimeoutReturnsOnCall[len(fake.batchTimeoutArgsForCall)]
 	fake.batchTimeoutArgsForCall = append(fake.batchTimeoutArgsForCall, struct {
 	}{})
-	stub := fake.BatchTimeoutStub
-	fakeReturns := fake.batchTimeoutReturns
 	fake.recordInvocation("BatchTimeout", []interface{}{})
 	fake.batchTimeoutMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.BatchTimeoutStub != nil {
+		return fake.BatchTimeoutStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.batchTimeoutReturns
 	return fakeReturns.result1
 }
 
@@ -226,16 +214,15 @@ func (fake *OrdererConfig) Capabilities() channelconfig.OrdererCapabilities {
 	ret, specificReturn := fake.capabilitiesReturnsOnCall[len(fake.capabilitiesArgsForCall)]
 	fake.capabilitiesArgsForCall = append(fake.capabilitiesArgsForCall, struct {
 	}{})
-	stub := fake.CapabilitiesStub
-	fakeReturns := fake.capabilitiesReturns
 	fake.recordInvocation("Capabilities", []interface{}{})
 	fake.capabilitiesMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.CapabilitiesStub != nil {
+		return fake.CapabilitiesStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.capabilitiesReturns
 	return fakeReturns.result1
 }
 
@@ -279,16 +266,15 @@ func (fake *OrdererConfig) ConsensusMetadata() []byte {
 	ret, specificReturn := fake.consensusMetadataReturnsOnCall[len(fake.consensusMetadataArgsForCall)]
 	fake.consensusMetadataArgsForCall = append(fake.consensusMetadataArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusMetadataStub
-	fakeReturns := fake.consensusMetadataReturns
 	fake.recordInvocation("ConsensusMetadata", []interface{}{})
 	fake.consensusMetadataMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusMetadataStub != nil {
+		return fake.ConsensusMetadataStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusMetadataReturns
 	return fakeReturns.result1
 }
 
@@ -332,16 +318,15 @@ func (fake *OrdererConfig) ConsensusState() orderer.ConsensusType_State {
 	ret, specificReturn := fake.consensusStateReturnsOnCall[len(fake.consensusStateArgsForCall)]
 	fake.consensusStateArgsForCall = append(fake.consensusStateArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusStateStub
-	fakeReturns := fake.consensusStateReturns
 	fake.recordInvocation("ConsensusState", []interface{}{})
 	fake.consensusStateMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusStateStub != nil {
+		return fake.ConsensusStateStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusStateReturns
 	return fakeReturns.result1
 }
 
@@ -385,16 +370,15 @@ func (fake *OrdererConfig) ConsensusType() string {
 	ret, specificReturn := fake.consensusTypeReturnsOnCall[len(fake.consensusTypeArgsForCall)]
 	fake.consensusTypeArgsForCall = append(fake.consensusTypeArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusTypeStub
-	fakeReturns := fake.consensusTypeReturns
 	fake.recordInvocation("ConsensusType", []interface{}{})
 	fake.consensusTypeMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusTypeStub != nil {
+		return fake.ConsensusTypeStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusTypeReturns
 	return fakeReturns.result1
 }
 
@@ -438,16 +422,15 @@ func (fake *OrdererConfig) Consenters() []*common.Consenter {
 	ret, specificReturn := fake.consentersReturnsOnCall[len(fake.consentersArgsForCall)]
 	fake.consentersArgsForCall = append(fake.consentersArgsForCall, struct {
 	}{})
-	stub := fake.ConsentersStub
-	fakeReturns := fake.consentersReturns
 	fake.recordInvocation("Consenters", []interface{}{})
 	fake.consentersMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsentersStub != nil {
+		return fake.ConsentersStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consentersReturns
 	return fakeReturns.result1
 }
 
@@ -486,74 +469,20 @@ func (fake *OrdererConfig) ConsentersReturnsOnCall(i int, result1 []*common.Cons
 	}{result1}
 }
 
-func (fake *OrdererConfig) KafkaBrokers() []string {
-	fake.kafkaBrokersMutex.Lock()
-	ret, specificReturn := fake.kafkaBrokersReturnsOnCall[len(fake.kafkaBrokersArgsForCall)]
-	fake.kafkaBrokersArgsForCall = append(fake.kafkaBrokersArgsForCall, struct {
-	}{})
-	stub := fake.KafkaBrokersStub
-	fakeReturns := fake.kafkaBrokersReturns
-	fake.recordInvocation("KafkaBrokers", []interface{}{})
-	fake.kafkaBrokersMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *OrdererConfig) KafkaBrokersCallCount() int {
-	fake.kafkaBrokersMutex.RLock()
-	defer fake.kafkaBrokersMutex.RUnlock()
-	return len(fake.kafkaBrokersArgsForCall)
-}
-
-func (fake *OrdererConfig) KafkaBrokersCalls(stub func() []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = stub
-}
-
-func (fake *OrdererConfig) KafkaBrokersReturns(result1 []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = nil
-	fake.kafkaBrokersReturns = struct {
-		result1 []string
-	}{result1}
-}
-
-func (fake *OrdererConfig) KafkaBrokersReturnsOnCall(i int, result1 []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = nil
-	if fake.kafkaBrokersReturnsOnCall == nil {
-		fake.kafkaBrokersReturnsOnCall = make(map[int]struct {
-			result1 []string
-		})
-	}
-	fake.kafkaBrokersReturnsOnCall[i] = struct {
-		result1 []string
-	}{result1}
-}
-
 func (fake *OrdererConfig) MaxChannelsCount() uint64 {
 	fake.maxChannelsCountMutex.Lock()
 	ret, specificReturn := fake.maxChannelsCountReturnsOnCall[len(fake.maxChannelsCountArgsForCall)]
 	fake.maxChannelsCountArgsForCall = append(fake.maxChannelsCountArgsForCall, struct {
 	}{})
-	stub := fake.MaxChannelsCountStub
-	fakeReturns := fake.maxChannelsCountReturns
 	fake.recordInvocation("MaxChannelsCount", []interface{}{})
 	fake.maxChannelsCountMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.MaxChannelsCountStub != nil {
+		return fake.MaxChannelsCountStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.maxChannelsCountReturns
 	return fakeReturns.result1
 }
 
@@ -597,16 +526,15 @@ func (fake *OrdererConfig) Organizations() map[string]channelconfig.OrdererOrg {
 	ret, specificReturn := fake.organizationsReturnsOnCall[len(fake.organizationsArgsForCall)]
 	fake.organizationsArgsForCall = append(fake.organizationsArgsForCall, struct {
 	}{})
-	stub := fake.OrganizationsStub
-	fakeReturns := fake.organizationsReturns
 	fake.recordInvocation("Organizations", []interface{}{})
 	fake.organizationsMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.OrganizationsStub != nil {
+		return fake.OrganizationsStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.organizationsReturns
 	return fakeReturns.result1
 }
 
@@ -662,8 +590,6 @@ func (fake *OrdererConfig) Invocations() map[string][][]interface{} {
 	defer fake.consensusTypeMutex.RUnlock()
 	fake.consentersMutex.RLock()
 	defer fake.consentersMutex.RUnlock()
-	fake.kafkaBrokersMutex.RLock()
-	defer fake.kafkaBrokersMutex.RUnlock()
 	fake.maxChannelsCountMutex.RLock()
 	defer fake.maxChannelsCountMutex.RUnlock()
 	fake.organizationsMutex.RLock()

--- a/orderer/consensus/etcdraft/mocks/orderer_config.go
+++ b/orderer/consensus/etcdraft/mocks/orderer_config.go
@@ -81,16 +81,6 @@ type OrdererConfig struct {
 	consentersReturnsOnCall map[int]struct {
 		result1 []*common.Consenter
 	}
-	KafkaBrokersStub        func() []string
-	kafkaBrokersMutex       sync.RWMutex
-	kafkaBrokersArgsForCall []struct {
-	}
-	kafkaBrokersReturns struct {
-		result1 []string
-	}
-	kafkaBrokersReturnsOnCall map[int]struct {
-		result1 []string
-	}
 	MaxChannelsCountStub        func() uint64
 	maxChannelsCountMutex       sync.RWMutex
 	maxChannelsCountArgsForCall []struct {
@@ -120,16 +110,15 @@ func (fake *OrdererConfig) BatchSize() *orderer.BatchSize {
 	ret, specificReturn := fake.batchSizeReturnsOnCall[len(fake.batchSizeArgsForCall)]
 	fake.batchSizeArgsForCall = append(fake.batchSizeArgsForCall, struct {
 	}{})
-	stub := fake.BatchSizeStub
-	fakeReturns := fake.batchSizeReturns
 	fake.recordInvocation("BatchSize", []interface{}{})
 	fake.batchSizeMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.BatchSizeStub != nil {
+		return fake.BatchSizeStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.batchSizeReturns
 	return fakeReturns.result1
 }
 
@@ -173,16 +162,15 @@ func (fake *OrdererConfig) BatchTimeout() time.Duration {
 	ret, specificReturn := fake.batchTimeoutReturnsOnCall[len(fake.batchTimeoutArgsForCall)]
 	fake.batchTimeoutArgsForCall = append(fake.batchTimeoutArgsForCall, struct {
 	}{})
-	stub := fake.BatchTimeoutStub
-	fakeReturns := fake.batchTimeoutReturns
 	fake.recordInvocation("BatchTimeout", []interface{}{})
 	fake.batchTimeoutMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.BatchTimeoutStub != nil {
+		return fake.BatchTimeoutStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.batchTimeoutReturns
 	return fakeReturns.result1
 }
 
@@ -226,16 +214,15 @@ func (fake *OrdererConfig) Capabilities() channelconfig.OrdererCapabilities {
 	ret, specificReturn := fake.capabilitiesReturnsOnCall[len(fake.capabilitiesArgsForCall)]
 	fake.capabilitiesArgsForCall = append(fake.capabilitiesArgsForCall, struct {
 	}{})
-	stub := fake.CapabilitiesStub
-	fakeReturns := fake.capabilitiesReturns
 	fake.recordInvocation("Capabilities", []interface{}{})
 	fake.capabilitiesMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.CapabilitiesStub != nil {
+		return fake.CapabilitiesStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.capabilitiesReturns
 	return fakeReturns.result1
 }
 
@@ -279,16 +266,15 @@ func (fake *OrdererConfig) ConsensusMetadata() []byte {
 	ret, specificReturn := fake.consensusMetadataReturnsOnCall[len(fake.consensusMetadataArgsForCall)]
 	fake.consensusMetadataArgsForCall = append(fake.consensusMetadataArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusMetadataStub
-	fakeReturns := fake.consensusMetadataReturns
 	fake.recordInvocation("ConsensusMetadata", []interface{}{})
 	fake.consensusMetadataMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusMetadataStub != nil {
+		return fake.ConsensusMetadataStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusMetadataReturns
 	return fakeReturns.result1
 }
 
@@ -332,16 +318,15 @@ func (fake *OrdererConfig) ConsensusState() orderer.ConsensusType_State {
 	ret, specificReturn := fake.consensusStateReturnsOnCall[len(fake.consensusStateArgsForCall)]
 	fake.consensusStateArgsForCall = append(fake.consensusStateArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusStateStub
-	fakeReturns := fake.consensusStateReturns
 	fake.recordInvocation("ConsensusState", []interface{}{})
 	fake.consensusStateMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusStateStub != nil {
+		return fake.ConsensusStateStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusStateReturns
 	return fakeReturns.result1
 }
 
@@ -385,16 +370,15 @@ func (fake *OrdererConfig) ConsensusType() string {
 	ret, specificReturn := fake.consensusTypeReturnsOnCall[len(fake.consensusTypeArgsForCall)]
 	fake.consensusTypeArgsForCall = append(fake.consensusTypeArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusTypeStub
-	fakeReturns := fake.consensusTypeReturns
 	fake.recordInvocation("ConsensusType", []interface{}{})
 	fake.consensusTypeMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusTypeStub != nil {
+		return fake.ConsensusTypeStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusTypeReturns
 	return fakeReturns.result1
 }
 
@@ -438,16 +422,15 @@ func (fake *OrdererConfig) Consenters() []*common.Consenter {
 	ret, specificReturn := fake.consentersReturnsOnCall[len(fake.consentersArgsForCall)]
 	fake.consentersArgsForCall = append(fake.consentersArgsForCall, struct {
 	}{})
-	stub := fake.ConsentersStub
-	fakeReturns := fake.consentersReturns
 	fake.recordInvocation("Consenters", []interface{}{})
 	fake.consentersMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsentersStub != nil {
+		return fake.ConsentersStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consentersReturns
 	return fakeReturns.result1
 }
 
@@ -486,74 +469,20 @@ func (fake *OrdererConfig) ConsentersReturnsOnCall(i int, result1 []*common.Cons
 	}{result1}
 }
 
-func (fake *OrdererConfig) KafkaBrokers() []string {
-	fake.kafkaBrokersMutex.Lock()
-	ret, specificReturn := fake.kafkaBrokersReturnsOnCall[len(fake.kafkaBrokersArgsForCall)]
-	fake.kafkaBrokersArgsForCall = append(fake.kafkaBrokersArgsForCall, struct {
-	}{})
-	stub := fake.KafkaBrokersStub
-	fakeReturns := fake.kafkaBrokersReturns
-	fake.recordInvocation("KafkaBrokers", []interface{}{})
-	fake.kafkaBrokersMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *OrdererConfig) KafkaBrokersCallCount() int {
-	fake.kafkaBrokersMutex.RLock()
-	defer fake.kafkaBrokersMutex.RUnlock()
-	return len(fake.kafkaBrokersArgsForCall)
-}
-
-func (fake *OrdererConfig) KafkaBrokersCalls(stub func() []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = stub
-}
-
-func (fake *OrdererConfig) KafkaBrokersReturns(result1 []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = nil
-	fake.kafkaBrokersReturns = struct {
-		result1 []string
-	}{result1}
-}
-
-func (fake *OrdererConfig) KafkaBrokersReturnsOnCall(i int, result1 []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = nil
-	if fake.kafkaBrokersReturnsOnCall == nil {
-		fake.kafkaBrokersReturnsOnCall = make(map[int]struct {
-			result1 []string
-		})
-	}
-	fake.kafkaBrokersReturnsOnCall[i] = struct {
-		result1 []string
-	}{result1}
-}
-
 func (fake *OrdererConfig) MaxChannelsCount() uint64 {
 	fake.maxChannelsCountMutex.Lock()
 	ret, specificReturn := fake.maxChannelsCountReturnsOnCall[len(fake.maxChannelsCountArgsForCall)]
 	fake.maxChannelsCountArgsForCall = append(fake.maxChannelsCountArgsForCall, struct {
 	}{})
-	stub := fake.MaxChannelsCountStub
-	fakeReturns := fake.maxChannelsCountReturns
 	fake.recordInvocation("MaxChannelsCount", []interface{}{})
 	fake.maxChannelsCountMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.MaxChannelsCountStub != nil {
+		return fake.MaxChannelsCountStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.maxChannelsCountReturns
 	return fakeReturns.result1
 }
 
@@ -597,16 +526,15 @@ func (fake *OrdererConfig) Organizations() map[string]channelconfig.OrdererOrg {
 	ret, specificReturn := fake.organizationsReturnsOnCall[len(fake.organizationsArgsForCall)]
 	fake.organizationsArgsForCall = append(fake.organizationsArgsForCall, struct {
 	}{})
-	stub := fake.OrganizationsStub
-	fakeReturns := fake.organizationsReturns
 	fake.recordInvocation("Organizations", []interface{}{})
 	fake.organizationsMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.OrganizationsStub != nil {
+		return fake.OrganizationsStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.organizationsReturns
 	return fakeReturns.result1
 }
 
@@ -662,8 +590,6 @@ func (fake *OrdererConfig) Invocations() map[string][][]interface{} {
 	defer fake.consensusTypeMutex.RUnlock()
 	fake.consentersMutex.RLock()
 	defer fake.consentersMutex.RUnlock()
-	fake.kafkaBrokersMutex.RLock()
-	defer fake.kafkaBrokersMutex.RUnlock()
 	fake.maxChannelsCountMutex.RLock()
 	defer fake.maxChannelsCountMutex.RUnlock()
 	fake.organizationsMutex.RLock()

--- a/orderer/consensus/solo/mocks/orderer_config.go
+++ b/orderer/consensus/solo/mocks/orderer_config.go
@@ -81,16 +81,6 @@ type OrdererConfig struct {
 	consentersReturnsOnCall map[int]struct {
 		result1 []*common.Consenter
 	}
-	KafkaBrokersStub        func() []string
-	kafkaBrokersMutex       sync.RWMutex
-	kafkaBrokersArgsForCall []struct {
-	}
-	kafkaBrokersReturns struct {
-		result1 []string
-	}
-	kafkaBrokersReturnsOnCall map[int]struct {
-		result1 []string
-	}
 	MaxChannelsCountStub        func() uint64
 	maxChannelsCountMutex       sync.RWMutex
 	maxChannelsCountArgsForCall []struct {
@@ -120,16 +110,15 @@ func (fake *OrdererConfig) BatchSize() *orderer.BatchSize {
 	ret, specificReturn := fake.batchSizeReturnsOnCall[len(fake.batchSizeArgsForCall)]
 	fake.batchSizeArgsForCall = append(fake.batchSizeArgsForCall, struct {
 	}{})
-	stub := fake.BatchSizeStub
-	fakeReturns := fake.batchSizeReturns
 	fake.recordInvocation("BatchSize", []interface{}{})
 	fake.batchSizeMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.BatchSizeStub != nil {
+		return fake.BatchSizeStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.batchSizeReturns
 	return fakeReturns.result1
 }
 
@@ -173,16 +162,15 @@ func (fake *OrdererConfig) BatchTimeout() time.Duration {
 	ret, specificReturn := fake.batchTimeoutReturnsOnCall[len(fake.batchTimeoutArgsForCall)]
 	fake.batchTimeoutArgsForCall = append(fake.batchTimeoutArgsForCall, struct {
 	}{})
-	stub := fake.BatchTimeoutStub
-	fakeReturns := fake.batchTimeoutReturns
 	fake.recordInvocation("BatchTimeout", []interface{}{})
 	fake.batchTimeoutMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.BatchTimeoutStub != nil {
+		return fake.BatchTimeoutStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.batchTimeoutReturns
 	return fakeReturns.result1
 }
 
@@ -226,16 +214,15 @@ func (fake *OrdererConfig) Capabilities() channelconfig.OrdererCapabilities {
 	ret, specificReturn := fake.capabilitiesReturnsOnCall[len(fake.capabilitiesArgsForCall)]
 	fake.capabilitiesArgsForCall = append(fake.capabilitiesArgsForCall, struct {
 	}{})
-	stub := fake.CapabilitiesStub
-	fakeReturns := fake.capabilitiesReturns
 	fake.recordInvocation("Capabilities", []interface{}{})
 	fake.capabilitiesMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.CapabilitiesStub != nil {
+		return fake.CapabilitiesStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.capabilitiesReturns
 	return fakeReturns.result1
 }
 
@@ -279,16 +266,15 @@ func (fake *OrdererConfig) ConsensusMetadata() []byte {
 	ret, specificReturn := fake.consensusMetadataReturnsOnCall[len(fake.consensusMetadataArgsForCall)]
 	fake.consensusMetadataArgsForCall = append(fake.consensusMetadataArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusMetadataStub
-	fakeReturns := fake.consensusMetadataReturns
 	fake.recordInvocation("ConsensusMetadata", []interface{}{})
 	fake.consensusMetadataMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusMetadataStub != nil {
+		return fake.ConsensusMetadataStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusMetadataReturns
 	return fakeReturns.result1
 }
 
@@ -332,16 +318,15 @@ func (fake *OrdererConfig) ConsensusState() orderer.ConsensusType_State {
 	ret, specificReturn := fake.consensusStateReturnsOnCall[len(fake.consensusStateArgsForCall)]
 	fake.consensusStateArgsForCall = append(fake.consensusStateArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusStateStub
-	fakeReturns := fake.consensusStateReturns
 	fake.recordInvocation("ConsensusState", []interface{}{})
 	fake.consensusStateMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusStateStub != nil {
+		return fake.ConsensusStateStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusStateReturns
 	return fakeReturns.result1
 }
 
@@ -385,16 +370,15 @@ func (fake *OrdererConfig) ConsensusType() string {
 	ret, specificReturn := fake.consensusTypeReturnsOnCall[len(fake.consensusTypeArgsForCall)]
 	fake.consensusTypeArgsForCall = append(fake.consensusTypeArgsForCall, struct {
 	}{})
-	stub := fake.ConsensusTypeStub
-	fakeReturns := fake.consensusTypeReturns
 	fake.recordInvocation("ConsensusType", []interface{}{})
 	fake.consensusTypeMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsensusTypeStub != nil {
+		return fake.ConsensusTypeStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consensusTypeReturns
 	return fakeReturns.result1
 }
 
@@ -438,16 +422,15 @@ func (fake *OrdererConfig) Consenters() []*common.Consenter {
 	ret, specificReturn := fake.consentersReturnsOnCall[len(fake.consentersArgsForCall)]
 	fake.consentersArgsForCall = append(fake.consentersArgsForCall, struct {
 	}{})
-	stub := fake.ConsentersStub
-	fakeReturns := fake.consentersReturns
 	fake.recordInvocation("Consenters", []interface{}{})
 	fake.consentersMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ConsentersStub != nil {
+		return fake.ConsentersStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.consentersReturns
 	return fakeReturns.result1
 }
 
@@ -486,74 +469,20 @@ func (fake *OrdererConfig) ConsentersReturnsOnCall(i int, result1 []*common.Cons
 	}{result1}
 }
 
-func (fake *OrdererConfig) KafkaBrokers() []string {
-	fake.kafkaBrokersMutex.Lock()
-	ret, specificReturn := fake.kafkaBrokersReturnsOnCall[len(fake.kafkaBrokersArgsForCall)]
-	fake.kafkaBrokersArgsForCall = append(fake.kafkaBrokersArgsForCall, struct {
-	}{})
-	stub := fake.KafkaBrokersStub
-	fakeReturns := fake.kafkaBrokersReturns
-	fake.recordInvocation("KafkaBrokers", []interface{}{})
-	fake.kafkaBrokersMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *OrdererConfig) KafkaBrokersCallCount() int {
-	fake.kafkaBrokersMutex.RLock()
-	defer fake.kafkaBrokersMutex.RUnlock()
-	return len(fake.kafkaBrokersArgsForCall)
-}
-
-func (fake *OrdererConfig) KafkaBrokersCalls(stub func() []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = stub
-}
-
-func (fake *OrdererConfig) KafkaBrokersReturns(result1 []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = nil
-	fake.kafkaBrokersReturns = struct {
-		result1 []string
-	}{result1}
-}
-
-func (fake *OrdererConfig) KafkaBrokersReturnsOnCall(i int, result1 []string) {
-	fake.kafkaBrokersMutex.Lock()
-	defer fake.kafkaBrokersMutex.Unlock()
-	fake.KafkaBrokersStub = nil
-	if fake.kafkaBrokersReturnsOnCall == nil {
-		fake.kafkaBrokersReturnsOnCall = make(map[int]struct {
-			result1 []string
-		})
-	}
-	fake.kafkaBrokersReturnsOnCall[i] = struct {
-		result1 []string
-	}{result1}
-}
-
 func (fake *OrdererConfig) MaxChannelsCount() uint64 {
 	fake.maxChannelsCountMutex.Lock()
 	ret, specificReturn := fake.maxChannelsCountReturnsOnCall[len(fake.maxChannelsCountArgsForCall)]
 	fake.maxChannelsCountArgsForCall = append(fake.maxChannelsCountArgsForCall, struct {
 	}{})
-	stub := fake.MaxChannelsCountStub
-	fakeReturns := fake.maxChannelsCountReturns
 	fake.recordInvocation("MaxChannelsCount", []interface{}{})
 	fake.maxChannelsCountMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.MaxChannelsCountStub != nil {
+		return fake.MaxChannelsCountStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.maxChannelsCountReturns
 	return fakeReturns.result1
 }
 
@@ -597,16 +526,15 @@ func (fake *OrdererConfig) Organizations() map[string]channelconfig.OrdererOrg {
 	ret, specificReturn := fake.organizationsReturnsOnCall[len(fake.organizationsArgsForCall)]
 	fake.organizationsArgsForCall = append(fake.organizationsArgsForCall, struct {
 	}{})
-	stub := fake.OrganizationsStub
-	fakeReturns := fake.organizationsReturns
 	fake.recordInvocation("Organizations", []interface{}{})
 	fake.organizationsMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.OrganizationsStub != nil {
+		return fake.OrganizationsStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.organizationsReturns
 	return fakeReturns.result1
 }
 
@@ -662,8 +590,6 @@ func (fake *OrdererConfig) Invocations() map[string][][]interface{} {
 	defer fake.consensusTypeMutex.RUnlock()
 	fake.consentersMutex.RLock()
 	defer fake.consentersMutex.RUnlock()
-	fake.kafkaBrokersMutex.RLock()
-	defer fake.kafkaBrokersMutex.RUnlock()
 	fake.maxChannelsCountMutex.RLock()
 	defer fake.maxChannelsCountMutex.RUnlock()
 	fake.organizationsMutex.RLock()


### PR DESCRIPTION
Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: I1aefd584e0217642c1315544da8eb1e1849ec759

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description

Remove kafka brokers from shared config

#### Related issues

Issue: #3513 
Epic: #3511 
