### PR TITLE
Remove requests from BFT memory pool when syncing

### DIFF
--- a/orderer/consensus/smartbft/util.go
+++ b/orderer/consensus/smartbft/util.go
@@ -466,3 +466,33 @@ func (conCert ConsenterCertificate) IsConsenterOfChannel(configBlock *cb.Block) 
 	}
 	return cluster.ErrNotInChannel
 }
+
+type worker struct {
+	work      [][]byte
+	f         func([]byte)
+	workerNum int
+	id        int
+}
+
+func (w *worker) doWork() {
+	// sanity check
+	if w.workerNum == 0 {
+		panic("worker number is not defined")
+	}
+
+	if w.f == nil {
+		panic("worker function is not defined")
+	}
+
+	if len(w.work) == 0 {
+		panic("work is not defined")
+	}
+
+	for i, datum := range w.work {
+		if i%w.workerNum != w.id {
+			continue
+		}
+
+		w.f(datum)
+	}
+}

--- a/orderer/consensus/smartbft/util_test.go
+++ b/orderer/consensus/smartbft/util_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package smartbft
+
+import (
+	"encoding/binary"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorker(t *testing.T) {
+	work := make([][]byte, 13)
+
+	for i := 0; i < 13; i++ {
+		work[i] = make([]byte, 2)
+		binary.BigEndian.PutUint16(work[i], uint16(i))
+	}
+
+	workDone := make(map[int]struct{})
+
+	var lock sync.Mutex
+
+	var workers []worker
+	for i := 0; i < 7; i++ {
+		workers = append(workers, worker{
+			workerNum: 7,
+			work:      work,
+			id:        i,
+			f: func(data []byte) {
+				lock.Lock()
+				defer lock.Unlock()
+
+				workDone[int(binary.BigEndian.Uint16(data))] = struct{}{}
+			},
+		})
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(7)
+
+	for i := 0; i < len(workers); i++ {
+		go func(i int, w worker) {
+			defer wg.Done()
+			w.doWork()
+		}(i, workers[i])
+	}
+
+	wg.Wait()
+
+	assert.Len(t, workDone, 13)
+}


### PR DESCRIPTION
When a BFT node commits a block, it goes through the transactions in the block and searches whether they exist in the in-memory pool, and if so, it removes them from the pool.

When a follower node syncs blocks from another node, the requests of these blocks still remain in its request pool. They not only take up memory, but also holds the semaphore resources which throttle needlessly the client.

This commit goes through the requests of a block that is committed through synchronization and removes them as well. This is needed because the library only sees the last block committed during synchronization and not the entire range.
