### PR TITLE
fix the multi-arch Docker peer build again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 env:
   GO_VER: 1.18.7
   ALPINE_VER: 3.16
+  FABRIC_VER: ${{ github.ref_name }}
   DOCKER_REGISTRY: ghcr.io
 
 permissions:
@@ -49,13 +50,12 @@ jobs:
         run: ./ci/scripts/create_binary_package.sh
         env:
           TARGET: ${{ matrix.target }}-${{ matrix.arch }}
-          BASE_VERSION: ${{ github.ref_name }}
-          RELEASE: ${{ github.ref_name }}
+          RELEASE: ${{ env.FABRIC_VER }}
       - name: Publish Release Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: hyperledger-fabric-${{ matrix.target }}-${{ matrix.arch }}-${{ github.ref_name }}.tar.gz
-          path: release/${{ matrix.target }}-${{ matrix.arch }}/hyperledger-fabric-${{ matrix.target }}-${{ matrix.arch }}-${{ github.ref_name }}.tar.gz
+          name: hyperledger-fabric-${{ matrix.target }}-${{ matrix.arch }}-${{ env.FABRIC_VER }}.tar.gz
+          path: release/${{ matrix.target }}-${{ matrix.arch }}/hyperledger-fabric-${{ matrix.target }}-${{ matrix.arch }}-${{ env.FABRIC_VER }}.tar.gz
 
 
   build-and-push-docker-images:
