### PR TITLE
Ordrer v3: stop using solo in orderer/common/server unit tests

### DIFF
--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -815,6 +815,7 @@ func initializeMultichannelRegistrar(
 		}
 	}
 
+	// TODO Orderer v3: remove once all tests stop using solo https://github.com/hyperledger/fabric/issues/3514
 	consenters["solo"] = solo.New()
 
 	registrar.Initialize(consenters)


### PR DESCRIPTION
Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: I00846aa130d5b9fb486ace5f84898a0b0affddf5

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description

Stop using solo in orderer/common/server unit tests

#### Related issues

Issue: #3514 
Epic: #3511 
