### PR TITLE
Orderer v3: remove kafka from build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 #   - docker-list - generates a list of docker images that 'make docker' produces
 #   - docker-tag-latest - re-tags the images made by 'make docker' with the :latest tag
 #   - docker-tag-stable - re-tags the images made by 'make docker' with the :stable tag
-#   - docker-thirdparty - pulls thirdparty images (kafka,zookeeper,couchdb)
+#   - docker-thirdparty - pulls thirdparty images (couchdb, etc)
 #   - docs - builds the documentation in html format
 #   - gotools - installs go tools like golint
 #   - help-docs - generate the command reference docs
@@ -52,8 +52,6 @@ BASE_VERSION = 2.5.0
 # 3rd party image version
 # These versions are also set in the runners in ./integration/runners/
 COUCHDB_VER ?= 3.2.2
-KAFKA_VER ?= 5.3.1
-ZOOKEEPER_VER ?= 5.3.1
 
 # Disable implicit rules
 .SUFFIXES:
@@ -162,8 +160,6 @@ unit-tests: unit-test
 # can be built by a peer configured to use the ccenv-1.4 as the builder image.
 .PHONY: docker-thirdparty
 docker-thirdparty: docker-thirdparty-couchdb
-	docker pull confluentinc/cp-zookeeper:${ZOOKEEPER_VER}
-	docker pull confluentinc/cp-kafka:${KAFKA_VER}
 	docker pull hyperledger/fabric-ccenv:1.4
 
 .PHONY: docker-thirdparty-couchdb

--- a/discovery/test/testdata/configtx.yaml
+++ b/discovery/test/testdata/configtx.yaml
@@ -218,7 +218,7 @@ Application: &ApplicationDefaults
 ################################################################################
 Orderer: &OrdererDefaults
     # Orderer Type: The orderer implementation to start
-    # Available types are "solo" and "kafka"
+    # Available types are "solo" and "etcdraft"
     OrdererType: solo
 
     Addresses:
@@ -241,12 +241,6 @@ Orderer: &OrdererDefaults
         # the serialized messages in a batch. A message larger than the preferred
         # max bytes will result in a batch larger than preferred max bytes.
         PreferredMaxBytes: 512 KB
-
-    Kafka:
-        # Brokers: A list of Kafka brokers to which the orderer connects
-        # NOTE: Use IP:port notation
-        Brokers:
-            - 127.0.0.1:9092
 
     # Organizations is the list of orgs which are defined as participants on
     # the orderer side of the network

--- a/internal/configtxgen/genesisconfig/config.go
+++ b/internal/configtxgen/genesisconfig/config.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	// The type key for etcd based RAFT consensus.
+	// EtcdRaft The type key for etcd based RAFT consensus.
 	EtcdRaft = "etcdraft"
 )
 
