### PR TITLE
Go version check - print warning for higher release

### DIFF
--- a/scripts/check_go_version.sh
+++ b/scripts/check_go_version.sh
@@ -33,6 +33,11 @@ patch () {
 # go release must be >= ci release
 [ "$(release "$GO_VERSION")" -ge "$(release "$CI_VERSION")" ] || fail
 
+# If go release is greater than the expected ci release, things may not work, print a warning.
+if [ "$(release "$GO_VERSION")" -gt "$(release "$CI_VERSION")" ]; then
+  echo "WARNING: Your Go release $GO_VERSION is greater than expected release $CI_VERSION, CI may or may not work depending on Go changes."
+fi
+
 # if releases are equal, patch must be >= ci patch
 if [ "$(release "$GO_VERSION")" -eq "$(release "$CI_VERSION")" ]; then
     [ "$(patch "$GO_VERSION")" -ge "$(patch "$CI_VERSION")" ] || fail


### PR DESCRIPTION
If Go release is higher than expected CI release, CI checks may not work, print a Warning. e.g. Current Fabric expects Go 1.18 and goimports will currently fail with Go 1.19.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>