### PR TITLE
fix: security: XSS

### DIFF
--- a/internal/configtxlator/rest/protolator_handlers.go
+++ b/internal/configtxlator/rest/protolator_handlers.go
@@ -68,21 +68,21 @@ func Encode(w http.ResponseWriter, r *http.Request) {
 	msg, err := getMsgType(r)
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintln(w, err)
+		escapeFprintln(w, err)
 		return
 	}
 
 	err = protolator.DeepUnmarshalJSON(r.Body, msg)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintln(w, err)
+		escapeFprintln(w, err)
 		return
 	}
 
 	data, err := proto.Marshal(msg)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintln(w, err)
+		escapeFprintln(w, err)
 		return
 	}
 


### PR DESCRIPTION
------------------------
The modified function `Fprintln` could be used to replace the `fmt.Fprintln` calls in the `Encode` function in order to prevent potential XSS vulnerabilities in the output.

Signed-off-by: Bhaskar <bhaskarvilles.eth@ethereum.email>

#### Type of change
- Bug fix

