### PR TITLE
Revert "Remove an unused config parameter from peer"

### DIFF
--- a/core/deliverservice/config.go
+++ b/core/deliverservice/config.go
@@ -142,6 +142,12 @@ func (c *DeliverServiceConfig) loadDeliverServiceConfig() {
 	}
 
 	c.KeepaliveOptions = comm.DefaultKeepaliveOptions
+	if viper.IsSet("peer.keepalive.deliveryClient.interval") {
+		c.KeepaliveOptions.ClientInterval = viper.GetDuration("peer.keepalive.deliveryClient.interval")
+	}
+	if viper.IsSet("peer.keepalive.deliveryClient.timeout") {
+		c.KeepaliveOptions.ClientTimeout = viper.GetDuration("peer.keepalive.deliveryClient.timeout")
+	}
 
 	c.SecOpts = comm.SecureOptions{
 		UseTLS:            viper.GetBool("peer.tls.enabled"),

--- a/core/deliverservice/config_test.go
+++ b/core/deliverservice/config_test.go
@@ -86,6 +86,8 @@ func TestGlobalConfig(t *testing.T) {
 	viper.Set("peer.deliveryclient.reConnectBackoffThreshold", "25s")
 	viper.Set("peer.deliveryclient.reconnectTotalTimeThreshold", "20s")
 	viper.Set("peer.deliveryclient.connTimeout", "10s")
+	viper.Set("peer.keepalive.deliveryClient.interval", "5s")
+	viper.Set("peer.keepalive.deliveryClient.timeout", "2s")
 
 	coreConfig := deliverservice.GlobalConfig()
 
@@ -96,8 +98,8 @@ func TestGlobalConfig(t *testing.T) {
 		ReconnectTotalTimeThreshold: 20 * time.Second,
 		ConnectionTimeout:           10 * time.Second,
 		KeepaliveOptions: comm.KeepaliveOptions{
-			ClientInterval:    time.Second * 60,
-			ClientTimeout:     time.Second * 20,
+			ClientInterval:    time.Second * 5,
+			ClientTimeout:     time.Second * 2,
 			ServerInterval:    time.Hour * 2,
 			ServerTimeout:     time.Second * 20,
 			ServerMinInterval: time.Minute,

--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -79,6 +79,10 @@ type Config struct {
 	// hardware threads on the machine.
 	ValidatorPoolSize int
 
+	// ----- Peer Delivery Client Keepalive -----
+	// DeliveryClient Keepalive settings for communication with ordering nodes.
+	DeliverClientKeepaliveOptions comm.KeepaliveOptions
+
 	// ----- Profile -----
 	// TODO: create separate sub-struct for Profile config.
 
@@ -265,6 +269,14 @@ func (c *Config) load() error {
 	c.ValidatorPoolSize = viper.GetInt("peer.validatorPoolSize")
 	if c.ValidatorPoolSize <= 0 {
 		c.ValidatorPoolSize = runtime.NumCPU()
+	}
+
+	c.DeliverClientKeepaliveOptions = comm.DefaultKeepaliveOptions
+	if viper.IsSet("peer.keepalive.deliveryClient.interval") {
+		c.DeliverClientKeepaliveOptions.ClientInterval = viper.GetDuration("peer.keepalive.deliveryClient.interval")
+	}
+	if viper.IsSet("peer.keepalive.deliveryClient.timeout") {
+		c.DeliverClientKeepaliveOptions.ClientTimeout = viper.GetDuration("peer.keepalive.deliveryClient.timeout")
 	}
 
 	c.GatewayOptions = gatewayconfig.GetOptions(viper.GetViper())

--- a/core/peer/config_test.go
+++ b/core/peer/config_test.go
@@ -342,6 +342,7 @@ func TestGlobalConfig(t *testing.T) {
 		ChaincodeListenAddress:                "0.0.0.0:7052",
 		ChaincodeAddress:                      "0.0.0.0:7052",
 		ValidatorPoolSize:                     1,
+		DeliverClientKeepaliveOptions:         comm.DefaultKeepaliveOptions,
 
 		VMEndpoint:           "unix:///var/run/docker.sock",
 		VMDockerTLSEnabled:   false,
@@ -397,11 +398,12 @@ func TestGlobalConfigDefault(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedConfig := &Config{
-		AuthenticationTimeWindow: 15 * time.Minute,
-		PeerAddress:              "localhost:8080",
-		ValidatorPoolSize:        runtime.NumCPU(),
-		VMNetworkMode:            "host",
-		GatewayOptions:           config.GetOptions(viper.GetViper()),
+		AuthenticationTimeWindow:      15 * time.Minute,
+		PeerAddress:                   "localhost:8080",
+		ValidatorPoolSize:             runtime.NumCPU(),
+		VMNetworkMode:                 "host",
+		DeliverClientKeepaliveOptions: comm.DefaultKeepaliveOptions,
+		GatewayOptions:                config.GetOptions(viper.GetViper()),
 	}
 
 	require.Equal(t, expectedConfig, coreConfig)
@@ -433,10 +435,11 @@ func TestPropagateEnvironment(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedConfig := &Config{
-		AuthenticationTimeWindow: 15 * time.Minute,
-		PeerAddress:              "localhost:8080",
-		ValidatorPoolSize:        runtime.NumCPU(),
-		VMNetworkMode:            "host",
+		AuthenticationTimeWindow:      15 * time.Minute,
+		PeerAddress:                   "localhost:8080",
+		ValidatorPoolSize:             runtime.NumCPU(),
+		VMNetworkMode:                 "host",
+		DeliverClientKeepaliveOptions: comm.DefaultKeepaliveOptions,
 		ExternalBuilders: []ExternalBuilder{
 			{
 				Name:                 "testName",

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -79,6 +79,16 @@ peer:
             # Timeout is the duration the client waits for a response from
             # peer nodes before closing the connection
             timeout: 20s
+        # DeliveryClient keepalive settings for communication with ordering
+        # nodes.
+        deliveryClient:
+            # Interval is the time between pings to ordering nodes.  This must
+            # greater than or equal to the minInterval specified by ordering
+            # nodes.
+            interval: 60s
+            # Timeout is the duration the client waits for a response from
+            # ordering nodes before closing the connection
+            timeout: 20s
 
 
     # Gossip related configuration


### PR DESCRIPTION
It turns out the delivery client keepalive settings were still being used.
We need to revert the change in main branch and release-2.5 branch.

This reverts commit ccfa8a4a78f51e81bed877c8336e3de6141d3774.
