### PR TITLE
Add purgeInterval to core.yaml

### DIFF
--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -728,6 +728,10 @@ ledger:
     # deprioritizedDataReconcilerInterval (unit: minutes). Note that the
     # interval needs to be greater than the reconcileSleepInterval
     deprioritizedDataReconcilerInterval: 60m
+    # The frequency to purge private data (in number of blocks).
+    # Private data is purged from the peer's private data store based on
+    # the collection property blockToLive or an explicit chaincode call to PurgePrivateData().
+    purgeInterval: 100
 
   snapshots:
     # Path on the file system where peer will store ledger snapshots


### PR DESCRIPTION
Users that need to purge private data may want to purge more frequently that the default of every 100 blocks. Expose purgeInterval configuration setting in core.yaml.

Resolves #3816 

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
