### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -8,8 +8,12 @@ on:
     types:
       - created
       - edited
+permissions: {}
 jobs:
   notify:
+    permissions:
+      issues: write # to comment on or close issue
+
     name: Invalid Issue Usage
     if: contains(github.event.comment.body, '/invalid') && github.event.issue.state == 'open'
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -6,8 +6,12 @@ on:
   issue_comment:
     types: [created]
 name: Automatically Trigger Azure Pipeline
+permissions: {}
 jobs:
   trigger:
+    permissions:
+      pull-requests: write # to comment on pull request
+
     name: TriggerAZP
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/ci-run')
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -15,6 +15,9 @@ env:
   PATH: /opt/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
   GO_VER: 1.18.2
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   basic-checks:
     name: Basic Checks


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.