### PR TITLE
BFT Block Puller: orderer can deliver header+sigs

### DIFF
--- a/common/deliver/deliver.go
+++ b/common/deliver/deliver.go
@@ -328,6 +328,10 @@ func (h *Handler) deliverBlocks(ctx context.Context, srv *Server, envelope *cb.E
 
 		logger.Debugf("[channel: %s] Delivering block [%d] for (%p) for %s", chdr.ChannelId, block.Header.Number, seekInfo, addr)
 
+		if seekInfo.ContentType == ab.SeekInfo_HEADER_WITH_SIG {
+			block.Data = nil
+		}
+
 		signedData := &protoutil.SignedData{Data: envelope.Payload, Identity: shdr.Creator, Signature: envelope.Signature}
 		if err := srv.SendBlockResponse(block, chdr.ChannelId, chain, signedData); err != nil {
 			logger.Warningf("[channel: %s] Error sending to %s: %s", chdr.ChannelId, addr, err)


### PR DESCRIPTION


Change-Id: I47e9767e7f322145291a8ffa498500ee99714cc6


#### Type of change

- New feature

#### Description
When the SeekInfo message SeekContentType is HEADER_WITH_SIGS, send a block with nil block.data.


#### Related issues

Issue: #4241 

