### PR TITLE
Orderer v3: fix IsChannelMember to match public keys

### DIFF
--- a/integration/raft/config_test.go
+++ b/integration/raft/config_test.go
@@ -961,11 +961,14 @@ var _ = Describe("EndToEnd reconfiguration and onboarding", func() {
 			By("Creating testchannel, joining all orderers")
 			channelparticipation.JoinOrderersAppChannelCluster(network, "testchannel", network.Orderers...)
 
-			By("Finding leader")
+			By("Finding leader testchannel")
 			_ = FindLeader(ordererRunners)
 
 			By("Creating mychannel with a subset of orderers")
 			channelparticipation.JoinOrderersAppChannelCluster(network, "mychannel", o1)
+
+			By("Finding leader mychannel")
+			_ = FindLeader(ordererRunners[:1])
 
 			By("Waiting for the channel to be available")
 			assertBlockReception(map[string]int{

--- a/orderer/consensus/etcdraft/consenter.go
+++ b/orderer/consensus/etcdraft/consenter.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package etcdraft
 
 import (
-	"bytes"
 	"path"
 	"reflect"
 	"time"
@@ -291,16 +290,19 @@ func (c *Consenter) IsChannelMember(joinBlock *common.Block) (bool, error) {
 		return false, errors.Wrapf(err, "failed to validate config metadata of ordering config")
 	}
 
-	// TODO https://github.com/hyperledger/fabric/issues/3998
-	member := false
-	for _, consenter := range configMetadata.Consenters {
-		if bytes.Equal(c.Cert, consenter.ServerTlsCert) || bytes.Equal(c.Cert, consenter.ClientTlsCert) {
-			member = true
-			break
-		}
+	consenters := make(map[uint64]*etcdraft.Consenter)
+	for i, c := range configMetadata.Consenters {
+		consenters[uint64(i+1)] = c // the IDs don't matter
 	}
 
-	return member, nil
+	if _, err := c.detectSelfID(consenters); err != nil {
+		if err != cluster.ErrNotInChannel {
+			return false, errors.Wrapf(err, "failed to detect self ID by comparing public keys")
+		}
+		return false, nil
+	}
+
+	return true, nil
 }
 
 // RemoveInactiveChainRegistry stops and removes the inactive chain registry.


### PR DESCRIPTION

#### Type of change

- Bug fix
- Improvement (improvement to code, performance, etc)
- 
#### Description

Orderer v3: fix IsChannelMember to match public keys

- Remove system channel usage from:  `integration/raft/cft_test.go` use-case: "disregards certificate renewal if only the validity period changed"
- Fix a bug in IsChannelMember  that manifested in that test
- Addresses the bug reported in issue #3998

#### Related issues

Addresses: #3998 
Parent issue: #3515 