### PR TITLE
BFT BlockPuller: clean redundant map

### DIFF
--- a/gossip/service/gossip_service.go
+++ b/gossip/service/gossip_service.go
@@ -479,7 +479,7 @@ func (g *GossipService) Stop() {
 		g.privateHandlers[chainID].close()
 
 		if g.deliveryService[chainID] != nil {
-			g.deliveryService[chainID].Stop()
+			_ = g.deliveryService[chainID].StopDeliverForChannel()
 		}
 	}
 	g.gossipSvc.Stop()
@@ -522,7 +522,7 @@ func (g *GossipService) onStatusChangeFactory(channelID string, committer blocks
 			}
 		} else {
 			logger.Info("Renounced leadership, stopping delivery service for channel", channelID)
-			if err := g.deliveryService[channelID].StopDeliverForChannel(channelID); err != nil {
+			if err := g.deliveryService[channelID].StopDeliverForChannel(); err != nil {
 				logger.Errorf("Delivery service is not able to stop blocks delivery for chain, due to %+v", err)
 			}
 		}

--- a/gossip/service/integration_test.go
+++ b/gossip/service/integration_test.go
@@ -55,15 +55,11 @@ func (eds *embeddingDeliveryService) StartDeliverForChannel(chainID string, ledg
 	return eds.DeliverService.StartDeliverForChannel(chainID, ledgerInfo, finalizer)
 }
 
-func (eds *embeddingDeliveryService) StopDeliverForChannel(chainID string) error {
+func (eds *embeddingDeliveryService) StopDeliverForChannel() error {
 	eds.stopOnce.Do(func() {
 		eds.stopSignal.Done()
 	})
-	return eds.DeliverService.StopDeliverForChannel(chainID)
-}
-
-func (eds *embeddingDeliveryService) Stop() {
-	eds.DeliverService.Stop()
+	return eds.DeliverService.StopDeliverForChannel()
 }
 
 type embeddingDeliveryServiceFactory struct {
@@ -182,6 +178,6 @@ func TestLeaderYield(t *testing.T) {
 	t.Log("p1 has taken over leadership")
 	p0.chains[channelName].Stop()
 	p1.chains[channelName].Stop()
-	p0.deliveryService[channelName].Stop()
-	p1.deliveryService[channelName].Stop()
+	p0.deliveryService[channelName].StopDeliverForChannel()
+	p1.deliveryService[channelName].StopDeliverForChannel()
 }


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

The gossip service:
- It contains a map of channelID -> DeliverService (an interface).
- The DeliveryService is  implemented by a deliveryServiceImpl, which contains blockProviders a map of channelID -> Deliverer.
- The implementation shows that the external and internal maps are always keyed together, with the same channelID, which means that the internal map has always a single entry...

Remove the redundant internal map.

#### Related issues

#4261 
