### PR TITLE
fix: security: XSS

### DIFF
--- a/internal/configtxlator/rest/protolator_handlers.go
+++ b/internal/configtxlator/rest/protolator_handlers.go
@@ -68,21 +68,21 @@ func Encode(w http.ResponseWriter, r *http.Request) {
 	msg, err := getMsgType(r)
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintln(w, err)
+		sanitizedFprintln(w, err)
 		return
 	}
 
 	err = protolator.DeepUnmarshalJSON(r.Body, msg)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintln(w, err)
+		sanitizedFprintln(w, err)
 		return
 	}
 
 	data, err := proto.Marshal(msg)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintln(w, err)
+		sanitizedFprintln(w, err)
 		return
 	}
 
@@ -90,3 +90,4 @@ func Encode(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Write(data)
 }
+


### PR DESCRIPTION
--------------------

function `sanitizedFprintln` could be used to replace the `fmt.Fprintln` calls in the `Encode` function in order to prevent potential XSS vulnerabilities in the output.

#### Type of change

- Bug fix
- 
#### Description

 input from the request body flows into fmt.Fprintln, This may result in a Reflected Cross-Site Scripting attack (XSS).
