### PR TITLE
Orderer v3: remove ORDERER_TRANSACTION

### DIFF
--- a/orderer/common/msgprocessor/msgprocessor.go
+++ b/orderer/common/msgprocessor/msgprocessor.go
@@ -47,9 +47,13 @@ const (
 	// Messages of this type should be processed by ProcessConfigUpdateMsg.
 	ConfigUpdateMsg
 
-	// ConfigMsg indicates message of type ORDERER_TRANSACTION or CONFIG.
+	// ConfigMsg indicates message of type CONFIG.
 	// Messages of this type should be processed by ProcessConfigMsg
 	ConfigMsg
+
+	// UnsupportedMsg indicates a message of type ORDERER_TRANSACTION, which is no longer supported, since support for
+	// the system channel was removed.
+	UnsupportedMsg
 )
 
 // Processor provides the methods necessary to classify and process any message which

--- a/orderer/common/msgprocessor/standardchannel.go
+++ b/orderer/common/msgprocessor/standardchannel.go
@@ -85,8 +85,8 @@ func (s *StandardChannel) ClassifyMsg(chdr *cb.ChannelHeader) Classification {
 	case int32(cb.HeaderType_CONFIG_UPDATE):
 		return ConfigUpdateMsg
 	case int32(cb.HeaderType_ORDERER_TRANSACTION):
-		// In order to maintain backwards compatibility, we must classify these messages
-		return ConfigMsg
+		// Not supported in v3
+		return UnsupportedMsg
 	case int32(cb.HeaderType_CONFIG):
 		// In order to maintain backwards compatibility, we must classify these messages
 		return ConfigMsg

--- a/orderer/common/msgprocessor/standardchannel_test.go
+++ b/orderer/common/msgprocessor/standardchannel_test.go
@@ -60,7 +60,7 @@ func TestClassifyMsg(t *testing.T) {
 	})
 	t.Run("OrdererTx", func(t *testing.T) {
 		class := (&StandardChannel{}).ClassifyMsg(&cb.ChannelHeader{Type: int32(cb.HeaderType_ORDERER_TRANSACTION)})
-		require.Equal(t, class, ConfigMsg)
+		require.Equal(t, class, UnsupportedMsg)
 	})
 	t.Run("ConfigTx", func(t *testing.T) {
 		class := (&StandardChannel{}).ClassifyMsg(&cb.ChannelHeader{Type: int32(cb.HeaderType_CONFIG)})

--- a/orderer/common/multichannel/chainsupport.go
+++ b/orderer/common/multichannel/chainsupport.go
@@ -73,7 +73,7 @@ func newChainSupport(
 	cs.Processor = msgprocessor.NewStandardChannel(cs, msgprocessor.CreateStandardChannelFilters(cs, registrar.config), bccsp)
 
 	// Set up the block writer
-	cs.BlockWriter = newBlockWriter(lastBlock, registrar, cs)
+	cs.BlockWriter = newBlockWriter(lastBlock, cs)
 
 	// Set up the consenter
 	consenterType := ledgerResources.SharedConfig().ConsensusType()

--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -322,6 +322,8 @@ func (r *Registrar) BroadcastChannelSupport(msg *cb.Envelope) (*cb.ChannelHeader
 		isConfig = true
 	case msgprocessor.ConfigMsg:
 		return chdr, false, nil, errors.New("message is of type that cannot be processed directly")
+	case msgprocessor.UnsupportedMsg:
+		return chdr, false, nil, errors.New("message is of type that is no longer supported")
 	default:
 	}
 

--- a/orderer/common/multichannel/util_test.go
+++ b/orderer/common/multichannel/util_test.go
@@ -155,14 +155,6 @@ func makeConfigTxMig(chainID string, i int) *cb.Envelope {
 	})
 }
 
-func wrapConfigTx(env *cb.Envelope) *cb.Envelope {
-	result, err := protoutil.CreateSignedEnvelope(cb.HeaderType_ORDERER_TRANSACTION, "testchannelid", mockCrypto(), env, msgVersion, epoch)
-	if err != nil {
-		panic(err)
-	}
-	return result
-}
-
 func makeConfigTxFromConfigUpdateEnvelope(chainID string, configUpdateEnv *cb.ConfigUpdateEnvelope) *cb.Envelope {
 	configUpdateTx, err := protoutil.CreateSignedEnvelope(cb.HeaderType_CONFIG_UPDATE, chainID, mockCrypto(), configUpdateEnv, msgVersion, epoch)
 	if err != nil {

--- a/orderer/consensus/etcdraft/chain.go
+++ b/orderer/consensus/etcdraft/chain.go
@@ -1265,7 +1265,7 @@ func (c *Chain) isConfig(env *common.Envelope) (bool, error) {
 		return false, err
 	}
 
-	return h.Type == int32(common.HeaderType_CONFIG) || h.Type == int32(common.HeaderType_ORDERER_TRANSACTION), nil
+	return h.Type == int32(common.HeaderType_CONFIG), nil
 }
 
 func (c *Chain) configureComm() error {
@@ -1388,13 +1388,7 @@ func (c *Chain) writeConfigBlock(block *common.Block, index uint64) {
 		}
 
 	case common.HeaderType_ORDERER_TRANSACTION:
-		// If this config is channel creation, no extra inspection is needed
-		c.raftMetadataLock.Lock()
-		c.opts.BlockMetadata.RaftIndex = index
-		m := protoutil.MarshalOrPanic(c.opts.BlockMetadata)
-		c.raftMetadataLock.Unlock()
-
-		c.support.WriteConfigBlock(block, m)
+		c.logger.Panicf("Programming error: unsupported legacy system channel config type: %s", common.HeaderType(hdr.Type))
 
 	default:
 		c.logger.Panicf("Programming error: unexpected config type: %s", common.HeaderType(hdr.Type))

--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -1774,24 +1774,6 @@ var _ = Describe("Chain", func() {
 					}
 					return updateRaftConfigValue(metadata)
 				}
-				createChannelEnv = func(metadata *raftprotos.ConfigMetadata) *common.Envelope {
-					configEnv := newConfigEnv("another-channel",
-						common.HeaderType_CONFIG,
-						newConfigUpdateEnv(channelID, nil, updateRaftConfigValue(metadata)))
-
-					// Wrap config env in Orderer transaction
-					return &common.Envelope{
-						Payload: marshalOrPanic(&common.Payload{
-							Header: &common.Header{
-								ChannelHeader: marshalOrPanic(&common.ChannelHeader{
-									Type:      int32(common.HeaderType_ORDERER_TRANSACTION),
-									ChannelId: channelID,
-								}),
-							},
-							Data: marshalOrPanic(configEnv),
-						}),
-					}
-				}
 			)
 
 			BeforeEach(func() {
@@ -1819,20 +1801,6 @@ var _ = Describe("Chain", func() {
 
 			AfterEach(func() {
 				network.stop()
-			})
-
-			Context("channel creation", func() {
-				It("succeeds with valid config metadata", func() {
-					metadata := &raftprotos.ConfigMetadata{Options: options}
-					for _, consenter := range consenters {
-						metadata.Consenters = append(metadata.Consenters, consenter)
-					}
-
-					Expect(c1.Configure(createChannelEnv(metadata), 0)).To(Succeed())
-					network.exec(func(c *chain) {
-						Eventually(c.support.WriteConfigBlockCallCount, LongEventualTimeout).Should(Equal(1))
-					})
-				})
 			})
 
 			Context("reconfiguration", func() {
@@ -2026,40 +1994,6 @@ var _ = Describe("Chain", func() {
 
 					network.exec(func(c *chain) {
 						Eventually(c.support.WriteBlockCallCount, defaultTimeout).Should(Equal(2))
-					})
-				})
-
-				It("does not reconfigure raft cluster if it's a channel creation tx", func() {
-					configEnv := newConfigEnv("another-channel",
-						common.HeaderType_CONFIG,
-						newConfigUpdateEnv(channelID, nil, removeConsenterConfigValue(2)))
-
-					// Wrap config env in Orderer transaction
-					channelCreationEnv := &common.Envelope{
-						Payload: marshalOrPanic(&common.Payload{
-							Header: &common.Header{
-								ChannelHeader: marshalOrPanic(&common.ChannelHeader{
-									Type:      int32(common.HeaderType_ORDERER_TRANSACTION),
-									ChannelId: channelID,
-								}),
-							},
-							Data: marshalOrPanic(configEnv),
-						}),
-					}
-
-					c1.cutter.CutNext = true
-
-					Expect(c1.Configure(channelCreationEnv, 0)).To(Succeed())
-					network.exec(func(c *chain) {
-						Eventually(c.support.WriteConfigBlockCallCount, LongEventualTimeout).Should(Equal(1))
-					})
-
-					// assert c2 is not evicted
-					Consistently(c2.Errored).ShouldNot(BeClosed())
-					Expect(c2.Order(env, 0)).To(Succeed())
-
-					network.exec(func(c *chain) {
-						Eventually(c.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(2))
 					})
 				})
 

--- a/orderer/consensus/etcdraft/util.go
+++ b/orderer/consensus/etcdraft/util.go
@@ -159,16 +159,7 @@ func ConfigEnvelopeFromBlock(block *common.Block) (*common.Envelope, error) {
 
 	switch channelHeader.Type {
 	case int32(common.HeaderType_ORDERER_TRANSACTION):
-		payload, err := protoutil.UnmarshalPayload(envelope.Payload)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal envelope to extract config payload for orderer transaction")
-		}
-		configEnvelop, err := protoutil.UnmarshalEnvelope(payload.Data)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal config envelope for orderer type transaction")
-		}
-
-		return configEnvelop, nil
+		return nil, errors.Errorf("unsupported legacy system channel header type: %v", channelHeader.Type)
 	case int32(common.HeaderType_CONFIG):
 		return envelope, nil
 	default:

--- a/protoutil/commonutils.go
+++ b/protoutil/commonutils.go
@@ -207,7 +207,7 @@ func IsConfigBlock(block *cb.Block) bool {
 		return false
 	}
 
-	return cb.HeaderType(hdr.Type) == cb.HeaderType_CONFIG || cb.HeaderType(hdr.Type) == cb.HeaderType_ORDERER_TRANSACTION
+	return cb.HeaderType(hdr.Type) == cb.HeaderType_CONFIG
 }
 
 // ChannelHeader returns the *cb.ChannelHeader for a given *cb.Envelope.

--- a/protoutil/commonutils_test.go
+++ b/protoutil/commonutils_test.go
@@ -413,7 +413,7 @@ func TestIsConfigBlock(t *testing.T) {
 	block = newBlock(env)
 
 	result = IsConfigBlock(block)
-	require.True(t, result, "IsConfigBlock returns true for blocks with ORDERER_TRANSACTION envelope")
+	require.False(t, result, "IsConfigBlock returns false for blocks with ORDERER_TRANSACTION envelope since it is no longer supported")
 
 	// scenario 3: MESSAGE envelope
 	envType = int32(cb.HeaderType_MESSAGE)


### PR DESCRIPTION
Change-Id: I97bdd9fbc60195bbaf7c4486e43dbf7f28bbff66

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description

The ORDERER_TRANSACTION type is no longer used, reject it everywhere

#### Related issues

Issue: #3515 #4204