### PR TITLE
Security vulnerability scanning using govulncheck (release-2.2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,3 +319,10 @@ unit-test-clean:
 .PHONY: filename-spaces
 spaces:
 	@scripts/check_file_name_spaces.sh
+
+.PHONY: scan
+scan: scan-govulncheck
+
+.PHONY: scan-govulncheck
+scan-govulncheck: gotool.govulncheck
+	govulncheck ./...

--- a/gotools.mk
+++ b/gotools.mk
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-GOTOOLS = counterfeiter ginkgo gocov gocov-xml goimports golint misspell mockery protoc-gen-go
+GOTOOLS = counterfeiter ginkgo gocov gocov-xml goimports golint govulncheck misspell mockery protoc-gen-go
 BUILD_DIR ?= build
 GOTOOLS_BINDIR ?= $(shell go env GOPATH)/bin
 
@@ -14,6 +14,7 @@ go.fqp.gocov         := github.com/axw/gocov/gocov
 go.fqp.gocov-xml     := github.com/AlekSi/gocov-xml
 go.fqp.goimports     := golang.org/x/tools/cmd/goimports
 go.fqp.golint        := golang.org/x/lint/golint
+go.fqp.govulncheck   := golang.org/x/vuln/cmd/govulncheck@latest
 go.fqp.misspell      := github.com/client9/misspell/cmd/misspell
 go.fqp.mockery       := github.com/vektra/mockery/cmd/mockery
 go.fqp.protoc-gen-go := github.com/golang/protobuf/protoc-gen-go


### PR DESCRIPTION
Add a makefile target for vulnerability scanning, which can later be used for scheduled vulnerability scans.

Cherry-pick of e6808b162f889a0b568e98731d39cf64afcb79b0 from main branch.

Contributes to https://github.com/hyperledger/fabric/issues/3860