### PR TITLE
Return channel header on missing system channel

### DIFF
--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -438,7 +438,7 @@ func (r *Registrar) BroadcastChannelSupport(msg *cb.Envelope) (*cb.ChannelHeader
 	if cs == nil {
 		sysChan := r.SystemChannel()
 		if sysChan == nil {
-			return nil, false, nil, errors.New("channel creation request not allowed because the orderer system channel is not defined")
+			return chdr, false, nil, errors.New("channel creation request not allowed because the orderer system channel is not defined")
 		}
 		cs = sysChan
 	}


### PR DESCRIPTION
#### Type of change
- Improvement (improvement to log)

#### Description

Currently, It fails to report the channel name in
the log as it failed to return the channel header
to the caller.

#### Additional details

> 2023-02-08 23:07:45.078 UTC 138d WARN [orderer.common.broadcast] ProcessMessage -> **[channel: unknown]** Could not get message processor for serving 10.244.0.9:33422: channel creation request not allowed because the orderer system channel is not defined

It failed to report the channel name when it failed to locate the channel. As shown in the above log `**[channel: unknown]**`

Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>