### PR TITLE
Orderer v3: prevent join to system channel

### DIFF
--- a/orderer/common/channelparticipation/restapi.go
+++ b/orderer/common/channelparticipation/restapi.go
@@ -260,13 +260,13 @@ func (h *HTTPHandler) serveJoin(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	channelID, isAppChannel, err := ValidateJoinBlock(block)
+	channelID, err := ValidateJoinBlock(block)
 	if err != nil {
 		h.sendResponseJsonError(resp, http.StatusBadRequest, errors.WithMessage(err, "invalid join block"))
 		return
 	}
 
-	info, err := h.registrar.JoinChannel(channelID, block, isAppChannel)
+	info, err := h.registrar.JoinChannel(channelID, block, true)
 	if err != nil {
 		h.sendJoinError(err, resp)
 		return

--- a/orderer/common/channelparticipation/validator.go
+++ b/orderer/common/channelparticipation/validator.go
@@ -7,43 +7,47 @@ SPDX-License-Identifier: Apache-2.0
 package channelparticipation
 
 import (
-	"errors"
-
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/bccsp/factory"
 	"github.com/hyperledger/fabric/common/channelconfig"
+	"github.com/hyperledger/fabric/orderer/common/types"
 	"github.com/hyperledger/fabric/protoutil"
+	"github.com/pkg/errors"
 )
 
 // ValidateJoinBlock checks whether this block can be used as a join block for the channel participation API.
-// It returns the channel ID, and whether it is an system channel if it contains consortiums, or otherwise
-// an application channel if an application group exists. It returns an error when it cannot be used as a join-block.
-func ValidateJoinBlock(configBlock *cb.Block) (channelID string, isAppChannel bool, err error) {
+// It returns the channel ID.
+// It verifies that it is not a system channel by checking that consortiums config does not exist.
+// It verifies it is an application channel by checking that the application group exists.
+// It returns an error when it cannot be used as a join-block.
+func ValidateJoinBlock(configBlock *cb.Block) (channelID string, err error) {
 	if !protoutil.IsConfigBlock(configBlock) {
-		return "", false, errors.New("block is not a config block")
+		return "", errors.New("block is not a config block")
 	}
 
 	envelope, err := protoutil.ExtractEnvelope(configBlock, 0)
 	if err != nil {
-		return "", false, err
+		return "", err
 	}
 
 	cryptoProvider := factory.GetDefault()
 	bundle, err := channelconfig.NewBundleFromEnvelope(envelope, cryptoProvider)
 	if err != nil {
-		return "", false, err
+		return "", err
 	}
 
 	channelID = bundle.ConfigtxValidator().ChannelID()
 
 	// Check channel type
 	_, isSystemChannel := bundle.ConsortiumsConfig()
-	if !isSystemChannel {
-		_, isAppChannel = bundle.ApplicationConfig()
-		if !isAppChannel {
-			return "", false, errors.New("invalid config: must have at least one of application or consortiums")
-		}
+	if isSystemChannel {
+		return "", errors.WithMessage(types.ErrSystemChannelNotSupported, "invalid config: contains consortiums")
 	}
 
-	return channelID, isAppChannel, err
+	_, isAppChannel := bundle.ApplicationConfig()
+	if !isAppChannel {
+		return "", errors.New("invalid config: must contain application config")
+	}
+
+	return channelID, err
 }

--- a/orderer/common/types/errors.go
+++ b/orderer/common/types/errors.go
@@ -9,7 +9,12 @@ package types
 import "github.com/pkg/errors"
 
 // ErrSystemChannelExists is returned when trying to join or remove an application channel when the system channel exists.
+//
+// Deprecated: system channel no longer supported
 var ErrSystemChannelExists = errors.New("system channel exists")
+
+// ErrSystemChannelNotSupported  is returned when trying to join with a system channel config block.
+var ErrSystemChannelNotSupported = errors.New("system channel not supported")
 
 // ErrChannelAlreadyExists is returned when trying to join a app channel that already exists (when the system channel does not
 // exist), or when trying to join the system channel when it already exists.


### PR DESCRIPTION



Change-Id: I8a8a0d8810bf8337b66c07434d3a6d392ca963f4

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description

Prevent a system channel block from being accepted as valid input to channel participation join.

#### Related issues

Issue: #3515 
Epic: #3511 
