### PR TITLE
Bump CouchDB to 3.3.2 (release-2.5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ FABRIC_VER ?= 2.5.0
 
 # 3rd party image version
 # These versions are also set in the runners in ./integration/runners/
-COUCHDB_VER ?= 3.2.2
+COUCHDB_VER ?= 3.3.2
 KAFKA_VER ?= 5.3.1
 ZOOKEEPER_VER ?= 5.3.1
 

--- a/integration/nwo/runner/couchdb.go
+++ b/integration/nwo/runner/couchdb.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	CouchDBDefaultImage = "couchdb:3.2.2"
+	CouchDBDefaultImage = "couchdb:3.3.2"
 	CouchDBUsername     = "admin"
 	CouchDBPassword     = "adminpw"
 )


### PR DESCRIPTION
Bump CouchDB to 3.3.2.