### PR TITLE
Fix bug in purging private key from statedb

### DIFF
--- a/core/ledger/kvledger/txmgmt/validation/validator.go
+++ b/core/ledger/kvledger/txmgmt/validation/validator.go
@@ -293,9 +293,8 @@ func (v *validator) validateKVReadHash(ns, coll string, kvReadHash *kvrwset.KVRe
 }
 
 type AppInitiatedPurgeUpdate struct {
-	CompositeKey              *privacyenabledstate.HashedCompositeKey
-	Version                   *version.Height
-	DeletePrivateKeyFromState bool
+	CompositeKey *privacyenabledstate.HashedCompositeKey
+	Version      *version.Height
 }
 
 type pvtdataPurgeTracker struct {
@@ -321,19 +320,10 @@ func (p *pvtdataPurgeTracker) update(rwset *rwsetutil.TxRwSet, version *version.
 
 				if hashedWrite.IsPurge {
 					p.m[ck] = &AppInitiatedPurgeUpdate{
-						CompositeKey:              &ck,
-						Version:                   version,
-						DeletePrivateKeyFromState: true,
+						CompositeKey: &ck,
+						Version:      version,
 					}
-					continue
 				}
-
-				existingUpdate, ok := p.m[ck]
-				if !ok {
-					continue
-				}
-				// the hash of a key that was purged in a previous transaction, got overwritten by this transaction
-				existingUpdate.DeletePrivateKeyFromState = false
 			}
 		}
 	}

--- a/core/ledger/kvledger/txmgmt/validation/validator_test.go
+++ b/core/ledger/kvledger/txmgmt/validation/validator_test.go
@@ -416,8 +416,7 @@ func TestPrvtdataPurgeUpdates(t *testing.T) {
 						CollectionName: "coll1",
 						KeyHash:        string(util.ComputeStringHash("key1")),
 					},
-					Version:                   version.NewHeight(1, 0),
-					DeletePrivateKeyFromState: true,
+					Version: version.NewHeight(1, 0),
 				},
 				{
 					CompositeKey: &privacyenabledstate.HashedCompositeKey{
@@ -425,8 +424,7 @@ func TestPrvtdataPurgeUpdates(t *testing.T) {
 						CollectionName: "coll1",
 						KeyHash:        string(util.ComputeStringHash("key2")),
 					},
-					Version:                   version.NewHeight(1, 0),
-					DeletePrivateKeyFromState: true,
+					Version: version.NewHeight(1, 0),
 				},
 			},
 		)
@@ -449,8 +447,7 @@ func TestPrvtdataPurgeUpdates(t *testing.T) {
 						CollectionName: "coll1",
 						KeyHash:        string(util.ComputeStringHash("key1")),
 					},
-					Version:                   version.NewHeight(1, 0),
-					DeletePrivateKeyFromState: false,
+					Version: version.NewHeight(1, 0),
 				},
 				{
 					CompositeKey: &privacyenabledstate.HashedCompositeKey{
@@ -458,8 +455,7 @@ func TestPrvtdataPurgeUpdates(t *testing.T) {
 						CollectionName: "coll1",
 						KeyHash:        string(util.ComputeStringHash("key2")),
 					},
-					Version:                   version.NewHeight(1, 0),
-					DeletePrivateKeyFromState: true,
+					Version: version.NewHeight(1, 0),
 				},
 			},
 		)
@@ -482,8 +478,7 @@ func TestPrvtdataPurgeUpdates(t *testing.T) {
 						CollectionName: "coll1",
 						KeyHash:        string(util.ComputeStringHash("key1")),
 					},
-					Version:                   version.NewHeight(1, 1),
-					DeletePrivateKeyFromState: true,
+					Version: version.NewHeight(1, 1),
 				},
 				{
 					CompositeKey: &privacyenabledstate.HashedCompositeKey{
@@ -491,8 +486,7 @@ func TestPrvtdataPurgeUpdates(t *testing.T) {
 						CollectionName: "coll1",
 						KeyHash:        string(util.ComputeStringHash("key2")),
 					},
-					Version:                   version.NewHeight(1, 1),
-					DeletePrivateKeyFromState: true,
+					Version: version.NewHeight(1, 1),
 				},
 			},
 		)


### PR DESCRIPTION
Signed-off-by: manish <manish.sethi@gmail.com>

This PR
- Makes the read of private key via hashed-index from the private data store, prior to adding the purge-marker, so as to avoid the race condition, where the hashed-index entries could be deleted via the background process, before they are read in the commit path.

- Deletes the purged key from statedb even when the private key is overwritten by a succeeding transaction in the block, and the corresponding private data is missing

#### Type of change
- Bug fix

#### Related issues
closes #3828 