### PR TITLE
Orderer v3: remove solo from integration (4)

### DIFF
--- a/integration/raft/migration_test.go
+++ b/integration/raft/migration_test.go
@@ -33,7 +33,7 @@ import (
 	ginkgomon "github.com/tedsuo/ifrit/ginkgomon_v2"
 )
 
-var _ = Describe("Solo2RaftMigration", func() {
+var _ = Describe("ConsensusTypeMigration", func() {
 	var (
 		testDir string
 		client  *docker.Client
@@ -42,12 +42,13 @@ var _ = Describe("Solo2RaftMigration", func() {
 		process                ifrit.Process
 		o1Proc, o2Proc, o3Proc ifrit.Process
 
-		o1Runner, o2Runner *ginkgomon.Runner
+		o1Runner *ginkgomon.Runner
+		o2Runner *ginkgomon.Runner
 	)
 
 	BeforeEach(func() {
 		var err error
-		testDir, err = ioutil.TempDir("", "solo2raft-migration")
+		testDir, err = ioutil.TempDir("", "consensus-type-migration")
 		Expect(err).NotTo(HaveOccurred())
 
 		client, err = docker.NewClientFromEnv()
@@ -74,54 +75,57 @@ var _ = Describe("Solo2RaftMigration", func() {
 		_ = os.RemoveAll(testDir)
 	})
 
-	// These tests execute the migration config updates on a solo based system, restart the orderer onto a Raft-based
-	// system, and verifies that the newly restarted orderer (single node) cluster performs as expected.
-	Describe("Solo to Raft migration", func() {
+	// These tests execute the migration config updates on an etcdraft based system, but do not restart the orderer
+	// to a "future-type" consensus-type that currently does not exist. However, these tests try to maintain as much as
+	// possible the testing infrastructure for consensus-type migration that existed when "solo" and "kafka" were still
+	// supported. When a future type that can be migrated to from raft becomes available, some test-cases within this
+	// suite will need to be completed and revised.
+	Describe("Raft to future-type migration", func() {
 		var (
-			orderer                                  *nwo.Orderer
-			peer                                     *nwo.Peer
-			syschannel, channel1, channel2, channel3 string
-			raftMetadata                             []byte
+			orderer                        *nwo.Orderer
+			peer                           *nwo.Peer
+			syschannel, channel1, channel2 string
 		)
 
 		BeforeEach(func() {
-			network = nwo.New(solo2RaftMultiChannel(), testDir, client, StartPort(), components)
+			network = nwo.New(raftMultiChannel(), testDir, client, StartPort(), components)
 			network.GenerateConfigTree()
 			network.Bootstrap()
 
 			orderer = network.Orderer("orderer")
 			peer = network.Peer("Org1", "peer0")
 
+			syschannel = network.SystemChannel.Name
+			channel1 = "testchannel1"
+			channel2 = "testchannel2"
+
 			o1Runner = network.OrdererRunner(orderer)
 
 			o1Proc = ifrit.Invoke(o1Runner)
 			Eventually(o1Proc.Ready(), network.EventuallyTimeout).Should(BeClosed())
-
-			raftMetadata = prepareRaftMetadata(network)
-
-			syschannel = network.SystemChannel.Name
-			channel1 = "testchannel1"
-			channel2 = "testchannel2"
-			channel3 = "testchannel3"
+			Eventually(o1Runner.Err(), network.EventuallyTimeout, time.Second).Should(gbytes.Say(
+				fmt.Sprintf("Raft leader changed: 0 -> 1 channel=%s node=1", syschannel)))
 
 			By("Create & join first channel, deploy and invoke chaincode")
 			network.CreateChannel(channel1, orderer, peer)
+			Eventually(o1Runner.Err(), network.EventuallyTimeout, time.Second).Should(gbytes.Say(
+				fmt.Sprintf("Raft leader changed: 0 -> 1 channel=%s node=1", channel1)))
 		})
 
-		// This test executes the "green path" migration config updates on solo based system with a system channel
+		// This test executes the "green path" migration config updates on an etcdraft based system with a system channel
 		// and a standard channel, and verifies that these config updates have the desired effect.
 		//
 		// The green path is entering maintenance mode, and then changing the consensus type.
 		// In maintenance mode we check that channel creation is blocked and that normal transactions are blocked.
 		//
 		// We also check that after entering maintenance mode, we can exit it without making any changes - the "abort path".
-		It("executes solo2raft green path", func() {
+		It("executes raft2future green path", func() {
 			//=== The abort path ======================================================================================
 			//=== Step 1: Config update on system channel, MAINTENANCE ===
 			By("1) Config update on system channel, State=MAINTENANCE, enter maintenance-mode")
 			config, updatedConfig := prepareTransition(network, peer, orderer, syschannel,
-				"solo", protosorderer.ConsensusType_STATE_NORMAL,
-				"solo", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
+				"etcdraft", protosorderer.ConsensusType_STATE_NORMAL,
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 			nwo.UpdateOrdererConfig(network, orderer, syschannel, config, updatedConfig, peer, orderer)
 
 			By("1) Verify: system channel1 config changed")
@@ -129,7 +133,7 @@ var _ = Describe("Solo2RaftMigration", func() {
 			Expect(sysStartBlockNum).ToNot(Equal(0))
 			config = nwo.GetConfig(network, peer, orderer, syschannel)
 			consensusTypeValue := extractOrdererConsensusType(config)
-			validateConsensusTypeValue(consensusTypeValue, "solo", protosorderer.ConsensusType_STATE_MAINTENANCE)
+			validateConsensusTypeValue(consensusTypeValue, "etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE)
 
 			By("1) Verify: new channels cannot be created")
 			exitCode := network.CreateChannelExitCode(channel2, orderer, peer)
@@ -138,8 +142,8 @@ var _ = Describe("Solo2RaftMigration", func() {
 			//=== Step 2: Config update on standard channel, MAINTENANCE ===
 			By("2) Config update on standard channel, State=MAINTENANCE, enter maintenance-mode")
 			config, updatedConfig = prepareTransition(network, peer, orderer, channel1,
-				"solo", protosorderer.ConsensusType_STATE_NORMAL,
-				"solo", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
+				"etcdraft", protosorderer.ConsensusType_STATE_NORMAL,
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 			nwo.UpdateOrdererConfig(network, orderer, channel1, config, updatedConfig, peer, orderer)
 
 			By("2) Verify: standard channel config changed")
@@ -147,7 +151,7 @@ var _ = Describe("Solo2RaftMigration", func() {
 			Expect(std1EntryBlockNum).ToNot(Equal(0))
 			config = nwo.GetConfig(network, peer, orderer, channel1)
 			consensusTypeValue = extractOrdererConsensusType(config)
-			validateConsensusTypeValue(consensusTypeValue, "solo", protosorderer.ConsensusType_STATE_MAINTENANCE)
+			validateConsensusTypeValue(consensusTypeValue, "etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE)
 
 			By("2) Verify: Normal TX's on standard channel are blocked")
 			assertTxFailed(network, orderer, channel1)
@@ -160,8 +164,8 @@ var _ = Describe("Solo2RaftMigration", func() {
 			//=== Step 3: config update on system channel, State=NORMAL, abort ===
 			By("3) Config update on system channel, State=NORMAL, exit maintenance-mode - abort path")
 			config, updatedConfig = prepareTransition(network, peer, orderer, syschannel,
-				"solo", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"solo", nil, protosorderer.ConsensusType_STATE_NORMAL)
+				"etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE,
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_NORMAL)
 			nwo.UpdateOrdererConfig(network, orderer, syschannel, config, updatedConfig, peer, orderer)
 
 			By("3) Verify: system channel config changed")
@@ -180,8 +184,8 @@ var _ = Describe("Solo2RaftMigration", func() {
 			//=== Step 4: config update on standard channel, State=NORMAL, abort ===
 			By("4) Config update on standard channel, State=NORMAL, exit maintenance-mode - abort path")
 			config, updatedConfig = prepareTransition(network, peer, orderer, channel1,
-				"solo", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"solo", nil, protosorderer.ConsensusType_STATE_NORMAL)
+				"etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE,
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_NORMAL)
 			nwo.UpdateOrdererConfig(network, orderer, channel1, config, updatedConfig, peer, orderer)
 
 			By("4) Verify: standard channel config changed")
@@ -199,8 +203,8 @@ var _ = Describe("Solo2RaftMigration", func() {
 			//=== Step 5: Config update on system channel, MAINTENANCE, again ===
 			By("5) Config update on system channel, State=MAINTENANCE, enter maintenance-mode again")
 			config, updatedConfig = prepareTransition(network, peer, orderer, syschannel,
-				"solo", protosorderer.ConsensusType_STATE_NORMAL,
-				"solo", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
+				"etcdraft", protosorderer.ConsensusType_STATE_NORMAL,
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 			nwo.UpdateOrdererConfig(network, orderer, syschannel, config, updatedConfig, peer, orderer)
 
 			By("5) Verify: system channel config changed")
@@ -208,13 +212,13 @@ var _ = Describe("Solo2RaftMigration", func() {
 			Expect(sysStartBlockNum).ToNot(Equal(0))
 			config = nwo.GetConfig(network, peer, orderer, syschannel)
 			consensusTypeValue = extractOrdererConsensusType(config)
-			validateConsensusTypeValue(consensusTypeValue, "solo", protosorderer.ConsensusType_STATE_MAINTENANCE)
+			validateConsensusTypeValue(consensusTypeValue, "etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE)
 
 			//=== Step 6: Config update on standard channel1, MAINTENANCE, again ===
 			By("6) Config update on standard channel1, State=MAINTENANCE, enter maintenance-mode again")
 			config, updatedConfig = prepareTransition(network, peer, orderer, channel1,
-				"solo", protosorderer.ConsensusType_STATE_NORMAL,
-				"solo", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
+				"etcdraft", protosorderer.ConsensusType_STATE_NORMAL,
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 			nwo.UpdateOrdererConfig(network, orderer, channel1, config, updatedConfig, peer, orderer)
 
 			By("6) Verify: standard channel config changed")
@@ -223,7 +227,7 @@ var _ = Describe("Solo2RaftMigration", func() {
 
 			config = nwo.GetConfig(network, peer, orderer, channel1)
 			consensusTypeValue = extractOrdererConsensusType(config)
-			validateConsensusTypeValue(consensusTypeValue, "solo", protosorderer.ConsensusType_STATE_MAINTENANCE)
+			validateConsensusTypeValue(consensusTypeValue, "etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE)
 
 			By("6) Verify: delivery request from peer is blocked")
 			err = checkPeerDeliverRequest(orderer, peer, network, channel1)
@@ -235,8 +239,8 @@ var _ = Describe("Solo2RaftMigration", func() {
 			//=== Step 7: Config update on standard channel2, MAINTENANCE ===
 			By("7) Config update on standard channel2, State=MAINTENANCE, enter maintenance-mode again")
 			config, updatedConfig = prepareTransition(network, peer, orderer, channel2,
-				"solo", protosorderer.ConsensusType_STATE_NORMAL,
-				"solo", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
+				"etcdraft", protosorderer.ConsensusType_STATE_NORMAL,
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 			nwo.UpdateOrdererConfig(network, orderer, channel2, config, updatedConfig, peer, orderer)
 
 			By("7) Verify: standard channel config changed")
@@ -245,7 +249,7 @@ var _ = Describe("Solo2RaftMigration", func() {
 
 			config = nwo.GetConfig(network, peer, orderer, channel2)
 			consensusTypeValue = extractOrdererConsensusType(config)
-			validateConsensusTypeValue(consensusTypeValue, "solo", protosorderer.ConsensusType_STATE_MAINTENANCE)
+			validateConsensusTypeValue(consensusTypeValue, "etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE)
 
 			By("7) Verify: delivery request from peer is blocked")
 			err = checkPeerDeliverRequest(orderer, peer, network, channel2)
@@ -254,97 +258,57 @@ var _ = Describe("Solo2RaftMigration", func() {
 			By("7) Verify: Normal TX's on standard channel are blocked")
 			assertTxFailed(network, orderer, channel2)
 
-			//=== Step 8: config update on system channel, State=MAINTENANCE, type=etcdraft ===
-			By("8) Config update on system channel, State=MAINTENANCE, type=etcdraft")
-			config, updatedConfig = prepareTransition(network, peer, orderer, syschannel,
-				"solo", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_MAINTENANCE)
-			nwo.UpdateOrdererConfig(network, orderer, syschannel, config, updatedConfig, peer, orderer)
+			// Note:
+			// The following testing steps should be completed once we have a consensus-type ("future-type") that can be
+			// migrated to from etcdraft.
 
-			By("8) Verify: system channel config changed")
-			sysBlockNum = nwo.CurrentConfigBlockNumber(network, peer, orderer, syschannel)
-			Expect(sysBlockNum).To(Equal(sysStartBlockNum + 1))
+			//=== Step 8: config update on system channel, State=MAINTENANCE, type=future-type ===
 
-			By("8) Verify: new channels cannot be created")
-			exitCode = network.CreateChannelExitCode(channel3, orderer, peer)
-			Expect(exitCode).ToNot(Equal(0))
+			//=== Step 9: config update on standard channel1, State=MAINTENANCE, type=future-type ===
 
-			//=== Step 9: config update on standard channel1, State=MAINTENANCE, type=etcdraft ===
-			By("9) Config update on standard channel1, State=MAINTENANCE, type=etcdraft")
-			config, updatedConfig = prepareTransition(network, peer, orderer, channel1,
-				"solo", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_MAINTENANCE)
-			nwo.UpdateOrdererConfig(network, orderer, channel1, config, updatedConfig, peer, orderer)
-
-			By("9) Verify: standard channel config changed")
-			std1BlockNum = nwo.CurrentConfigBlockNumber(network, peer, orderer, channel1)
-			Expect(std1BlockNum).To(Equal(std1EntryBlockNum + 1))
-
-			By("9) Verify: delivery request from peer is blocked")
-			err = checkPeerDeliverRequest(orderer, peer, network, channel1)
-			Expect(err).To(MatchError(errors.New("FORBIDDEN")))
-
-			By("9) Verify: Normal TX's on standard channel are blocked")
-			assertTxFailed(network, orderer, channel1)
-
-			//=== Step 10: config update on standard channel2, State=MAINTENANCE, type=etcdraft ===
-			By("10) Config update on standard channel2, State=MAINTENANCE, type=etcdraft")
-			config, updatedConfig = prepareTransition(network, peer, orderer, channel2,
-				"solo", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_MAINTENANCE)
-			nwo.UpdateOrdererConfig(network, orderer, channel2, config, updatedConfig, peer, orderer)
-
-			By("10) Verify: standard channel config changed")
-			std2BlockNum := nwo.CurrentConfigBlockNumber(network, peer, orderer, channel2)
-			Expect(std2BlockNum).To(Equal(std2EntryBlockNum + 1))
-
-			By("10) Verify: delivery request from peer is blocked")
-			err = checkPeerDeliverRequest(orderer, peer, network, channel2)
-			Expect(err).To(MatchError(errors.New("FORBIDDEN")))
-
-			By("10) Verify: Normal TX's on standard channel are blocked")
-			assertTxFailed(network, orderer, channel2)
+			//=== Step 10: config update on standard channel2, State=MAINTENANCE, type=future-type ===
 		})
 
 		// This test executes the migration flow and checks that forbidden transitions are rejected.
 		// These transitions are enforced by the maintenance filter:
 		// - Entry to & exit from maintenance mode can only change ConsensusType.State.
 		// - In maintenance mode one can only change ConsensusType.Type & ConsensusType.Metadata.
-		// - ConsensusType.Type can only change from "solo" to "etcdraft", and only in maintenance mode.
-		It("executes solo2raft forbidden transitions", func() {
+		// - ConsensusType.Type can only change from "etcdraft" to "future-type" (to be replaced by future consensus
+		//   protocol), and only in maintenance mode.
+		It("executes raft2future forbidden transitions", func() {
 			//=== Step 1: ===
 			By("1) Config update on system channel, changing both ConsensusType State & Type is forbidden")
 			assertTransitionFailed(network, peer, orderer, syschannel,
-				"solo", protosorderer.ConsensusType_STATE_NORMAL,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_MAINTENANCE)
+				"etcdraft", protosorderer.ConsensusType_STATE_NORMAL,
+				"testing-only", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 
 			//=== Step 2: ===
 			By("2) Config update on standard channel, changing both ConsensusType State & Type is forbidden")
 			assertTransitionFailed(network, peer, orderer, channel1,
-				"solo", protosorderer.ConsensusType_STATE_NORMAL,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_MAINTENANCE)
+				"etcdraft", protosorderer.ConsensusType_STATE_NORMAL,
+				"testing-only", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 
 			//=== Step 3: ===
 			By("3) Config update on system channel, changing both ConsensusType State & some other value is forbidden")
 			config, updatedConfig := prepareTransition(network, peer, orderer, syschannel,
-				"solo", protosorderer.ConsensusType_STATE_NORMAL,
-				"solo", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
+				"etcdraft", protosorderer.ConsensusType_STATE_NORMAL,
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 			updateConfigWithBatchTimeout(updatedConfig)
 			updateOrdererConfigFailed(network, orderer, syschannel, config, updatedConfig, peer, orderer)
 
 			//=== Step 4: ===
 			By("4) Config update on standard channel, both ConsensusType State & some other value is forbidden")
 			config, updatedConfig = prepareTransition(network, peer, orderer, channel1,
-				"solo", protosorderer.ConsensusType_STATE_NORMAL,
-				"solo", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
+				"etcdraft", protosorderer.ConsensusType_STATE_NORMAL,
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 			updateConfigWithBatchTimeout(updatedConfig)
 			updateOrdererConfigFailed(network, orderer, channel1, config, updatedConfig, peer, orderer)
 
 			//=== Step 5: ===
 			By("5) Config update on system channel, State=MAINTENANCE, enter maintenance-mode")
 			config, updatedConfig = prepareTransition(network, peer, orderer, syschannel,
-				"solo", protosorderer.ConsensusType_STATE_NORMAL,
-				"solo", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
+				"etcdraft", protosorderer.ConsensusType_STATE_NORMAL,
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 			nwo.UpdateOrdererConfig(network, orderer, syschannel, config, updatedConfig, peer, orderer)
 
 			By("5) Verify: system channel config changed")
@@ -352,13 +316,13 @@ var _ = Describe("Solo2RaftMigration", func() {
 			Expect(sysStartBlockNum).ToNot(Equal(0))
 			config = nwo.GetConfig(network, peer, orderer, syschannel)
 			consensusTypeValue := extractOrdererConsensusType(config)
-			validateConsensusTypeValue(consensusTypeValue, "solo", protosorderer.ConsensusType_STATE_MAINTENANCE)
+			validateConsensusTypeValue(consensusTypeValue, "etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE)
 
 			//=== Step 6: ===
 			By("6) Config update on standard channel, State=MAINTENANCE, enter maintenance-mode")
 			config, updatedConfig = prepareTransition(network, peer, orderer, channel1,
-				"solo", protosorderer.ConsensusType_STATE_NORMAL,
-				"solo", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
+				"etcdraft", protosorderer.ConsensusType_STATE_NORMAL,
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 			nwo.UpdateOrdererConfig(network, orderer, channel1, config, updatedConfig, peer, orderer)
 
 			By("6) Verify: standard channel config changed")
@@ -366,61 +330,41 @@ var _ = Describe("Solo2RaftMigration", func() {
 			Expect(std1StartBlockNum).ToNot(Equal(0))
 			config = nwo.GetConfig(network, peer, orderer, channel1)
 			consensusTypeValue = extractOrdererConsensusType(config)
-			validateConsensusTypeValue(consensusTypeValue, "solo", protosorderer.ConsensusType_STATE_MAINTENANCE)
+			validateConsensusTypeValue(consensusTypeValue, "etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE)
 
 			//=== Step 7: ===
 			By("7) Config update on system channel, change ConsensusType.Type to unsupported type, forbidden")
 			assertTransitionFailed(network, peer, orderer, syschannel,
-				"solo", protosorderer.ConsensusType_STATE_MAINTENANCE,
+				"etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE,
 				"melville", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 
 			//=== Step 8: ===
 			By("8) Config update on standard channel, change ConsensusType.Type to unsupported type, forbidden")
 			assertTransitionFailed(network, peer, orderer, channel1,
-				"solo", protosorderer.ConsensusType_STATE_MAINTENANCE,
+				"etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE,
 				"hesse", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 
 			//=== Step 9: ===
 			By("9) Config update on system channel, change ConsensusType.Type and State, forbidden")
 			assertTransitionFailed(network, peer, orderer, syschannel,
-				"solo", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_NORMAL)
+				"etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE,
+				"testing-only", nil, protosorderer.ConsensusType_STATE_NORMAL)
 
 			//=== Step 10: ===
 			By("10) Config update on standard channel, change ConsensusType.Type and State, forbidden")
 			assertTransitionFailed(network, peer, orderer, channel1,
-				"solo", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_NORMAL)
+				"etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE,
+				"testing-only", nil, protosorderer.ConsensusType_STATE_NORMAL)
 
-			//=== Step 11: ===
-			By("11) Config update on system channel, changing both ConsensusType.Type and other value is permitted")
-			config, updatedConfig = prepareTransition(network, peer, orderer, syschannel,
-				"solo", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_MAINTENANCE)
-			updateConfigWithBatchTimeout(updatedConfig)
-			nwo.UpdateOrdererConfig(network, orderer, syschannel, config, updatedConfig, peer, orderer)
+			// Note:
+			// The following testing steps should be completed once we have a consensus-type ("future-type" that can be
+			// migrated to from etcdraft.
 
-			By("11) Verify: system channel config changed")
-			sysBlockNum := nwo.CurrentConfigBlockNumber(network, peer, orderer, syschannel)
-			Expect(sysBlockNum).To(Equal(sysStartBlockNum + 1))
-			config = nwo.GetConfig(network, peer, orderer, syschannel)
-			consensusTypeValue = extractOrdererConsensusType(config)
-			validateConsensusTypeValue(consensusTypeValue, "etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE)
+			//=== Step 11: Config update on system channel, changing both ConsensusType.Type and other value is permitted ===
+			// Change consensus type and batch-timeout
 
-			//=== Step 12: ===
-			By("12) Config update on standard channel, changing both ConsensusType.Type and other value is permitted")
-			config, updatedConfig = prepareTransition(network, peer, orderer, channel1,
-				"solo", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_MAINTENANCE)
-			updateConfigWithBatchTimeout(updatedConfig)
-			nwo.UpdateOrdererConfig(network, orderer, channel1, config, updatedConfig, peer, orderer)
-
-			By("12) Verify: standard channel config changed")
-			std1BlockNum := nwo.CurrentConfigBlockNumber(network, peer, orderer, channel1)
-			Expect(std1BlockNum).To(Equal(std1StartBlockNum + 1))
-			config = nwo.GetConfig(network, peer, orderer, channel1)
-			consensusTypeValue = extractOrdererConsensusType(config)
-			validateConsensusTypeValue(consensusTypeValue, "etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE)
+			//=== Step 12: Config update on standard channel, changing both ConsensusType.Type and other value is permitted ===
+			// Change consensus type and batch-timeout
 
 			//=== Step 13: ===
 			By("13) Config update on system channel, changing value other than ConsensusType.Type is permitted")
@@ -432,8 +376,8 @@ var _ = Describe("Solo2RaftMigration", func() {
 			nwo.UpdateOrdererConfig(network, orderer, syschannel, config, updatedConfig, peer, orderer)
 
 			By("13) Verify: system channel config changed")
-			sysBlockNum = nwo.CurrentConfigBlockNumber(network, peer, orderer, syschannel)
-			Expect(sysBlockNum).To(Equal(sysStartBlockNum + 2))
+			sysBlockNum := nwo.CurrentConfigBlockNumber(network, peer, orderer, syschannel)
+			Expect(sysBlockNum).To(Equal(sysStartBlockNum + 1))
 
 			//=== Step 14: ===
 			By("14) Config update on standard channel, changing value other than ConsensusType.Type is permitted")
@@ -445,14 +389,14 @@ var _ = Describe("Solo2RaftMigration", func() {
 			nwo.UpdateOrdererConfig(network, orderer, channel1, config, updatedConfig, peer, orderer)
 
 			By("14) Verify: standard channel config changed")
-			std1BlockNum = nwo.CurrentConfigBlockNumber(network, peer, orderer, channel1)
-			Expect(std1BlockNum).To(Equal(std1StartBlockNum + 2))
+			std1BlockNum := nwo.CurrentConfigBlockNumber(network, peer, orderer, channel1)
+			Expect(std1BlockNum).To(Equal(std1StartBlockNum + 1))
 
 			//=== Step 15: ===
 			By("15) Config update on system channel, changing both ConsensusType State & some other value is forbidden")
 			config, updatedConfig = prepareTransition(network, peer, orderer, syschannel,
 				"etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_NORMAL)
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_NORMAL)
 			updateConfigWithBatchTimeout(updatedConfig)
 			updateOrdererConfigFailed(network, orderer, syschannel, config, updatedConfig, peer, orderer)
 
@@ -460,17 +404,21 @@ var _ = Describe("Solo2RaftMigration", func() {
 			By("16) Config update on standard channel, both ConsensusType State & some other value is forbidden")
 			config, updatedConfig = prepareTransition(network, peer, orderer, channel1,
 				"etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_NORMAL)
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_NORMAL)
 			updateConfigWithBatchTimeout(updatedConfig)
 			updateOrdererConfigFailed(network, orderer, channel1, config, updatedConfig, peer, orderer)
 		})
 
-		It("executes bootstrap to raft - single node", func() {
+		// Note:
+		// Instead of booting to a future-type which does not exist yet, we change some other config value in
+		// maintenance mode, reboot, and exit maintenance mode. Once we have a future consensus-type that cab be
+		// migrated to from raft is available, this test should be completed.
+		It("executes bootstrap to future-type - single node", func() {
 			//=== Step 1: Config update on system channel, MAINTENANCE ===
 			By("1) Config update on system channel, State=MAINTENANCE")
 			config, updatedConfig := prepareTransition(network, peer, orderer, syschannel,
-				"solo", protosorderer.ConsensusType_STATE_NORMAL,
-				"solo", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
+				"etcdraft", protosorderer.ConsensusType_STATE_NORMAL,
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 			nwo.UpdateOrdererConfig(network, orderer, syschannel, config, updatedConfig, peer, orderer)
 
 			By("1) Verify: system channel config changed")
@@ -479,7 +427,7 @@ var _ = Describe("Solo2RaftMigration", func() {
 
 			config = nwo.GetConfig(network, peer, orderer, syschannel)
 			consensusTypeValue := extractOrdererConsensusType(config)
-			validateConsensusTypeValue(consensusTypeValue, "solo", protosorderer.ConsensusType_STATE_MAINTENANCE)
+			validateConsensusTypeValue(consensusTypeValue, "etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE)
 
 			By("1) Verify: new channels cannot be created")
 			exitCode := network.CreateChannelExitCode(channel2, orderer, peer)
@@ -488,8 +436,8 @@ var _ = Describe("Solo2RaftMigration", func() {
 			//=== Step 2: Config update on standard channel, MAINTENANCE ===
 			By("2) Config update on standard channel, State=MAINTENANCE")
 			config, updatedConfig = prepareTransition(network, peer, orderer, channel1,
-				"solo", protosorderer.ConsensusType_STATE_NORMAL,
-				"solo", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
+				"etcdraft", protosorderer.ConsensusType_STATE_NORMAL,
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_MAINTENANCE)
 			nwo.UpdateOrdererConfig(network, orderer, channel1, config, updatedConfig, peer, orderer)
 
 			By("2) Verify: standard channel config changed")
@@ -498,7 +446,7 @@ var _ = Describe("Solo2RaftMigration", func() {
 
 			config = nwo.GetConfig(network, peer, orderer, channel1)
 			consensusTypeValue = extractOrdererConsensusType(config)
-			validateConsensusTypeValue(consensusTypeValue, "solo", protosorderer.ConsensusType_STATE_MAINTENANCE)
+			validateConsensusTypeValue(consensusTypeValue, "etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE)
 
 			By("2) Verify: Normal TX's on standard channel are blocked")
 			assertTxFailed(network, orderer, channel1)
@@ -508,22 +456,26 @@ var _ = Describe("Solo2RaftMigration", func() {
 			err := checkPeerDeliverRequest(orderer, peer, network, channel1)
 			Expect(err).To(MatchError(errors.New("FORBIDDEN")))
 
-			//=== Step 3: config update on system channel, State=MAINTENANCE, type=etcdraft ===
-			By("3) Config update on system channel, State=MAINTENANCE, type=etcdraft")
-			config, updatedConfig = prepareTransition(network, peer, orderer, syschannel,
-				"solo", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_MAINTENANCE)
+			//=== Step 3: config update on system channel, State=MAINTENANCE, type=etcdraft, (in-lieu of future-type) other value changed ===
+			By("3) Config update on system channel, State=MAINTENANCE, type=etcdraft, (in-lieu of future-type) other value changed")
+			config = nwo.GetConfig(network, peer, orderer, syschannel)
+			consensusTypeValue = extractOrdererConsensusType(config)
+			validateConsensusTypeValue(consensusTypeValue, "etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE)
+			updatedConfig = proto.Clone(config).(*common.Config)
+			updateConfigWithBatchTimeout(updatedConfig)
 			nwo.UpdateOrdererConfig(network, orderer, syschannel, config, updatedConfig, peer, orderer)
 
 			By("3) Verify: system channel config changed")
 			sysBlockNum := nwo.CurrentConfigBlockNumber(network, peer, orderer, syschannel)
 			Expect(sysBlockNum).To(Equal(sysStartBlockNum + 1))
 
-			//=== Step 4: config update on standard channel, State=MAINTENANCE, type=etcdraft ===
-			By("4) Config update on standard channel, State=MAINTENANCE, type=etcdraft")
-			config, updatedConfig = prepareTransition(network, peer, orderer, channel1,
-				"solo", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_MAINTENANCE)
+			//=== Step 4: config update on standard channel, State=MAINTENANCE, type=etcdraft, (in-lieu of future-type) other value changed ===
+			By("4) Config update on standard channel, State=MAINTENANCE, type=etcdraft, (in-lieu of future-type) other value changed")
+			config = nwo.GetConfig(network, peer, orderer, channel1)
+			consensusTypeValue = extractOrdererConsensusType(config)
+			validateConsensusTypeValue(consensusTypeValue, "etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE)
+			updatedConfig = proto.Clone(config).(*common.Config)
+			updateConfigWithBatchTimeout(updatedConfig)
 			nwo.UpdateOrdererConfig(network, orderer, channel1, config, updatedConfig, peer, orderer)
 
 			By("4) Verify: standard channel config changed")
@@ -537,7 +489,7 @@ var _ = Describe("Solo2RaftMigration", func() {
 
 			//=== Step 6: restart ===
 			By("6) restarting orderer1")
-			network.Consensus.Type = "etcdraft"
+			network.Consensus.Type = "etcdraft" // Note: change to future-type
 
 			o1Runner = network.OrdererRunner(orderer)
 			o1Proc = ifrit.Invoke(o1Runner)
@@ -570,7 +522,7 @@ var _ = Describe("Solo2RaftMigration", func() {
 			By("9) Release - executing config transaction on system channel with restarted orderer")
 			config, updatedConfig = prepareTransition(network, peer, orderer, syschannel,
 				"etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_NORMAL)
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_NORMAL)
 			nwo.UpdateOrdererConfig(network, orderer, syschannel, config, updatedConfig, peer, orderer)
 
 			By("9) Verify: system channel config changed")
@@ -580,7 +532,7 @@ var _ = Describe("Solo2RaftMigration", func() {
 			By("10) Release - executing config transaction on standard channel with restarted orderer")
 			config, updatedConfig = prepareTransition(network, peer, orderer, channel1,
 				"etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE,
-				"etcdraft", raftMetadata, protosorderer.ConsensusType_STATE_NORMAL)
+				"etcdraft", nil, protosorderer.ConsensusType_STATE_NORMAL)
 			nwo.UpdateOrdererConfig(network, orderer, channel1, config, updatedConfig, peer, orderer)
 
 			By("10) Verify: standard channel config changed")
@@ -678,8 +630,10 @@ func updateConfigWithConsensusType(
 	updatedConfig *common.Config,
 	consensusTypeValue *protosorderer.ConsensusType,
 ) {
+	if consensusTypeValue.Type != consensusType {
+		consensusTypeValue.Metadata = consensusMetadata
+	}
 	consensusTypeValue.Type = consensusType
-	consensusTypeValue.Metadata = consensusMetadata
 	consensusTypeValue.State = migState
 	updatedConfig.ChannelGroup.Groups["Orderer"].Values["ConsensusType"] = &common.ConfigValue{
 		ModPolicy: "Admins",
@@ -703,8 +657,8 @@ func updateConfigWithBatchTimeout(updatedConfig *common.Config) {
 	}
 }
 
-func solo2RaftMultiChannel() *nwo.Config {
-	config := nwo.BasicSolo()
+func raftMultiChannel() *nwo.Config {
+	config := nwo.MultiChannelEtcdRaft()
 	config.Channels = []*nwo.Channel{
 		{Name: "testchannel1", Profile: "TwoOrgsChannel"},
 		{Name: "testchannel2", Profile: "TwoOrgsChannel"},

--- a/orderer/common/msgprocessor/maintenancefilter.go
+++ b/orderer/common/msgprocessor/maintenancefilter.go
@@ -46,7 +46,9 @@ func NewMaintenanceFilter(support MaintenanceFilterSupport, bccsp bccsp.BCCSP) *
 		bccsp:                         bccsp,
 	}
 	mf.permittedTargetConsensusTypes["etcdraft"] = true
-	mf.permittedTargetConsensusTypes["solo"] = true
+	// Until we have a BFT consensus type, we use this for integration testing of consensus-type migration.
+	// Caution: proposing a config block with this type will cause panic.
+	mf.permittedTargetConsensusTypes["testing-only"] = true
 	return mf
 }
 


### PR DESCRIPTION

Signed-off-by: Yoav Tock <tock@il.ibm.com>
Change-Id: I1c422996895620f26fd3125caf3dd2143f9396d3


#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
Orderer v3: remove solo from integration - part 4.

Change consensus-type migration tests to use raft as the starting point instead of solo, while maintaining as much as possible the testing infrastructure for a future consensus-type.

#### Related issues

Issue: #3514 
Epic: #3511 
