### PR TITLE
Fix failure in 'basic checks'

### DIFF
--- a/docs/source/commands/ledgerutil.md
+++ b/docs/source/commands/ledgerutil.md
@@ -214,8 +214,8 @@ Flags:
                              Default is the current directory.
 
 Args:
-  [<blockStorePath>]  Path to file system of target peer, used to access block
-                      store. Defaults to '/var/hyperledger/production'.
+  [<blockStorePath>]  Path to file system of target peer, used to access
+                      block store. Defaults to '/var/hyperledger/production'.
                       IMPORTANT: If the configuration for target peer's file
                       system path was changed, the new path MUST be provided.
 ```


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

This patch fixes failure during 'basic checks' in the CI. It is possibly caused by the update of Go to v1.20.

#### Additional details

During the "basic checks" job, the command references are compared with the generated ones. Since the Go version is updated to v1.20, the CI job generates slightly different documents from those in the repository, which were generated with the previous versions of Go.

#### Related issues

#4157