### PR TITLE
Fixes #4180 peer chaincode error message formatting

### DIFF
--- a/internal/peer/chaincode/common.go
+++ b/internal/peer/chaincode/common.go
@@ -154,7 +154,7 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, invoke bool, cf *ChaincodeCmdFac
 			return errors.WithMessage(err, "error while unmarshalling chaincode action")
 		}
 		if proposalResp.Endorsement == nil {
-			return errors.Errorf("endorsement failure during invoke. response: %v", proposalResp.Response)
+			return errors.Errorf("endorsement failure during invoke. response: %v", proto.MarshalTextString(proposalResp.Response))
 		}
 		logger.Infof("Chaincode invoke successful. result: %v", ca.Response)
 	} else {
@@ -162,7 +162,7 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, invoke bool, cf *ChaincodeCmdFac
 			return errors.New("error during query: received nil proposal response")
 		}
 		if proposalResp.Endorsement == nil {
-			return errors.Errorf("endorsement failure during query. response: %v", proposalResp.Response)
+			return errors.Errorf("endorsement failure during query. response: %v", proto.MarshalTextString(proposalResp.Response))
 		}
 
 		if chaincodeQueryRaw && chaincodeQueryHex {

--- a/internal/peer/chaincode/query_test.go
+++ b/internal/peer/chaincode/query_test.go
@@ -80,7 +80,8 @@ func TestQueryCmdEndorsementFailure(t *testing.T) {
 		err = cmd.Execute()
 		require.Error(t, err)
 		require.Regexp(t, "endorsement failure during query", err.Error())
-		require.Regexp(t, fmt.Sprintf("response: status:%d payload:\"%s\"", ccRespStatus[i], ccRespPayload[i]), err.Error())
+		require.Regexp(t, fmt.Sprintf("status: %d", ccRespStatus[i]), err.Error())
+		require.Regexp(t, fmt.Sprintf("payload: \"%s\"", ccRespPayload[i]), err.Error())
 	}
 
 	// failure - nil proposal response


### PR DESCRIPTION
#### Type of change

- Bug fix #4180

#### Description

Uses proto.MarshalTextString to insert the protocol buffer response message into the error string