@@ -87,6 +87,11 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+          config-inline: |
+            [worker.oci]
+              max-parallelism = 1
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -98,18 +103,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-        #      - name: Login to Docker Hub Container Registry
-        #        uses: docker/login-action@v2
-        #        with:
-        #          registry: docker.io
-        #          username: ${{ secrets.DOCKERHUB_USERNAME }}
-        #          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          # For the docker hub registry:
+          # username: ${{ secrets.DOCKERHUB_USERNAME }}
+          # password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.DOCKER_REGISTRY }}/hyperledger/fabric-${{ matrix.COMPONENT }}
+          images: ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/fabric-${{ matrix.COMPONENT }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -126,6 +128,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
+            FABRIC_VER=${{ env.FABRIC_VER }}
             ALPINE_VER=${{ env.ALPINE_VER }}
             GO_VER=${{ env.GO_VER }}
             GO_TAGS=
@@ -147,6 +150,6 @@ jobs:
         with:
           allowUpdates: "true"
           artifacts: "*.tar.gz/*.tar.gz"
-          bodyFile: release_notes/${{ github.ref_name }}.md
-          tag: ${{ github.ref_name }}
+          bodyFile: release_notes/${{ env.FABRIC_VER }}.md
+          tag: ${{ env.FABRIC_VER }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@
 #   - verify - runs unit tests for only the changed package tree
 
 ALPINE_VER ?= 3.16
-BASE_VERSION ?= 2.5.0
+FABRIC_VER ?= 2.5.0
 
 # 3rd party image version
 # These versions are also set in the runners in ./integration/runners/
@@ -62,18 +62,18 @@ MAKEFLAGS += --no-builtin-rules
 BUILD_DIR ?= build
 
 EXTRA_VERSION ?= $(shell git rev-parse --short HEAD)
-PROJECT_VERSION=$(BASE_VERSION)-snapshot-$(EXTRA_VERSION)
+PROJECT_VERSION=$(FABRIC_VER)-snapshot-$(EXTRA_VERSION)
 
 # TWO_DIGIT_VERSION is derived, e.g. "2.0", especially useful as a local tag
 # for two digit references to most recent baseos and ccenv patch releases
-TWO_DIGIT_VERSION = $(shell echo $(BASE_VERSION) | cut -d '.' -f 1,2)
+TWO_DIGIT_VERSION = $(shell echo $(FABRIC_VER) | cut -d '.' -f 1,2)
 
 PKGNAME = github.com/hyperledger/fabric
 ARCH=$(shell go env GOARCH)
 MARCH=$(shell go env GOOS)-$(shell go env GOARCH)
 
 # defined in common/metadata/metadata.go
-METADATA_VAR = Version=$(BASE_VERSION)
+METADATA_VAR = Version=$(FABRIC_VER)
 METADATA_VAR += CommitSHA=$(EXTRA_VERSION)
 METADATA_VAR += BaseDockerLabel=$(BASE_DOCKER_LABEL)
 METADATA_VAR += DockerNamespace=$(DOCKER_NS)
@@ -223,6 +223,7 @@ tools: $(TOOLS_EXES)
 $(RELEASE_EXES): %: $(BUILD_DIR)/bin/%
 
 $(BUILD_DIR)/bin/%: GO_LDFLAGS = $(METADATA_VAR:%=-X $(PKGNAME)/common/metadata.%)
+$(BUILD_DIR)/bin/%: GO_LDFLAGS += -w -extldflags '-static'
 $(BUILD_DIR)/bin/%:
 	@echo "Building $@"
 	@mkdir -p $(@D)
@@ -247,11 +248,9 @@ $(BUILD_DIR)/images/%/$(DUMMY):
 	$(DBUILD) -f images/$*/Dockerfile \
 		--build-arg GO_VER=$(GO_VER) \
 		--build-arg ALPINE_VER=$(ALPINE_VER) \
+		--build-arg FABRIC_VER=$(FABRIC_VER) \
 		$(BUILD_ARGS) \
 		-t $(DOCKER_NS)/fabric-$* ./$(BUILD_CONTEXT)
-	docker tag $(DOCKER_NS)/fabric-$* $(DOCKER_NS)/fabric-$*:$(BASE_VERSION)
-	docker tag $(DOCKER_NS)/fabric-$* $(DOCKER_NS)/fabric-$*:$(TWO_DIGIT_VERSION)
-	docker tag $(DOCKER_NS)/fabric-$* $(DOCKER_NS)/fabric-$*:$(DOCKER_TAG)
 	@touch $@
 
 # builds release packages for the host platform

--- a/images/orderer/Dockerfile
+++ b/images/orderer/Dockerfile
@@ -4,6 +4,7 @@
 
 ARG GO_VER
 ARG ALPINE_VER
+
 FROM alpine:${ALPINE_VER} as base
 RUN apk add --no-cache tzdata
 # set up nsswitch.conf for Go's "netgo" implementation
@@ -24,6 +25,8 @@ WORKDIR $GOPATH/src/github.com/hyperledger/fabric
 
 FROM golang as orderer
 ARG GO_TAGS
+ARG FABRIC_VER
+ENV FABRIC_VER ${FABRIC_VER}
 RUN make orderer GO_TAGS=${GO_TAGS}
 
 FROM base

--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -4,7 +4,6 @@
 
 ARG GO_VER
 ARG ALPINE_VER
-
 FROM alpine:${ALPINE_VER} as peer-base
 RUN apk add --no-cache tzdata
 # set up nsswitch.conf for Go's "netgo" implementation
@@ -25,6 +24,8 @@ WORKDIR $GOPATH/src/github.com/hyperledger/fabric
 
 FROM golang as peer
 ARG GO_TAGS
+ARG FABRIC_VER
+ENV FABRIC_VER ${FABRIC_VER}
 RUN make peer GO_TAGS=${GO_TAGS}
 RUN make ccaasbuilder
 

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -19,6 +19,8 @@ WORKDIR $GOPATH/src/github.com/hyperledger/fabric
 
 FROM golang as tools
 ARG GO_TAGS
+ARG FABRIC_VER
+ENV FABRIC_VER ${FABRIC_VER}
 RUN make tools GO_TAGS=${GO_TAGS}
 
 FROM golang:${GO_VER}-alpine${ALPINE_VER}


### PR DESCRIPTION
Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>

#### Type of change

- Bug fix
- New feature

#### Description

This PR runs the Fabric release pipeline correctly as a "release" practice triggered through GH.

The `FABRIC_VER` of a component is inferred from the _semrev_ tag applied by the Release process.   The `FABRIC_VER` is applied throughout the Makefile, docker images, and metadata encoded into the client binaries.


#### Additional details

This commit: 

- Adds a work-around for concurrency issues encountered when building multiple target architectures with buildx in parallel.  When multiple buildx builders run concurrently, an unpredictable but frequent error occurs when communicating with the buildx builder.  This manifests as "Error : 403 Forbidden" when pushing _some but not all_ of the image layers to ghcr.io.   This is most likely a resource (CPU, disk, RAM, etc.) being exhausted on the GH executor, and NOT an authentication error when connecting to the container registry.    (Serializing the buildx builder steps seems to have eliminated the sporadic crash.) 

- Solves a `SIGSEGV` error encountered when running the dynamically linked (peer, orderer, etc.) images on the alpine arm64 images.  The problem stems from producing a dynamically linked (libc.so) executable on the golang-alpine base image, copying it, and running on a vanilla alpine container.   (Alpine does NOT include support for libc, and something is either wrong with the libmusl for arm64, or it worked by accident on the amd64.)

```
$(BUILD_DIR)/bin/%: GO_LDFLAGS += -w -extldflags '-static'
```

#### Related issues
