### PR TITLE
Update jq command in channel config docs

### DIFF
--- a/docs/source/channel_update_tutorial.rst
+++ b/docs/source/channel_update_tutorial.rst
@@ -715,7 +715,7 @@ channel configuration.
 .. code:: bash
 
   configtxlator proto_decode --input config_block.pb --type common.Block --output config_block.json
-  jq .data.data[0].payload.data.config config_block.json > config.json
+  jq ".data.data[0].payload.data.config" config_block.json > config.json
 
 The ``config.json`` is the now trimmed JSON representing the latest channel configuration
 that we will update.

--- a/docs/source/config_update.md
+++ b/docs/source/config_update.md
@@ -978,7 +978,7 @@ configtxlator proto_decode --input config_block.pb --type common.Block --output 
 Finally, we'll scope out all of the unnecessary metadata from the config, which makes it easier to read. You are free to call this file whatever you want, but in this example we'll call it `config.json`.
 
 ```
-jq .data.data[0].payload.data.config config_block.json > config.json
+jq ".data.data[0].payload.data.config" config_block.json > config.json
 ```
 
 Now let's make a copy of `config.json` called `modified_config.json`. **Do not edit ``config.json`` directly**, as we will be using it to compute the difference between ``config.json`` and ``modified_config.json`` in a later step.


### PR DESCRIPTION
I've found that quotes are needed around the jq target path.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
