### PR TITLE
Add delivery client logging (backport #3692 release-2.2)

### DIFF
--- a/core/deliverservice/deliveryclient.go
+++ b/core/deliverservice/deliveryclient.go
@@ -118,7 +118,6 @@ func (d *deliverServiceImpl) StartDeliverForChannel(chainID string, ledgerInfo b
 		logger.Errorf(errMsg)
 		return errors.New(errMsg)
 	}
-	logger.Info("This peer will retrieve blocks from ordering service and disseminate to other peers in the organization for channel", chainID)
 
 	dc := &blocksprovider.Deliverer{
 		ChannelID:     chainID,
@@ -138,6 +137,12 @@ func (d *deliverServiceImpl) StartDeliverForChannel(chainID string, ledgerInfo b
 		BlockGossipDisabled: !d.conf.DeliverServiceConfig.BlockGossipEnabled,
 		InitialRetryDelay:   100 * time.Millisecond,
 		YieldLeadership:     !d.conf.IsStaticLeader,
+	}
+
+	if dc.BlockGossipDisabled {
+		logger.Infow("This peer will retrieve blocks from ordering service (will not disseminate them to other peers in the organization)", "channel", chainID)
+	} else {
+		logger.Infow("This peer will retrieve blocks from ordering service and disseminate to other peers in the organization", "channel", chainID)
 	}
 
 	if d.conf.DeliverGRPCClient.MutualTLSRequired() {

--- a/internal/pkg/peer/blocksprovider/blocksprovider.go
+++ b/internal/pkg/peer/blocksprovider/blocksprovider.go
@@ -114,9 +114,6 @@ const backoffExponentBase = 1.2
 // DeliverBlocks used to pull out blocks from the ordering service to
 // distributed them across peers
 func (d *Deliverer) DeliverBlocks() {
-	if d.BlockGossipDisabled {
-		d.Logger.Infof("Will pull blocks without forwarding them to remote peers via gossip")
-	}
 	failureCounter := 0
 	totalDuration := time.Duration(0)
 
@@ -135,18 +132,19 @@ func (d *Deliverer) DeliverBlocks() {
 		if failureCounter > 0 {
 			var sleepDuration time.Duration
 			if failureCounter-1 > maxFailures {
-				sleepDuration = d.MaxRetryDelay
+				sleepDuration = d.MaxRetryDelay // configured from peer.deliveryclient.reConnectBackoffThreshold
 			} else {
-				sleepDuration = time.Duration(math.Pow(1.2, float64(failureCounter-1))*100) * time.Millisecond
+				sleepDuration = time.Duration(math.Pow(backoffExponentBase, float64(failureCounter-1))*100) * time.Millisecond
 			}
 			totalDuration += sleepDuration
 			if totalDuration > d.MaxRetryDuration {
 				if d.YieldLeadership {
-					d.Logger.Warningf("attempted to retry block delivery for more than %v, giving up", d.MaxRetryDuration)
+					d.Logger.Warningf("attempted to retry block delivery for more than peer.deliveryclient.reconnectTotalTimeThreshold duration %v, giving up", d.MaxRetryDuration)
 					return
 				}
 				d.Logger.Warningf("peer is a static leader, ignoring peer.deliveryclient.reconnectTotalTimeThreshold")
 			}
+			d.Logger.Warningf("Disconnected from ordering service. Attempt to re-connect in %v", sleepDuration)
 			d.sleeper.Sleep(sleepDuration, d.DoneC)
 		}
 
@@ -170,6 +168,7 @@ func (d *Deliverer) DeliverBlocks() {
 		}
 
 		connLogger := d.Logger.With("orderer-address", endpoint.Address)
+		connLogger.Infow("Pulling next blocks from ordering service", "nextBlock", ledgerHeight)
 
 		recv := make(chan *orderer.DeliverResponse)
 		go func() {

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -349,13 +349,15 @@ peer:
         # of blocks committed in the past.
         blockGossipEnabled: true
         # It sets the total time the delivery service may spend in reconnection
-        # attempts until its retry logic gives up and returns an error
+        # attempts until its retry logic gives up and returns an error,
+        # ignored if peer is a static leader
         reconnectTotalTimeThreshold: 3600s
 
         # It sets the delivery service <-> ordering service node connection timeout
         connTimeout: 3s
 
-        # It sets the delivery service maximal delay between consecutive retries
+        # It sets the delivery service maximal delay between consecutive retries.
+        # Time between retries will have exponential backoff until hitting this threshold.
         reConnectBackoffThreshold: 3600s
 
         # A list of orderer endpoint addresses which should be overridden


### PR DESCRIPTION
Add logging for delivery client connections to ordering service, as well as disconnections.
This will help with troubleshooting when connections between peer and orderer are in doubt.

Also improve related log messages and config descriptions.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
