### PR TITLE
Improve logging for orderer endpoint override

### DIFF
--- a/internal/pkg/gateway/endpoint.go
+++ b/internal/pkg/gateway/endpoint.go
@@ -89,6 +89,7 @@ func (ef *endpointFactory) newOrderer(address, mspid string, tlsRootCerts [][]by
 		connAddress = override.Address
 		connCerts = override.RootCerts
 		logAddess = fmt.Sprintf("%s (mapped from %s)", connAddress, address)
+		logger.Debugw("Overriding orderer endpoint address", "from", address, "to", connAddress)
 	}
 	conn, err := ef.newConnection(connAddress, connCerts)
 	if err != nil {

--- a/internal/pkg/gateway/registry.go
+++ b/internal/pkg/gateway/registry.go
@@ -275,7 +275,7 @@ func (reg *registry) orderers(channel string) ([]*orderer, error) {
 			client, err := reg.endpointFactory.newOrderer(ep.address, ep.mspid, ep.tlsRootCerts)
 			if err != nil {
 				// Failed to connect to this orderer for some reason.  Log the problem and skip to the next one.
-				reg.logger.Warnw("Failed to connect to orderer", "address", ep.logAddress, "err", err)
+				reg.logger.Warnw("Failed to connect to orderer", "address", ep.address, "err", err)
 				continue
 			}
 			var loaded bool
@@ -285,10 +285,10 @@ func (reg *registry) orderers(channel string) ([]*orderer, error) {
 				err = client.closeConnection()
 				if err != nil {
 					// Failed to close this new connection.  Log the problem.
-					reg.logger.Warnw("Failed to close connection to orderer", "address", ep.logAddress, "err", err)
+					reg.logger.Warnw("Failed to close connection to orderer", "address", client.endpointConfig.logAddress, "err", err)
 				}
 			} else {
-				reg.logger.Infow("Added orderer to registry", "address", ep.logAddress)
+				reg.logger.Infow("Added orderer to registry", "address", client.endpointConfig.logAddress)
 			}
 		}
 		orderers = append(orderers, entry.(*orderer))


### PR DESCRIPTION
When writing log messages for orderer connections, the log address was being extracted from the wrong object.  This is fixed here. Also a debug log message is now written before connecting if the address is overridden.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
