### PR TITLE
Update command docs - remove unnecessary orderer flags

### DIFF
--- a/docs/source/channel_update_tutorial.rst
+++ b/docs/source/channel_update_tutorial.rst
@@ -172,11 +172,11 @@ If the command is successful, you will see the creation of the Org3 peer:
 
 This Docker Compose file has been configured to bridge across our initial network,
 so that the Org3 peer resolves with the existing peers and ordering
-node of the test network. 
+node of the test network.
 
-.. note:: the `./addOrg3.sh up` command uses a `fabric-tools` CLI container to perform 
-          the channel configuration update process demonstrated below. This is to avoid the 
-          `jq` dependency requirement for first-time users. However, it is recommended to 
+.. note:: the `./addOrg3.sh up` command uses a `fabric-tools` CLI container to perform
+          the channel configuration update process demonstrated below. This is to avoid the
+          `jq` dependency requirement for first-time users. However, it is recommended to
           follow the process below directly on your local machine instead of using the unnecessary
           CLI container.
 
@@ -292,9 +292,9 @@ We'll use the ``jq`` tool once more to append the Org3 configuration definition
 
   jq -s '.[0] * {"channel_group":{"groups":{"Application":{"groups": {"Org3MSP":.[1]}}}}}' config.json ../organizations/peerOrganizations/org3.example.com/org3.json > modified_config.json
 
-Now we have two JSON files of interest -- ``config.json`` and 
-``modified_config.json``. The initial file contains only Org1 and Org2 
-material, whereas the "modified" file contains all three Orgs. At this 
+Now we have two JSON files of interest -- ``config.json`` and
+``modified_config.json``. The initial file contains only Org1 and Org2
+material, whereas the "modified" file contains all three Orgs. At this
 point it's simply a matter of re-encoding these two JSON files and calculating
 the delta.
 
@@ -561,7 +561,7 @@ on the ledger. The commands below assume that we are still using the channel
 ``channel1``.
 
 After the chaincode has been to deployed we can use the following steps to use
-invoke Basic chaincode as Org3. Copy and paste the following environment 
+invoke Basic chaincode as Org3. Copy and paste the following environment
 variables in your terminal in order to interact with the network as the Org3
 admin:
 
@@ -635,7 +635,7 @@ channel.
 .. code:: bash
 
     # use the --name flag to select the chaincode whose definition you want to query
-    peer lifecycle chaincode querycommitted --channelID channel1 --name basic --cafile "${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem"
+    peer lifecycle chaincode querycommitted --channelID channel1 --name basic
 
 A successful command will return information about the committed definition:
 

--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -672,9 +672,7 @@ definition can be committed to a channel.
     which checks a chaincode named `mycc` at version `1.0` on channel `mychannel`.
 
     ```
-    export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-
-    peer lifecycle chaincode checkcommitreadiness -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --name mycc --version 1.0 --init-required --sequence 1
+    peer lifecycle chaincode checkcommitreadiness --channelID mychannel --name mycc --version 1.0 --init-required --sequence 1
     ```
 
     If successful, the command will return the organizations that have approved
@@ -691,9 +689,7 @@ definition can be committed to a channel.
     JSON.
 
     ```
-    export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-
-    peer lifecycle chaincode checkcommitreadiness -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --name mycc --version 1.0 --init-required --sequence 1 --output json
+    peer lifecycle chaincode checkcommitreadiness --channelID mychannel --name mycc --version 1.0 --init-required --sequence 1 --output json
     ```
 
     If successful, the command will return a JSON map that shows if an organization
@@ -737,9 +733,7 @@ chaincode.
     specific chaincode definition and the organizations that have approved it.
 
     ```
-    export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-
-    peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --name mycc --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051
+    peer lifecycle chaincode querycommitted --channelID mychannel --name mycc --peerAddresses peer0.org1.example.com:7051
 
     Committed chaincode definition for chaincode 'mycc' on channel 'mychannel':
     Version: 1, Sequence: 1, Endorsement Plugin: escc, Validation Plugin: vscc
@@ -750,9 +744,7 @@ chaincode.
   definitions on that channel.
 
     ```
-    export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-
-    peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051
+    peer lifecycle chaincode querycommitted --channelID mychannel --peerAddresses peer0.org1.example.com:7051
 
     Committed chaincode definitions on channel 'mychannel':
     Name: mycc, Version: 1, Sequence: 1, Endorsement Plugin: escc, Validation Plugin: vscc
