### PR TITLE
Remove peer and orderer ENTRYPOINTS as they were breaking the test network

### DIFF
--- a/images/orderer/Dockerfile
+++ b/images/orderer/Dockerfile
@@ -67,7 +67,7 @@ COPY    --from=builder  sampleconfig/configtx.yaml  ${FABRIC_CFG_PATH}
 
 VOLUME  /etc/hyperledger/fabric
 VOLUME  /var/hyperledger
+
 EXPOSE  7050
 
-ENTRYPOINT  [ "orderer" ]
-CMD         [ "start" ]
+CMD     [ "orderer", "start" ]

--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -74,5 +74,4 @@ VOLUME  /var/hyperledger
 
 EXPOSE  7051
 
-ENTRYPOINT  [ "peer" ]
-CMD         [ "node", "start" ]
+CMD     [ "peer", "node", "start" ]

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -71,5 +71,3 @@ COPY    --from=builder  build/bin       /usr/local/bin
 
 VOLUME  /etc/hyperledger/fabric
 VOLUME  /var/hyperledger
-
-ENTRYPOINT [ "bash" ]


### PR DESCRIPTION
Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>

#### Type of change

- Bug fix

#### Description

In PR #3882 the peer and orderer Dockerfiles introduced an ENTRYPOINT command, breaking the test network's mechanism for launching the containers with the CMD.  This PR reverts the ENTRYPOINT addition for compatibility with the Compose test network.
