### PR TITLE
Fix the build

### DIFF
--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -635,7 +635,7 @@ var _ = Describe("EndToEnd", func() {
 		var process ifrit.Process
 
 		BeforeEach(func() {
-			network = nwo.New(nwo.FullEtcdRaft(), testDir, client, StartPort(), components)
+			network = nwo.New(nwo.BasicEtcdRaft(), testDir, client, StartPort(), components)
 
 			network.GenerateConfigTree()
 			network.Bootstrap()


### PR DESCRIPTION
The commit https://github.com/hyperledger/fabric/commit/116551e788071298854f3d61df198b32d0b3156d added a scenario test that uses the FullEtcdRaft() network.  This had been removed in an earlier commit. The test has been changed to use BasicEtcRaft()

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
