### PR TITLE
Add Consensus.Type to orderer.yaml

### DIFF
--- a/sampleconfig/orderer.yaml
+++ b/sampleconfig/orderer.yaml
@@ -320,3 +320,7 @@ Consensus:
     # SnapDir specifies the location at which snapshots for etcd/raft are
     # stored. Each channel will have its own subdir named after channel ID.
     SnapDir: /var/hyperledger/production/orderer/etcdraft/snapshot
+
+    # Type specifies the consensus type to run.
+    # Currently supported types are 'etcdraft' and 'BFT'
+    Type: "etcdraft"


### PR DESCRIPTION
   
Currently, the way the orderer initialization logic works is it requires defining a consensus type in the orderer.yaml.
This commit adds the type to the orderer.yaml for completeness as done in the integration tests.
