### PR TITLE
Remove duplicate ThreeOrgRaft nwo network

### DIFF
--- a/integration/gateway/endorsing_orgs_test.go
+++ b/integration/gateway/endorsing_orgs_test.go
@@ -43,7 +43,7 @@ var _ = Describe("GatewayService with endorsing orgs", func() {
 		client, err := docker.NewClientFromEnv()
 		Expect(err).NotTo(HaveOccurred())
 
-		config := nwo.ThreeOrgRaft()
+		config := nwo.ThreeOrgEtcdRaft()
 		network = nwo.New(config, testDir, client, StartPort(), components)
 
 		network.GenerateConfigTree()

--- a/integration/gateway/gateway_discovery_test.go
+++ b/integration/gateway/gateway_discovery_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GatewayService with endorser discovery", func() {
 		client, err := docker.NewClientFromEnv()
 		Expect(err).NotTo(HaveOccurred())
 
-		config := nwo.ThreeOrgRaft()
+		config := nwo.ThreeOrgEtcdRaft()
 		network = nwo.New(config, testDir, client, StartPort(), components)
 
 		network.GenerateConfigTree()

--- a/integration/nwo/standard_networks.go
+++ b/integration/nwo/standard_networks.go
@@ -202,47 +202,6 @@ func MinimalRaft() *Config {
 	return config
 }
 
-func ThreeOrgRaft() *Config {
-	config := BasicEtcdRaft()
-
-	config.Organizations = append(
-		config.Organizations,
-		&Organization{
-			Name:   "Org3",
-			MSPID:  "Org3MSP",
-			Domain: "org3.example.com",
-			Users:  2,
-			CA:     &CA{Hostname: "ca"},
-		},
-	)
-	config.Consortiums[0].Organizations = append(
-		config.Consortiums[0].Organizations,
-		"Org3",
-	)
-	config.SystemChannel.Profile = "ThreeOrgsOrdererGenesis"
-	config.Channels[0].Profile = "ThreeOrgsChannel"
-	config.Peers = append(
-		config.Peers,
-		&Peer{
-			Name:         "peer0",
-			Organization: "Org3",
-			Channels: []*PeerChannel{
-				{Name: "testchannel", Anchor: true},
-			},
-		},
-	)
-	config.Profiles = []*Profile{{
-		Name:     "ThreeOrgsOrdererGenesis",
-		Orderers: []string{"orderer"},
-	}, {
-		Name:          "ThreeOrgsChannel",
-		Consortium:    "SampleConsortium",
-		Organizations: []string{"Org1", "Org2", "Org3"},
-	}}
-
-	return config
-}
-
 func MultiChannelEtcdRaft() *Config {
 	config := BasicConfig()
 

--- a/integration/pvtdata/data_purge_test.go
+++ b/integration/pvtdata/data_purge_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Pvtdata purge", func() {
 		testDir, err = ioutil.TempDir("", "purgedata")
 		Expect(err).NotTo(HaveOccurred())
 
-		config := nwo.ThreeOrgRaft()
+		config := nwo.ThreeOrgEtcdRaft()
 		network = nwo.New(config, testDir, nil, StartPort(), components)
 
 		network.GenerateConfigTree()


### PR DESCRIPTION
A duplicate ThreeOrgEtcdRaft was introduced in #3643 so removing the original network

Signed-off-by: James Taylor <jamest@uk.ibm.com>