### PR TITLE
Revert "Fix firewall warnings for integration tests on Mac"

### DIFF
--- a/integration/nwo/template/core_template.go
+++ b/integration/nwo/template/core_template.go
@@ -16,7 +16,7 @@ peer:
   address: 127.0.0.1:{{ .PeerPort Peer "Listen" }}
   addressAutoDetect: true
   listenAddress: 127.0.0.1:{{ .PeerPort Peer "Listen" }}
-  chaincodeListenAddress: 127.0.0.1:{{ .PeerPort Peer "Chaincode" }}
+  chaincodeListenAddress: 0.0.0.0:{{ .PeerPort Peer "Chaincode" }}
   keepalive:
     minInterval: 60s
     client:


### PR DESCRIPTION
This reverts commit 412f3661cb05061a0a9413d16b24f5326f07b3fa.

The change caused integration tests to fail on a number of developer macs (both amd64 and arm64).