### PR TITLE
set Orderer SendBufferSize to 100 as default

### DIFF
--- a/docs/source/deployorderer/ordererchecklist.md
+++ b/docs/source/deployorderer/ordererchecklist.md
@@ -97,7 +97,7 @@ ServerTimeout: 20s
 # SendBufferSize is the maximum number of messages in the egress buffer.
 # Consensus messages are dropped if the buffer is full, and transaction
 # messages are waiting for space to be freed.
-SendBufferSize: 10
+SendBufferSize: 100
 # ClientCertificate governs the file location of the client TLS certificate
 # If not set, the server General.TLS.Certificate is re-used.
 ClientCertificate:

--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -164,7 +164,7 @@ var Defaults = TopLevel{
 			RPCTimeout:                           time.Second * 7,
 			DialTimeout:                          time.Second * 5,
 			ReplicationBufferSize:                20971520,
-			SendBufferSize:                       10,
+			SendBufferSize:                       100,
 			ReplicationBackgroundRefreshInterval: time.Minute * 5,
 			ReplicationRetryTimeout:              time.Second * 5,
 			ReplicationPullTimeout:               time.Second * 5,

--- a/orderer/common/server/etcdraft_test.go
+++ b/orderer/common/server/etcdraft_test.go
@@ -196,7 +196,7 @@ func testEtcdRaftOSNSuccess(gt *GomegaWithT, configPath, configtxgen, orderer, c
 	gt.Eventually(ordererProcess.Err, time.Minute).Should(gbytes.Say("General.Cluster.ReplicationRetryTimeout = 5s"))
 	gt.Eventually(ordererProcess.Err, time.Minute).Should(gbytes.Say("General.Cluster.ReplicationBackgroundRefreshInterval = 5m0s"))
 	gt.Eventually(ordererProcess.Err, time.Minute).Should(gbytes.Say("General.Cluster.ReplicationMaxRetries = 12"))
-	gt.Eventually(ordererProcess.Err, time.Minute).Should(gbytes.Say("General.Cluster.SendBufferSize = 10"))
+	gt.Eventually(ordererProcess.Err, time.Minute).Should(gbytes.Say("General.Cluster.SendBufferSize = 100"))
 	gt.Eventually(ordererProcess.Err, time.Minute).Should(gbytes.Say("General.Cluster.CertExpirationWarningThreshold = 168h0m0s"))
 
 	// Consensus.EvictionSuspicion is not specified in orderer.yaml, so let's ensure

--- a/orderer/common/server/testdata/orderer.yaml
+++ b/orderer/common/server/testdata/orderer.yaml
@@ -46,7 +46,7 @@ General:
         # SendBufferSize is the maximum number of messages in the egress buffer.
         # Consensus messages are dropped if the buffer is full, and transaction
         # messages are waiting for space to be freed.
-        SendBufferSize: 10
+        SendBufferSize: 100
         # ClientCertificate governs the file location of the client TLS certificate
         # used to establish mutual TLS connections with other ordering service nodes.
         ClientCertificate:

--- a/sampleconfig/orderer.yaml
+++ b/sampleconfig/orderer.yaml
@@ -64,7 +64,7 @@ General:
         # SendBufferSize is the maximum number of messages in the egress buffer.
         # Consensus messages are dropped if the buffer is full, and transaction
         # messages are waiting for space to be freed.
-        SendBufferSize: 10
+        SendBufferSize: 100
 
         # ClientCertificate governs the file location of the client TLS certificate
         # used to establish mutual TLS connections with other ordering service nodes.


### PR DESCRIPTION
10 has shown to be a bottleneck for Raft performance. 100 appears to be a better default, so proposing that this value is set to 100 by default

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description

10 has shown to be a bottleneck for Raft performance. 100 appears to be a better default, so proposing that this value is set to 100 by default

