### PR TITLE
Method AppRootCAsByChain() not thread safe

### DIFF
--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -92,11 +92,8 @@ func (p *Peer) updateTrustedRoots(cm channelconfig.Resources) {
 
 	p.CredentialSupport.BuildTrustedRootsForChain(cm)
 
-	// now iterate over all roots for all app and orderer channels
-	var trustedRoots [][]byte
-	for _, roots := range p.CredentialSupport.AppRootCAsByChain() {
-		trustedRoots = append(trustedRoots, roots...)
-	}
+	trustedRoots := p.CredentialSupport.AppRootCAsByChain()
+
 	trustedRoots = append(trustedRoots, p.ServerConfig.SecOpts.ClientRootCAs...)
 	trustedRoots = append(trustedRoots, p.ServerConfig.SecOpts.ServerRootCAs...)
 

--- a/internal/pkg/comm/connection.go
+++ b/internal/pkg/comm/connection.go
@@ -75,10 +75,15 @@ func (cs *CredentialSupport) GetPeerCredentials() credentials.TransportCredentia
 	})
 }
 
-func (cs *CredentialSupport) AppRootCAsByChain() map[string][][]byte {
+func (cs *CredentialSupport) AppRootCAsByChain() [][]byte {
 	cs.mutex.RLock()
 	defer cs.mutex.RUnlock()
-	return cs.appRootCAsByChain
+	trustedRoots := make([][]byte, 0, len(cs.appRootCAsByChain))
+	// iterate over all roots for all app and orderer channels
+	for _, roots := range cs.appRootCAsByChain {
+		trustedRoots = append(trustedRoots, roots...)
+	}
+	return trustedRoots
 }
 
 // BuildTrustedRootsForChain populates the appRootCAs and orderRootCAs maps by


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

As described in issue #4233 

#### Related issues

issue: #4233 