### PR TITLE
Add delivery client logging

### DIFF
--- a/core/deliverservice/deliveryclient.go
+++ b/core/deliverservice/deliveryclient.go
@@ -116,7 +116,6 @@ func (d *deliverServiceImpl) StartDeliverForChannel(chainID string, ledgerInfo b
 		logger.Errorf(errMsg)
 		return errors.New(errMsg)
 	}
-	logger.Info("This peer will retrieve blocks from ordering service and disseminate to other peers in the organization for channel", chainID)
 
 	dc := &blocksprovider.Deliverer{
 		ChannelID:     chainID,
@@ -140,6 +139,12 @@ func (d *deliverServiceImpl) StartDeliverForChannel(chainID string, ledgerInfo b
 		BlockGossipDisabled: !d.conf.DeliverServiceConfig.BlockGossipEnabled,
 		InitialRetryDelay:   100 * time.Millisecond,
 		YieldLeadership:     !d.conf.IsStaticLeader,
+	}
+
+	if dc.BlockGossipDisabled {
+		logger.Infow("This peer will retrieve blocks from ordering service (will not disseminate them to other peers in the organization)", "channel", chainID)
+	} else {
+		logger.Infow("This peer will retrieve blocks from ordering service and disseminate to other peers in the organization", "channel", chainID)
 	}
 
 	if d.conf.DeliverServiceConfig.SecOpts.RequireClientCert {

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -358,13 +358,15 @@ peer:
         # of blocks committed in the past.
         blockGossipEnabled: true
         # It sets the total time the delivery service may spend in reconnection
-        # attempts until its retry logic gives up and returns an error
+        # attempts until its retry logic gives up and returns an error,
+        # ignored if peer is a static leader
         reconnectTotalTimeThreshold: 3600s
 
         # It sets the delivery service <-> ordering service node connection timeout
         connTimeout: 3s
 
-        # It sets the delivery service maximal delay between consecutive retries
+        # It sets the delivery service maximal delay between consecutive retries.
+        # Time between retries will have exponential backoff until hitting this threshold.
         reConnectBackoffThreshold: 3600s
 
         # A list of orderer endpoint addresses which should be overridden


### PR DESCRIPTION
Add logging for delivery client connections to ordering service, as well as disconnections.
This will help with troubleshooting when connections between peer and orderer are in doubt.

Also improve related log messages and config descriptions.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>