### PR TITLE
BroadcastTimeout for Gateway

### DIFF
--- a/core/peer/config_test.go
+++ b/core/peer/config_test.go
@@ -383,6 +383,7 @@ func TestGlobalConfig(t *testing.T) {
 		GatewayOptions: config.Options{
 			Enabled:            true,
 			EndorsementTimeout: 10 * time.Second,
+			BroadcastTimeout:   10 * time.Second,
 			DialTimeout:        60 * time.Second,
 		},
 	}

--- a/internal/pkg/gateway/config/options.go
+++ b/internal/pkg/gateway/config/options.go
@@ -18,6 +18,8 @@ type Options struct {
 	Enabled bool
 	// EndorsementTimeout is used to specify the maximum time to wait for endorsement responses from external peers.
 	EndorsementTimeout time.Duration
+	// BroadcastTimeout is used to specify the maximum time to wait for responses from ordering nodes.
+	BroadcastTimeout time.Duration
 	// DialTimeout is used to specify the maximum time to wait for connecting to external peers and orderer nodes.
 	DialTimeout time.Duration
 }
@@ -25,6 +27,7 @@ type Options struct {
 var defaultOptions = Options{
 	Enabled:            true,
 	EndorsementTimeout: 10 * time.Second,
+	BroadcastTimeout:   10 * time.Second,
 	DialTimeout:        30 * time.Second,
 }
 
@@ -36,6 +39,9 @@ func GetOptions(v *viper.Viper) Options {
 	}
 	if v.IsSet("peer.gateway.endorsementTimeout") {
 		options.EndorsementTimeout = v.GetDuration("peer.gateway.endorsementTimeout")
+	}
+	if v.IsSet("peer.gateway.broadcastTimeout") {
+		options.BroadcastTimeout = v.GetDuration("peer.gateway.broadcastTimeout")
 	}
 	if v.IsSet("peer.gateway.dialTimeout") {
 		options.DialTimeout = v.GetDuration("peer.gateway.dialTimeout")

--- a/internal/pkg/gateway/config/options_test.go
+++ b/internal/pkg/gateway/config/options_test.go
@@ -20,6 +20,7 @@ peer:
   gateway:
     enabled: true
     endorsementTimeout: 30s
+    broadcastTimeout: 20s
     dialTimeout: 2m
 `)
 
@@ -44,6 +45,7 @@ func TestOverriddenOptions(t *testing.T) {
 	expectedOptions := Options{
 		Enabled:            true,
 		EndorsementTimeout: 30 * time.Second,
+		BroadcastTimeout:   20 * time.Second,
 		DialTimeout:        2 * time.Minute,
 	}
 	require.Equal(t, expectedOptions, options)
@@ -58,6 +60,7 @@ func TestDisabledGatewayOption(t *testing.T) {
 	expectedOptions := Options{
 		Enabled:            false,
 		EndorsementTimeout: 10 * time.Second,
+		BroadcastTimeout:   10 * time.Second,
 		DialTimeout:        30 * time.Second,
 	}
 	require.Equal(t, expectedOptions, options)

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -53,6 +53,9 @@ peer:
         # endorsementTimeout is the duration the gateway waits for a response
         # from other endorsing peers before returning a timeout error to the client.
         endorsementTimeout: 30s
+        # broadcastTimeout is the duration the gateway waits for a response
+        # from ordering nodes before returning a timeout error to the client.
+        broadcastTimeout: 30s
         # dialTimeout is the duration the gateway waits for a connection
         # to other network nodes.
         dialTimeout: 2m


### PR DESCRIPTION
The Gateway has retry logic for failing ordering nodes, however if an ordering node doesn’t respond, then the Submit call will timeout without allowing other ordering nodes to be tried. This commit implements a BroadcastTimeout that allows individual OSN’s to timeout before the overall Submit timeout expires. Similar logic already exists for calls to endorser peers.

Resolves https://github.com/hyperledger/fabric-gateway/issues/529

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
