### PR TITLE
Backport PR 4011 to release-2.4 (fix IsChannelMember)

### DIFF
--- a/integration/nwo/standard_networks.go
+++ b/integration/nwo/standard_networks.go
@@ -302,3 +302,111 @@ func MultiNodeEtcdRaft() *Config {
 	}}
 	return config
 }
+
+// === configurations for testing without the system channel ===
+
+// BasicConfig is a configuration with two organizations and one peer per org.
+// This configuration does not specify a consensus type.
+func BasicConfig() *Config {
+	return &Config{
+		Organizations: []*Organization{{
+			Name:          "OrdererOrg",
+			MSPID:         "OrdererMSP",
+			Domain:        "example.com",
+			EnableNodeOUs: false,
+			Users:         0,
+			CA:            &CA{Hostname: "ca"},
+		}, {
+			Name:          "Org1",
+			MSPID:         "Org1MSP",
+			Domain:        "org1.example.com",
+			EnableNodeOUs: true,
+			Users:         2,
+			CA:            &CA{Hostname: "ca"},
+		}, {
+			Name:          "Org2",
+			MSPID:         "Org2MSP",
+			Domain:        "org2.example.com",
+			EnableNodeOUs: true,
+			Users:         2,
+			CA:            &CA{Hostname: "ca"},
+		}},
+		Consortiums: []*Consortium{{
+			Name: "SampleConsortium",
+			Organizations: []string{
+				"Org1",
+				"Org2",
+			},
+		}},
+		Consensus: &Consensus{
+			BootstrapMethod: "file",
+		},
+		SystemChannel: &SystemChannel{
+			Name:    "systemchannel",
+			Profile: "TwoOrgsOrdererGenesis",
+		},
+		Orderers: []*Orderer{
+			{Name: "orderer", Organization: "OrdererOrg"},
+		},
+		Channels: []*Channel{
+			{Name: "testchannel", Profile: "TwoOrgsChannel"},
+		},
+		Peers: []*Peer{{
+			Name:         "peer0",
+			Organization: "Org1",
+			Channels: []*PeerChannel{
+				{Name: "testchannel", Anchor: true},
+			},
+		}, {
+			Name:         "peer0",
+			Organization: "Org2",
+			Channels: []*PeerChannel{
+				{Name: "testchannel", Anchor: true},
+			},
+		}},
+		Profiles: []*Profile{
+			{
+				Name:     "TwoOrgsOrdererGenesis",
+				Orderers: []string{"orderer"},
+			},
+			{
+				Name:          "TwoOrgsChannel",
+				Consortium:    "SampleConsortium",
+				Organizations: []string{"Org1", "Org2"},
+			},
+		},
+	}
+}
+
+func BasicEtcdRaftNoSysChan() *Config {
+	config := BasicConfig()
+
+	config.Consensus.Type = "etcdraft"
+	config.Profiles = []*Profile{
+		{
+			Name:          "TwoOrgsAppChannelEtcdRaft",
+			Consortium:    "SampleConsortium",
+			Orderers:      []string{"orderer"},
+			Organizations: []string{"Org1", "Org2"},
+		},
+	}
+	config.SystemChannel = nil
+	config.Consensus.ChannelParticipationEnabled = true
+	config.Consensus.BootstrapMethod = "none"
+	config.Consortiums = nil
+	config.Channels = []*Channel{{Name: "testchannel", Profile: "TwoOrgsAppChannelEtcdRaft"}}
+
+	return config
+}
+
+func MultiNodeEtcdRaftNoSysChan() *Config {
+	config := BasicEtcdRaftNoSysChan()
+	config.Orderers = []*Orderer{
+		{Name: "orderer1", Organization: "OrdererOrg"},
+		{Name: "orderer2", Organization: "OrdererOrg"},
+		{Name: "orderer3", Organization: "OrdererOrg"},
+	}
+	config.Profiles[0].Orderers = []string{"orderer1", "orderer2", "orderer3"}
+
+	return config
+}

--- a/integration/nwo/template/orderer_template.go
+++ b/integration/nwo/template/orderer_template.go
@@ -36,7 +36,9 @@ General:
     ServerInterval: 7200s
     ServerTimeout: 20s
   BootstrapMethod: {{ .Consensus.BootstrapMethod }}
+  {{- if eq $w.Consensus.BootstrapMethod "file" }}
   BootstrapFile: {{ .RootDir }}/{{ .SystemChannel.Name }}_block.pb
+  {{- end }}
   LocalMSPDir: {{ $w.OrdererLocalMSPDir Orderer }}
   LocalMSPID: {{ ($w.Organization Orderer.Organization).MSPID }}
   Profile:


### PR DESCRIPTION

Change-Id: I7205dbe264248c4ad534499955bb22710d07444d

#### Type of change

- Bug fix

#### Description
PR 4011 addressed a bug (#3998) in IsChannelMember that manifested itself in the test

`integration/raft/cft_test.go` use-case: "disregards certificate renewal if only the validity period changed"

after it was converted to run without the system channel.

Here we
- Backport the fix (in etcdraft/consenter.go)
- Add the same test case which runs without the system channel (w/o the fix this test case fails).
- Backport some test infrastructure that helps running tests without the system channel.


#### Related issues

#3998 the issue describing the bug
#4011 the PR fixing the bug on main