@@ -765,9 +757,7 @@ chaincode.
     - For querying a specific chaincode definition
 
       ```
-      export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-
-      peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --name mycc --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051 --output json
+      peer lifecycle chaincode querycommitted --channelID mychannel --name mycc --peerAddresses peer0.org1.example.com:7051 --output json
       ```
 
       If successful, the command will return a JSON that has committed chaincode definition for chaincode 'mycc' on channel 'mychannel'.
@@ -799,9 +789,7 @@ chaincode.
     - For querying all chaincode definitions on that channel
 
       ```
-      export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-
-      peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051 --output json
+      peer lifecycle chaincode querycommitted --channelID mychannel --peerAddresses peer0.org1.example.com:7051 --output json
       ```
 
       If successful, the command will return a JSON that has committed chaincode definitions on channel 'mychannel'.

--- a/docs/source/deploy_chaincode.md
+++ b/docs/source/deploy_chaincode.md
@@ -501,7 +501,7 @@ The chaincode definition endorsements by channel members are submitted to the or
 You can use the [peer lifecycle chaincode querycommitted](commands/peerlifecycle.html#peer-lifecycle-chaincode-querycommitted) command to confirm that the chaincode definition has been committed to the channel.
 
 ```
-peer lifecycle chaincode querycommitted --channelID mychannel --name basic --cafile "${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem"
+peer lifecycle chaincode querycommitted --channelID mychannel --name basic
 ```
 
 If the chaincode was successful committed to the channel, the `querycommitted` command will return the sequence and version of the chaincode definition:

--- a/docs/wrappers/peer_lifecycle_chaincode_postscript.md
+++ b/docs/wrappers/peer_lifecycle_chaincode_postscript.md
@@ -271,9 +271,7 @@ definition can be committed to a channel.
     which checks a chaincode named `mycc` at version `1.0` on channel `mychannel`.
 
     ```
-    export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-
-    peer lifecycle chaincode checkcommitreadiness -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --name mycc --version 1.0 --init-required --sequence 1
+    peer lifecycle chaincode checkcommitreadiness --channelID mychannel --name mycc --version 1.0 --init-required --sequence 1
     ```
 
     If successful, the command will return the organizations that have approved
@@ -290,9 +288,7 @@ definition can be committed to a channel.
     JSON.
 
     ```
-    export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-
-    peer lifecycle chaincode checkcommitreadiness -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --name mycc --version 1.0 --init-required --sequence 1 --output json
+    peer lifecycle chaincode checkcommitreadiness --channelID mychannel --name mycc --version 1.0 --init-required --sequence 1 --output json
     ```
 
     If successful, the command will return a JSON map that shows if an organization
@@ -336,9 +332,7 @@ chaincode.
     specific chaincode definition and the organizations that have approved it.
 
     ```
-    export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-
-    peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --name mycc --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051
+    peer lifecycle chaincode querycommitted --channelID mychannel --name mycc --peerAddresses peer0.org1.example.com:7051
 
     Committed chaincode definition for chaincode 'mycc' on channel 'mychannel':
     Version: 1, Sequence: 1, Endorsement Plugin: escc, Validation Plugin: vscc
@@ -349,9 +343,7 @@ chaincode.
   definitions on that channel.
 
     ```
-    export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-
-    peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051
+    peer lifecycle chaincode querycommitted --channelID mychannel --peerAddresses peer0.org1.example.com:7051
 
     Committed chaincode definitions on channel 'mychannel':
     Name: mycc, Version: 1, Sequence: 1, Endorsement Plugin: escc, Validation Plugin: vscc
@@ -364,9 +356,7 @@ chaincode.
     - For querying a specific chaincode definition
 
       ```
-      export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-
-      peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --name mycc --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051 --output json
+      peer lifecycle chaincode querycommitted --channelID mychannel --name mycc --peerAddresses peer0.org1.example.com:7051 --output json
       ```
 
       If successful, the command will return a JSON that has committed chaincode definition for chaincode 'mycc' on channel 'mychannel'.
@@ -398,9 +388,7 @@ chaincode.
     - For querying all chaincode definitions on that channel
 
       ```
-      export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-
-      peer lifecycle chaincode querycommitted -o orderer.example.com:7050 --channelID mychannel --tls --cafile $ORDERER_CA --peerAddresses peer0.org1.example.com:7051 --output json
+      peer lifecycle chaincode querycommitted --channelID mychannel --peerAddresses peer0.org1.example.com:7051 --output json
       ```
 
       If successful, the command will return a JSON that has committed chaincode definitions on channel 'mychannel'.


### PR DESCRIPTION
The CLI commands "querycommitted" and "checkcommitreadiness" only query a peer, they do not interact with an orderer node. Therefore the orderer flags -o --tls --cafile are not needed on these commands.

Update the command reference docs and user docs accordingly.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
