### PR TITLE
Return orderer error text to client

### DIFF
--- a/internal/pkg/gateway/api.go
+++ b/internal/pkg/gateway/api.go
@@ -497,7 +497,7 @@ func (gs *Server) broadcastToAll(orderers []*orderer, txn *common.Envelope, wait
 				waitCh <- nil
 			} else {
 				logger.Warnw("Unsuccessful response sending transaction to orderer", "endpoint", ord.logAddress, "status", status, "info", response.GetInfo())
-				waitCh <- errorDetail(ord.endpointConfig, fmt.Sprintf("received unsuccessful response from orderer: %s", common.Status_name[int32(status)]))
+				waitCh <- errorDetail(ord.endpointConfig, fmt.Sprintf("received unsuccessful response from orderer: status=%s, info=%s", common.Status_name[int32(status)], response.GetInfo()))
 			}
 		}(o)
 	}
@@ -554,7 +554,7 @@ func (gs *Server) submitNonBFT(ctx context.Context, orderers []*orderer, txn *co
 
 		if status >= 400 && status < 500 {
 			// client error - don't retry
-			return nil, newRpcError(codes.Aborted, fmt.Sprintf("received unsuccessful response from orderer: %s", common.Status_name[int32(status)]))
+			return nil, newRpcError(codes.Aborted, fmt.Sprintf("received unsuccessful response from orderer: status=%s, info=%s", common.Status_name[int32(status)], response.GetInfo()))
 		}
 	}
 	return nil, newRpcError(codes.Unavailable, "no orderers could successfully process transaction", errDetails...)


### PR DESCRIPTION
If a call from the gateway to an orderer node returns an error in the BroadcastResponse message, then it is appended to the details field of the rpc error that gets returned to the client application.  However, the Info field of that message is not getting passed on, so the client could be lacking valuable information on the underlying cause of the error.  This commit fixes that.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
