### PR TITLE
Use env variables to initialize the PKCS11 BCCSP

### DIFF
--- a/bccsp/factory/nopkcs11.go
+++ b/bccsp/factory/nopkcs11.go
@@ -10,7 +10,10 @@ SPDX-License-Identifier: Apache-2.0
 package factory
 
 import (
+	"reflect"
+
 	"github.com/hyperledger/fabric/bccsp"
+	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
 
@@ -80,4 +83,15 @@ func GetBCCSPFromOpts(config *FactoryOpts) (bccsp.BCCSP, error) {
 		return nil, errors.Wrapf(err, "Could not initialize BCCSP %s", f.Name())
 	}
 	return csp, nil
+}
+
+// StringToKeyIds returns a DecodeHookFunc that converts
+// strings to pkcs11.KeyIDMapping.
+func StringToKeyIds() mapstructure.DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		return data, nil
+	}
 }

--- a/internal/peer/common/common.go
+++ b/internal/peer/common/common.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"reflect"
 	"strings"
 	"time"
 
@@ -21,7 +20,6 @@ import (
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/bccsp"
 	"github.com/hyperledger/fabric/bccsp/factory"
-	"github.com/hyperledger/fabric/bccsp/pkcs11"
 	"github.com/hyperledger/fabric/common/channelconfig"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/core/config"
@@ -165,7 +163,7 @@ func InitBCCSPConfig(bccspConfig *factory.FactoryOpts) error {
 	opts := viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 		mapstructure.StringToTimeDurationHookFunc(),
 		mapstructure.StringToSliceHookFunc(","),
-		StringToKeyIds(),
+		factory.StringToKeyIds(),
 	))
 
 	if err := subv.Unmarshal(&bccspConfig, opts); err != nil {
@@ -206,38 +204,6 @@ func InitCrypto(mspMgrConfigDir, localMSPID, localMSPType string) error {
 	}
 
 	return nil
-}
-
-// StringToKeyIds returns a DecodeHookFunc that converts
-// strings to pkcs11.KeyIDMapping.
-func StringToKeyIds() mapstructure.DecodeHookFunc {
-	return func(
-		f reflect.Type,
-		t reflect.Type,
-		data interface{}) (interface{}, error) {
-		if f.Kind() != reflect.String {
-			return data, nil
-		}
-
-		if t != reflect.TypeOf(pkcs11.KeyIDMapping{}) {
-			return data, nil
-		}
-
-		res := pkcs11.KeyIDMapping{}
-		raw := data.(string)
-		if raw == "" {
-			return res, nil
-		}
-
-		rec := strings.Fields(raw)
-		if len(rec) != 2 {
-			return res, nil
-		}
-		res.SKI = rec[0]
-		res.ID = rec[1]
-
-		return res, nil
-	}
 }
 
 // SetBCCSPKeystorePath sets the file keystore path for the SW BCCSP provider

