### PR TITLE
change order of raft state change notification

### DIFF
--- a/orderer/consensus/etcdraft/chain.go
+++ b/orderer/consensus/etcdraft/chain.go
@@ -792,6 +792,14 @@ func (c *Chain) run() {
 				case c.observeC <- soft:
 				default:
 				}
+
+				lcs := c.Node.leaderChangeSubscription.Load()
+				if lcs != nil {
+					if soft.Lead != raft.None {
+						subscription := lcs.(func(uint64))
+						subscription(soft.Lead)
+					}
+				}
 			}
 
 			c.apply(app.entries)

--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -1880,7 +1880,7 @@ var _ = Describe("Chain", func() {
 					metadata := &raftprotos.ConfigMetadata{Options: options}
 					for id, consenter := range consenters {
 						if id == 1 {
-							// remove second consenter
+							// remove first consenter, which is the leader
 							continue
 						}
 						metadata.Consenters = append(metadata.Consenters, consenter)

--- a/orderer/consensus/etcdraft/node.go
+++ b/orderer/consensus/etcdraft/node.go
@@ -151,15 +151,6 @@ func (n *node) run(campaign bool) {
 				n.chain.snapC <- &rd.Snapshot
 			}
 
-			lcs := n.leaderChangeSubscription.Load()
-
-			if lcs != nil && rd.SoftState != nil {
-				if l := atomic.LoadUint64(&rd.SoftState.Lead); l != raft.None {
-					subscription := lcs.(func(uint64))
-					subscription(l)
-				}
-			}
-
 			// skip empty apply
 			if len(rd.CommittedEntries) != 0 || rd.SoftState != nil {
 				n.chain.applyC <- apply{rd.CommittedEntries, rd.SoftState}


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description
Change the order of notification about the raft state change,
first to chain loop and then abdicateleadership go rountine.

#### Additional details
Analysis and observation noted down in the issue: https://github.com/hyperledger/fabric/issues/3629#issuecomment-1353191438 

#### Related issues
#3629 

Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>