### PR TITLE
Rename ThreeOrgRaft nwo standard networks

### DIFF
--- a/integration/gateway/endorsing_orgs_test.go
+++ b/integration/gateway/endorsing_orgs_test.go
@@ -43,7 +43,7 @@ var _ = Describe("GatewayService with endorsing orgs", func() {
 		client, err := docker.NewClientFromEnv()
 		Expect(err).NotTo(HaveOccurred())
 
-		config := nwo.ThreeOrgRaft()
+		config := nwo.ThreeOrgEtcdRaft()
 		network = nwo.New(config, testDir, client, StartPort(), components)
 
 		network.GenerateConfigTree()

--- a/integration/gateway/gateway_discovery_test.go
+++ b/integration/gateway/gateway_discovery_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GatewayService with endorser discovery", func() {
 		client, err := docker.NewClientFromEnv()
 		Expect(err).NotTo(HaveOccurred())
 
-		config := nwo.ThreeOrgRaft()
+		config := nwo.ThreeOrgEtcdRaft()
 		network = nwo.New(config, testDir, client, StartPort(), components)
 
 		network.GenerateConfigTree()

--- a/integration/nwo/standard_networks.go
+++ b/integration/nwo/standard_networks.go
@@ -227,7 +227,7 @@ func MinimalRaft() *Config {
 	return config
 }
 
-func ThreeOrgRaft() *Config {
+func ThreeOrgEtcdRaft() *Config {
 	config := BasicEtcdRaft()
 
 	config.Organizations = append(

--- a/integration/pvtdata/data_purge_test.go
+++ b/integration/pvtdata/data_purge_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Pvtdata purge", func() {
 		testDir, err = ioutil.TempDir("", "purgedata")
 		Expect(err).NotTo(HaveOccurred())
 
-		config := nwo.ThreeOrgRaft()
+		config := nwo.ThreeOrgEtcdRaft()
 		network = nwo.New(config, testDir, nil, StartPort(), components)
 
 		network.GenerateConfigTree()


### PR DESCRIPTION
The name has changed in the main branch as a result of hyperledger#3643 and hyperledger#3853, and this rename should make it easier to backport PRs with mergify

Signed-off-by: James Taylor <jamest@uk.ibm.com>
