### PR TITLE
Nominate Yoav Tock to be a maintainer of Fabric core

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,16 +5,18 @@ See [the documentation on Maintainers](https://hyperledger-fabric.readthedocs.io
 
 **Active Maintainers**
 
-| Name | GitHub | Chat | email
-|------|--------|------|----------------------
-| Alessandro Sorniotti | [ale-linux][ale-linux] | aso | <ale.linux@sopit.net>
-| Andrew Coleman | [andrew-coleman][andrew-coleman] | andrew-coleman | <andrew_coleman@uk.ibm.com>
-| Artem Barger | [c0rwin][c0rwin] | c0rwin | <artem@bargr.net>
+| Name                    | GitHub | Chat | email
+|-------------------------|--------|------|----------------------
+| Alessandro Sorniotti    | [ale-linux][ale-linux] | aso | <ale.linux@sopit.net>
+| Andrew Coleman          | [andrew-coleman][andrew-coleman] | andrew-coleman | <andrew_coleman@uk.ibm.com>
+| Artem Barger            | [c0rwin][c0rwin] | c0rwin | <artem@bargr.net>
 | Senthilnathan Natarajan | [cendhu][cendhu] | Senthil1 | <cendhu@gmail.com>
-| Dave Enyeart | [denyeart][denyeart] | dave.enyeart | <enyeart@us.ibm.com>
-| Jay Guo | [guoger][guoger] | guoger | <guojiannan1101@gmail.com>
-| Manish Sethi | [manish-sethi][manish-sethi] | manish-sethi | <manish.sethi@gmail.com>
-| Yacov Manevich | [yacovm][yacovm] | yacovm | <yacov.manevich@ibm.com>
+| Dave Enyeart            | [denyeart][denyeart] | dave.enyeart | <enyeart@us.ibm.com>
+| Jay Guo                 | [guoger][guoger] | guoger | <guojiannan1101@gmail.com>
+| Manish Sethi            | [manish-sethi][manish-sethi] | manish-sethi | <manish.sethi@gmail.com>
+| Yacov Manevich          | [yacovm][yacovm] | yacovm | <yacov.manevich@ibm.com>
+| Yoav Tock               | [tock-ibm][tock-ibm] | tock-ibm | <tock@il.ibm.com>
+
 
 **Documentation Maintainers**
 


### PR DESCRIPTION
Yoav has been a significant contributor to Fabric core's ordering service. 

He designed and implemented the system channel removal feature which is one of the two main features in Fabric v2.3.

He also took part in the implementation of the SmartBFT consensus library (https://github.com/SmartBFT-Go/consensus/) which is now being introduced as the first BFT consensus of Fabric. 

Currently, he plays an important role in the re-architecture of the ordering service for Fabric v3.0 which includes:

- Removing the support for Kafka 
- Removing the system channel from the ordering service
- Inverting the control between the Fabric consensus and the dependencies. 

Additionally, he participates in code reviews of pull requests with high risk potential such as: https://github.com/hyperledger/fabric/pull/3863 and https://github.com/hyperledger/fabric/pull/3651

Lastly, he is among the top contributors of code in the last several months.

I therefore nominate Yoav as a maintainer of Fabric core. 