### PR TITLE
Fix purge private data integration test flake

### DIFF
--- a/integration/pvtdatapurge/data_purge_test.go
+++ b/integration/pvtdatapurge/data_purge_test.go
@@ -319,6 +319,10 @@ var _ = Describe("Pvtdata purge", func() {
 			marblechaincodeutil.AssertDoesNotExistInCollectionMPD(network, channelID, chaincode.Name, `test-marble-9-purge`, org3Peer1)
 
 			By("Adding two marbles, removing Org3 from the collection, purging the marbles, and confirming that they still got purged from Org3")
+
+			// Make sure all peers are up and connected after prior test, before continuing with this test
+			network.VerifyMembership(network.Peers, channelID)
+
 			marblechaincodeutil.AddMarble(network, orderer, channelID, chaincode.Name, `{"name":"test-marble-10-purge-after-ineligible", "color":"white", "size":4, "owner":"liz", "price":4}`, org2Peer0)
 			marblechaincodeutil.AddMarble(network, orderer, channelID, chaincode.Name, `{"name":"test-marble-11-purge-after-ineligible", "color":"orange", "size":80, "owner":"clive", "price":88}`, org2Peer0)
 


### PR DESCRIPTION
Prior test restarted peers.
Need to make sure all peers are up and connected before continuing to next test.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
