### PR TITLE
Gateway registry should provide cluster size

### DIFF
--- a/internal/pkg/gateway/registry.go
+++ b/internal/pkg/gateway/registry.go
@@ -251,7 +251,7 @@ func sorter(e []*endorserState, host string) func(i, j int) bool {
 }
 
 // Returns a set of broadcastClients that can order a transaction for the given channel.
-func (reg *registry) orderers(channel string) ([]*orderer, error) {
+func (reg *registry) orderers(channel string) ([]*orderer, int, error) {
 	var orderers []*orderer
 	var ordererEndpoints []*endpointConfig
 	addr, exists := reg.channelOrderers.Load(channel)
@@ -262,7 +262,7 @@ func (reg *registry) orderers(channel string) ([]*orderer, error) {
 		// no entry in the map - get the orderer config from discovery
 		channelOrderers, err := reg.config(channel)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		// A config update may have saved this first, in which case don't overwrite it.
 		addr, _ = reg.channelOrderers.LoadOrStore(channel, channelOrderers)
@@ -294,7 +294,7 @@ func (reg *registry) orderers(channel string) ([]*orderer, error) {
 		orderers = append(orderers, entry.(*orderer))
 	}
 
-	return orderers, nil
+	return orderers, len(ordererEndpoints), nil
 }
 
 func (reg *registry) lookupEndorser(endpoint string, pkiid gossipcommon.PKIidType, channel string) *endorser {


### PR DESCRIPTION
When submitting a transaction to BFT orderers, the gateway needs to know the number of consenters in the channel config as well as the array of connected orderers.  The quorum size size is calculated from the former which might be larger than the size of the latter.  These two values should be returned by the same registry lookup to ensure they are not out of sync.

Resolves the PR comment for the previous commit:
https://github.com/hyperledger/fabric/pull/3975#discussion_r1098447996

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
