### PR TITLE
Fix orderer Dockerfile for /etc/nsswitch.conf

### DIFF
--- a/images/orderer/Dockerfile
+++ b/images/orderer/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache tzdata
 # set up nsswitch.conf for Go's "netgo" implementation
 # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 
 FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
 RUN apk add --no-cache \


### PR DESCRIPTION
Make orderer Dockerfile consistent with peer Dockerfile with respect to /etc/nsswitch.conf.

The orderer Dockerfile stopped working with alpine 3.16.3 (November 12 release), since etc/nsswitch.conf was added to the alpine image.

The new alpine etc/nsswitch.conf file content is the same as what Fabric has been adding to the image, so we'll keep the Fabric file content in case the Dockerfile is used on other platforms.

Relevant Alpine 3.16.3 commit:
https://git.alpinelinux.org/aports/commit/?h=v3.16.3&id=348653a9ba0701e8e968b3344e72313a9ef334e4

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
