### PR TITLE
Remove Purge-Marker to avoid unnecessary scanning

### DIFF
--- a/core/ledger/pvtdatastorage/kv_encoding.go
+++ b/core/ledger/pvtdatastorage/kv_encoding.go
@@ -33,6 +33,7 @@ var (
 	hashedIndexKeyPrefix             = []byte{'b'}
 	purgeMarkerKeyPrefix             = []byte{'c'}
 	purgeMarkerCollKeyPrefix         = []byte{'d'}
+	purgeMarkerForReconKeyPrefix     = []byte{'e'}
 
 	nilByte    = byte(0)
 	emptyValue = []byte{}
@@ -295,6 +296,15 @@ func encodePurgeMarkerCollKey(k *purgeMarkerCollKey) []byte {
 
 func encodePurgeMarkerKey(k *purgeMarkerKey) []byte {
 	encKey := append(purgeMarkerKeyPrefix, []byte(k.ns)...)
+	encKey = append(encKey, nilByte)
+	encKey = append(encKey, []byte(k.coll)...)
+	encKey = append(encKey, nilByte)
+	encKey = append(encKey, k.pvtkeyHash...)
+	return encKey
+}
+
+func encodePurgeMarkerForReconKey(k *purgeMarkerKey) []byte {
+	encKey := append(purgeMarkerForReconKeyPrefix, []byte(k.ns)...)
 	encKey = append(encKey, nilByte)
 	encKey = append(encKey, []byte(k.coll)...)
 	encKey = append(encKey, nilByte)


### PR DESCRIPTION
This PR removes the Purge-Marker after purging all the associated keys and hashed indexes. In addition, for reconciliation, it introduces a separate marker

Signed-off-by: manish <manish.sethi@gmail.com>

#### Type of change
- New feature

#### Related issues
Closes #3444