### PR TITLE
Fix typo in logger name

### DIFF
--- a/orderer/common/channelparticipation/restapi.go
+++ b/orderer/common/channelparticipation/restapi.go
@@ -64,7 +64,7 @@ type HTTPHandler struct {
 
 func NewHTTPHandler(config localconfig.ChannelParticipation, registrar ChannelManagement) *HTTPHandler {
 	handler := &HTTPHandler{
-		logger:    flogging.MustGetLogger("orderer.commmon.channelparticipation"),
+		logger:    flogging.MustGetLogger("orderer.common.channelparticipation"),
 		config:    config,
 		registrar: registrar,
 		router:    mux.NewRouter(),

--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -41,7 +41,7 @@ const (
 	epoch      = 0
 )
 
-var logger = flogging.MustGetLogger("orderer.commmon.multichannel")
+var logger = flogging.MustGetLogger("orderer.common.multichannel")
 
 // Registrar serves as a point of access and control for the individual channel resources.
 type Registrar struct {
@@ -727,7 +727,7 @@ func (r *Registrar) createFollower(
 	joinBlock *cb.Block,
 	channelID string,
 ) (*follower.Chain, types.ChannelInfo, error) {
-	fLog := flogging.MustGetLogger("orderer.commmon.follower")
+	fLog := flogging.MustGetLogger("orderer.common.follower")
 	blockPullerCreator, err := follower.NewBlockPullerCreator(
 		channelID, fLog, r.signer, r.clusterDialer, r.config.General.Cluster, r.bccsp)
 	if err != nil {


### PR DESCRIPTION
commmon -> common


#### Type of change

- Bug fix

#### Description

Typo in the word _common_ being written with 3 `m`'s instead of only 2.