### PR TITLE
bug fix 4127. Restore RSA support for x509 public key import on PKCS11

### DIFF
--- a/bccsp/pkcs11/ecdsakey_test.go
+++ b/bccsp/pkcs11/ecdsakey_test.go
@@ -32,5 +32,5 @@ func TestX509PublicKeyImportOptsKeyImporter(t *testing.T) {
 	cert.PublicKey = "Hello world"
 	_, err = ki.KeyImport(cert, &bccsp.X509PublicKeyImportOpts{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Certificate's public key type not recognized. Supported keys: [ECDSA]")
+	assert.Contains(t, err.Error(), "Certificate's public key type not recognized. Supported keys: [ECDSA, RSA]")
 }

--- a/bccsp/pkcs11/pkcs11_test.go
+++ b/bccsp/pkcs11/pkcs11_test.go
@@ -13,6 +13,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/sha512"
 	"crypto/x509"
@@ -845,6 +846,16 @@ func TestECDSAKeyImportFromECDSAPublicKey(t *testing.T) {
 	if !valid {
 		t.Fatal("Failed verifying ECDSA signature. Signature not valid.")
 	}
+}
+
+func TestX509RSAKeyImport(t *testing.T) {
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err, "key generation failed")
+	cert := &x509.Certificate{PublicKey: pk.Public()}
+	key, err := currentBCCSP.KeyImport(cert, &bccsp.X509PublicKeyImportOpts{Temporary: false})
+	assert.NoError(t, err, "key import failed")
+	assert.NotNil(t, key, "key must not be nil")
+	assert.Equal(t, &rsaPublicKey{pubKey: &pk.PublicKey}, key)
 }
 
 func TestKeyImportFromX509ECDSAPublicKey(t *testing.T) {

--- a/bccsp/pkcs11/rsa.go
+++ b/bccsp/pkcs11/rsa.go
@@ -1,0 +1,52 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pkcs11
+
+import (
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/fabric/bccsp"
+)
+
+// An rsaPublicKey wraps the standard library implementation of an RSA public
+// key with functions that satisfy the bccsp.Key interface.
+//
+// NOTE: Fabric does not support RSA signing or verification. This code simply
+// allows MSPs to include RSA CAs in their certificate chains.
+type rsaPublicKey struct{ pubKey *rsa.PublicKey }
+
+func (k *rsaPublicKey) Symmetric() bool               { return false }
+func (k *rsaPublicKey) Private() bool                 { return false }
+func (k *rsaPublicKey) PublicKey() (bccsp.Key, error) { return k, nil }
+
+// Bytes converts this key to its serialized representation.
+func (k *rsaPublicKey) Bytes() (raw []byte, err error) {
+	if k.pubKey == nil {
+		return nil, errors.New("Failed marshalling key. Key is nil.")
+	}
+	raw, err = x509.MarshalPKIXPublicKey(k.pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("Failed marshalling key [%s]", err)
+	}
+	return
+}
+
+// SKI returns the subject key identifier of this key.
+func (k *rsaPublicKey) SKI() []byte {
+	if k.pubKey == nil {
+		return nil
+	}
+
+	// Marshal the public key and hash it
+	raw := x509.MarshalPKCS1PublicKey(k.pubKey)
+	hash := sha256.Sum256(raw)
+	return hash[:]
+}

--- a/bccsp/pkcs11/rsa_test.go
+++ b/bccsp/pkcs11/rsa_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pkcs11
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type rsaPublicKeyASN struct {
+	N *big.Int
+	E int
+}
+
+func TestRSAPublicKey(t *testing.T) {
+	lowLevelKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	k := &rsaPublicKey{&lowLevelKey.PublicKey}
+
+	require.False(t, k.Symmetric())
+	require.False(t, k.Private())
+
+	k.pubKey = nil
+	ski := k.SKI()
+	require.Nil(t, ski)
+
+	k.pubKey = &lowLevelKey.PublicKey
+	ski = k.SKI()
+	raw, err := asn1.Marshal(rsaPublicKeyASN{N: k.pubKey.N, E: k.pubKey.E})
+	require.NoError(t, err, "asn1 marshal failed")
+	hash := sha256.New()
+	hash.Write(raw)
+	ski2 := hash.Sum(nil)
+	require.Equal(t, ski, ski2, "SKI is not computed in the right way.")
+
+	pk, err := k.PublicKey()
+	require.NoError(t, err)
+	require.Equal(t, k, pk)
+
+	bytes, err := k.Bytes()
+	require.NoError(t, err)
+	bytes2, err := x509.MarshalPKIXPublicKey(k.pubKey)
+	require.Equal(t, bytes2, bytes, "bytes are not computed in the right way.")
+
+	_, err = (&rsaPublicKey{}).Bytes()
+	require.EqualError(t, err, "Failed marshalling key. Key is nil.")
+}


### PR DESCRIPTION
<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

<!--- Describe your changes in detail, including motivation. -->
While RSA has never been supported by Fabric for transaction signing and
verification, prior to version 2.x, MSPs could include CA certificates
that included RSA public keys. This was broken with the removal of the
unsupported RSA code.

It was fixed in SW but the error is still in PKCS11

This change modifies the key import function used by the MSP on PKCS11 to convert
an RSA public key to a bccsp.Key that can then be used as part of an MSP
identity.

This code does *not* add support for RSA on transaction paths.
#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues
https://github.com/hyperledger/fabric/issues/4127

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
