### PR TITLE
Bump CouchDB to 3.3.2 (release-2.2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ BASE_VERSION = 2.2.11
 
 # 3rd party image version
 # These versions are also set in the runners in ./integration/runners/
-COUCHDB_VER ?= 3.2.2
+COUCHDB_VER ?= 3.3.2
 KAFKA_VER ?= 5.3.1
 ZOOKEEPER_VER ?= 5.3.1
 

--- a/docs/source/couchdb_as_state_database.rst
+++ b/docs/source/couchdb_as_state_database.rst
@@ -67,7 +67,7 @@ can be utilized with either LevelDB or CouchDB state database, e.g. ``GetState``
 ``GetStateByRange``, ``GetStateByPartialCompositeKey``. Additionally when you utilize CouchDB as
 the state database and model assets as JSON in chaincode, you can perform JSON queries against
 the data in the state database by using the ``GetQueryResult`` API and passing a CouchDB query string.
-The query string follows the `CouchDB JSON query syntax <http://docs.couchdb.org/en/3.2.2/api/database/find.html>`__.
+The query string follows the `CouchDB JSON query syntax <http://docs.couchdb.org/en/stable/api/database/find.html>`__.
 
 The `asset transfer Fabric sample <https://github.com/hyperledger/fabric-samples/blob/main/asset-transfer-ledger-queries/chaincode-go/asset_transfer_ledger_chaincode.go>`__
 demonstrates use of CouchDB queries from chaincode. It includes a ``queryAssetsByOwner()`` function
@@ -132,7 +132,7 @@ any JSON query with a sort. Indexes enable you to query data from chaincode when
 a large amount of data on your ledger. Indexes can be packaged alongside chaincode
 in a ``/META-INF/statedb/couchdb/indexes`` directory. Each index must be defined in
 its own text file with extension ``*.json`` with the index definition formatted in JSON
-following the `CouchDB index JSON syntax <http://docs.couchdb.org/en/3.2.2/api/database/find.html#db-index>`__.
+following the `CouchDB index JSON syntax <http://docs.couchdb.org/en/stable/api/database/find.html#db-index>`__.
 For example, to support the above marble query, a sample index on the ``docType`` and ``owner``
 fields is provided:
 
@@ -235,7 +235,7 @@ variables using Docker Compose scripting.
 For CouchDB installations outside of the docker images supplied with Fabric,
 the
 `local.ini file of that installation
-<http://docs.couchdb.org/en/3.2.2/config/intro.html#configuration-files>`__
+<http://docs.couchdb.org/en/stable/config/intro.html#configuration-files>`__
 must be edited to set the admin username and password.
 
 Docker compose scripts only set the username and password at the creation of

--- a/docs/source/couchdb_tutorial.rst
+++ b/docs/source/couchdb_tutorial.rst
@@ -222,7 +222,7 @@ the CouchDB recommended practice.
 
 In general, you should model index fields to match the fields that will be used
 in query filters and sorts. For more details on building an index in JSON
-format refer to the `CouchDB documentation <http://docs.couchdb.org/en/3.2.2/api/database/find.html#db-index>`__.
+format refer to the `CouchDB documentation <http://docs.couchdb.org/en/stable/api/database/find.html#db-index>`__.
 
 A final word on indexing, Fabric takes care of indexing the documents in the
 database using a pattern called ``index warming``. CouchDB does not typically
@@ -377,7 +377,7 @@ includes two JSON query functions:
       where a selector JSON query string can be passed into the function. This query
       would be useful to client applications that need to dynamically build
       their own queries at runtime. For more information on query selectors refer
-      to `CouchDB selector syntax <http://docs.couchdb.org/en/3.2.2/api/database/find.html#find-selectors>`__.
+      to `CouchDB selector syntax <http://docs.couchdb.org/en/stable/api/database/find.html#find-selectors>`__.
 
 
   * **QueryAssetsByOwner**
@@ -738,7 +738,7 @@ Iterating on your index definition
 If you have access to your peer's CouchDB state database in a development
 environment, you can iteratively test various indexes in support of
 your chaincode queries. Any changes to chaincode though would require
-redeployment. Use the `CouchDB Fauxton interface <http://docs.couchdb.org/en/3.2.2/fauxton/index.html>`__ or a command
+redeployment. Use the `CouchDB Fauxton interface <http://docs.couchdb.org/en/stable/fauxton/index.html>`__ or a command
 line curl utility to create and update indexes.
 
 .. note:: The Fauxton interface is a web UI for the creation, update, and

--- a/integration/runner/couchdb.go
+++ b/integration/runner/couchdb.go
@@ -23,7 +23,7 @@ import (
 	"github.com/tedsuo/ifrit"
 )
 
-const CouchDBDefaultImage = "couchdb:3.2.2"
+const CouchDBDefaultImage = "couchdb:3.3.2"
 const CouchDBUsername = "admin"
 const CouchDBPassword = "adminpw"
 


### PR DESCRIPTION
Bump CouchDB to 3.3.2.