### PR TITLE
BFT Block Puller: verify attestation

### DIFF
--- a/gossip/api/crypto.go
+++ b/gossip/api/crypto.go
@@ -37,6 +37,11 @@ type MessageCryptoService interface {
 	// else returns error
 	VerifyBlock(channelID common.ChannelID, seqNum uint64, block *cb.Block) error
 
+	// VerifyBlockAttestation does the same as VerifyBlock, except it assumes block.Data = nil. It therefore does not
+	// compute the block.Data.Hash() and compare it to the block.Header.DataHash. This is used when the orderer
+	// delivers a block with header & metadata only, as an attestation of block existence.
+	VerifyBlockAttestation(channelID string, block *cb.Block) error
+
 	// Sign signs msg with this peer's signing key and outputs
 	// the signature if no error occurred.
 	Sign(msg []byte) ([]byte, error)

--- a/gossip/comm/comm_test.go
+++ b/gossip/comm/comm_test.go
@@ -97,6 +97,12 @@ func (*naiveSecProvider) VerifyBlock(channelID common.ChannelID, seqNum uint64, 
 	return nil
 }
 
+// VerifyBlockAttestation returns nil if the block attestation is properly signed,
+// else returns error
+func (*naiveSecProvider) VerifyBlockAttestation(channelID string, signedBlock *cb.Block) error {
+	return nil
+}
+
 // Sign signs msg with this peer's signing key and outputs
 // the signature if no error occurred.
 func (*naiveSecProvider) Sign(msg []byte) ([]byte, error) {

--- a/gossip/gossip/channel/channel_test.go
+++ b/gossip/gossip/channel/channel_test.go
@@ -146,6 +146,10 @@ func (cs *cryptoService) VerifyBlock(channelID common.ChannelID, seqNum uint64, 
 	return args.Get(0).(error)
 }
 
+func (*cryptoService) VerifyBlockAttestation(channelID string, signedBlock *cb.Block) error {
+	panic("Should not be called in this test")
+}
+
 func (cs *cryptoService) Sign(msg []byte) ([]byte, error) {
 	panic("Should not be called in this test")
 }

--- a/gossip/gossip/gossip_test.go
+++ b/gossip/gossip/gossip_test.go
@@ -177,6 +177,12 @@ func (*naiveCryptoService) VerifyBlock(channelID common.ChannelID, seqNum uint64
 	return nil
 }
 
+// VerifyBlockAttestation returns nil if the block attestation is properly signed,
+// else returns error
+func (*naiveCryptoService) VerifyBlockAttestation(channelID string, signedBlock *cb.Block) error {
+	return nil
+}
+
 // Sign signs msg with this peer's signing key and outputs
 // the signature if no error occurred.
 func (*naiveCryptoService) Sign(msg []byte) ([]byte, error) {

--- a/gossip/gossip/orgs_test.go
+++ b/gossip/gossip/orgs_test.go
@@ -81,6 +81,12 @@ func (*configurableCryptoService) VerifyBlock(channelID common.ChannelID, seqNum
 	return nil
 }
 
+// VerifyBlockAttestation returns nil if the block attestation is properly signed,
+// else returns error
+func (*configurableCryptoService) VerifyBlockAttestation(channelID string, signedBlock *cb.Block) error {
+	return nil
+}
+
 // Sign signs msg with this peer's signing key and outputs
 // the signature if no error occurred.
 func (*configurableCryptoService) Sign(msg []byte) ([]byte, error) {

--- a/gossip/identity/identity_test.go
+++ b/gossip/identity/identity_test.go
@@ -82,6 +82,12 @@ func (*naiveCryptoService) VerifyBlock(channelID common.ChannelID, seqNum uint64
 	return nil
 }
 
+// VerifyBlockAttestation returns nil if the block attestation is properly signed,
+// else returns error
+func (*naiveCryptoService) VerifyBlockAttestation(channelID string, signedBlock *cb.Block) error {
+	return nil
+}
+
 // VerifyByChannel verifies a peer's signature on a message in the context
 // of a specific channel
 func (*naiveCryptoService) VerifyByChannel(_ common.ChannelID, _ api.PeerIdentityType, _, _ []byte) error {

--- a/gossip/service/gossip_service_test.go
+++ b/gossip/service/gossip_service_test.go
@@ -843,6 +843,12 @@ func (*naiveCryptoService) VerifyBlock(chainID gossipcommon.ChannelID, seqNum ui
 	return nil
 }
 
+// VerifyBlockAttestation returns nil if the block attestation is properly signed,
+// else returns error
+func (*naiveCryptoService) VerifyBlockAttestation(channelID string, signedBlock *common.Block) error {
+	return nil
+}
+
 // Sign signs msg with this peer's signing key and outputs
 // the signature if no error occurred.
 func (*naiveCryptoService) Sign(msg []byte) ([]byte, error) {

--- a/gossip/state/state_test.go
+++ b/gossip/state/state_test.go
@@ -121,6 +121,12 @@ func (*cryptoServiceMock) VerifyBlock(channelID common.ChannelID, seqNum uint64,
 	return nil
 }
 
+// VerifyBlockAttestation returns nil if the block attestation is properly signed,
+// else returns error
+func (*cryptoServiceMock) VerifyBlockAttestation(channelID string, signedBlock *pcomm.Block) error {
+	return nil
+}
+
 // Sign signs msg with this peer's signing key and outputs
 // the signature if no error occurred.
 func (*cryptoServiceMock) Sign(msg []byte) ([]byte, error) {

--- a/internal/pkg/peer/blocksprovider/blocksprovider.go
+++ b/internal/pkg/peer/blocksprovider/blocksprovider.go
@@ -66,6 +66,11 @@ type GossipServiceAdapter interface {
 //go:generate counterfeiter -o fake/block_verifier.go --fake-name BlockVerifier . BlockVerifier
 type BlockVerifier interface {
 	VerifyBlock(channelID gossipcommon.ChannelID, blockNum uint64, block *common.Block) error
+
+	// VerifyBlockAttestation does the same as VerifyBlock, except it assumes block.Data = nil. It therefore does not
+	// compute the block.Data.Hash() and compare it to the block.Header.DataHash. This is used when the orderer
+	// delivers a block with header & metadata only, as an attestation of block existence.
+	VerifyBlockAttestation(channelID string, block *common.Block) error
 }
 
 //go:generate counterfeiter -o fake/orderer_connection_source.go --fake-name OrdererConnectionSource . OrdererConnectionSource

--- a/internal/pkg/peer/blocksprovider/fake/block_verifier.go
+++ b/internal/pkg/peer/blocksprovider/fake/block_verifier.go
@@ -23,6 +23,18 @@ type BlockVerifier struct {
 	verifyBlockReturnsOnCall map[int]struct {
 		result1 error
 	}
+	VerifyBlockAttestationStub        func(string, *commona.Block) error
+	verifyBlockAttestationMutex       sync.RWMutex
+	verifyBlockAttestationArgsForCall []struct {
+		arg1 string
+		arg2 *commona.Block
+	}
+	verifyBlockAttestationReturns struct {
+		result1 error
+	}
+	verifyBlockAttestationReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -35,15 +47,16 @@ func (fake *BlockVerifier) VerifyBlock(arg1 common.ChannelID, arg2 uint64, arg3 
 		arg2 uint64
 		arg3 *commona.Block
 	}{arg1, arg2, arg3})
+	stub := fake.VerifyBlockStub
+	fakeReturns := fake.verifyBlockReturns
 	fake.recordInvocation("VerifyBlock", []interface{}{arg1, arg2, arg3})
 	fake.verifyBlockMutex.Unlock()
-	if fake.VerifyBlockStub != nil {
-		return fake.VerifyBlockStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.verifyBlockReturns
 	return fakeReturns.result1
 }
 
@@ -89,11 +102,75 @@ func (fake *BlockVerifier) VerifyBlockReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *BlockVerifier) VerifyBlockAttestation(arg1 string, arg2 *commona.Block) error {
+	fake.verifyBlockAttestationMutex.Lock()
+	ret, specificReturn := fake.verifyBlockAttestationReturnsOnCall[len(fake.verifyBlockAttestationArgsForCall)]
+	fake.verifyBlockAttestationArgsForCall = append(fake.verifyBlockAttestationArgsForCall, struct {
+		arg1 string
+		arg2 *commona.Block
+	}{arg1, arg2})
+	stub := fake.VerifyBlockAttestationStub
+	fakeReturns := fake.verifyBlockAttestationReturns
+	fake.recordInvocation("VerifyBlockAttestation", []interface{}{arg1, arg2})
+	fake.verifyBlockAttestationMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *BlockVerifier) VerifyBlockAttestationCallCount() int {
+	fake.verifyBlockAttestationMutex.RLock()
+	defer fake.verifyBlockAttestationMutex.RUnlock()
+	return len(fake.verifyBlockAttestationArgsForCall)
+}
+
+func (fake *BlockVerifier) VerifyBlockAttestationCalls(stub func(string, *commona.Block) error) {
+	fake.verifyBlockAttestationMutex.Lock()
+	defer fake.verifyBlockAttestationMutex.Unlock()
+	fake.VerifyBlockAttestationStub = stub
+}
+
+func (fake *BlockVerifier) VerifyBlockAttestationArgsForCall(i int) (string, *commona.Block) {
+	fake.verifyBlockAttestationMutex.RLock()
+	defer fake.verifyBlockAttestationMutex.RUnlock()
+	argsForCall := fake.verifyBlockAttestationArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *BlockVerifier) VerifyBlockAttestationReturns(result1 error) {
+	fake.verifyBlockAttestationMutex.Lock()
+	defer fake.verifyBlockAttestationMutex.Unlock()
+	fake.VerifyBlockAttestationStub = nil
+	fake.verifyBlockAttestationReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *BlockVerifier) VerifyBlockAttestationReturnsOnCall(i int, result1 error) {
+	fake.verifyBlockAttestationMutex.Lock()
+	defer fake.verifyBlockAttestationMutex.Unlock()
+	fake.VerifyBlockAttestationStub = nil
+	if fake.verifyBlockAttestationReturnsOnCall == nil {
+		fake.verifyBlockAttestationReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.verifyBlockAttestationReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *BlockVerifier) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.verifyBlockMutex.RLock()
 	defer fake.verifyBlockMutex.RUnlock()
+	fake.verifyBlockAttestationMutex.RLock()
+	defer fake.verifyBlockAttestationMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/internal/pkg/peer/blocksprovider/fake/deliver_streamer.go
+++ b/internal/pkg/peer/blocksprovider/fake/deliver_streamer.go
@@ -36,15 +36,16 @@ func (fake *DeliverStreamer) Deliver(arg1 context.Context, arg2 *grpc.ClientConn
 		arg1 context.Context
 		arg2 *grpc.ClientConn
 	}{arg1, arg2})
+	stub := fake.DeliverStub
+	fakeReturns := fake.deliverReturns
 	fake.recordInvocation("Deliver", []interface{}{arg1, arg2})
 	fake.deliverMutex.Unlock()
-	if fake.DeliverStub != nil {
-		return fake.DeliverStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.deliverReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/internal/pkg/peer/blocksprovider/fake/dialer.go
+++ b/internal/pkg/peer/blocksprovider/fake/dialer.go
@@ -39,15 +39,16 @@ func (fake *Dialer) Dial(arg1 string, arg2 [][]byte) (*grpc.ClientConn, error) {
 		arg1 string
 		arg2 [][]byte
 	}{arg1, arg2Copy})
+	stub := fake.DialStub
+	fakeReturns := fake.dialReturns
 	fake.recordInvocation("Dial", []interface{}{arg1, arg2Copy})
 	fake.dialMutex.Unlock()
-	if fake.DialStub != nil {
-		return fake.DialStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.dialReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/internal/pkg/peer/blocksprovider/fake/gossip_service_adapter.go
+++ b/internal/pkg/peer/blocksprovider/fake/gossip_service_adapter.go
@@ -37,15 +37,16 @@ func (fake *GossipServiceAdapter) AddPayload(arg1 string, arg2 *gossip.Payload) 
 		arg1 string
 		arg2 *gossip.Payload
 	}{arg1, arg2})
+	stub := fake.AddPayloadStub
+	fakeReturns := fake.addPayloadReturns
 	fake.recordInvocation("AddPayload", []interface{}{arg1, arg2})
 	fake.addPayloadMutex.Unlock()
-	if fake.AddPayloadStub != nil {
-		return fake.AddPayloadStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addPayloadReturns
 	return fakeReturns.result1
 }
 
@@ -96,9 +97,10 @@ func (fake *GossipServiceAdapter) Gossip(arg1 *gossip.GossipMessage) {
 	fake.gossipArgsForCall = append(fake.gossipArgsForCall, struct {
 		arg1 *gossip.GossipMessage
 	}{arg1})
+	stub := fake.GossipStub
 	fake.recordInvocation("Gossip", []interface{}{arg1})
 	fake.gossipMutex.Unlock()
-	if fake.GossipStub != nil {
+	if stub != nil {
 		fake.GossipStub(arg1)
 	}
 }

--- a/internal/pkg/peer/blocksprovider/fake/ledger_info.go
+++ b/internal/pkg/peer/blocksprovider/fake/ledger_info.go
@@ -29,15 +29,16 @@ func (fake *LedgerInfo) LedgerHeight() (uint64, error) {
 	ret, specificReturn := fake.ledgerHeightReturnsOnCall[len(fake.ledgerHeightArgsForCall)]
 	fake.ledgerHeightArgsForCall = append(fake.ledgerHeightArgsForCall, struct {
 	}{})
+	stub := fake.LedgerHeightStub
+	fakeReturns := fake.ledgerHeightReturns
 	fake.recordInvocation("LedgerHeight", []interface{}{})
 	fake.ledgerHeightMutex.Unlock()
-	if fake.LedgerHeightStub != nil {
-		return fake.LedgerHeightStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.ledgerHeightReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/internal/pkg/peer/blocksprovider/fake/orderer_connection_source.go
+++ b/internal/pkg/peer/blocksprovider/fake/orderer_connection_source.go
@@ -30,15 +30,16 @@ func (fake *OrdererConnectionSource) RandomEndpoint() (*orderers.Endpoint, error
 	ret, specificReturn := fake.randomEndpointReturnsOnCall[len(fake.randomEndpointArgsForCall)]
 	fake.randomEndpointArgsForCall = append(fake.randomEndpointArgsForCall, struct {
 	}{})
+	stub := fake.RandomEndpointStub
+	fakeReturns := fake.randomEndpointReturns
 	fake.recordInvocation("RandomEndpoint", []interface{}{})
 	fake.randomEndpointMutex.Unlock()
-	if fake.RandomEndpointStub != nil {
-		return fake.RandomEndpointStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.randomEndpointReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 


### PR DESCRIPTION
Change-Id: Ia34ff4536453581895c4f13b2d73f0e7066ce125

#### Type of change

- New feature

#### Description

BFT Block Puller: verify attestation. 
Verify a block attestation, which is a block with block.Data=nil.
Verification is the same as verifying a regular block, except computing the data hash and comparing it to the hash in the header, and extracting the channel ID.

#### Related issues
#4240 
#4243 
