### PR TITLE
Publish release artifacts to conventional installation paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,16 +51,17 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}-${{ matrix.arch }}
           RELEASE: ${{ env.FABRIC_VER }}
+
       - name: Publish Release Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: hyperledger-fabric-${{ matrix.target }}-${{ matrix.arch }}-${{ env.FABRIC_VER }}.tar.gz
-          path: release/${{ matrix.target }}-${{ matrix.arch }}/hyperledger-fabric-${{ matrix.target }}-${{ matrix.arch }}-${{ env.FABRIC_VER }}.tar.gz
-
+          # <name> of the artifact must not collide between platform/arch builds
+          name: release-${{ matrix.target }}-${{ matrix.arch }}
+          # <path> of the artifact may include multiple files.
+          path: release/${{ matrix.target }}-${{ matrix.arch }}/*.tar.gz
 
   build-and-push-docker-images:
     name: Build and Push
-
     runs-on: ubuntu-20.04
 
     permissions:
@@ -135,7 +136,9 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    needs: [ build-binaries, build-and-push-docker-images ]
+    needs:
+      - build-binaries
+      - build-and-push-docker-images
     runs-on: ubuntu-20.04
     permissions:
       contents: write
@@ -149,7 +152,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: "true"
-          artifacts: "*.tar.gz/*.tar.gz"
+          artifacts: "release-*-*/*.tar.gz"
           bodyFile: release_notes/${{ env.FABRIC_VER }}.md
           tag: ${{ env.FABRIC_VER }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,9 @@ PROJECT_VERSION=$(FABRIC_VER)-snapshot-$(EXTRA_VERSION)
 
 # TWO_DIGIT_VERSION is derived, e.g. "2.0", especially useful as a local tag
 # for two digit references to most recent baseos and ccenv patch releases
-TWO_DIGIT_VERSION = $(shell echo $(FABRIC_VER) | cut -d '.' -f 1,2)
+# TWO_DIGIT_VERSION removes the (optional) semrev 'v' character from the git
+# tag triggering a Fabric release.
+TWO_DIGIT_VERSION = $(shell echo $(FABRIC_VER) | sed -e  's/^v\(.*\)/\1/' | cut -d '.' -f 1,2)
 
 PKGNAME = github.com/hyperledger/fabric
 ARCH=$(shell go env GOARCH)

--- a/ci/scripts/create_binary_package.sh
+++ b/ci/scripts/create_binary_package.sh
@@ -14,4 +14,8 @@ cd "release/${TARGET}"
 if [ "$TARGET" == "windows-amd64" ]; then
     for FILE in bin/*; do mv $FILE $FILE.exe; done
 fi
-tar -czvf "hyperledger-fabric-${TARGET}-${RELEASE}.tar.gz" bin config builders
+
+# Trim the semrev 'v' from the start of the RELEASE attribute
+VERSION=$(echo $RELEASE | sed -e  's/^v\(.*\)/\1/')
+
+tar -czvf "hyperledger-fabric-${TARGET}-${VERSION}.tar.gz" bin config builders

--- a/scripts/install-fabric.sh
+++ b/scripts/install-fabric.sh
@@ -24,7 +24,8 @@ _arg_comp=('' )
 _arg_fabric_version="2.4.4"
 _arg_ca_version="1.5.5"
 
-ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m |sed 's/x86_64/amd64/g')" |sed 's/darwin-arm64/darwin-amd64/g')
+REGISTRY=${FABRIC_DOCKER_REGISTRY:-docker.io/hyperledger}
+ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m |sed 's/x86_64/amd64/g')")
 MARCH=$(uname -m)
 
 die()
@@ -143,10 +144,10 @@ singleImagePull() {
     while [[ $# -gt 0 ]]
     do
         image_name="$1"
-        echo "====>  hyperledger/fabric-$image_name:$three_digit_image_tag"
-        ${CONTAINER_CLI} pull "hyperledger/fabric-$image_name:$three_digit_image_tag"
-        ${CONTAINER_CLI} tag "hyperledger/fabric-$image_name:$three_digit_image_tag" "hyperledger/fabric-$image_name"
-        ${CONTAINER_CLI} tag "hyperledger/fabric-$image_name:$three_digit_image_tag" "hyperledger/fabric-$image_name:$two_digit_image_tag"
+        echo "====>  ${REGISTRY}/fabric-$image_name:$three_digit_image_tag"
+        ${CONTAINER_CLI} pull "${REGISTRY}/fabric-$image_name:$three_digit_image_tag"
+        ${CONTAINER_CLI} tag "${REGISTRY}/fabric-$image_name:$three_digit_image_tag" "${REGISTRY}/fabric-$image_name"
+        ${CONTAINER_CLI} tag "${REGISTRY}/fabric-$image_name:$three_digit_image_tag" "${REGISTRY}/fabric-$image_name:$two_digit_image_tag"
         shift
     done
 }


### PR DESCRIPTION
Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>

#### Type of change

- Bug fix

#### Description

This PR updates the release pipeline to publish binary assets to the traditional paths within the GH Release.

In addition, this applies the `TWO_DIGIT_VERSION` release tag, without the leading 'v', to determine the coordinates of the embedded ccenv builder image.

This PR updates the target version of `install-fabric.sh` to 2.5.0 / 1.5.6, and includes an optional `FABRIC_DOCKER_REGISTRY` environment variable in order to override the default Docker Hub container registry.


#### Related issues

#### Release Note
