### PR TITLE
Update govulncheck to use Go 1.20.2

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -5,6 +5,7 @@
 name: "Security vulnerability scan"
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "50 1 * * *"
 
@@ -29,6 +30,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: 1.20.2
       - name: Scan
         run: make scan


### PR DESCRIPTION
govulncheck couldn't be found with just '1.20'.
Let's try the exact version '1.20.2'.

Also enable workflow_dispatch for on-demand runs.