### PR TITLE
Add chaincode initialization guidance to docs

### DIFF
--- a/docs/source/chaincode_lifecycle.md
+++ b/docs/source/chaincode_lifecycle.md
@@ -181,6 +181,13 @@ consistent across organizations:
   you increment the chaincode version. You can pass `--isInit` and initialize the
   chaincode using any function in your chaincode.
 
+  Note that in most scenarios it is recommended to embed initialization logic into chaincode rather than use the chaincode lifecycle mechanism described above.
+  Chaincode functions often perform checks against existing state, and initialization state can be implemented like any other chaincode state and be checked in subsequent chaincode function calls.
+  Handling initialization state within chaincode logic rather than with the chaincode lifecycle
+  mechanism has the benefit that you are not limited to a single initialization function,
+  rather you are in full control of initialization logic and can call your own
+  functions that initialize state from an application consistent with how all other application functions are called.
+
 The chaincode definition also includes the **Package Identifier**. This is a
 required parameter for each organization that wants to use the chaincode. The
 package ID does not need to be the same for all organizations. An organization

--- a/docs/source/channel_update_tutorial.rst
+++ b/docs/source/channel_update_tutorial.rst
@@ -624,7 +624,7 @@ for Org3:
 .. code:: bash
 
     # use the --package-id flag to provide the package identifier
-    # use the --init-required flag to request the ``Init`` function be invoked to initialize the chaincode
+    # use the --init-required flag to require the execution of an initialization function before other chaincode functions can be called.
     peer lifecycle chaincode approveformyorg -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile "${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem" --channelID channel1 --name basic --version 1.0 --package-id $CC_PACKAGE_ID --sequence 1
 
 

--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -550,8 +550,8 @@ channel `mychannel`.
 
   * Use the `--package-id` flag to pass in the chaincode package identifier. Use
     the `--signature-policy` flag to define an endorsement policy for the chaincode.
-    Use the `init-required` flag to request the execution of the `Init`
-    function to initialize the chaincode.
+    Use the `init-required` flag to require the execution of an initialization function
+    before other chaincode functions can be called.
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem

--- a/docs/source/upgrade_to_newest_version.md
+++ b/docs/source/upgrade_to_newest_version.md
@@ -12,6 +12,9 @@ Before attempting to upgrade from v1.4.x to v2.x, make sure to consider the foll
 
 ### Prior to upgrading peer nodes
 
+It is important to ensure chaincode utilizes good practices consistent with v2.x prior to upgrading nodes and enabling the new chaincode lifecycle.
+Consider updating chaincode based on the below guidelines prior to upgrading nodes.
+
 #### Chaincode shim changes (Go chaincode only)
 
 The v2.x `ccenv` image that is used to build Go chaincodes no longer automatically vendors the Go chaincode shim dependency like the v1.4 `ccenv` image did.
@@ -40,6 +43,19 @@ For v1.4 Nodejs chaincode libraries, the supported node runtime is v8. Though no
 Also please note that the v1.4 libraries themselves are not supported, and will no longer get updates. Please migrate to a v2 Node chaincode library.
 
 For detailed information please refer to the [compatibility](https://github.com/hyperledger/fabric-chaincode-node/blob/main/COMPATIBILITY.md) document in the `fabric-chaincode-node` repository.
+
+#### Chaincode initialization
+
+The new chaincode lifecycle does not have an option to automatically call a chaincode `Init` function upon chaincode deployment.
+Instead, the new chaincode lifecycle has a mechanism to flag that chaincode initialization is required,
+by using the `--init-required` flag, and providing a `--isInit` flag on the `peer chaincode invoke` command.
+However, is most scenarios it is recommended to embed initialization logic into chaincode rather than use the chaincode lifecycle mechanism.
+Chaincode functions often perform checks against existing state, and initialization state can be implemented like any other chaincode state and be checked in subsequent chaincode function calls.
+Handling initialization state within chaincode logic rather than with the chaincode lifecycle
+mechanism has the benefit that you are not limited to a single initialization function,
+rather you are in full control of initialization logic and can call your own
+functions that initialize state from an application consistent with how all other application functions are called.
+
 ### While upgrading peer nodes
 
 #### Peer databases upgrade

--- a/docs/source/upgrade_to_newest_version.md
+++ b/docs/source/upgrade_to_newest_version.md
@@ -49,7 +49,7 @@ For detailed information please refer to the [compatibility](https://github.com/
 The new chaincode lifecycle does not have an option to automatically call a chaincode `Init` function upon chaincode deployment.
 Instead, the new chaincode lifecycle has a mechanism to flag that chaincode initialization is required,
 by using the `--init-required` flag, and providing a `--isInit` flag on the `peer chaincode invoke` command.
-However, is most scenarios it is recommended to embed initialization logic into chaincode rather than use the chaincode lifecycle mechanism.
+However, in most scenarios it is recommended to embed initialization logic into chaincode rather than use the chaincode lifecycle mechanism.
 Chaincode functions often perform checks against existing state, and initialization state can be implemented like any other chaincode state and be checked in subsequent chaincode function calls.
 Handling initialization state within chaincode logic rather than with the chaincode lifecycle
 mechanism has the benefit that you are not limited to a single initialization function,

--- a/docs/wrappers/peer_lifecycle_chaincode_postscript.md
+++ b/docs/wrappers/peer_lifecycle_chaincode_postscript.md
@@ -149,8 +149,8 @@ channel `mychannel`.
 
   * Use the `--package-id` flag to pass in the chaincode package identifier. Use
     the `--signature-policy` flag to define an endorsement policy for the chaincode.
-    Use the `init-required` flag to request the execution of the `Init`
-    function to initialize the chaincode.
+    Use the `init-required` flag to require the execution of an initialization function
+    before other chaincode functions can be called.
 
     ```
     export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem

--- a/scripts/help_docs.sh
+++ b/scripts/help_docs.sh
@@ -54,7 +54,7 @@ checkHelpTextCurrent() {
 
   generateHelpText "$tempfile" "$@"
   if ! diff -u "$doc" "$tempfile"; then
-    echo "The command line help docs are out of date and need to be regenerated"
+    echo "The command line help docs are out of date and need to be regenerated, see docs/source/docs_guide.md for more details."
     exit 2
   fi
 


### PR DESCRIPTION
Add chaincode initialization guidance to docs,
including the option to manage initialization as regular chaincode state rather than with the chaincode lifecycle initialization mechanism.
