### PR TITLE
Gateway should apply OrdererEndpointOverrides

### DIFF
--- a/internal/pkg/gateway/api.go
+++ b/internal/pkg/gateway/api.go
@@ -431,11 +431,11 @@ func (gs *Server) Submit(ctx context.Context, request *gp.SubmitRequest) (*gp.Su
 	var errDetails []proto.Message
 	for _, index := range rand.Perm(len(orderers)) {
 		orderer := orderers[index]
-		logger.Infow("Sending transaction to orderer", "txID", request.TransactionId, "endpoint", orderer.address)
+		logger.Infow("Sending transaction to orderer", "txID", request.TransactionId, "endpoint", orderer.logAddress)
 		response, err := gs.broadcast(ctx, orderer, txn)
 		if err != nil {
 			errDetails = append(errDetails, errorDetail(orderer.endpointConfig, err.Error()))
-			logger.Warnw("Error sending transaction to orderer", "txID", request.TransactionId, "endpoint", orderer.address, "err", err)
+			logger.Warnw("Error sending transaction to orderer", "txID", request.TransactionId, "endpoint", orderer.logAddress, "err", err)
 			continue
 		}
 
@@ -444,7 +444,7 @@ func (gs *Server) Submit(ctx context.Context, request *gp.SubmitRequest) (*gp.Su
 			return &gp.SubmitResponse{}, nil
 		}
 
-		logger.Warnw("Unsuccessful response sending transaction to orderer", "txID", request.TransactionId, "endpoint", orderer.address, "status", status, "info", response.GetInfo())
+		logger.Warnw("Unsuccessful response sending transaction to orderer", "txID", request.TransactionId, "endpoint", orderer.logAddress, "status", status, "info", response.GetInfo())
 
 		if status >= 400 && status < 500 {
 			// client error - don't retry

--- a/internal/pkg/gateway/apiutils.go
+++ b/internal/pkg/gateway/apiutils.go
@@ -95,7 +95,7 @@ func toRpcStatus(err error) *status.Status {
 }
 
 func errorDetail(e *endpointConfig, msg string) *gp.ErrorDetail {
-	return &gp.ErrorDetail{Address: e.address, MspId: e.mspid, Message: msg}
+	return &gp.ErrorDetail{Address: e.logAddress, MspId: e.mspid, Message: msg}
 }
 
 func getResultFromProposalResponse(proposalResponse *peer.ProposalResponse) ([]byte, error) {

--- a/internal/pkg/gateway/registry.go
+++ b/internal/pkg/gateway/registry.go
@@ -275,7 +275,7 @@ func (reg *registry) orderers(channel string) ([]*orderer, error) {
 			client, err := reg.endpointFactory.newOrderer(ep.address, ep.mspid, ep.tlsRootCerts)
 			if err != nil {
 				// Failed to connect to this orderer for some reason.  Log the problem and skip to the next one.
-				reg.logger.Warnw("Failed to connect to orderer", "address", ep.address, "err", err)
+				reg.logger.Warnw("Failed to connect to orderer", "address", ep.logAddress, "err", err)
 				continue
 			}
 			var loaded bool
@@ -285,10 +285,10 @@ func (reg *registry) orderers(channel string) ([]*orderer, error) {
 				err = client.closeConnection()
 				if err != nil {
 					// Failed to close this new connection.  Log the problem.
-					reg.logger.Warnw("Failed to close connection to orderer", "address", ep.address, "err", err)
+					reg.logger.Warnw("Failed to close connection to orderer", "address", ep.logAddress, "err", err)
 				}
 			} else {
-				reg.logger.Infow("Added orderer to registry", "address", ep.address)
+				reg.logger.Infow("Added orderer to registry", "address", ep.logAddress)
 			}
 		}
 		orderers = append(orderers, entry.(*orderer))
@@ -460,7 +460,7 @@ func (reg *registry) closeStaleOrdererConnections(channel string, channelOrderer
 				if found {
 					err := client.(*orderer).closeConnection()
 					if err != nil {
-						reg.logger.Errorw("Failed to close connection to orderer", "address", ep.address, "mspid", ep.mspid, "err", err)
+						reg.logger.Errorw("Failed to close connection to orderer", "address", ep.logAddress, "mspid", ep.mspid, "err", err)
 					}
 				}
 			}


### PR DESCRIPTION
The peer local config allows the endpoint addresses and TLS root certs or ordering nodes to be overridden. The gateway should apply these overrides when connecting to orderer nodes for transaction submit.

Resolves https://github.com/hyperledger/fabric-gateway/issues/530

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
