### PR TITLE
Raft WAL deadlock test

### DIFF
--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -337,7 +337,7 @@ var _ = Describe("Chain", func() {
 				close(cutter.Block)
 
 				By("cutting next batch directly")
-				cutter.CutNext = true
+				cutter.SetCutNext(true)
 				err := chain.Order(env, 0)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeFields.fakeNormalProposalsReceived.AddCallCount()).To(Equal(1))
@@ -358,7 +358,7 @@ var _ = Describe("Chain", func() {
 				Expect(fakeFields.fakeDataPersistDuration.ObserveArgsForCall(2)).Should(Equal(float64(0)))
 
 				By("respecting batch timeout")
-				cutter.CutNext = false
+				cutter.SetCutNext(false)
 				timeout := time.Second
 				support.SharedConfigReturns(mockOrdererWithBatchTimeout(timeout, nil))
 				err = chain.Order(env, 0)
@@ -425,7 +425,7 @@ var _ = Describe("Chain", func() {
 				clock.WaitForNWatchersAndIncrement(timeout/2, 2)
 
 				By("force a batch to be cut before timer expires")
-				cutter.CutNext = true
+				cutter.SetCutNext(true)
 				err = chain.Order(env, 0)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -435,7 +435,7 @@ var _ = Describe("Chain", func() {
 				Expect(cutter.CurBatch()).To(HaveLen(0))
 
 				// this should start a fresh timer
-				cutter.CutNext = false
+				cutter.SetCutNext(false)
 				err = chain.Order(env, 0)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(cutter.CurBatch, LongEventualTimeout).Should(HaveLen(1))
@@ -460,7 +460,7 @@ var _ = Describe("Chain", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(cutter.CurBatch, LongEventualTimeout).Should(HaveLen(1))
 
-				cutter.IsolatedTx = true
+				cutter.SetIsolatedTx(true)
 				err = chain.Order(env, 0)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -721,7 +721,7 @@ var _ = Describe("Chain", func() {
 						// to generate WAL data, we start a chain,
 						// order several envelopes and then halt the chain.
 						close(cutter.Block)
-						cutter.CutNext = true
+						cutter.SetCutNext(true)
 
 						// enque some data to be persisted on disk by raft
 						err := chain.Order(env, uint64(0))
@@ -764,7 +764,7 @@ var _ = Describe("Chain", func() {
 						// chain should keep functioning
 						campaign(c.Chain, c.observe)
 
-						c.cutter.CutNext = true
+						c.cutter.SetCutNext(true)
 
 						err := c.Order(env, uint64(0))
 						Expect(err).NotTo(HaveOccurred())
@@ -790,7 +790,7 @@ var _ = Describe("Chain", func() {
 						// chain should keep functioning
 						campaign(c.Chain, c.observe)
 
-						c.cutter.CutNext = true
+						c.cutter.SetCutNext(true)
 
 						err := c.Order(env, uint64(0))
 						Expect(err).NotTo(HaveOccurred())
@@ -809,7 +809,7 @@ var _ = Describe("Chain", func() {
 						// chain should keep functioning
 						campaign(c.Chain, c.observe)
 
-						c.cutter.CutNext = true
+						c.cutter.SetCutNext(true)
 
 						err := c.Order(env, uint64(0))
 						Expect(err).NotTo(HaveOccurred())
@@ -849,7 +849,7 @@ var _ = Describe("Chain", func() {
 						opts.SnapshotCatchUpEntries = 2
 
 						close(cutter.Block)
-						cutter.CutNext = true
+						cutter.SetCutNext(true)
 
 						ledgerLock.Lock()
 						ledger = map[uint64]*common.Block{
@@ -1035,7 +1035,7 @@ var _ = Describe("Chain", func() {
 								return c.observe
 							}, LongEventualTimeout).Should(Receive(StateEqual(1, raft.StateLeader)))
 
-							c.cutter.CutNext = true
+							c.cutter.SetCutNext(true)
 							err = c.Order(env, uint64(0))
 							Expect(err).NotTo(HaveOccurred())
 							Eventually(c.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(1))
@@ -1185,7 +1185,7 @@ var _ = Describe("Chain", func() {
 								campaign(c.Chain, c.observe)
 
 								By("Ordering one more block to trigger snapshot")
-								c.cutter.CutNext = true
+								c.cutter.SetCutNext(true)
 								err = c.Order(largeEnv, uint64(0))
 								Expect(err).NotTo(HaveOccurred())
 
@@ -1221,7 +1221,7 @@ var _ = Describe("Chain", func() {
 							for i := 0; i < cnt; i++ {
 								c1.support.WriteBlock(support.WriteBlockArgsForCall(i))
 							}
-							c1.cutter.CutNext = true
+							c1.cutter.SetCutNext(true)
 							c1.opts.SnapshotIntervalSize = 1024
 
 							By("Restarting chain")
@@ -1410,7 +1410,7 @@ var _ = Describe("Chain", func() {
 			fakeHaltCallbacker = &mocks.HaltCallbacker{}
 			network = createNetwork(timeout, channelID, dataDir, raftMetadata, consenters, cryptoProvider, tlsCA, fakeHaltCallbacker.HaltCallback)
 			c1, c2 = network.chains[1], network.chains[2]
-			c1.cutter.CutNext = true
+			c1.cutter.SetCutNext(true)
 			network.init()
 			network.start()
 		})
@@ -1463,7 +1463,7 @@ var _ = Describe("Chain", func() {
 			Expect(status).To(Equal(orderer_types.StatusInactive))
 
 			By("Asserting leader can still serve requests as single-node cluster")
-			c2.cutter.CutNext = true
+			c2.cutter.SetCutNext(true)
 			Expect(c2.Order(env, 0)).To(Succeed())
 			Eventually(c2.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(1))
 			Expect(c1.fakeFields.fakeActiveNodes.SetArgsForCall(2)).To(Equal(float64(0))) // was halted
@@ -1496,7 +1496,7 @@ var _ = Describe("Chain", func() {
 			}, LongEventualTimeout).Should(Receive(StateEqual(2, raft.StateLeader)))
 
 			By("Asserting leader can still serve requests as single-node cluster")
-			c2.cutter.CutNext = true
+			c2.cutter.SetCutNext(true)
 			Expect(c2.Order(env, 0)).To(Succeed())
 			Eventually(c2.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(1))
 
@@ -1551,7 +1551,7 @@ var _ = Describe("Chain", func() {
 			Expect(status).To(Equal(orderer_types.StatusInactive))
 
 			By("Asserting leader can still serve requests as single-node cluster")
-			c2.cutter.CutNext = true
+			c2.cutter.SetCutNext(true)
 			Expect(c2.Order(env, 0)).To(Succeed())
 			Eventually(c2.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(1))
 			lastSetActiveNodes := c1.fakeFields.fakeActiveNodes.SetCallCount() - 1
@@ -1571,7 +1571,7 @@ var _ = Describe("Chain", func() {
 			Eventually(c1.Chain.Errored, LongEventualTimeout).Should(BeClosed())
 
 			By("Asserting leader can still serve requests as single-node cluster")
-			c2.cutter.CutNext = true
+			c2.cutter.SetCutNext(true)
 			Expect(c2.Order(env, 0)).To(Succeed())
 			Eventually(c2.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(1))
 		})
@@ -1655,7 +1655,7 @@ var _ = Describe("Chain", func() {
 				}, LongEventualTimeout).Should(Equal(2))
 				Expect(c2.fakeFields.fakeActiveNodes.SetArgsForCall(1)).To(Equal(float64(2)))
 
-				c1.cutter.CutNext = true
+				c1.cutter.SetCutNext(true)
 				err := c1.Order(env, 0)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1675,7 +1675,7 @@ var _ = Describe("Chain", func() {
 				c1.opts.SnapshotIntervalSize = 1
 				c1.opts.SnapshotCatchUpEntries = 1
 
-				c1.cutter.CutNext = true
+				c1.cutter.SetCutNext(true)
 
 				var blocksLock sync.Mutex
 				blocks := make(map[uint64]*common.Block) // storing written blocks for block puller
@@ -1787,7 +1787,7 @@ var _ = Describe("Chain", func() {
 				network.elect(1)
 
 				By("Submitting first tx to cut the block")
-				c1.cutter.CutNext = true
+				c1.cutter.SetCutNext(true)
 				err := c1.Order(env, 0)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1834,7 +1834,7 @@ var _ = Describe("Chain", func() {
 
 					By("creating new configuration with removed node and new one")
 					configEnv := newConfigEnv(channelID, common.HeaderType_CONFIG, newConfigUpdateEnv(channelID, nil, value))
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 
 					By("sending config transaction")
 					Expect(c1.Configure(configEnv, 0)).To(Succeed())
@@ -1874,7 +1874,7 @@ var _ = Describe("Chain", func() {
 
 					By("creating new configuration with removed node and new one")
 					configEnv := newConfigEnv(channelID, common.HeaderType_CONFIG, newConfigUpdateEnv(channelID, nil, value))
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 
 					By("sending config transaction")
 					Expect(c1.Configure(configEnv, 0)).To(Succeed())
@@ -1916,7 +1916,7 @@ var _ = Describe("Chain", func() {
 
 						By("creating new configuration with removed node and new one")
 						configEnv := newConfigEnv(channelID, common.HeaderType_CONFIG, newConfigUpdateEnv(channelID, nil, value))
-						c1.cutter.CutNext = true
+						c1.cutter.SetCutNext(true)
 
 						step1 := c1.getStepFunc()
 						count := c1.rpc.SendConsensusCallCount() // record current step call count
@@ -1944,7 +1944,7 @@ var _ = Describe("Chain", func() {
 				It("adding node to the cluster", func() {
 					addConsenterUpdate := addConsenterConfigValue()
 					configEnv := newConfigEnv(channelID, common.HeaderType_CONFIG, newConfigUpdateEnv(channelID, nil, addConsenterUpdate))
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 
 					By("sending config transaction")
 					err := c1.Configure(configEnv, 0)
@@ -1986,7 +1986,7 @@ var _ = Describe("Chain", func() {
 					Eventually(c4.support.WriteConfigBlockCallCount, defaultTimeout).Should(Equal(1))
 
 					By("submitting new transaction to follower")
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 					err = c4.Order(env, 0)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(c4.fakeFields.fakeNormalProposalsReceived.AddCallCount()).To(Equal(1))
@@ -2004,7 +2004,7 @@ var _ = Describe("Chain", func() {
 					By("Configuring an additional node")
 					addConsenterUpdate := addConsenterConfigValue()
 					configEnv := newConfigEnv(channelID, common.HeaderType_CONFIG, newConfigUpdateEnv(channelID, nil, addConsenterUpdate))
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 
 					By("Sending config transaction")
 					err := c1.Configure(configEnv, 0)
@@ -2052,7 +2052,7 @@ var _ = Describe("Chain", func() {
 					By("Sending data blocks to leader")
 					numOfBlocks := 100
 					for i := 0; i < numOfBlocks; i++ {
-						c1.cutter.CutNext = true
+						c1.cutter.SetCutNext(true)
 						err := c1.Order(env, 0)
 						Expect(err).NotTo(HaveOccurred())
 					}
@@ -2080,7 +2080,7 @@ var _ = Describe("Chain", func() {
 					// new configuration and successfully rejoins replica set.
 
 					configEnv := newConfigEnv(channelID, common.HeaderType_CONFIG, newConfigUpdateEnv(channelID, nil, addConsenterConfigValue()))
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 
 					step1 := c1.getStepFunc()
 					count := c1.rpc.SendConsensusCallCount() // record current step call count
@@ -2115,7 +2115,7 @@ var _ = Describe("Chain", func() {
 					if i3 > i2 {
 						candidate = 3
 					}
-					network.chains[candidate].cutter.CutNext = true
+					network.chains[candidate].cutter.SetCutNext(true)
 					network.elect(candidate)
 
 					_, raftmetabytes := c1.support.WriteConfigBlockArgsForCall(0)
@@ -2160,7 +2160,7 @@ var _ = Describe("Chain", func() {
 					// Restart the cluster and ensure it picks up updates and capable to finish reconfiguration.
 
 					configEnv := newConfigEnv(channelID, common.HeaderType_CONFIG, newConfigUpdateEnv(channelID, nil, addConsenterConfigValue()))
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 
 					step1 := c1.getStepFunc()
 					count := c1.rpc.SendConsensusCallCount() // record current step call count
@@ -2219,7 +2219,7 @@ var _ = Describe("Chain", func() {
 					if i3 > i2 {
 						candidate = 3
 					}
-					network.chains[candidate].cutter.CutNext = true
+					network.chains[candidate].cutter.SetCutNext(true)
 					network.elect(candidate)
 
 					c4.start()
@@ -2252,7 +2252,7 @@ var _ = Describe("Chain", func() {
 						common.HeaderType_CONFIG,
 						newConfigUpdateEnv(channelID, nil, removeConsenterConfigValue(1))) // remove nodeID == 1
 
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 
 					By("sending config transaction")
 					err := c1.Configure(configEnv, 0)
@@ -2301,7 +2301,7 @@ var _ = Describe("Chain", func() {
 					}
 
 					By("submitting transaction to new leader")
-					newLeader.cutter.CutNext = true
+					newLeader.cutter.SetCutNext(true)
 					err = newLeader.Order(env, 0)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -2309,7 +2309,7 @@ var _ = Describe("Chain", func() {
 					Eventually(remainingFollower.support.WriteBlockCallCount, LongEventualTimeout).Should(Equal(2))
 
 					By("trying to submit to new node, expected to fail")
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 					err = c1.Order(env, 0)
 					Expect(err).To(HaveOccurred())
 
@@ -2321,7 +2321,7 @@ var _ = Describe("Chain", func() {
 
 				It("does not deadlock if leader steps down while config block is in-flight", func() {
 					configEnv := newConfigEnv(channelID, common.HeaderType_CONFIG, newConfigUpdateEnv(channelID, nil, addConsenterConfigValue()))
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 
 					signal := make(chan struct{})
 					stub := c1.support.WriteConfigBlockStub
@@ -2413,7 +2413,7 @@ var _ = Describe("Chain", func() {
 
 			It("orders envelope on leader", func() {
 				By("instructed to cut next block")
-				c1.cutter.CutNext = true
+				c1.cutter.SetCutNext(true)
 				err := c1.Order(env, 0)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(c1.fakeFields.fakeNormalProposalsReceived.AddCallCount()).To(Equal(1))
@@ -2425,7 +2425,7 @@ var _ = Describe("Chain", func() {
 					})
 
 				By("respect batch timeout")
-				c1.cutter.CutNext = false
+				c1.cutter.SetCutNext(false)
 
 				err = c1.Order(env, 0)
 				Expect(err).NotTo(HaveOccurred())
@@ -2442,7 +2442,7 @@ var _ = Describe("Chain", func() {
 
 			It("orders envelope on follower", func() {
 				By("instructed to cut next block")
-				c1.cutter.CutNext = true
+				c1.cutter.SetCutNext(true)
 				err := c2.Order(env, 0)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(c2.fakeFields.fakeNormalProposalsReceived.AddCallCount()).To(Equal(1))
@@ -2455,7 +2455,7 @@ var _ = Describe("Chain", func() {
 					})
 
 				By("respect batch timeout")
-				c1.cutter.CutNext = false
+				c1.cutter.SetCutNext(false)
 
 				err = c2.Order(env, 0)
 				Expect(err).NotTo(HaveOccurred())
@@ -2477,7 +2477,7 @@ var _ = Describe("Chain", func() {
 				})
 
 				It("waits for in flight blocks to be committed", func() {
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 					// disconnect c1 to disrupt consensus
 					network.disconnect(1)
 
@@ -2505,8 +2505,8 @@ var _ = Describe("Chain", func() {
 				})
 
 				It("resets block in flight when steps down from leader", func() {
-					c1.cutter.CutNext = true
-					c2.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
+					c2.cutter.SetCutNext(true)
 					// disconnect c1 to disrupt consensus
 					network.disconnect(1)
 
@@ -2599,7 +2599,7 @@ var _ = Describe("Chain", func() {
 
 				It("does not deadlock if propose is blocked", func() {
 					signal := make(chan struct{})
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 					c1.support.SequenceStub = func() uint64 {
 						signal <- struct{}{}
 						<-signal
@@ -2670,7 +2670,7 @@ var _ = Describe("Chain", func() {
 			It("leader retransmits lost messages", func() {
 				// This tests that heartbeats will trigger leader to retransmit lost MsgApp
 
-				c1.cutter.CutNext = true
+				c1.cutter.SetCutNext(true)
 
 				network.disconnect(1) // drop MsgApp
 
@@ -2695,7 +2695,7 @@ var _ = Describe("Chain", func() {
 				// this ensures that the created blocks are not written out
 				network.disconnect(1)
 
-				c1.cutter.CutNext = true
+				c1.cutter.SetCutNext(true)
 				for i := 0; i < 3; i++ {
 					Expect(c1.Order(env, 0)).To(Succeed())
 				}
@@ -2738,8 +2738,8 @@ var _ = Describe("Chain", func() {
 				// - c2 commits block1
 				// - c2 accepts env2, and creates block2
 				// - c2 commits block2
-				c1.cutter.CutNext = true
-				c2.cutter.CutNext = true
+				c1.cutter.SetCutNext(true)
+				c2.cutter.SetCutNext(true)
 
 				step1 := c1.getStepFunc()
 				c1.setStepFunc(func(dest uint64, msg *orderer.ConsensusRequest) error {
@@ -2823,7 +2823,7 @@ var _ = Describe("Chain", func() {
 					// this ensures that the created blocks are not written out
 					network.disconnect(1)
 
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 					// config block
 					err := c1.Order(configEnv, 0)
 					Expect(err).NotTo(HaveOccurred())
@@ -2862,7 +2862,7 @@ var _ = Describe("Chain", func() {
 				})
 
 				It("continues creating blocks on leader after a config block has been successfully written out", func() {
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 					// config block
 					err := c1.Configure(configEnv, 0)
 					Expect(err).NotTo(HaveOccurred())
@@ -2904,7 +2904,7 @@ var _ = Describe("Chain", func() {
 					Expect(countSnapShotsForChain(c3)).Should(Equal(0))
 
 					By("order envelop on node 1 to accumulate bytes")
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 					err := c1.Order(env, 0)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -2974,7 +2974,7 @@ var _ = Describe("Chain", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(i).To(Equal(uint64(1)))
 
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 
 					err = c1.Order(env, 0)
 					Expect(err).NotTo(HaveOccurred())
@@ -3013,7 +3013,7 @@ var _ = Describe("Chain", func() {
 
 				It("lagged node can catch up using snapshot", func() {
 					network.disconnect(2)
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 
 					c2Lasti, _ := c2.opts.MemoryStorage.LastIndex()
 					var blockCnt int
@@ -3063,7 +3063,7 @@ var _ = Describe("Chain", func() {
 					network.elect(2)
 
 					By("order envelope on new leader")
-					c2.cutter.CutNext = true
+					c2.cutter.SetCutNext(true)
 					err := c2.Order(env, 0)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -3089,7 +3089,7 @@ var _ = Describe("Chain", func() {
 				It("follower cannot be elected if its log is not up-to-date", func() {
 					network.disconnect(2)
 
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 					err := c1.Order(env, 0)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -3116,7 +3116,7 @@ var _ = Describe("Chain", func() {
 				It("PreVote prevents reconnected node from disturbing network", func() {
 					network.disconnect(2)
 
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 					err := c1.Order(env, 0)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -3138,7 +3138,7 @@ var _ = Describe("Chain", func() {
 				It("follower can catch up and then campaign with success", func() {
 					network.disconnect(2)
 
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 					for i := 0; i < 10; i++ {
 						err := c1.Order(env, 0)
 						Expect(err).NotTo(HaveOccurred())
@@ -3157,7 +3157,7 @@ var _ = Describe("Chain", func() {
 
 				It("purges blockcutter, stops timer and discards created blocks if leadership is lost", func() {
 					// enqueue one transaction into 1's blockcutter to test for purging of block cutter
-					c1.cutter.CutNext = false
+					c1.cutter.SetCutNext(false)
 					err := c1.Order(env, 0)
 					Expect(err).NotTo(HaveOccurred())
 					Eventually(c1.cutter.CurBatch, LongEventualTimeout).Should(HaveLen(1))
@@ -3218,7 +3218,7 @@ var _ = Describe("Chain", func() {
 					network.elect(2)
 					network.connect(1)
 
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 					err := c1.Order(env, 0)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -3231,7 +3231,7 @@ var _ = Describe("Chain", func() {
 				It("aborts waiting for block to be committed upon leadership lost", func() {
 					network.disconnect(1)
 
-					c1.cutter.CutNext = true
+					c1.cutter.SetCutNext(true)
 					err := c1.Order(env, 0)
 					Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
- There was a bug described at issue #4201. 
- The bug caused a deadlock on etcd raft orderer chain apply change on orderer startup.
- Issue #4201 fixed the issue. 
- We wanted to add a test can check this scenario with high probability (because of the multiple go routines, and how the code is built, this can't be 100% test.)
- We simulated the scenario of the deadlock using a test and debug logs (on the unfixed code) in #4262.
- This PR adds the same test but without the debug logs.

#### Type of change

- Bug fix
- Test update

#### Description

Please look at #4199, PR #4201 and PR #4262.