--- a/internal/peer/common/common.go
+++ b/internal/peer/common/common.go
@@ -38,6 +38,7 @@ import (
 const (
 	UndefinedParamValue = ""
 	CmdRoot             = "core"
+	CmdRootPeerBCCSP    = "CORE_PEER_BCCSP"
 )
 
 var (
@@ -162,7 +163,17 @@ func InitCrypto(mspMgrConfigDir, localMSPID, localMSPType string) error {
 	// Init the BCCSP
 	SetBCCSPKeystorePath()
 	bccspConfig := factory.GetDefaultOpts()
-	if err := viper.UnmarshalKey("peer.BCCSP", &bccspConfig); err != nil {
+
+	subv := viper.Sub("peer.BCCSP")
+	if subv == nil {
+		return errors.WithMessage(err, "could not get peer BCCSP configuration")
+	}
+	subv.SetEnvPrefix(CmdRootPeerBCCSP)
+	subv.AutomaticEnv()
+	subv.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	subv.SetTypeByDefaultValue(true)
+
+	if err = subv.Unmarshal(&bccspConfig); err != nil {
 		return errors.WithMessage(err, "could not decode peer BCCSP configuration")
 	}
 

--- a/internal/peer/common/commonpkcs11_test.go
+++ b/internal/peer/common/commonpkcs11_test.go
@@ -1,0 +1,79 @@
+//go:build pkcs11
+// +build pkcs11
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common_test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hyperledger/fabric/bccsp/factory"
+	"github.com/hyperledger/fabric/core/config/configtest"
+	"github.com/hyperledger/fabric/internal/peer/common"
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBCCSPPKCS11EnvVars(t *testing.T) {
+	t.Setenv("CORE_PEER_BCCSP_DEFAULT", "PKCS11")
+	t.Setenv("CORE_PEER_BCCSP_PKCS11_HASH", "SHA2")
+	t.Setenv("CORE_PEER_BCCSP_PKCS11_SECURITY", "384")
+	t.Setenv("CORE_PEER_BCCSP_PKCS11_LIBRARY", "lib.so")
+	t.Setenv("CORE_PEER_BCCSP_PKCS11_LABEL", "token")
+	t.Setenv("CORE_PEER_BCCSP_PKCS11_PIN", "password")
+	t.Setenv("CORE_PEER_BCCSP_PKCS11_SOFTWAREVERIFY", "1")
+	t.Setenv("CORE_PEER_BCCSP_PKCS11_IMMUTABLE", "true")
+	t.Setenv("CORE_PEER_BCCSP_PKCS11_ALTID", "01234567890abcdef")
+	t.Setenv("CORE_PEER_BCCSP_PKCS11_KEYIDS", "1 2,3 4")
+
+	viper.SetConfigName(common.CmdRoot)
+	viper.SetEnvPrefix(common.CmdRoot)
+	configtest.AddDevConfigPath(nil)
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+	if err := viper.ReadInConfig(); err != nil {
+		fmt.Printf("could not read config %s\n", err)
+		os.Exit(-1)
+	}
+
+	bccspConfig := factory.GetDefaultOpts()
+	subv := viper.Sub("peer.BCCSP")
+	require.NotNil(t, subv)
+
+	subv.SetEnvPrefix(common.CmdRootPeerBCCSP)
+	subv.AutomaticEnv()
+	subv.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	subv.SetTypeByDefaultValue(true)
+
+	opts := viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
+		mapstructure.StringToTimeDurationHookFunc(),
+		mapstructure.StringToSliceHookFunc(","),
+		common.StringToKeyIds(),
+	))
+
+	err := subv.Unmarshal(&bccspConfig, opts)
+	require.NoError(t, err)
+
+	require.Equal(t, "PKCS11", bccspConfig.Default)
+	require.Equal(t, "SHA2", bccspConfig.PKCS11.Hash)
+	require.Equal(t, 384, bccspConfig.PKCS11.Security)
+	require.Equal(t, "lib.so", bccspConfig.PKCS11.Library)
+	require.Equal(t, "token", bccspConfig.PKCS11.Label)
+	require.Equal(t, "password", bccspConfig.PKCS11.Pin)
+	require.Equal(t, true, bccspConfig.PKCS11.SoftwareVerify)
+	require.Equal(t, true, bccspConfig.PKCS11.Immutable)
+	require.Equal(t, "01234567890abcdef", bccspConfig.PKCS11.AltID)
+	require.Equal(t, 2, len(bccspConfig.PKCS11.KeyIDs))
+	require.Equal(t, "1", bccspConfig.PKCS11.KeyIDs[0].SKI)
+	require.Equal(t, "2", bccspConfig.PKCS11.KeyIDs[0].ID)
+	require.Equal(t, "3", bccspConfig.PKCS11.KeyIDs[1].SKI)
+	require.Equal(t, "4", bccspConfig.PKCS11.KeyIDs[1].ID)
+}

--- a/internal/peer/common/commonpkcs11_test.go
+++ b/internal/peer/common/commonpkcs11_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hyperledger/fabric/bccsp/factory"
 	"github.com/hyperledger/fabric/core/config/configtest"
 	"github.com/hyperledger/fabric/internal/peer/common"
-	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
@@ -45,21 +44,7 @@ func TestBCCSPPKCS11EnvVars(t *testing.T) {
 	}
 
 	bccspConfig := factory.GetDefaultOpts()
-	subv := viper.Sub("peer.BCCSP")
-	require.NotNil(t, subv)
-
-	subv.SetEnvPrefix(common.CmdRootPeerBCCSP)
-	subv.AutomaticEnv()
-	subv.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	subv.SetTypeByDefaultValue(true)
-
-	opts := viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
-		mapstructure.StringToTimeDurationHookFunc(),
-		mapstructure.StringToSliceHookFunc(","),
-		common.StringToKeyIds(),
-	))
-
-	err := subv.Unmarshal(&bccspConfig, opts)
+	err := common.InitBCCSPConfig(bccspConfig)
 	require.NoError(t, err)
 
 	require.Equal(t, "PKCS11", bccspConfig.Default)

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -344,6 +344,7 @@ peer:
             SoftwareVerify:
             Immutable:
             AltID:
+            KeyIds:
 
     # Path on the file system where peer will find MSP local configurations
     # The path may be relative to FABRIC_CFG_PATH or an absolute path.

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -341,6 +341,9 @@ peer:
             Pin:
             Hash:
             Security:
+            SoftwareVerify:
+            Immutable:
+            AltID:
 
     # Path on the file system where peer will find MSP local configurations
     # The path may be relative to FABRIC_CFG_PATH or an absolute path.

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -22,6 +22,7 @@ serial_packages=(
 pkcs11_packages=(
     "github.com/hyperledger/fabric/bccsp/factory"
     "github.com/hyperledger/fabric/bccsp/pkcs11"
+    "github.com/hyperledger/fabric/internal/peer/common"
 )
 
 # packages that are only tested when they (or their deps) change


### PR DESCRIPTION
The environment variables to configure the PKCS11 BCCSP are ignored for the peer node, such as CORE_PEER_BCCSP_PKCS11_LIBRARY. This change allows specifying the BCCSP Default and to configure all of the PKCS11 BCCSP settings using environment variables.

This is an alternative solution to the problem proposed in https://github.com/hyperledger/fabric/pull/3681

Signed-off-by: Fred Partanskiy <pfi79@mail.ru>