### PR TITLE
Add Consensus.Type to orderer.yaml

### DIFF
--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -24,7 +24,7 @@ type TopLevel struct {
 	General              General
 	FileLedger           FileLedger
 	Debug                Debug
-	Consensus            interface{}
+	Consensus            Consensus
 	Operations           Operations
 	Metrics              Metrics
 	ChannelParticipation ChannelParticipation
@@ -199,6 +199,11 @@ var Defaults = TopLevel{
 	Admin: Admin{
 		ListenAddress: "127.0.0.1:0",
 	},
+	Consensus: Consensus{
+		Type:    "etcdraft",
+		WALDir:  "/var/hyperledger/production/orderer/etcdraft/wal",
+		SnapDir: "/var/hyperledger/production/orderer/etcdraft/snapshot",
+	},
 }
 
 // Load parses the orderer YAML file and environment, producing
@@ -345,6 +350,15 @@ func (c *TopLevel) completeInitialization(configDir string) {
 		case c.General.MaxSendMsgSize == 0:
 			logger.Infof("General.MaxSendMsgSize is unset, setting to %v", Defaults.General.MaxSendMsgSize)
 			c.General.MaxSendMsgSize = Defaults.General.MaxSendMsgSize
+		case c.Consensus.Type == "":
+			logger.Infof("Consensus.Type is unset, setting to %v", Defaults.Consensus.Type)
+			c.Consensus.Type = Defaults.Consensus.Type
+		case c.Consensus.WALDir == "":
+			logger.Infof("Consensus.WALDir is unset, setting to %v", Defaults.Consensus.WALDir)
+			c.Consensus.WALDir = Defaults.Consensus.WALDir
+		case c.Consensus.SnapDir == "" && c.Consensus.Type == "etcdraft":
+			logger.Infof("Consensus.Snapdir is unset, setting to %v", Defaults.Consensus.SnapDir)
+			c.Consensus.SnapDir = Defaults.Consensus.SnapDir
 		default:
 			return
 		}
@@ -362,5 +376,7 @@ func translateCAs(configDir string, certificateAuthorities []string) []string {
 
 // Consensus indicates the orderer type.
 type Consensus struct {
-	Type string `yaml:"type,omitempty"`
+	Type    string `yaml:"type,omitempty"`
+	WALDir  string `yaml:"type,omitempty"`
+	SnapDir string `yaml:"type,omitempty"`
 }

--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/hyperledger/fabric/orderer/common/onboarding"
 	server_mocks "github.com/hyperledger/fabric/orderer/common/server/mocks"
 	"github.com/hyperledger/fabric/orderer/consensus"
-	"github.com/hyperledger/fabric/orderer/consensus/etcdraft"
 	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -769,7 +768,8 @@ func TestUpdateTrustedRoots(t *testing.T) {
 		FileLedger: localconfig.FileLedger{
 			Location: ledgerDir,
 		},
-		Consensus: etcdraft.Config{
+		Consensus: localconfig.Consensus{
+			Type:    "etcdraft",
 			WALDir:  path.Join(tmpDir, "etcdraft", "wal"),
 			SnapDir: path.Join(tmpDir, "etcdraft", "snap"),
 		},
@@ -842,7 +842,8 @@ func TestUpdateTrustedRoots(t *testing.T) {
 		FileLedger: localconfig.FileLedger{
 			Location: ledgerDir,
 		},
-		Consensus: etcdraft.Config{
+		Consensus: localconfig.Consensus{
+			Type:    "etcdraft",
 			WALDir:  path.Join(tmpDir, "etcdraft", "wal"),
 			SnapDir: path.Join(tmpDir, "etcdraft", "snap"),
 		},

--- a/sampleconfig/orderer.yaml
+++ b/sampleconfig/orderer.yaml
@@ -313,6 +313,10 @@ Consensus:
     # The allowed key-value pairs here depend on consensus plugin. For etcd/raft,
     # we use following options:
 
+    # Type specifies the consensus type to run.
+    # Currently supported types are 'etcdraft' and 'BFT'
+    Type: etcdraft
+
     # WALDir specifies the location at which Write Ahead Logs for etcd/raft are
     # stored. Each channel will have its own subdir named after channel ID.
     WALDir: /var/hyperledger/production/orderer/etcdraft/wal


### PR DESCRIPTION
#### Type of change

- Fixing incomplete implementation

#### Description

Currently, the way the orderer initialization logic works is it required defining a consensus type in the orderer.yaml. This commit adds the type to the orderer.yaml for completeness as done in the integration tests.