### PR TITLE
synchronize access to wal storage from chain and node

### DIFF
--- a/orderer/consensus/etcdraft/chain.go
+++ b/orderer/consensus/etcdraft/chain.go
@@ -1149,12 +1149,10 @@ func (c *Chain) apply(ents []raftpb.Entry) {
 				continue
 			}
 
-			if err := c.Node.storage.Sync(); err != nil {
-				c.logger.Debugf("Failed to sync raft log, error: %s", err)
-			}
+			// persist the WAL entries into disk
+			c.Node.storage.WALSyncC <- struct{}{}
 
 			c.confState = *c.Node.ApplyConfChange(cc)
-
 			switch cc.Type {
 			case raftpb.ConfChangeAddNode:
 				c.logger.Infof("Applied config change to add node %d, current nodes in channel: %+v", cc.NodeID, c.confState.Voters)

--- a/orderer/consensus/etcdraft/node.go
+++ b/orderer/consensus/etcdraft/node.go
@@ -171,6 +171,11 @@ func (n *node) run(campaign bool) {
 			// to the followers and them writing to their disks. Check 10.2.1 in thesis
 			n.send(rd.Messages)
 
+		case <-n.storage.WALSyncC:
+			if err := n.storage.Sync(); err != nil {
+				n.logger.Warnf("Failed to sync raft log, error: %s", err)
+			}
+
 		case <-n.chain.haltC:
 			raftTicker.Stop()
 			n.Stop()

--- a/orderer/consensus/etcdraft/storage.go
+++ b/orderer/consensus/etcdraft/storage.go
@@ -59,6 +59,7 @@ type RaftStorage struct {
 
 	// a queue that keeps track of indices of snapshots on disk
 	snapshotIndex []uint64
+	WALSyncC      chan struct{}
 }
 
 // CreateStorage attempts to create a storage to persist etcd/raft data.
@@ -113,6 +114,7 @@ func CreateStorage(
 		walDir:        walDir,
 		snapDir:       snapDir,
 		snapshotIndex: ListSnapshots(lg, snapDir),
+		WALSyncC:      make(chan struct{}),
 	}, nil
 }
 


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description
sychronized the access to raft/wal stroage from
node ready loop and chain apply go routine

#### Related issues
#3903 

Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>