### PR TITLE
Add workflow_dispatch option for release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@
 name: Release
 
 on:
+  workflow_dispatch: # workflow_dispatch must be enabled in main branch to support release action on older release branches
   push:
     tags: [ v2.* ]
 


### PR DESCRIPTION
Older release branches such as release-2.2 have a release action that gets triggered based on a manual workflow_dispatch. 
The 'main' branch must also have workflow_dispatch enabled in order to trigger the release action on specific release branches.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
