### PR TITLE
Prepare static binaries for release targets and docker runtimes, and dynamic binaries for local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,6 @@ tools: $(TOOLS_EXES)
 $(RELEASE_EXES): %: $(BUILD_DIR)/bin/%
 
 $(BUILD_DIR)/bin/%: GO_LDFLAGS = $(METADATA_VAR:%=-X $(PKGNAME)/common/metadata.%)
-$(BUILD_DIR)/bin/%: GO_LDFLAGS += -w -extldflags '-static'
 $(BUILD_DIR)/bin/%:
 	@echo "Building $@"
 	@mkdir -p $(@D)
@@ -263,6 +262,7 @@ release-all: check-go-version $(RELEASE_PLATFORMS:%=release/%)
 
 .PHONY: $(RELEASE_PLATFORMS:%=release/%)
 $(RELEASE_PLATFORMS:%=release/%): GO_LDFLAGS = $(METADATA_VAR:%=-X $(PKGNAME)/common/metadata.%)
+$(RELEASE_PLATFORMS:%=release/%): GO_LDFLAGS += -w -extldflags '-static'
 $(RELEASE_PLATFORMS:%=release/%): release/%: $(foreach exe,$(RELEASE_EXES),release/%/bin/$(exe))
 $(RELEASE_PLATFORMS:%=release/%): release/%: ccaasbuilder/%
 

--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,8 @@ $(BUILD_DIR)/images/%/$(DUMMY):
 		--build-arg GO_VER=$(GO_VER) \
 		--build-arg ALPINE_VER=$(ALPINE_VER) \
 		--build-arg FABRIC_VER=$(FABRIC_VER) \
+		--build-arg TARGETARCH=$(ARCH) \
+		--build-arg TARGETOS=linux \
 		$(BUILD_ARGS) \
 		-t $(DOCKER_NS)/fabric-$* ./$(BUILD_CONTEXT)
 	@touch $@

--- a/images/orderer/Dockerfile
+++ b/images/orderer/Dockerfile
@@ -27,6 +27,11 @@ FROM golang as orderer
 ARG GO_TAGS
 ARG FABRIC_VER
 ENV FABRIC_VER ${FABRIC_VER}
+
+# Disable cgo when building in the container.  This will create a static binary, which can be
+# copied and run in the base alpine container without the libc/musl runtime.
+ENV CGO_ENABLED 0
+
 RUN make orderer GO_TAGS=${GO_TAGS}
 
 FROM base

--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -26,6 +26,11 @@ FROM golang as peer
 ARG GO_TAGS
 ARG FABRIC_VER
 ENV FABRIC_VER ${FABRIC_VER}
+
+# Disable cgo when building in the container.  This will create a static binary, which can be
+# copied and run in the base alpine container without the libc/musl runtime.
+ENV CGO_ENABLED 0
+
 RUN make peer GO_TAGS=${GO_TAGS}
 RUN make ccaasbuilder
 

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -21,6 +21,11 @@ FROM golang as tools
 ARG GO_TAGS
 ARG FABRIC_VER
 ENV FABRIC_VER ${FABRIC_VER}
+
+# Disable cgo when building in the container.  This will create a static binary, which can be
+# copied and run in the base alpine container without the libc/musl runtime.
+ENV CGO_ENABLED 0
+
 RUN make tools GO_TAGS=${GO_TAGS}
 
 FROM golang:${GO_VER}-alpine${ALPINE_VER}


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

This PR fixes two problems with the release-2.5 Makefile: 

- On rancher desktop, `TARGETOS` AND `TARGETARCH` are not automatically set by the "docker" build agent, leading to an error when building the image locally without `buildx` or builders from docker.io.   This sets the variables to `linux` and `go env GOARCH` when building the containers locally, aligning with the default values set by buildx.

- The introduction of statically linked binaries was necessary for running ARM64 on the Alpine containers, but it caused a regression and forced the peer to sigsegv when built _locally_ on an emulated ubuntu64 linux.   With this update, the locally built peer images will continue to be created as dynamically linked binaries, with the static linking enabled only for the release target and for binaries deployed to alpine in Docker. 

#### Related issues

- #2994 
- #3372 