@@ -38,16 +38,6 @@ const (
 	// only the sample MSP and uses solo for ordering.
 	SampleSingleMSPSoloProfile = "SampleSingleMSPSolo"
 
-	// SampleInsecureKafkaProfile references the sample profile which does not
-	// include any MSPs and uses Kafka for ordering.
-	SampleInsecureKafkaProfile = "SampleInsecureKafka"
-	// SampleDevModeKafkaProfile references the sample profile which requires only
-	// basic membership for admin privileges and uses Kafka for ordering.
-	SampleDevModeKafkaProfile = "SampleDevModeKafka"
-	// SampleSingleMSPKafkaProfile references the sample profile which includes
-	// only the sample MSP and uses Kafka for ordering.
-	SampleSingleMSPKafkaProfile = "SampleSingleMSPKafka"
-
 	// SampleDevModeEtcdRaftProfile references the sample profile used for testing
 	// the etcd/raft-based ordering service.
 	SampleDevModeEtcdRaftProfile = "SampleDevModeEtcdRaft"
@@ -55,7 +45,7 @@ const (
 	// SampleAppChannelInsecureSoloProfile references the sample profile which
 	// does not include any MSPs and uses solo for ordering.
 	SampleAppChannelInsecureSoloProfile = "SampleAppChannelInsecureSolo"
-	// SampleApppChannelEtcdRaftProfile references the sample profile used for
+	// SampleAppChannelEtcdRaftProfile references the sample profile used for
 	// testing the etcd/raft-based ordering service using the channel
 	// participation API.
 	SampleAppChannelEtcdRaftProfile = "SampleAppChannelEtcdRaft"
@@ -155,7 +145,6 @@ type Orderer struct {
 	BatchTimeout     time.Duration            `yaml:"BatchTimeout"`
 	BatchSize        BatchSize                `yaml:"BatchSize"`
 	ConsenterMapping []*Consenter             `yaml:"ConsenterMapping"`
-	Kafka            Kafka                    `yaml:"Kafka"`
 	EtcdRaft         *etcdraft.ConfigMetadata `yaml:"EtcdRaft"`
 	Organizations    []*Organization          `yaml:"Organizations"`
 	MaxChannels      uint64                   `yaml:"MaxChannels"`
@@ -180,11 +169,6 @@ type Consenter struct {
 	ServerTLSCert string `yaml:"ServerTLSCert"`
 }
 
-// Kafka contains configuration for the Kafka-based orderer.
-type Kafka struct {
-	Brokers []string `yaml:"Brokers"`
-}
-
 var genesisDefaults = TopLevel{
 	Orderer: &Orderer{
 		OrdererType:  "solo",
@@ -193,9 +177,6 @@ var genesisDefaults = TopLevel{
 			MaxMessageCount:   500,
 			AbsoluteMaxBytes:  10 * 1024 * 1024,
 			PreferredMaxBytes: 2 * 1024 * 1024,
-		},
-		Kafka: Kafka{
-			Brokers: []string{"127.0.0.1:9092"},
 		},
 		EtcdRaft: &etcdraft.ConfigMetadata{
 			Options: &etcdraft.Options{
@@ -343,11 +324,6 @@ loop:
 	switch ord.OrdererType {
 	case "solo":
 		// nothing to be done here
-	case "kafka":
-		if ord.Kafka.Brokers == nil {
-			logger.Infof("Orderer.Kafka unset, setting to %v", genesisDefaults.Orderer.Kafka.Brokers)
-			ord.Kafka.Brokers = genesisDefaults.Orderer.Kafka.Brokers
-		}
 	case EtcdRaft:
 		if ord.EtcdRaft == nil {
 			logger.Panicf("%s configuration missing", EtcdRaft)

--- a/internal/configtxgen/genesisconfig/config_test.go
+++ b/internal/configtxgen/genesisconfig/config_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package genesisconfig
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hyperledger/fabric-protos-go/orderer/etcdraft"
@@ -21,11 +20,11 @@ func TestLoadProfile(t *testing.T) {
 	defer cleanup()
 
 	pNames := []string{
-		SampleDevModeKafkaProfile,
 		SampleDevModeSoloProfile,
 		SampleSingleMSPChannelProfile,
-		SampleSingleMSPKafkaProfile,
 		SampleSingleMSPSoloProfile,
+		SampleDevModeEtcdRaftProfile,
+		SampleAppChannelEtcdRaftProfile,
 	}
 	for _, pName := range pNames {
 		t.Run(pName, func(t *testing.T) {
@@ -39,11 +38,11 @@ func TestLoadProfileWithPath(t *testing.T) {
 	devConfigDir := configtest.GetDevConfigDir()
 
 	pNames := []string{
-		SampleDevModeKafkaProfile,
 		SampleDevModeSoloProfile,
 		SampleSingleMSPChannelProfile,
-		SampleSingleMSPKafkaProfile,
 		SampleSingleMSPSoloProfile,
+		SampleDevModeEtcdRaftProfile,
+		SampleAppChannelEtcdRaftProfile,
 	}
 	for _, pName := range pNames {
 		t.Run(pName, func(t *testing.T) {
@@ -112,17 +111,7 @@ func TestConsensusSpecificInit(t *testing.T) {
 			},
 		}
 		profile.completeInitialization(devConfigDir)
-		require.Nil(t, profile.Orderer.Kafka.Brokers, "Kafka config settings should not be set")
-	})
-
-	t.Run("kafka", func(t *testing.T) {
-		profile := &Profile{
-			Orderer: &Orderer{
-				OrdererType: "kafka",
-			},
-		}
-		profile.completeInitialization(devConfigDir)
-		require.NotNil(t, profile.Orderer.Kafka.Brokers, "Kafka config settings should be set")
+		require.NotNil(t, profile.Orderer.BatchSize)
 	})
 
 	t.Run("raft", func(t *testing.T) {
@@ -290,7 +279,6 @@ func TestLoadConfigCache(t *testing.T) {
 	// With the caching behavior, the update should not be reflected.
 	initial, err := c.load(cfg, configPath)
 	require.NoError(t, err)
-	os.Setenv("ORDERER_KAFKA_RETRY_SHORTINTERVAL", "120s")
 	updated, err := c.load(cfg, configPath)
 	require.NoError(t, err)
 	require.Equal(t, initial, updated, "expected %#v to equal %#v", updated, initial)

--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -332,15 +332,6 @@ Orderer: &OrdererDefaults
       MSPID: OrdererOrg4
       Identity: /path/to/identity
 
-    Kafka:
-        # Brokers: A list of Kafka brokers to which the orderer connects. Edit
-        # this list to identify the brokers of the ordering service.
-        # NOTE: Use IP:port notation.
-        Brokers:
-            - kafka0:9092
-            - kafka1:9092
-            - kafka2:9092
-
     # EtcdRaft defines configuration which must be set when the "etcdraft"
     # orderertype is chosen.
     EtcdRaft:


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Remove kafka from Makefile target docker-third-party as we no longer need kafka and zookeeper

#### Related issues

Issue: #3513 
Epic: #3511 
