### PR TITLE
Re-add Go to fabric-tools image

### DIFF
--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -50,13 +50,19 @@ RUN make tools GO_TAGS=${GO_TAGS} FABRIC_VER=${FABRIC_VER}
 ARG UBUNTU_VER
 FROM ubuntu:${UBUNTU_VER}
 
+ARG TARGETARCH
+ARG TARGETOS
 ARG FABRIC_VER
+ARG GO_VER
 
 RUN apt update && apt install -y \
     bash \
     curl \
     jq \
     tzdata
+
+RUN curl -sL https://go.dev/dl/go${GO_VER}.${TARGETOS}-${TARGETARCH}.tar.gz | tar zxvf - -C /usr/local
+ENV PATH="/usr/local/go/bin:$PATH"
 
 # set up nsswitch.conf for Go's "netgo" implementation
 # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275


### PR DESCRIPTION
Since the images are no longer based on the golang alpine images, need to manually install go to the fabric-tools image. go is needed for users that use fabric-tools image to package go chaincodes.