### PR TITLE
Switch base docker image from golang-alpine to ubuntu:20.04 (backport #3882)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ on:
 
 env:
   GO_VER: 1.18.9
-  ALPINE_VER: 3.16
+  UBUNTU_VER: 20.04
   FABRIC_VER: ${{ github.ref_name }}
-  DOCKER_REGISTRY: docker.io    # or ghcr.io
+  DOCKER_REGISTRY: ${{ github.repository_owner == 'hyperledger' && 'docker.io' || 'ghcr.io' }}
 
 permissions:
   contents: read
@@ -101,8 +101,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ contains(env.DOCKER_REGISTRY, 'docker.io') && secrets.DOCKERHUB_USERNAME || github.actor }}
-          password: ${{ contains(env.DOCKER_REGISTRY, 'docker.io') && secrets.DOCKERHUB_TOKEN    || secrets.GITHUB_TOKEN }}
+          username: ${{ env.DOCKER_REGISTRY == 'docker.io' && secrets.DOCKERHUB_USERNAME || github.actor }}
+          password: ${{ env.DOCKER_REGISTRY == 'docker.io' && secrets.DOCKERHUB_TOKEN    || secrets.GITHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
@@ -126,7 +126,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             FABRIC_VER=${{ env.FABRIC_VER }}
-            ALPINE_VER=${{ env.ALPINE_VER }}
+            UBUNTU_VER=${{ env.UBUNTU_VER }}
             GO_VER=${{ env.GO_VER }}
             GO_TAGS=
 

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@
 #   - unit-test - runs the go-test based unit tests
 #   - verify - runs unit tests for only the changed package tree
 
-ALPINE_VER ?= 3.16
-BASE_VERSION = 3.0.0
+UBUNTU_VER ?= 20.04
+FABRIC_VER ?= 3.0.0
 
 # 3rd party image version
 # These versions are also set in the runners in ./integration/runners/
@@ -244,7 +244,7 @@ $(BUILD_DIR)/images/%/$(DUMMY):
 	@mkdir -p $(@D)
 	$(DBUILD) -f images/$*/Dockerfile \
 		--build-arg GO_VER=$(GO_VER) \
-		--build-arg ALPINE_VER=$(ALPINE_VER) \
+		--build-arg UBUNTU_VER=$(UBUNTU_VER) \
 		--build-arg FABRIC_VER=$(FABRIC_VER) \
 		--build-arg TARGETARCH=$(ARCH) \
 		--build-arg TARGETOS=linux \

--- a/images/baseos/Dockerfile
+++ b/images/baseos/Dockerfile
@@ -1,11 +1,30 @@
-# Copyright IBM Corp. All Rights Reserved.
+#
+# Copyright contributors to the Hyperledger Fabric project
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+# 	  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 ARG GO_VER
-ARG ALPINE_VER
+ARG UBUNTU_VER
 
-FROM alpine:${ALPINE_VER} as base
-RUN apk add --no-cache tzdata
-RUN addgroup -g 500 chaincode && adduser -u 500 -D -h /home/chaincode -G chaincode chaincode
-USER chaincode
+FROM ubuntu:${UBUNTU_VER} as base
+
+RUN apt update && apt install -y \
+    tzdata
+
+RUN     addgroup --gid 500 chaincode
+RUN     adduser  --disabled-password --gecos "" --uid 500 --gid 500 --home /home/chaincode chaincode
+
+USER    chaincode

--- a/images/ccenv/Dockerfile
+++ b/images/ccenv/Dockerfile
@@ -1,18 +1,44 @@
-# Copyright IBM Corp. All Rights Reserved.
+#
+# Copyright contributors to the Hyperledger Fabric project
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+# 	  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
+ARG UBUNTU_VER
+FROM ubuntu:${UBUNTU_VER}
+
+ARG TARGETARCH
+ARG TARGETOS
 ARG GO_VER
-ARG ALPINE_VER
-FROM golang:${GO_VER}-alpine${ALPINE_VER}
-RUN apk add --no-cache \
-	binutils-gold \
-	g++ \
-	gcc \
-	git \
-	musl-dev
 
-RUN mkdir -p /chaincode/output /chaincode/input
-RUN addgroup -g 500 chaincode && adduser -u 500 -D -h /home/chaincode -G chaincode chaincode
-RUN chown -R chaincode:chaincode /chaincode
+RUN apt update && apt install -y \
+    binutils-gold \
+    curl \
+    g++ \
+    gcc \
+    git
+
+RUN curl -sL https://go.dev/dl/go${GO_VER}.${TARGETOS}-${TARGETARCH}.tar.gz | tar zxvf - -C /usr/local
+ENV PATH="/usr/local/go/bin:$PATH"
+
+RUN addgroup --gid 500 chaincode
+RUN adduser  --disabled-password --gecos "" --uid 500 --gid 500 --home /home/chaincode chaincode
+
+RUN mkdir    -p /chaincode/output /chaincode/input
+RUN chown    -R chaincode:chaincode /chaincode
+
 USER chaincode
+
+

--- a/images/orderer/Dockerfile
+++ b/images/orderer/Dockerfile
@@ -67,7 +67,7 @@ COPY    --from=builder  sampleconfig/configtx.yaml  ${FABRIC_CFG_PATH}
 
 VOLUME  /etc/hyperledger/fabric
 VOLUME  /var/hyperledger
+
 EXPOSE  7050
 
-ENTRYPOINT  [ "orderer" ]
-CMD         [ "start" ]
+CMD     [ "orderer", "start" ]

--- a/images/orderer/Dockerfile
+++ b/images/orderer/Dockerfile
@@ -1,46 +1,73 @@
-# Copyright IBM Corp. All Rights Reserved.
+#
+# Copyright contributors to the Hyperledger Fabric project
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+# 	  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
+###############################################################################
+# Build image
+###############################################################################
+
+ARG UBUNTU_VER
+FROM ubuntu:${UBUNTU_VER} as builder
+
+ARG TARGETARCH
+ARG TARGETOS
+ARG FABRIC_VER
 ARG GO_VER
-ARG ALPINE_VER
+ARG GO_TAGS
 
-FROM alpine:${ALPINE_VER} as base
-RUN apk add --no-cache tzdata
+RUN apt update && apt install -y \
+    git \
+    gcc \
+    curl \
+    make
+
+RUN curl -sL https://go.dev/dl/go${GO_VER}.${TARGETOS}-${TARGETARCH}.tar.gz | tar zxf - -C /usr/local
+ENV PATH="/usr/local/go/bin:$PATH"
+
+ADD . .
+
+RUN make orderer GO_TAGS=${GO_TAGS} FABRIC_VER=${FABRIC_VER}
+
+
+###############################################################################
+# Runtime image
+###############################################################################
+
+ARG UBUNTU_VER
+FROM ubuntu:${UBUNTU_VER}
+
+ARG FABRIC_VER
+
 # set up nsswitch.conf for Go's "netgo" implementation
 # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 
-FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
-RUN apk add --no-cache \
-	bash \
-	binutils-gold \
-	gcc \
-	git \
-	make \
-	musl-dev
-ADD . $GOPATH/src/github.com/hyperledger/fabric
-WORKDIR $GOPATH/src/github.com/hyperledger/fabric
+ENV     FABRIC_CFG_PATH /var/hyperledger/fabric/config
+ENV     FABRIC_VER      ${FABRIC_VER}
 
-FROM golang as orderer
-ARG GO_TAGS
-ARG FABRIC_VER
-ENV FABRIC_VER ${FABRIC_VER}
+COPY    --from=builder  build/bin/orderer           /usr/local/bin
+COPY    --from=builder  sampleconfig/msp            ${FABRIC_CFG_PATH}/msp
+COPY    --from=builder  sampleconfig/orderer.yaml   ${FABRIC_CFG_PATH}
+COPY    --from=builder  sampleconfig/configtx.yaml  ${FABRIC_CFG_PATH}
 
-# Disable cgo when building in the container.  This will create a static binary, which can be
-# copied and run in the base alpine container without the libc/musl runtime.
-ENV CGO_ENABLED 0
+VOLUME  /etc/hyperledger/fabric
+VOLUME  /var/hyperledger
+EXPOSE  7050
 
-RUN make orderer GO_TAGS=${GO_TAGS}
-
-FROM base
-ENV FABRIC_CFG_PATH /etc/hyperledger/fabric
-VOLUME /etc/hyperledger/fabric
-VOLUME /var/hyperledger
-COPY --from=orderer /go/src/github.com/hyperledger/fabric/build/bin /usr/local/bin
-COPY --from=orderer /go/src/github.com/hyperledger/fabric/sampleconfig/msp ${FABRIC_CFG_PATH}/msp
-COPY --from=orderer /go/src/github.com/hyperledger/fabric/sampleconfig/orderer.yaml ${FABRIC_CFG_PATH}
-COPY --from=orderer /go/src/github.com/hyperledger/fabric/sampleconfig/configtx.yaml ${FABRIC_CFG_PATH}
-EXPOSE 7050
-CMD ["orderer"]
+ENTRYPOINT  [ "orderer" ]
+CMD         [ "start" ]

--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -74,5 +74,4 @@ VOLUME  /var/hyperledger
 
 EXPOSE  7051
 
-ENTRYPOINT  [ "peer" ]
-CMD         [ "node", "start" ]
+CMD     [ "peer", "node", "start" ]

--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -1,48 +1,78 @@
-# Copyright IBM Corp. All Rights Reserved.
+#
+# Copyright contributors to the Hyperledger Fabric project
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+# 	  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
+###############################################################################
+# Build image
+###############################################################################
+
+ARG UBUNTU_VER
+FROM ubuntu:${UBUNTU_VER} as builder
+
+ARG TARGETARCH
+ARG TARGETOS
+ARG FABRIC_VER
 ARG GO_VER
-ARG ALPINE_VER
-FROM alpine:${ALPINE_VER} as peer-base
-RUN apk add --no-cache tzdata
+ARG GO_TAGS
+
+RUN apt update && apt install -y \
+    git \
+    gcc \
+    curl \
+    make
+
+RUN curl -sL https://go.dev/dl/go${GO_VER}.${TARGETOS}-${TARGETARCH}.tar.gz | tar zxf - -C /usr/local
+ENV PATH="/usr/local/go/bin:$PATH"
+
+ADD . .
+
+RUN make peer GO_TAGS=${GO_TAGS} FABRIC_VER=${FABRIC_VER}
+RUN make ccaasbuilder
+
+
+###############################################################################
+# Runtime image
+###############################################################################
+
+ARG UBUNTU_VER
+FROM ubuntu:${UBUNTU_VER}
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG FABRIC_VER
+
 # set up nsswitch.conf for Go's "netgo" implementation
 # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 
-FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
-RUN apk add --no-cache \
-	bash \
-	binutils-gold \
-	gcc \
-	git \
-	make \
-	musl-dev
-ADD . $GOPATH/src/github.com/hyperledger/fabric
-WORKDIR $GOPATH/src/github.com/hyperledger/fabric
+ENV     FABRIC_CFG_PATH /var/hyperledger/fabric/config
+ENV     FABRIC_VER      ${FABRIC_VER}
 
-FROM golang as peer
-ARG GO_TAGS
-ARG FABRIC_VER
-ENV FABRIC_VER ${FABRIC_VER}
+COPY    --from=builder  build/bin/peer          /usr/local/bin
+COPY    --from=builder  sampleconfig/msp        ${FABRIC_CFG_PATH}/msp
+COPY    --from=builder  sampleconfig/core.yaml  ${FABRIC_CFG_PATH}/core.yaml
 
-# Disable cgo when building in the container.  This will create a static binary, which can be
-# copied and run in the base alpine container without the libc/musl runtime.
-ENV CGO_ENABLED 0
+COPY    --from=builder  release/${TARGETOS}-${TARGETARCH}/builders/ccaas/bin /opt/hyperledger/ccaas_builder/bin
 
-RUN make peer GO_TAGS=${GO_TAGS}
-RUN make ccaasbuilder
+VOLUME  /etc/hyperledger/fabric
+VOLUME  /var/hyperledger
 
-FROM peer-base
-ARG TARGETARCH
-ARG TARGETOS
-ENV FABRIC_CFG_PATH /etc/hyperledger/fabric
-VOLUME /etc/hyperledger/fabric
-VOLUME /var/hyperledger
-COPY --from=peer /go/src/github.com/hyperledger/fabric/build/bin /usr/local/bin
-COPY --from=peer /go/src/github.com/hyperledger/fabric/sampleconfig/msp ${FABRIC_CFG_PATH}/msp
-COPY --from=peer /go/src/github.com/hyperledger/fabric/sampleconfig/core.yaml ${FABRIC_CFG_PATH}/core.yaml
-COPY --from=peer /go/src/github.com/hyperledger/fabric/release/${TARGETOS}-${TARGETARCH}/builders/ccaas/bin/ /opt/hyperledger/ccaas_builder/bin/
-EXPOSE 7051
-CMD ["peer","node","start"]
+EXPOSE  7051
+
+ENTRYPOINT  [ "peer" ]
+CMD         [ "node", "start" ]

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -1,41 +1,75 @@
-# Copyright IBM Corp. All Rights Reserved.
+#
+# Copyright contributors to the Hyperledger Fabric project
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+# 	  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-ARG GO_VER
-ARG ALPINE_VER
-FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
+###############################################################################
+# Build image
+###############################################################################
 
-RUN apk add --no-cache \
-	bash \
-	binutils-gold \
-	gcc \
-	git \
-	make \
-	musl-dev;
+ARG UBUNTU_VER
+FROM ubuntu:${UBUNTU_VER} as builder
 
-ADD . $GOPATH/src/github.com/hyperledger/fabric
-WORKDIR $GOPATH/src/github.com/hyperledger/fabric
-
-FROM golang as tools
-ARG GO_TAGS
+ARG TARGETARCH
+ARG TARGETOS
 ARG FABRIC_VER
-ENV FABRIC_VER ${FABRIC_VER}
+ARG GO_VER
+ARG GO_TAGS
 
-# Disable cgo when building in the container.  This will create a static binary, which can be
-# copied and run in the base alpine container without the libc/musl runtime.
-ENV CGO_ENABLED 0
+RUN apt update && apt install -y \
+    git \
+    gcc \
+    curl \
+    make
 
-RUN make tools GO_TAGS=${GO_TAGS}
+RUN curl -sL https://go.dev/dl/go${GO_VER}.${TARGETOS}-${TARGETARCH}.tar.gz | tar zxf - -C /usr/local
+ENV PATH="/usr/local/go/bin:$PATH"
 
-FROM golang:${GO_VER}-alpine${ALPINE_VER}
-# git is required to support `go list -m`
-RUN apk add --no-cache \
-	bash \
-	git \
-	jq \
-	tzdata;
-ENV FABRIC_CFG_PATH /etc/hyperledger/fabric
-VOLUME /etc/hyperledger/fabric
-COPY --from=tools /go/src/github.com/hyperledger/fabric/build/bin /usr/local/bin
-COPY --from=tools /go/src/github.com/hyperledger/fabric/sampleconfig ${FABRIC_CFG_PATH}
+ADD . .
+
+RUN make tools GO_TAGS=${GO_TAGS} FABRIC_VER=${FABRIC_VER}
+
+
+###############################################################################
+# Runtime image
+###############################################################################
+
+ARG UBUNTU_VER
+FROM ubuntu:${UBUNTU_VER}
+
+ARG FABRIC_VER
+
+RUN apt update && apt install -y \
+    bash \
+    curl \
+    jq \
+    tzdata
+
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
+RUN echo 'hosts: files dns' > /etc/nsswitch.conf
+
+ENV     FABRIC_CFG_PATH /var/hyperledger/fabric/config
+ENV     FABRIC_VER      ${FABRIC_VER}
+
+COPY    --from=builder  sampleconfig    ${FABRIC_CFG_PATH}
+COPY    --from=builder  build/bin       /usr/local/bin
+
+VOLUME  /etc/hyperledger/fabric
+VOLUME  /var/hyperledger
+
+ENTRYPOINT [ "bash" ]

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -71,5 +71,3 @@ COPY    --from=builder  build/bin       /usr/local/bin
 
 VOLUME  /etc/hyperledger/fabric
 VOLUME  /var/hyperledger
-
-ENTRYPOINT [ "bash" ]

--- a/release_notes/v2.5.0-alpha3.md
+++ b/release_notes/v2.5.0-alpha3.md
@@ -1,0 +1,108 @@
+v2.5.0-alpha3 Release Notes - 21 Dec 2022
+=================================
+
+Improvements
+------------
+
+- Prepares multi-arch Docker images for linux/arm64 and linux/amd64
+- Converts base Docker images FROM alpine to FROM ubuntu:20.04 
+
+
+Fixes
+-----
+
+- Resolves SIGSEGV errors encountered with alpha1 release binaries
+- Resolves SIGSEGV errors running on alpine-based images on ARM64
+- Resolves [Issue #3867](https://github.com/hyperledger/fabric/issues/3867)
+
+
+Dependencies
+------------
+Fabric v2.5.0-alpha3 has been tested with the following dependencies:
+* Go 1.18.7
+* CouchDB v3.1.1
+
+Fabric docker images on dockerhub utilize Ubuntu 20.04
+
+
+Deprecations (existing)
+-----------------------
+
+**Ordering service system channel is deprecated**
+
+v2.3 introduced the ability to manage an ordering service without a system channel.
+Managing an ordering service without a system channel has privacy, scalability,
+and operational benefits. The use of a system channel is deprecated and may be removed in a future release.
+For information about removal of the system channel, see the [Create a channel without system channel documentation](https://hyperledger-fabric.readthedocs.io/en/release-2.3/create_channel/create_channel_participation.html).
+
+**FAB-15754: The 'Solo' consensus type is deprecated.**
+
+The 'Solo' consensus type has always been marked non-production and should be in
+use only in test environments; however, for compatibility it is still available,
+but may be removed entirely in a future release.
+
+**FAB-16408: The 'Kafka' consensus type is deprecated.**
+
+The 'Raft' consensus type was introduced in v1.4.1 and has become the preferred
+production consensus type.  There is a documented and tested migration path from
+Kafka to Raft, and existing users should migrate to the newer Raft consensus type.
+For compatibility with existing deployments, Kafka is still supported,
+but may be removed entirely in a future release.
+Additionally, the fabric-kafka and fabric-zookeeper docker images are no longer updated, maintained, or published.
+
+**Fabric CouchDB image is deprecated**
+
+v2.2.0 added support for CouchDB 3.1.0 as the recommended and tested version of CouchDB.
+If prior versions are utilized, a Warning will appear in the peer log.
+Note that CouchDB 3.1.0 requires that an admin username and password be set,
+while this was optional in CouchDB v2.x. See the
+[Fabric CouchDB documentation](https://hyperledger-fabric.readthedocs.io/en/v2.2.0/couchdb_as_state_database.html#couchdb-configuration)
+for configuration details.
+Also note that CouchDB 3.1.0 default max_document_size is reduced to 8MB. Set a higher value if needed in your environment.
+Finally, the fabric-couchdb docker image will not be updated to v3.1.0 and will no longer be updated, maintained, or published.
+Users can utilize the official CouchDB docker image maintained by the Apache CouchDB project instead.
+
+**FAB-7559: Support for specifying orderer endpoints at the global level in channel configuration is deprecated.**
+
+Utilize the new 'OrdererEndpoints' stanza within the channel configuration of an organization instead.
+Configuring orderer endpoints at the organization level accommodates
+scenarios where orderers are run by different organizations. Using
+this configuration ensures that only the TLS CA certificates of that organization
+are used for orderer communications; in contrast to the global channel level endpoints which
+would cause an aggregation of all orderer TLS CA certificates across
+all orderer organizations to be used for orderer communications.
+
+**FAB-17428: Support for configtxgen flag `--outputAnchorPeersUpdate` is deprecated.**
+
+The `--outputAnchorPeersUpdate` mechanism for updating anchor peers has always had
+limitations (for instance, it only works the first time anchor peers are updated).
+Instead, anchor peer updates should be performed through channel configuration updates.
+
+**FAB-15406: The fabric-tools docker image is deprecated**
+
+The fabric-tools docker image will not be published in future Fabric releases.
+Instead of using the fabric-tools docker image, users should utilize the
+published Fabric binaries. The Fabric binaries can be used to make client calls
+to Fabric runtime components, regardless of where the Fabric components are running.
+
+**FAB-15317: Block dissemination via gossip is deprecated**
+
+Block dissemination via gossip is deprecated and may be removed in a future release.
+Fabric peers can be configured to receive blocks directly from an ordering service
+node, and not gossip blocks, by using the following configuration:
+```
+peer.gossip.orgLeader: true
+peer.gossip.useLeaderElection: false
+peer.gossip.state.enabled: false
+peer.deliveryclient.blockGossipEnabled: false
+```
+
+**FAB-15061: Legacy chaincode lifecycle is deprecated**
+
+The legacy chaincode lifecycle from v1.x is deprecated and will be removed
+in a future release. To prepare for the eventual removal, utilize the v2.x
+chaincode lifecycle instead, by enabling V2_0 application capability on all
+channels, and redeploying all chaincodes using the v2.x lifecycle. The new
+chaincode lifecycle provides a more flexible and robust governance model
+for chaincodes. For more details see the
+[documentation for enabling the new lifecycle](https://hyperledger-fabric.readthedocs.io/en/release-2.2/enable_cc_lifecycle.html).


### PR DESCRIPTION
#### Type of change

- Bug fix
- New feature

#### Description

This PR is a back port merge from release-2.5 to mainline of: 

- cherry-pick 114695ab06884242e3cc0d8046137dd2b5b8f36b (#3882)
- cherry-pick 764fd40576598cd8c916c85153e260f5a7257de3  (#3894)
