### PR TITLE
Security vulnerability scanning using govulncheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,3 +361,10 @@ ccaasbuilder/%: ccaasbuilder-clean
 	cd ccaas_builder && go test -v ./cmd/release && GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false -o ../release/$(strip $(platform))/builders/ccaas/bin/ ./cmd/release/
 
 ccaasbuilder: ccaasbuilder/$(MARCH)
+
+.PHONY: scan
+scan: scan-govulncheck
+
+.PHONY: scan-govulncheck
+scan-govulncheck: gotool.govulncheck
+	govulncheck ./...

--- a/gotools.mk
+++ b/gotools.mk
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-GOTOOLS = counterfeiter ginkgo gocov gocov-xml gofumpt goimports golint misspell mockery protoc-gen-go staticcheck swagger
+GOTOOLS = counterfeiter ginkgo gocov gocov-xml gofumpt goimports golint govulncheck misspell mockery protoc-gen-go staticcheck swagger
 BUILD_DIR ?= build
 GOTOOLS_BINDIR ?= $(shell go env GOPATH)/bin
 
@@ -15,6 +15,7 @@ go.fqp.gocov-xml     := github.com/AlekSi/gocov-xml
 go.fqp.gofumpt       := mvdan.cc/gofumpt
 go.fqp.goimports     := golang.org/x/tools/cmd/goimports
 go.fqp.golint        := golang.org/x/lint/golint
+go.fqp.govulncheck   := golang.org/x/vuln/cmd/govulncheck@latest
 go.fqp.misspell      := github.com/client9/misspell/cmd/misspell
 go.fqp.mockery       := github.com/vektra/mockery/cmd/mockery
 go.fqp.protoc-gen-go := github.com/golang/protobuf/protoc-gen-go


### PR DESCRIPTION
Add a makefile target for vulnerability scanning, which can later be used for scheduled vulnerability scans.

Contributes to #3860