### PR TITLE
Remove whitespace character from ORDERER_GENERAL_LISTENPORT

### DIFF
--- a/orderer/README.md
+++ b/orderer/README.md
@@ -30,7 +30,7 @@ In order to tolerate crash faults, orderer uses file-based ledger to persist blo
 
 ## Experimenting with the orderer service
 
-To experiment with the orderer service you may build the orderer binary by simply typing `go build` in the `hyperledger/fabric/orderer` directory. You may then invoke the orderer binary with no parameters, or you can override the bind address and port by setting the environment variables `ORDERER_GENERAL_LISTENADDRESS` and `ORDERER_GENERAL_ LISTENPORT` respectively.
+To experiment with the orderer service you may build the orderer binary by simply typing `go build` in the `hyperledger/fabric/orderer` directory. You may then invoke the orderer binary with no parameters, or you can override the bind address and port by setting the environment variables `ORDERER_GENERAL_LISTENADDRESS` and `ORDERER_GENERAL_LISTENPORT` respectively.
 
 There are sample clients in the `fabric/orderer/sample_clients` directory.
 


### PR DESCRIPTION
Signed-off-by: kartik chauhan <chauhan.kartik25@gmail.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Documentation update

#### Description

<!--- Describe your changes in detail, including motivation. -->
env variable `ORDERER_GENERAL_ LISTENPORT` in section `Experimenting with the orderer service` of the page https://github.com/hyperledger/fabric/tree/main/orderer contains a whitespace character. Fixed the issue by removing the whitespace character.

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->
https://github.com/hyperledger/fabric/issues/3971

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->


