### PR TITLE
Use safe accessors for RWset protos

### DIFF
--- a/internal/pkg/gateway/event/chaincode.go
+++ b/internal/pkg/gateway/event/chaincode.go
@@ -19,15 +19,15 @@ func (event *ChaincodeEvent) Transaction() *Transaction {
 }
 
 func (event *ChaincodeEvent) ChaincodeID() string {
-	return event.message.ChaincodeId
+	return event.message.GetChaincodeId()
 }
 
 func (event *ChaincodeEvent) EventName() string {
-	return event.message.EventName
+	return event.message.GetEventName()
 }
 
 func (event *ChaincodeEvent) Payload() []byte {
-	return event.message.Payload
+	return event.message.GetPayload()
 }
 
 func (event *ChaincodeEvent) ProtoMessage() *peer.ChaincodeEvent {


### PR DESCRIPTION
Use the Getter functions rather than direct access to fields in the proto structures.

Backport of https://github.com/hyperledger/fabric/pull/3686 with modified unit test for different proto behaviour.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
