### PR TITLE
Add private write-set for purge operation

### DIFF
--- a/core/ledger/kvledger/txmgmt/rwsetutil/rwset_builder.go
+++ b/core/ledger/kvledger/txmgmt/rwsetutil/rwset_builder.go
@@ -116,10 +116,12 @@ func (b *RWSetBuilder) AddToPvtAndHashedWriteSet(ns string, coll string, key str
 	b.getOrCreateCollHashedRwBuilder(ns, coll).writeMap[key] = kvWriteHash
 }
 
-// AddToHashedWriteSetPurge adds a purge key to the hashed write-set
-func (b *RWSetBuilder) AddToHashedWriteSetPurge(ns string, coll string, key string) {
-	kvWriteHashPurge := newKVWriteHashPurge(key)
-	b.getOrCreateCollHashedRwBuilder(ns, coll).writeMap[key] = kvWriteHashPurge
+// AddToPvtAndHashedWriteSetForPurge adds a purge key to the hashed write-set
+func (b *RWSetBuilder) AddToPvtAndHashedWriteSetForPurge(ns string, coll string, key string) {
+	kvWrite, kvWriteHash := newPvtKVWriteAndHash(key, nil)
+	kvWriteHash.IsPurge = true
+	b.getOrCreateCollPvtRwBuilder(ns, coll).writeMap[key] = kvWrite
+	b.getOrCreateCollHashedRwBuilder(ns, coll).writeMap[key] = kvWriteHash
 }
 
 // AddToHashedMetadataWriteSet adds a metadata to a key in the hashed write-set

--- a/core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util.go
+++ b/core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util.go
@@ -362,11 +362,6 @@ func newPvtKVWriteAndHash(key string, value []byte) (*kvrwset.KVWrite, *kvrwset.
 	return kvWrite, &kvrwset.KVWriteHash{KeyHash: keyHash, IsDelete: kvWrite.IsDelete, ValueHash: valueHash}
 }
 
-func newKVWriteHashPurge(key string) *kvrwset.KVWriteHash {
-	keyHash := util.ComputeStringHash(key)
-	return &kvrwset.KVWriteHash{KeyHash: keyHash, IsDelete: true, IsPurge: true}
-}
-
 // IsKVWriteDelete returns true if the kvWrite indicates a delete operation. See FAB-18386 for details.
 func IsKVWriteDelete(kvWrite *kvrwset.KVWrite) bool {
 	return kvWrite.IsDelete || len(kvWrite.Value) == 0

--- a/core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util_test.go
+++ b/core/ledger/kvledger/txmgmt/rwsetutil/rwset_proto_util_test.go
@@ -245,16 +245,6 @@ func TestVersionConversion(t *testing.T) {
 	require.Equal(t, protoVer, newProtoVersion(internalVer))
 }
 
-func TestNewKVWriteHashPurge(t *testing.T) {
-	sampleKey := "purge-key1"
-	sampleKVWriteHash := &kvrwset.KVWriteHash{
-		KeyHash:  util.ComputeStringHash(sampleKey),
-		IsDelete: true,
-		IsPurge:  true,
-	}
-	require.Equal(t, sampleKVWriteHash, newKVWriteHashPurge(sampleKey))
-}
-
 func TestIsDelete(t *testing.T) {
 	t.Run("kvWrite", func(t *testing.T) {
 		kvWritesToBeInterpretedAsDelete := []*kvrwset.KVWrite{

--- a/core/ledger/kvledger/txmgmt/txmgr/tx_simulator.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/tx_simulator.go
@@ -127,7 +127,7 @@ func (s *txSimulator) PurgePrivateData(ns, coll, key string) error {
 		return err
 	}
 	s.writePerformed = true
-	s.rwsetBuilder.AddToHashedWriteSetPurge(ns, coll, key)
+	s.rwsetBuilder.AddToPvtAndHashedWriteSetForPurge(ns, coll, key)
 	return nil
 }
 

--- a/core/ledger/kvledger/txmgmt/validation/validator_test.go
+++ b/core/ledger/kvledger/txmgmt/validation/validator_test.go
@@ -376,8 +376,8 @@ func TestPrvtdataPurgeUpdates(t *testing.T) {
 
 	rwsetBuilder1 := rwsetutil.NewRWSetBuilder()
 	// key1 and key2 are purged, and key3 is written
-	rwsetBuilder1.AddToHashedWriteSetPurge("ns1", "coll1", "key1")
-	rwsetBuilder1.AddToHashedWriteSetPurge("ns1", "coll1", "key2")
+	rwsetBuilder1.AddToPvtAndHashedWriteSetForPurge("ns1", "coll1", "key1")
+	rwsetBuilder1.AddToPvtAndHashedWriteSetForPurge("ns1", "coll1", "key2")
 	rwsetBuilder1.AddToPvtAndHashedWriteSet("ns1", "coll1", "key3", []byte("value3"))
 	txRWset1 := rwsetBuilder1.GetTxReadWriteSet()
 

--- a/core/ledger/pvtdatastorage/store.go
+++ b/core/ledger/pvtdatastorage/store.go
@@ -599,7 +599,7 @@ func (s *Store) removePurgedDataFromCollPvtRWset(k *dataKey, v *rwset.Collection
 			return err
 		}
 
-		if keyHt.Compare(purgeMarkerHt) >= 0 {
+		if keyHt.Compare(purgeMarkerHt) > 0 {
 			filterInKVWrites = append(filterInKVWrites, w)
 			continue
 		}
@@ -840,7 +840,10 @@ func (s *Store) deleteDataMarkedForPurge() error {
 		if err := purgeMarkerIter.Error(); err != nil {
 			return err
 		}
-		hStart, hEnd := driveHashedIndexKeyRangeFromPurgeMarker(purgeMarkerIter.Key(), purgeMarkerIter.Value())
+		hStart, hEnd, err := driveHashedIndexKeyRangeFromPurgeMarker(purgeMarkerIter.Key(), purgeMarkerIter.Value())
+		if err != nil {
+			return err
+		}
 		hashedIndexIter, err := s.db.GetIterator(hStart, hEnd)
 		if err != nil {
 			return err

--- a/core/ledger/pvtdatastorage/store_test.go
+++ b/core/ledger/pvtdatastorage/store_test.go
@@ -840,6 +840,12 @@ func TestStoreFilterPurgedKeys(t *testing.T) {
 					Ns:         "ns-1",
 					Coll:       "coll-1",
 					PvtkeyHash: util.ComputeStringHash("key-1"),
+					TxNum:      2,
+				},
+				{
+					Ns:         "ns-1",
+					Coll:       "coll-1",
+					PvtkeyHash: util.ComputeStringHash("key-2"),
 					TxNum:      1,
 				},
 			},
@@ -895,39 +901,12 @@ func TestStoreFilterPurgedKeys(t *testing.T) {
 	require.True(t, testHashedIndexExists(t, s, hashedIndexKey2))
 	require.True(t, testHashedIndexExists(t, s, hashedIndexKey3))
 
+	// This this should filter out the pvt data for key-1 as the purge marker height is the same as the commit height of the data
+	// However, this should not cause filtering of pvt data for key-2 as the purge marker height is lower than the commit height of the data
 	pvtdata, err := s.GetPvtDataByBlockNum(1, nil)
 	require.NoError(t, err)
 	require.Len(t, pvtdata, 1)
 	require.Equal(t, uint64(2), pvtdata[0].SeqInBlock)
-	verifyRetrievedPvtData(txWriteSet, pvtdata[0].WriteSet)
-
-	// this should not cause any filtering of pvt data as the purge marker height is lower than the commit height of the data
-	pvtdata, err = s.GetPvtDataByBlockNum(1, nil)
-	require.NoError(t, err)
-	require.Len(t, pvtdata, 1)
-	require.Equal(t, uint64(2), pvtdata[0].SeqInBlock)
-	require.True(t, proto.Equal(txWriteSetProto, pvtdata[0].WriteSet))
-
-	// Add a purge marker for key-1 at block-2
-	require.NoError(
-		t,
-		s.Commit(2, nil, nil,
-			[]*PurgeMarker{
-				{
-					Ns:         "ns-1",
-					Coll:       "coll-1",
-					PvtkeyHash: util.ComputeStringHash("key-1"),
-					TxNum:      1,
-				},
-			},
-		),
-	)
-
-	pvtdata, err = s.GetPvtDataByBlockNum(1, nil)
-	require.NoError(t, err)
-	require.Len(t, pvtdata, 1)
-	require.Equal(t, uint64(2), pvtdata[0].SeqInBlock)
-	// this should cause removal of "key-1" from the pvt data
 	verifyRetrievedPvtData(
 		&rwsetutil.TxPvtRwSet{
 			NsPvtRwSet: []*rwsetutil.NsPvtRwSet{
@@ -963,10 +942,10 @@ func TestStoreFilterPurgedKeys(t *testing.T) {
 		pvtdata[0].WriteSet,
 	)
 
-	// Add a purge marker for key-2 at block-3
+	// Add a purge marker again for key-2 at block-2
 	require.NoError(
 		t,
-		s.Commit(3, nil, nil,
+		s.Commit(2, nil, nil,
 			[]*PurgeMarker{
 				{
 					Ns:         "ns-1",
@@ -978,12 +957,11 @@ func TestStoreFilterPurgedKeys(t *testing.T) {
 		),
 	)
 
+	// Now, key-2 should have been removed
 	pvtdata, err = s.GetPvtDataByBlockNum(1, nil)
 	require.NoError(t, err)
 	require.Len(t, pvtdata, 1)
 	require.Equal(t, uint64(2), pvtdata[0].SeqInBlock)
-
-	// this should cause removal of "key-2", in addition to the "key-1" from the pvt data
 	verifyRetrievedPvtData(
 		&rwsetutil.TxPvtRwSet{
 			NsPvtRwSet: []*rwsetutil.NsPvtRwSet{
@@ -1005,6 +983,51 @@ func TestStoreFilterPurgedKeys(t *testing.T) {
 										Value: []byte("value-3"),
 									},
 								},
+							},
+						},
+					},
+				},
+			},
+		},
+		pvtdata[0].WriteSet,
+	)
+
+	// Add a purge marker for key-3 at block-3
+	require.NoError(
+		t,
+		s.Commit(3, nil, nil,
+			[]*PurgeMarker{
+				{
+					Ns:         "ns-1",
+					Coll:       "coll-2",
+					PvtkeyHash: util.ComputeStringHash("key-3"),
+					TxNum:      1,
+				},
+			},
+		),
+	)
+
+	// This should cause removal of "key-3", in addition to the "key-1", and "key-2" from the pvt data
+	pvtdata, err = s.GetPvtDataByBlockNum(1, nil)
+	require.NoError(t, err)
+	require.Len(t, pvtdata, 1)
+	require.Equal(t, uint64(2), pvtdata[0].SeqInBlock)
+	verifyRetrievedPvtData(
+		&rwsetutil.TxPvtRwSet{
+			NsPvtRwSet: []*rwsetutil.NsPvtRwSet{
+				{
+					NameSpace: "ns-1",
+					CollPvtRwSets: []*rwsetutil.CollPvtRwSet{
+						{
+							CollectionName: "coll-1",
+							KvRwSet: &kvrwset.KVRWSet{
+								Writes: []*kvrwset.KVWrite{},
+							},
+						},
+						{
+							CollectionName: "coll-2",
+							KvRwSet: &kvrwset.KVRWSet{
+								Writes: []*kvrwset.KVWrite{},
 							},
 						},
 					},
@@ -1176,9 +1199,50 @@ func TestStoreProcessPurgeMarker(t *testing.T) {
 	require.True(t, proto.Equal(txWriteSetProto, pvtdata[0].WriteSet))
 
 	// Add a purge marker for key-1 at block-3
+	txWriteSetWithDelete := &rwsetutil.TxPvtRwSet{
+		NsPvtRwSet: []*rwsetutil.NsPvtRwSet{
+			{
+				NameSpace: "ns-1",
+				CollPvtRwSets: []*rwsetutil.CollPvtRwSet{
+					{
+						CollectionName: "coll-1",
+						KvRwSet: &kvrwset.KVRWSet{
+							Writes: []*kvrwset.KVWrite{
+								{
+									Key:      "key-1",
+									IsDelete: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	txWriteSetWithDeleteProto, err := txWriteSetWithDelete.ToProtoMsg()
+	require.NoError(t, err)
+
+	hashedIndexDeleteKey1 := &hashedIndexKey{
+		ns:         "ns-1",
+		coll:       "coll-1",
+		pvtkeyHash: util.ComputeStringHash("key-1"),
+		blkNum:     3,
+		txNum:      1,
+	}
+
 	require.NoError(
 		t,
-		s.Commit(3, nil, nil,
+		s.Commit(3,
+			// Add a delete for the private key to simulate the situation where this key
+			// is added along with the purge marker at the same transaction height
+			[]*ledger.TxPvtData{
+				{
+					SeqInBlock: 1,
+					WriteSet:   txWriteSetWithDeleteProto,
+				},
+			},
+			nil,
 			[]*PurgeMarker{
 				{
 					Ns:         "ns-1",
@@ -1189,6 +1253,8 @@ func TestStoreProcessPurgeMarker(t *testing.T) {
 			},
 		),
 	)
+
+	require.True(t, testHashedIndexExists(t, s, hashedIndexDeleteKey1))
 
 	// commit block 4 to kick off the background purger goroutine
 	require.NoError(t, s.Commit(4, nil, nil, nil))
@@ -1212,6 +1278,7 @@ func TestStoreProcessPurgeMarker(t *testing.T) {
 	)
 	require.True(t, testDataKeyExists(t, s, dataKeyColl2))
 	require.False(t, testHashedIndexExists(t, s, hashedIndexKey1))
+	require.False(t, testHashedIndexExists(t, s, hashedIndexDeleteKey1))
 	require.True(t, testHashedIndexExists(t, s, hashedIndexKey2))
 	require.True(t, testHashedIndexExists(t, s, hashedIndexKey3))
 
@@ -1247,6 +1314,27 @@ func TestStoreProcessPurgeMarker(t *testing.T) {
 									},
 								},
 							},
+						},
+					},
+				},
+			},
+		},
+		pvtdata[0].WriteSet,
+	)
+
+	pvtdata, err = s.GetPvtDataByBlockNum(3, nil)
+	require.NoError(t, err)
+	require.Len(t, pvtdata, 1)
+	require.Equal(t, uint64(1), pvtdata[0].SeqInBlock)
+	verifyRetrievedPvtData(
+		&rwsetutil.TxPvtRwSet{
+			NsPvtRwSet: []*rwsetutil.NsPvtRwSet{
+				{
+					NameSpace: "ns-1",
+					CollPvtRwSets: []*rwsetutil.CollPvtRwSet{
+						{
+							CollectionName: "coll-1",
+							KvRwSet:        &kvrwset.KVRWSet{},
 						},
 					},
 				},


### PR DESCRIPTION
This commit adds a private write-set for a purge operation. The private write-set contains the delete operation on the key getting purged.

Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Related issues
Closes #3761 
