### PR TITLE
use HasGet() instead of Has() and Get() on fastcache lib

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/cache.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/cache.go
@@ -63,11 +63,12 @@ func (c *cache) getState(chainID, namespace, key string) (*CacheValue, error) {
 
 	cacheKey := constructCacheKey(chainID, namespace, key)
 
-	if !cache.Has(cacheKey) {
+	valBytes, exist := cache.HasGet(nil, cacheKey)
+	if !exist {
 		return nil, nil
 	}
+
 	cacheValue := &CacheValue{}
-	valBytes := cache.Get(nil, cacheKey)
 	if err := proto.Unmarshal(valBytes, cacheValue); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->


- Improvement (improvement to code, performance, etc)


#### Description

This pull request addresses the issue of inefficiency when retrieving a stored value from Fastcache by consolidating the two API calls, `Has()` and `Get()`, into a single call using the `HasGet()` API. By doing so, the performance overhead associated with making two API calls is eliminated.






