### PR TITLE
Fix Makefile did't delete docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,6 @@ $(BUILD_DIR)/images/%/$(DUMMY):
 		--build-arg TARGETOS=linux \
 		$(BUILD_ARGS) \
 		-t $(DOCKER_NS)/fabric-$* ./$(BUILD_CONTEXT)
-	@touch $@
 
 # builds release packages for the host platform
 .PHONY: release
@@ -292,7 +291,7 @@ docker-list: $(RELEASE_IMAGES:%=%-docker-list)
 .PHONY: docker-clean
 docker-clean: $(RELEASE_IMAGES:%=%-docker-clean)
 %-docker-clean:
-	-@for image in "$$(docker images --quiet --filter=reference='$(DOCKER_NS)/fabric-$*:$(DOCKER_TAG)')"; do \
+	-@for image in "$$(docker images --quiet --filter=reference='$(DOCKER_NS)/fabric-$*')"; do \
 		[ -z "$$image" ] || docker rmi -f $$image; \
 	done
 	-@rm -rf $(BUILD_DIR)/images/$* || true


### PR DESCRIPTION
Because multi-architecture docker image patches removed tags from the docker image, the docker-clean target could not remove the docker image. This patch changes the docker-clean target to remove untagged docker images.