### PR TITLE
Disable fail-fast for integration test suite matrix

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -52,6 +52,7 @@ jobs:
     name: Integration Tests
     needs: basic-checks
     strategy:
+      fail-fast: false
       matrix:
         INTEGRATION_TEST_SUITE: ["raft","pvtdata","pvtdatapurge","ledger","lifecycle","e2e","discovery gossip devmode pluggable","gateway idemix pkcs11 configtx configtxlator","sbe nwo msp"]
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Allowing all suites to run to completion minimises the impact of test flakes. Only failing suites need to be re-run rather then re-running the entire integration test suite.