### PR TITLE
Add PurgedKeyAuditLogging config option

### DIFF
--- a/core/ledger/ledger_interface.go
+++ b/core/ledger/ledger_interface.go
@@ -118,6 +118,8 @@ type PrivateDataConfig struct {
 	// from other peers. A chance for eligible deprioritized missing data
 	// would be given after every DeprioritizedDataReconcilerInterval
 	DeprioritizedDataReconcilerInterval time.Duration
+	// PurgedKeyAuditLogging specifies whether to log private data keys purged from private data store (INFO level) when explicitly purged via chaincode
+	PurgedKeyAuditLogging bool
 }
 
 // HistoryDBConfig is a structure used to configure the transaction history database.

--- a/internal/peer/node/config.go
+++ b/internal/peer/node/config.go
@@ -41,6 +41,10 @@ func ledgerConfig() *ledger.Config {
 	if viper.IsSet("ledger.pvtdataStore.deprioritizedDataReconcilerInterval") {
 		deprioritizedDataReconcilerInterval = viper.GetDuration("ledger.pvtdataStore.deprioritizedDataReconcilerInterval")
 	}
+	purgedKeyAuditLogging := true
+	if viper.IsSet("ledger.pvtdataStore.purgedKeyAuditLogging") {
+		purgedKeyAuditLogging = viper.GetBool("ledger.pvtdataStore.purgedKeyAuditLogging")
+	}
 
 	fsPath := coreconfig.GetPath("peer.fileSystemPath")
 	ledgersDataRootDir := filepath.Join(fsPath, "ledgersData")
@@ -59,6 +63,7 @@ func ledgerConfig() *ledger.Config {
 			BatchesInterval:                     collElgProcDbBatchesInterval,
 			PurgeInterval:                       purgeInterval,
 			DeprioritizedDataReconcilerInterval: deprioritizedDataReconcilerInterval,
+			PurgedKeyAuditLogging:               purgedKeyAuditLogging,
 		},
 		HistoryDBConfig: &ledger.HistoryDBConfig{
 			Enabled: viper.GetBool("ledger.history.enableHistoryDatabase"),

--- a/internal/peer/node/config_test.go
+++ b/internal/peer/node/config_test.go
@@ -39,6 +39,7 @@ func TestLedgerConfig(t *testing.T) {
 					BatchesInterval:                     1000,
 					PurgeInterval:                       100,
 					DeprioritizedDataReconcilerInterval: 60 * time.Minute,
+					PurgedKeyAuditLogging:               true,
 				},
 				HistoryDBConfig: &ledger.HistoryDBConfig{
 					Enabled: false,
@@ -85,6 +86,7 @@ func TestLedgerConfig(t *testing.T) {
 					BatchesInterval:                     1000,
 					PurgeInterval:                       100,
 					DeprioritizedDataReconcilerInterval: 60 * time.Minute,
+					PurgedKeyAuditLogging:               true,
 				},
 				HistoryDBConfig: &ledger.HistoryDBConfig{
 					Enabled: false,
@@ -112,6 +114,7 @@ func TestLedgerConfig(t *testing.T) {
 				"ledger.pvtdataStore.collElgProcMaxDbBatchSize":           50000,
 				"ledger.pvtdataStore.collElgProcDbBatchesInterval":        10000,
 				"ledger.pvtdataStore.purgeInterval":                       1000,
+				"ledger.pvtdataStore.purgedKeyAuditLogging":               false,
 				"ledger.pvtdataStore.deprioritizedDataReconcilerInterval": "180m",
 				"ledger.history.enableHistoryDatabase":                    true,
 				"ledger.snapshots.rootDir":                                "/peerfs/customLocationForsnapshots",
@@ -139,6 +142,7 @@ func TestLedgerConfig(t *testing.T) {
 					BatchesInterval:                     10000,
 					PurgeInterval:                       1000,
 					DeprioritizedDataReconcilerInterval: 180 * time.Minute,
+					PurgedKeyAuditLogging:               false,
 				},
 				HistoryDBConfig: &ledger.HistoryDBConfig{
 					Enabled: true,

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -732,6 +732,8 @@ ledger:
     # Private data is purged from the peer's private data store based on
     # the collection property blockToLive or an explicit chaincode call to PurgePrivateData().
     purgeInterval: 100
+    # Whether to log private data keys purged from private data store (INFO level) when explicitly purged via chaincode
+    purgedKeyAuditLogging: true
 
   snapshots:
     # Path on the file system where peer will store ledger snapshots


### PR DESCRIPTION
Add peer config option to log purged private data keys. Useful to audit that private data has been purged from a peer, however some users may want to disable the audit logging to prevent private data keys from appearing in peer logs, while preserving the other pvtdatastorage log messages.

Sample log entry:
```
INFO [pvtdatastorage] process -> Purging private data from private data storage channel=mychannel chaincode=private collection=Org1MSPPrivateCollection key=assetp5 blockNum=12 tranNum=0
INFO [pvtdatastorage] process -> Purging private data from private data storage channel=mychannel chaincode=private collection=Org1MSPPrivateCollection key=assetp5 blockNum=13 tranNum=0
INFO [pvtdatastorage] process -> Purging private data from private data storage channel=mychannel chaincode=private collection=assetCollection key=assetp5 blockNum=12 tranNum=0
INFO [pvtdatastorage] process -> Purging private data from private data storage channel=mychannel chaincode=private collection=assetCollection key=assetp5 blockNum=13 tranNum=0

INFO [pvtdatastorage] deleteDataMarkedForPurge -> Purged private data from private data storage channel=mychannel numKeysPurged=2 numPrivateDataStoreRecordsPurged=4
```

Signed-off-by: David Enyeart <enyeart@us.ibm.com>