### PR TITLE
Fix chaincode interest for private data purge

### DIFF
--- a/core/ledger/kvledger/txmgmt/txmgr/tx_simulator.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/tx_simulator.go
@@ -128,7 +128,7 @@ func (s *txSimulator) PurgePrivateData(ns, coll, key string) error {
 	}
 	s.writePerformed = true
 	s.rwsetBuilder.AddToPvtAndHashedWriteSetForPurge(ns, coll, key)
-	return nil
+	return s.checkPrivateStateMetadata(ns, coll, key)
 }
 
 // SetPrivateDataMultipleKeys implements method in interface `ledger.TxSimulator`

--- a/core/ledger/kvledger/txmgmt/txmgr/txmgr_test.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/txmgr_test.go
@@ -1732,4 +1732,18 @@ func testTxSimulatorWithPrivateDataStateBasedEndorsement(t *testing.T, env testE
 	metadata = ledger.WritesetMetadata{}
 	metadata.Add(ns, coll, "key1", sbe2)
 	require.Equal(t, metadata, simRes3.WritesetMetadata)
+
+	// simulate tx4 that purges existing private data
+	s4, _ := txMgr.NewTxSimulator("test_tx4")
+	require.NoError(t, s4.PurgePrivateData(ns, coll, "key1"))
+	s4.Done()
+
+	blkAndPvtdata4, simRes4 := prepareNextBlockForTestFromSimulator(t, bg, s4)
+	_, _, _, err = txMgr.ValidateAndPrepare(blkAndPvtdata4, true)
+	require.NoError(t, err)
+	require.NoError(t, txMgr.Commit())
+	// check the metadata are captured
+	metadata = ledger.WritesetMetadata{}
+	metadata.Add(ns, coll, "key1", sbe2)
+	require.Equal(t, metadata, simRes4.WritesetMetadata)
 }


### PR DESCRIPTION
Gateway was not calculating chaincode interest correctly for purge private data calls, since writeset metadata was not being added for purge calls.
The collection level endorsement policies will now be honored instead of defaulting to the chaincode level endorsement policy.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>