### PR TITLE
Transfer leadership before submitting to raft library

### DIFF
--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -1436,8 +1436,14 @@ var _ = Describe("Chain", func() {
 
 			By("Configuring cluster to remove node")
 			Expect(c1.Configure(configEnv, 0)).To(Succeed())
+			select {
+			case <-c1.observe:
+			case <-time.After(LongEventualTimeout):
+				// abdicateleader might fail to transfer the leadership when the next candidate
+				// busy with applying committed entries
+				Fail("Expected a new leader to present")
+			}
 			Eventually(c2.support.WriteConfigBlockCallCount, LongEventualTimeout).Should(Equal(1))
-
 			Eventually(func() <-chan raft.SoftState {
 				c2.clock.Increment(interval)
 				return c2.observe
@@ -1463,7 +1469,7 @@ var _ = Describe("Chain", func() {
 			Expect(c2.fakeFields.fakeActiveNodes.SetArgsForCall(1)).To(Equal(float64(2)))
 		})
 
-		It("remove leader by reconfiguring cluster, but Halt before eviction", func() {
+		It("remove leader by reconfiguring cluster, check haltCallback is called", func() {
 			network.elect(1)
 
 			// trigger status dissemination
@@ -1476,9 +1482,12 @@ var _ = Describe("Chain", func() {
 
 			By("Configuring cluster to remove node")
 			Expect(c1.Configure(configEnv, 0)).To(Succeed())
-			Eventually(c2.support.WriteConfigBlockCallCount, LongEventualTimeout).Should(Equal(1))
 			c1.clock.WaitForNWatchersAndIncrement((ELECTION_TICK-1)*interval, 2)
-			c1.Halt()
+			Eventually(c2.support.WriteConfigBlockCallCount, LongEventualTimeout).Should(Equal(1))
+
+			By("Asserting the haltCallback is called when Halt is called before eviction")
+			c1.clock.Increment(interval)
+			Eventually(fakeHaltCallbacker.HaltCallbackCallCount).Should(Equal(1))
 
 			Eventually(func() <-chan raft.SoftState {
 				c2.clock.Increment(interval)
@@ -1489,19 +1498,6 @@ var _ = Describe("Chain", func() {
 			c2.cutter.CutNext = true
 			Expect(c2.Order(env, 0)).To(Succeed())
 			Eventually(c2.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(1))
-
-			By("Asserting the haltCallback is not called when Halt is called before eviction")
-			c1.clock.Increment(interval)
-			Eventually(fakeHaltCallbacker.HaltCallbackCallCount).Should(Equal(0))
-			By("Asserting the StatusReport responds correctly if the haltCallback is not called")
-			Eventually(
-				func() orderer_types.Status {
-					_, status := c1.StatusReport()
-					return status
-				},
-			).Should(Equal(orderer_types.StatusInactive))
-			cRel, _ := c1.StatusReport()
-			Expect(cRel).To(Equal(orderer_types.ConsensusRelationConsenter))
 
 			// active nodes metric hasn't changed because c.halt() wasn't called
 			Expect(c1.fakeFields.fakeActiveNodes.SetArgsForCall(1)).To(Equal(float64(2)))
@@ -1527,11 +1523,13 @@ var _ = Describe("Chain", func() {
 
 			By("Configuring cluster to remove node")
 			Expect(c1.Configure(configEnv, 0)).To(Succeed())
+			c1.clock.WaitForNWatchersAndIncrement(time.Duration(ELECTION_TICK)*interval, 2)
+			c2.Consensus(&orderer.ConsensusRequest{Payload: protoutil.MarshalOrPanic(&raftpb.Message{Type: raftpb.MsgTimeoutNow, To: 2})}, 0)
+			time.Sleep(time.Duration(ELECTION_TICK) * interval)
+			c1.clock.WaitForNWatchersAndIncrement(time.Duration(ELECTION_TICK)*interval, 2)
 			Eventually(c2.support.WriteConfigBlockCallCount, LongEventualTimeout).Should(Equal(1))
-			c2.clock.WaitForNWatchersAndIncrement(time.Duration(ELECTION_TICK)*interval, 2)
 			Eventually(c2.configurator.ConfigureCallCount, LongEventualTimeout).Should(Equal(2))
 
-			c1.clock.WaitForNWatchersAndIncrement(time.Duration(ELECTION_TICK)*interval, 2)
 			Eventually(c1.Chain.Errored, LongEventualTimeout).Should(BeClosed())
 			close(c1.stopped) // mark c1 stopped in network
 
@@ -1953,84 +1951,7 @@ var _ = Describe("Chain", func() {
 
 						By("sending config transaction")
 						Expect(c1.Configure(configEnv, 0)).To(Succeed())
-
-						Consistently(c1.observe).ShouldNot(Receive())
-						network.exec(func(c *chain) {
-							// wait for timeout timer to start
-							c.clock.WaitForNWatchersAndIncrement(time.Duration(ELECTION_TICK)*interval, 2)
-							Eventually(c.configurator.ConfigureCallCount, LongEventualTimeout).Should(Equal(2))
-						})
-					})
-				})
-
-				When("Follower is disconnected while leader cert is being rotated", func() {
-					It("still configures communication and transfer leader", func() {
-						metadata := &raftprotos.ConfigMetadata{Options: options}
-						for id, consenter := range consenters {
-							if id == 1 {
-								// remove second consenter
-								continue
-							}
-							metadata.Consenters = append(metadata.Consenters, consenter)
-						}
-
-						// add new consenter
-						newConsenter := &raftprotos.Consenter{
-							Host:          "localhost",
-							Port:          7050,
-							ServerTlsCert: serverTLSCert(tlsCA),
-							ClientTlsCert: clientTLSCert(tlsCA),
-						}
-						metadata.Consenters = append(metadata.Consenters, newConsenter)
-
-						value := map[string]*common.ConfigValue{
-							"ConsensusType": {
-								Version: 1,
-								Value: marshalOrPanic(&orderer.ConsensusType{
-									Metadata: marshalOrPanic(metadata),
-								}),
-							},
-						}
-
-						cnt := c1.rpc.SendConsensusCallCount()
-						network.disconnect(3)
-
-						// Trigger some heartbeats to be sent so that leader notices
-						// failed message delivery to 3, and mark it as Paused.
-						// This is to ensure leadership is transferred to 2.
-						Eventually(func() int {
-							c1.clock.Increment(interval)
-							return c1.rpc.SendConsensusCallCount()
-						}, LongEventualTimeout).Should(BeNumerically(">=", cnt+5))
-
-						By("creating new configuration with removed node and new one")
-						configEnv := newConfigEnv(channelID, common.HeaderType_CONFIG, newConfigUpdateEnv(channelID, nil, value))
-						c1.cutter.CutNext = true
-
-						By("sending config transaction")
-						Expect(c1.Configure(configEnv, 0)).To(Succeed())
-
-						Eventually(c1.observe, LongEventualTimeout).Should(Receive(StateEqual(2, raft.StateFollower)))
-						network.Lock()
-						network.leader = 2 // manually set network leader
-						network.Unlock()
-						network.disconnect(1)
-
-						network.exec(func(c *chain) {
-							Eventually(c.support.WriteConfigBlockCallCount, LongEventualTimeout).Should(Equal(1))
-							Eventually(c.configurator.ConfigureCallCount, LongEventualTimeout).Should(Equal(2))
-						}, 1, 2)
-
-						network.join(3, true)
-						Eventually(c3.support.WriteConfigBlockCallCount, LongEventualTimeout).Should(Equal(1))
-						Eventually(c3.configurator.ConfigureCallCount, LongEventualTimeout).Should(Equal(2))
-
-						By("Ordering normal transaction")
-						c2.cutter.CutNext = true
-						Expect(c3.Order(env, 0)).To(Succeed())
-						network.exec(func(c *chain) {
-							Eventually(c.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(2))
-						}, 2, 3)
+						c1.clock.WaitForNWatchersAndIncrement(time.Duration(ELECTION_TICK)*interval, 2)
 					})
 				})
 
@@ -2296,60 +2217,6 @@ var _ = Describe("Chain", func() {
 					Eventually(c4.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(2))
 				})
 
-				It("ensures that despite leader failure cluster continue to process configuration to remove the leader", func() {
-					// Scenario: Starting replica set of 3 nodes, electing nodeID = 1 to be the leader.
-					// Prepare config update transaction which removes leader (nodeID = 1), then leader
-					// fails right after it commits configuration block.
-
-					configEnv := newConfigEnv(channelID,
-						common.HeaderType_CONFIG,
-						newConfigUpdateEnv(channelID, nil, removeConsenterConfigValue(1))) // remove nodeID == 1
-
-					c1.cutter.CutNext = true
-
-					step1 := c1.getStepFunc()
-					count := c1.rpc.SendConsensusCallCount() // record current step call count
-					c1.setStepFunc(func(dest uint64, msg *orderer.ConsensusRequest) error {
-						// disconnect network after 4 MsgApp are sent by c1:
-						// - 2 MsgApp to c2 & c3 that replicate data to raft followers
-						// - 2 MsgApp to c2 & c3 that instructs followers to commit data
-						if c1.rpc.SendConsensusCallCount() == count+4 {
-							defer network.disconnect(1)
-						}
-
-						return step1(dest, msg)
-					})
-
-					By("sending config transaction")
-					err := c1.Configure(configEnv, 0)
-					Expect(err).NotTo(HaveOccurred())
-
-					network.exec(func(c *chain) {
-						Eventually(c.support.WriteConfigBlockCallCount, LongEventualTimeout).Should(Equal(1))
-					})
-
-					Eventually(c1.rpc.SendConsensusCallCount, LongEventualTimeout).Should(Equal(count + 6))
-					c1.setStepFunc(step1)
-
-					// elect node with higher index
-					i2, _ := c2.storage.LastIndex() // err is always nil
-					i3, _ := c3.storage.LastIndex()
-					candidate := uint64(2)
-					if i3 > i2 {
-						candidate = 3
-					}
-					network.chains[candidate].cutter.CutNext = true
-					network.elect(candidate)
-
-					By("submitting new transaction to follower")
-					err = c3.Order(env, 0)
-					Expect(err).NotTo(HaveOccurred())
-
-					// rest nodes are alive include a newly added, hence should write 2 blocks
-					Eventually(c2.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(2))
-					Eventually(c3.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(2))
-				})
-
 				It("removes leader from replica set", func() {
 					// Scenario: Starting replica set of 3 nodes, electing nodeID = 1 to be the leader.
 					// Prepare config update transaction which removes leader (nodeID = 1), this to
@@ -2368,18 +2235,13 @@ var _ = Describe("Chain", func() {
 					err := c1.Configure(configEnv, 0)
 					Expect(err).NotTo(HaveOccurred())
 
-					// every node has written config block to the OSN ledger
-					network.exec(
-						func(c *chain) {
-							Eventually(c.support.WriteConfigBlockCallCount, LongEventualTimeout).Should(Equal(1))
-							Eventually(c.fakeFields.fakeClusterSize.SetCallCount, LongEventualTimeout).Should(Equal(2))
-							Expect(c.fakeFields.fakeClusterSize.SetArgsForCall(1)).To(Equal(float64(2)))
-						})
+					time.Sleep(time.Duration(ELECTION_TICK) * interval)
+
+					Eventually(c2.support.WriteConfigBlockCallCount, LongEventualTimeout).Should(Equal(1))
+					Eventually(c2.fakeFields.fakeClusterSize.SetCallCount, LongEventualTimeout).Should(Equal(2))
 
 					// Assert c1 has exited
-					c1.clock.WaitForNWatchersAndIncrement(ELECTION_TICK*interval, 2)
 					Eventually(c1.Errored, LongEventualTimeout).Should(BeClosed())
-					close(c1.stopped)
 
 					var newLeader, remainingFollower *chain
 					var c2state raft.SoftState
@@ -2422,8 +2284,6 @@ var _ = Describe("Chain", func() {
 
 					Eventually(newLeader.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(2))
 					Eventually(remainingFollower.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(2))
-					// node 1 has been stopped should not write any block
-					Consistently(c1.support.WriteBlockCallCount).Should(Equal(1))
 
 					By("trying to submit to new node, expected to fail")
 					c1.cutter.CutNext = true

--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -1437,7 +1437,6 @@ var _ = Describe("Chain", func() {
 			By("Configuring cluster to remove node")
 			Expect(c1.Configure(configEnv, 0)).To(Succeed())
 			Eventually(c2.support.WriteConfigBlockCallCount, LongEventualTimeout).Should(Equal(1))
-			c1.clock.WaitForNWatchersAndIncrement(ELECTION_TICK*interval, 2)
 
 			Eventually(func() <-chan raft.SoftState {
 				c2.clock.Increment(interval)

--- a/orderer/consensus/etcdraft/storage.go
+++ b/orderer/consensus/etcdraft/storage.go
@@ -447,3 +447,8 @@ func (rs *RaftStorage) Close() error {
 
 	return nil
 }
+
+// Sync persists cached entries into disk
+func (rs *RaftStorage) Sync() error {
+	return rs.wal.Sync()
+}


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description

If transaction request rotates the current leader cert or removes it then transfer the leadership to another node before proposing the transaction for orderering. It would help to avoid the leadership transfer while committing the block

#### Additional details


#### Related issues
#3629 

Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>