### PR TITLE
Trim the (optional) semrev leading 'v' when resolving the ccenv image URL

### DIFF
--- a/core/chaincode/platforms/util/utils.go
+++ b/core/chaincode/platforms/util/utils.go
@@ -182,8 +182,10 @@ func GetDockerImageFromConfig(path string) string {
 }
 
 // twoDigitVersion truncates a 3 digit version (e.g. 2.0.0) to a 2 digit version (e.g. 2.0),
-// If version does not include dots (e.g. latest), just return the passed version
+// If version does not include dots (e.g. latest), just return the passed version.
+// If version starts with a semantic rev 'v' character, strip it when computing the docker label.
 func twoDigitVersion(version string) string {
+	version = strings.TrimPrefix(version, "v")
 	if strings.LastIndex(version, ".") < 0 {
 		return version
 	}

--- a/core/chaincode/platforms/util/utils_test.go
+++ b/core/chaincode/platforms/util/utils_test.go
@@ -119,8 +119,23 @@ func TestTwoDigitVersion(t *testing.T) {
 	actual := twoDigitVersion(version)
 	require.Equal(t, expected, actual, `Error parsing two digit version. Expected "%s", got "%s"`, expected, actual)
 
+	version = "2.0.0-beta123"
+	expected = "2.0"
+	actual = twoDigitVersion(version)
+	require.Equal(t, expected, actual, `Error parsing two digit version. Expected "%s", got "%s"`, expected, actual)
+
 	version = "latest"
 	expected = "latest"
+	actual = twoDigitVersion(version)
+	require.Equal(t, expected, actual, `Error parsing two digit version. Expected "%s", got "%s"`, expected, actual)
+
+	version = "v1.2.3"
+	expected = "1.2"
+	actual = twoDigitVersion(version)
+	require.Equal(t, expected, actual, `Error parsing two digit version. Expected "%s", got "%s"`, expected, actual)
+
+	version = "v1.2.3-beta1"
+	expected = "1.2"
 	actual = twoDigitVersion(version)
 	require.Equal(t, expected, actual, `Error parsing two digit version. Expected "%s", got "%s"`, expected, actual)
 }


### PR DESCRIPTION
Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>

#### Type of change

- Bug fix

#### Description

As reported in a [discord thread](https://discord.com/channels/905194001349627914/941396957635682314/1052993323612246097), the semrev 'v' in the peer metadata label is causing the hyperledger/fabric-ccenv:$(TWO_DIGIT_REVISION) label to crash when installing a chaincode package.  This PR strips the (optional) semrev leading `v` character from the two digit rev prior to resolving the chaincode image URL. 

When installing chaincode without this patch, the peer log reports: 
```
2022-12-20 07:54:55.098 EST 0415 DEBU [chaincode.platform] GenerateDockerfile -> 
FROM hyperledger/fabric-baseos:v2.5
ADD binpackage.tar /usr/local/bin
LABEL org.hyperledger.fabric.chaincode.type="GOLANG" \
      org.hyperledger.fabric.version="v2.5.0-alpha3"
ENV CORE_CHAINCODE_BUILDLEVEL=v2.5.0-alpha3
```
... 
```
2022-12-20 07:55:07.111 EST 0418 ERRO [dockercontroller] buildImage -> Error building image: manifest for hyperledger/fabric-baseos:v2.5 not found: manifest unknown: manifest unknown
2022-12-20 07:55:07.111 EST 0419 ERRO [dockercontroller] buildImage -> Build Output:
********************
Step 1/4 : FROM hyperledger/fabric-baseos:v2.5
```


cc: @lehors 