### PR TITLE
BFT review comments: channelparticipation.Join

### DIFF
--- a/integration/channelparticipation/channel_participation.go
+++ b/integration/channelparticipation/channel_participation.go
@@ -42,12 +42,11 @@ func Join(n *nwo.Network, o *nwo.Orderer, channel string, block *common.Block, e
 	if n.TLSEnabled {
 		client = authClient
 	}
-
-	doBody(client, req)
-
-	Eventually(func() ChannelInfo {
-		return ListOne(n, o, channel)
-	}, n.EventuallyTimeout).Should(Equal(expectedChannelInfo))
+	body := doBody(client, req)
+	c := &ChannelInfo{}
+	err = json.Unmarshal(body, c)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(*c).To(Equal(expectedChannelInfo))
 }
 
 func GenerateJoinRequest(url, channel string, blockBytes []byte) *http.Request {

--- a/integration/raft/cft_test.go
+++ b/integration/raft/cft_test.go
@@ -310,9 +310,9 @@ var _ = Describe("EndToEnd Crash Fault Tolerance", func() {
 			expectedChannelInfo := channelparticipation.ChannelInfo{
 				Name:              "testchannel",
 				URL:               "/participation/v1/channels/testchannel",
-				Status:            "active",
+				Status:            "onboarding",
 				ConsensusRelation: "consenter",
-				Height:            2,
+				Height:            0,
 			}
 			channelparticipation.Join(network, o4, "testchannel", configBlock, expectedChannelInfo)
 

--- a/integration/raft/channel_participation_test.go
+++ b/integration/raft/channel_participation_test.go
@@ -140,9 +140,9 @@ var _ = Describe("ChannelParticipation", func() {
 			expectedChannelInfoPTFollower := channelparticipation.ChannelInfo{
 				Name:              "participation-trophy",
 				URL:               "/participation/v1/channels/participation-trophy",
-				Status:            "active",
+				Status:            "onboarding",
 				ConsensusRelation: "follower",
-				Height:            3,
+				Height:            0,
 			}
 			channelparticipation.Join(network, orderer3, "participation-trophy", configBlockPT, expectedChannelInfoPTFollower)
 
@@ -259,9 +259,9 @@ var _ = Describe("ChannelParticipation", func() {
 			expectedChannelInfoPTFollower = channelparticipation.ChannelInfo{
 				Name:              "participation-trophy",
 				URL:               "/participation/v1/channels/participation-trophy",
-				Status:            "active",
+				Status:            "onboarding",
 				ConsensusRelation: "follower",
-				Height:            7,
+				Height:            0,
 			}
 			channelparticipation.Join(network, orderer1, "participation-trophy", configBlockPT, expectedChannelInfoPTFollower)
 
@@ -397,9 +397,9 @@ var _ = Describe("ChannelParticipation", func() {
 			expectedChannelInfoConsenter := channelparticipation.ChannelInfo{
 				Name:              "participation-trophy",
 				URL:               "/participation/v1/channels/participation-trophy",
-				Status:            "active",
+				Status:            "onboarding",
 				ConsensusRelation: "consenter",
-				Height:            5,
+				Height:            0,
 			}
 			channelparticipation.Join(network, orderer3, "participation-trophy", configBlockPT, expectedChannelInfoConsenter)
 

--- a/integration/raft/config_test.go
+++ b/integration/raft/config_test.go
@@ -316,9 +316,9 @@ var _ = Describe("EndToEnd reconfiguration and onboarding", func() {
 			expectedChannelInfo := channelparticipation.ChannelInfo{
 				Name:              "testchannel",
 				URL:               "/participation/v1/channels/testchannel",
-				Status:            "active",
+				Status:            "onboarding",
 				ConsensusRelation: "consenter",
-				Height:            2,
+				Height:            0,
 			}
 			channelparticipation.Join(network, orderer2, "testchannel", configBlock, expectedChannelInfo)
 
@@ -395,9 +395,9 @@ var _ = Describe("EndToEnd reconfiguration and onboarding", func() {
 			expectedChannelInfo = channelparticipation.ChannelInfo{
 				Name:              "testchannel",
 				URL:               "/participation/v1/channels/testchannel",
-				Status:            "active",
+				Status:            "onboarding",
 				ConsensusRelation: "follower",
-				Height:            2,
+				Height:            0,
 			}
 			channelparticipation.Join(network, orderer3, "testchannel", configBlock, expectedChannelInfo)
 
@@ -839,9 +839,9 @@ var _ = Describe("EndToEnd reconfiguration and onboarding", func() {
 			expectedChannelInfo := channelparticipation.ChannelInfo{
 				Name:              "testchannel",
 				URL:               "/participation/v1/channels/testchannel",
-				Status:            "active",
+				Status:            "onboarding",
 				ConsensusRelation: "consenter",
-				Height:            9,
+				Height:            0,
 			}
 			channelparticipation.Join(network, o4, "testchannel", configBlock, expectedChannelInfo)
 
@@ -876,9 +876,9 @@ var _ = Describe("EndToEnd reconfiguration and onboarding", func() {
 			expectedChannelInfo = channelparticipation.ChannelInfo{
 				Name:              "testchannel2",
 				URL:               "/participation/v1/channels/testchannel2",
-				Status:            "active",
+				Status:            "onboarding",
 				ConsensusRelation: "consenter",
-				Height:            2,
+				Height:            0,
 			}
 			channelparticipation.Join(network, o4, "testchannel2", configBlock, expectedChannelInfo)
 
@@ -1006,9 +1006,9 @@ var _ = Describe("EndToEnd reconfiguration and onboarding", func() {
 			expectedChannelInfo := channelparticipation.ChannelInfo{
 				Name:              "mychannel",
 				URL:               "/participation/v1/channels/mychannel",
-				Status:            "active",
+				Status:            "onboarding",
 				ConsensusRelation: "consenter",
-				Height:            2,
+				Height:            0,
 			}
 			channelparticipation.Join(network, o2, "mychannel", configBlock, expectedChannelInfo)
 
@@ -1033,9 +1033,9 @@ var _ = Describe("EndToEnd reconfiguration and onboarding", func() {
 			expectedChannelInfo = channelparticipation.ChannelInfo{
 				Name:              "mychannel",
 				URL:               "/participation/v1/channels/mychannel",
-				Status:            "active",
+				Status:            "onboarding",
 				ConsensusRelation: "consenter",
-				Height:            3,
+				Height:            0,
 			}
 			channelparticipation.Join(network, o3, "mychannel", configBlock, expectedChannelInfo)
 
@@ -1345,9 +1345,9 @@ var _ = Describe("EndToEnd reconfiguration and onboarding", func() {
 				expectedInfo := channelparticipation.ChannelInfo{
 					Name:              "testchannel",
 					URL:               "/participation/v1/channels/testchannel",
-					Status:            "active",
+					Status:            "onboarding",
 					ConsensusRelation: "consenter",
-					Height:            5,
+					Height:            0,
 				}
 				channelparticipation.Join(network, o1, "testchannel", configBlock, expectedInfo)
 
@@ -1563,9 +1563,9 @@ var _ = Describe("EndToEnd reconfiguration and onboarding", func() {
 				expectedInfo := channelparticipation.ChannelInfo{
 					Name:              "testchannel",
 					URL:               "/participation/v1/channels/testchannel",
-					Status:            "active",
+					Status:            "onboarding",
 					ConsensusRelation: "consenter",
-					Height:            uint64(blockNum + 1),
+					Height:            0,
 				}
 				channelparticipation.Join(network, orderers[i], "testchannel", configBlock, expectedInfo)
 

--- a/integration/raft/migration_test.go
+++ b/integration/raft/migration_test.go
@@ -424,9 +424,9 @@ var _ = Describe("ConsensusTypeMigration", func() {
 			expectedChannelInfo := channelparticipation.ChannelInfo{
 				Name:              channel2,
 				URL:               fmt.Sprintf("/participation/v1/channels/%s", channel2),
-				Status:            "active",
+				Status:            "onboarding",
 				ConsensusRelation: "consenter",
-				Height:            4,
+				Height:            0,
 			}
 			channelparticipation.Join(network, orderer2, channel2, configBlock, expectedChannelInfo)
 			Eventually(o2Runner.Err(), network.EventuallyTimeout, time.Second).Should(gbytes.Say("Raft leader changed: 0 -> "))

--- a/integration/smartbft/smartbft_test.go
+++ b/integration/smartbft/smartbft_test.go
@@ -326,6 +326,16 @@ var _ = Describe("EndToEnd Smart BFT configuration test", func() {
 			configBlock := nwo.GetConfigBlock(network, peer, orderer, "testchannel1")
 			Expect(configBlock).NotTo(Equal(nil))
 
+			By("Joining " + orderer5.Name + " to channel as a consenter")
+			expectedChannelInfoPT = channelparticipation.ChannelInfo{
+				Name:              "testchannel1",
+				URL:               "/participation/v1/channels/testchannel1",
+				Status:            "onboarding",
+				ConsensusRelation: "consenter",
+				Height:            0,
+			}
+			channelparticipation.Join(network, orderer5, "testchannel1", configBlock, expectedChannelInfoPT)
+
 			expectedChannelInfoPT = channelparticipation.ChannelInfo{
 				Name:              "testchannel1",
 				URL:               "/participation/v1/channels/testchannel1",
@@ -333,9 +343,9 @@ var _ = Describe("EndToEnd Smart BFT configuration test", func() {
 				ConsensusRelation: "consenter",
 				Height:            8,
 			}
-
-			By("Joining " + orderer5.Name + " to channel as a consenter")
-			channelparticipation.Join(network, orderer5, "testchannel1", configBlock, expectedChannelInfoPT)
+			Eventually(func() channelparticipation.ChannelInfo {
+				return channelparticipation.ListOne(network, orderer5, "testchannel1")
+			}, network.EventuallyTimeout).Should(Equal(expectedChannelInfoPT))
 
 			By("Waiting for the added orderer to see the leader")
 			Eventually(orderer5Runner.Err(), network.EventuallyTimeout, time.Second).Should(gbytes.Say("Message from 1 channel=testchannel1"))
@@ -864,6 +874,16 @@ var _ = Describe("EndToEnd Smart BFT configuration test", func() {
 				ordererProcesses = append(ordererProcesses, proc)
 				Eventually(proc.Ready(), network.EventuallyTimeout).Should(BeClosed())
 
+				By(">>>> joining " + newOrderer.Name + " to channel as a consenter")
+				expectedChannelInfoPT = channelparticipation.ChannelInfo{
+					Name:              "testchannel1",
+					URL:               "/participation/v1/channels/testchannel1",
+					Status:            "onboarding",
+					ConsensusRelation: "consenter",
+					Height:            0,
+				}
+				channelparticipation.Join(network, newOrderer, "testchannel1", configBlock, expectedChannelInfoPT)
+
 				expectedChannelInfoPT = channelparticipation.ChannelInfo{
 					Name:              "testchannel1",
 					URL:               "/participation/v1/channels/testchannel1",
@@ -871,9 +891,9 @@ var _ = Describe("EndToEnd Smart BFT configuration test", func() {
 					ConsensusRelation: "consenter",
 					Height:            uint64(2 + i),
 				}
-
-				By(">>>> joining " + newOrderer.Name + " to channel as a consenter")
-				channelparticipation.Join(network, newOrderer, "testchannel1", configBlock, expectedChannelInfoPT)
+				Eventually(func() channelparticipation.ChannelInfo {
+					return channelparticipation.ListOne(network, newOrderer, "testchannel1")
+				}, network.EventuallyTimeout).Should(Equal(expectedChannelInfoPT))
 
 				By("Waiting for the added orderer to see the leader")
 				Eventually(runner.Err(), network.EventuallyTimeout, time.Second).Should(gbytes.Say("Message from 1 channel=testchannel1"))
@@ -1028,16 +1048,26 @@ var _ = Describe("EndToEnd Smart BFT configuration test", func() {
 			}
 			Eventually(proc.Ready(), network.EventuallyTimeout).Should(BeClosed())
 
-			expectedChannelInfoPT := channelparticipation.ChannelInfo{
+			By("joining " + orderer5.Name + " to channel as a consenter")
+			expectedChannelInfo := channelparticipation.ChannelInfo{
+				Name:              "testchannel1",
+				URL:               "/participation/v1/channels/testchannel1",
+				Status:            "onboarding",
+				ConsensusRelation: "consenter",
+				Height:            0,
+			}
+			channelparticipation.Join(network, orderer5, "testchannel1", configBlock, expectedChannelInfo)
+
+			expectedChannelInfo = channelparticipation.ChannelInfo{
 				Name:              "testchannel1",
 				URL:               "/participation/v1/channels/testchannel1",
 				Status:            "active",
 				ConsensusRelation: "consenter",
 				Height:            8,
 			}
-
-			By("joining " + orderer5.Name + " to channel as a consenter")
-			channelparticipation.Join(network, orderer5, "testchannel1", configBlock, expectedChannelInfoPT)
+			Eventually(func() channelparticipation.ChannelInfo {
+				return channelparticipation.ListOne(network, orderer5, "testchannel1")
+			}, network.EventuallyTimeout).Should(Equal(expectedChannelInfo))
 
 			By("Waiting for the added orderer to see the leader")
 			Eventually(orderer5Runner.Err(), network.EventuallyTimeout, time.Second).Should(gbytes.Say("Message from 1 channel=testchannel1"))

--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Chain", func() {
 	BeforeEach(func() {
 		tlsCA, _ = tlsgen.NewCA()
 		channelID = "test-channel"
-		logger = flogging.NewFabricLogger(zap.NewExample())
+		logger = flogging.MustGetLogger("test")
 		env = &common.Envelope{
 			Payload: marshalOrPanic(&common.Payload{
 				Header: &common.Header{ChannelHeader: marshalOrPanic(&common.ChannelHeader{Type: int32(common.HeaderType_MESSAGE), ChannelId: channelID})},


### PR DESCRIPTION
Change-Id: I92a347a6105fbe99e934f8d4686378e58eb984ce


#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
Addressing review comments on the modification of channelparticipation.Join in the BFT commit.
This reverses the changes made to channelparticipation.Join in the BFT commit and fixes the respective tests accordingly.

Add retry to forwarding of the config-tx that causes a leader to abdicate, reducing the chances of integration test flakes.

#### Related issues
Raft IT flake #4066 