### PR TITLE
Orderer v3: Remove system channel usage from integration tests: lifecycle

### DIFF
--- a/integration/lifecycle/install_test.go
+++ b/integration/lifecycle/install_test.go
@@ -12,16 +12,17 @@ import (
 	"path/filepath"
 	"syscall"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/hyperledger/fabric/integration/channelparticipation"
 	"github.com/hyperledger/fabric/integration/nwo"
 	"github.com/hyperledger/fabric/integration/nwo/commands"
 	"github.com/hyperledger/fabric/integration/nwo/fabricconfig"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"github.com/tedsuo/ifrit"
+	ginkgomon "github.com/tedsuo/ifrit/ginkgomon_v2"
 )
 
 var _ = Describe("chaincode install", func() {
@@ -29,8 +30,9 @@ var _ = Describe("chaincode install", func() {
 		client  *docker.Client
 		testDir string
 
-		network *nwo.Network
-		process ifrit.Process
+		network                     *nwo.Network
+		ordererRunner               *ginkgomon.Runner
+		ordererProcess, peerProcess ifrit.Process
 	)
 
 	BeforeEach(func() {
@@ -44,7 +46,7 @@ var _ = Describe("chaincode install", func() {
 		cwd, err := os.Getwd()
 		Expect(err).NotTo(HaveOccurred())
 
-		network = nwo.New(nwo.BasicEtcdRaft(), testDir, client, StartPort(), components)
+		network = nwo.New(nwo.BasicEtcdRaftNoSysChan(), testDir, client, StartPort(), components)
 		network.ExternalBuilders = append(network.ExternalBuilders, fabricconfig.ExternalBuilder{
 			Path:                 filepath.Join(cwd, "..", "externalbuilders", "golang"),
 			Name:                 "external-golang",
@@ -53,14 +55,20 @@ var _ = Describe("chaincode install", func() {
 		network.GenerateConfigTree()
 		network.Bootstrap()
 
-		networkRunner := network.NetworkGroupRunner()
-		process = ifrit.Invoke(networkRunner)
-		Eventually(process.Ready(), network.EventuallyTimeout).Should(BeClosed())
+		// Start all the fabric processes
+		ordererRunner, ordererProcess, peerProcess = network.StartSingleOrdererNetwork("orderer")
 	})
 
 	AfterEach(func() {
-		process.Signal(syscall.SIGTERM)
-		Eventually(process.Wait(), network.EventuallyTimeout).Should(Receive())
+		if ordererProcess != nil {
+			ordererProcess.Signal(syscall.SIGTERM)
+			Eventually(ordererProcess.Wait(), network.EventuallyTimeout).Should(Receive())
+		}
+
+		if peerProcess != nil {
+			peerProcess.Signal(syscall.SIGTERM)
+			Eventually(peerProcess.Wait(), network.EventuallyTimeout).Should(Receive())
+		}
 		network.Cleanup()
 		os.RemoveAll(testDir)
 	})
@@ -80,7 +88,7 @@ var _ = Describe("chaincode install", func() {
 			orderer = network.Orderer("orderer")
 			org1Peer = network.Peer("Org1", "peer0")
 			org2Peer = network.Peer("Org2", "peer0")
-			network.CreateAndJoinChannels(orderer)
+			channelparticipation.JoinOrdererJoinPeersAppChannel(network, "testchannel", orderer, ordererRunner)
 
 			chaincode = nwo.Chaincode{
 				Name:            "failure-external",

--- a/integration/lifecycle/interop_test.go
+++ b/integration/lifecycle/interop_test.go
@@ -16,6 +16,7 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 	ab "github.com/hyperledger/fabric-protos-go/orderer"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/integration/channelparticipation"
 	"github.com/hyperledger/fabric/integration/nwo"
 	"github.com/hyperledger/fabric/integration/nwo/commands"
 	"github.com/hyperledger/fabric/protoutil"
@@ -35,7 +36,6 @@ var _ = Describe("Release interoperability", func() {
 
 		network                     *nwo.Network
 		ordererRunner               *ginkgomon.Runner
-		peerGroupRunner             ifrit.Runner
 		ordererProcess, peerProcess ifrit.Process
 
 		orderer   *nwo.Orderer
@@ -50,18 +50,13 @@ var _ = Describe("Release interoperability", func() {
 		client, err = docker.NewClientFromEnv()
 		Expect(err).NotTo(HaveOccurred())
 
-		network = nwo.New(nwo.MultiChannelEtcdRaft(), testDir, client, StartPort(), components)
+		network = nwo.New(nwo.MultiChannelEtcdRaftNoSysChan(), testDir, client, StartPort(), components)
 		network.GenerateConfigTree()
 		network.Bootstrap()
 
 		// Start all of the fabric processes
-		ordererRunner = network.OrdererRunner(network.Orderer("orderer"))
-		ordererProcess = ifrit.Invoke(ordererRunner)
-		Eventually(ordererProcess.Ready(), network.EventuallyTimeout).Should(BeClosed())
-
-		peerGroupRunner = network.PeerGroupRunner()
-		peerProcess = ifrit.Invoke(peerGroupRunner)
-		Eventually(peerProcess.Ready(), network.EventuallyTimeout).Should(BeClosed())
+		// Start all the fabric processes
+		ordererRunner, ordererProcess, peerProcess = network.StartSingleOrdererNetwork("orderer")
 
 		orderer = network.Orderer("orderer")
 		endorsers = []*nwo.Peer{
@@ -98,7 +93,7 @@ var _ = Describe("Release interoperability", func() {
 			Policy:  `AND ('Org1MSP.member','Org2MSP.member')`,
 		}
 
-		network.CreateAndJoinChannels(orderer)
+		channelparticipation.JoinOrdererJoinPeersAppChannel(network, "testchannel", orderer, ordererRunner)
 		nwo.DeployChaincodeLegacy(network, "testchannel", orderer, chaincode)
 		RunQueryInvokeQuery(network, orderer, "mycc", 100, endorsers...)
 
@@ -109,7 +104,7 @@ var _ = Describe("Release interoperability", func() {
 		RunQueryInvokeQuery(network, orderer, "mycc", 90, endorsers...)
 
 		By("restarting the network from persistence (1)")
-		ordererRunner, ordererProcess, peerGroupRunner, peerProcess = RestartNetwork(ordererProcess, peerProcess, network)
+		ordererRunner, ordererProcess, peerProcess = RestartNetwork(ordererProcess, peerProcess, network)
 
 		By("ensuring that the chaincode is still operational after the upgrade and restart")
 		RunQueryInvokeQuery(network, orderer, "mycc", 80, endorsers...)
@@ -147,7 +142,7 @@ var _ = Describe("Release interoperability", func() {
 		RunQueryInvokeQuery(network, orderer, "mycc", 70, endorsers[0])
 
 		By("restarting the network from persistence (2)")
-		ordererRunner, ordererProcess, peerGroupRunner, peerProcess = RestartNetwork(ordererProcess, peerProcess, network)
+		ordererRunner, ordererProcess, peerProcess = RestartNetwork(ordererProcess, peerProcess, network)
 
 		By("querying/invoking/querying the chaincode with the new definition again")
 		RunQueryInvokeQuery(network, orderer, "mycc", 60, endorsers[1])
@@ -194,7 +189,7 @@ var _ = Describe("Release interoperability", func() {
 				Policy:  `OR ('Org1MSP.member','Org2MSP.member')`,
 			}
 
-			network.CreateAndJoinChannels(orderer)
+			channelparticipation.JoinOrdererJoinPeersAppChannel(network, "testchannel", orderer, ordererRunner)
 			nwo.DeployChaincodeLegacy(network, "testchannel", orderer, chaincode)
 			RunQueryInvokeQuery(network, orderer, "mycc", 100, endorsers...)
 
@@ -242,7 +237,7 @@ var _ = Describe("Release interoperability", func() {
 
 		It("deploys a chaincode with the new lifecycle, invokes it and the tx is committed only after the chaincode is upgraded via _lifecycle", func() {
 			By("enabling V2_0 application capabilities")
-			network.CreateAndJoinChannels(orderer)
+			channelparticipation.JoinOrdererJoinPeersAppChannel(network, "testchannel", orderer, ordererRunner)
 			nwo.EnableCapabilities(network, "testchannel", "Application", "V2_0", orderer, network.Peer("Org1", "peer0"), network.Peer("Org2", "peer0"))
 
 			By("deploying the chaincode definition using _lifecycle")
@@ -338,7 +333,7 @@ var _ = Describe("Release interoperability", func() {
 					Ctor:            `{"Args":[""]}`,
 				}
 				By("Creating and joining the channel")
-				network.CreateAndJoinChannels(orderer)
+				channelparticipation.JoinOrdererJoinPeersAppChannel(network, "testchannel", orderer, ordererRunner)
 			})
 
 			It("Deploys two chaincodes with the new lifecycle and performs a successful cc2cc invocation", func() {
@@ -392,6 +387,7 @@ var _ = Describe("Release interoperability", func() {
 				Expect(sess).To(gbytes.Say("callee:bar"))
 
 				By("enabling the 2.0 capability on channel2")
+				channelparticipation.JoinOrdererJoinPeersAppChannel(network, "testchannel2", orderer, ordererRunner)
 				nwo.EnableCapabilities(network, "testchannel2", "Application", "V2_0", orderer, network.Peer("Org1", "peer0"), network.Peer("Org2", "peer0"))
 
 				By("deploying the callee chaincode using _lifecycle on channel2")

--- a/integration/lifecycle/lifecycle_suite_test.go
+++ b/integration/lifecycle/lifecycle_suite_test.go
@@ -111,7 +111,7 @@ func RunQueryInvokeQuery(n *nwo.Network, orderer *nwo.Orderer, chaincodeName str
 	ExpectWithOffset(1, sess).To(gbytes.Say(fmt.Sprint(initialQueryResult - 10)))
 }
 
-func RestartNetwork(ordererProcess, peerProcess ifrit.Process, network *nwo.Network) (*ginkgomon.Runner, ifrit.Process, ifrit.Runner, ifrit.Process) {
+func RestartNetwork(ordererProcess, peerProcess ifrit.Process, network *nwo.Network) (*ginkgomon.Runner, ifrit.Process, ifrit.Process) {
 	peerProcess.Signal(syscall.SIGTERM)
 	Eventually(peerProcess.Wait(), network.EventuallyTimeout).Should(Receive())
 	ordererProcess.Signal(syscall.SIGTERM)
@@ -126,7 +126,7 @@ func RestartNetwork(ordererProcess, peerProcess ifrit.Process, network *nwo.Netw
 	peerProcess = ifrit.Invoke(peerGroupRunner)
 	Eventually(peerProcess.Ready(), network.EventuallyTimeout).Should(BeClosed())
 
-	return ordererRunner, ordererProcess, peerGroupRunner, peerProcess
+	return ordererRunner, ordererProcess, peerProcess
 }
 
 func SignedProposal(channel, chaincode string, signer *nwo.SigningIdentity, args ...string) (*pb.SignedProposal, *pb.Proposal, string) {

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -285,7 +285,9 @@ func (n *Network) AddOrg(o *Organization, peers ...*Peer) {
 	}
 
 	n.Organizations = append(n.Organizations, o)
-	n.Consortiums[0].Organizations = append(n.Consortiums[0].Organizations, o.Name)
+	if n.Consortiums != nil {
+		n.Consortiums[0].Organizations = append(n.Consortiums[0].Organizations, o.Name)
+	}
 }
 
 // ConfigTxPath returns the path to the generated configtxgen configuration


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description
Orderer v3: Remove system channel usage from integration tests: lifecycle

#### Related issues

Epic: #3511
Issue: #3515

