### PR TITLE
Bump Go to 1.20.5 and Alpine to 3.18 (release-2.2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
         type: string
 
 env:
-  GO_VER: 1.20.4
+  GO_VER: 1.20.5
 
 permissions:
   contents: read

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -13,7 +13,7 @@ on:
 env:
   GOPATH: /opt/go
   PATH: /opt/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-  GO_VER: 1.20.4
+  GO_VER: 1.20.5
 
 jobs:
   basic-checks:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@
 #   - unit-test - runs the go-test based unit tests
 #   - verify - runs unit tests for only the changed package tree
 
-ALPINE_VER ?= 3.16
+ALPINE_VER ?= 3.18
 BASE_VERSION = 2.2.12
 
 # 3rd party image version
@@ -76,7 +76,7 @@ METADATA_VAR += CommitSHA=$(EXTRA_VERSION)
 METADATA_VAR += BaseDockerLabel=$(BASE_DOCKER_LABEL)
 METADATA_VAR += DockerNamespace=$(DOCKER_NS)
 
-GO_VER = 1.20.4
+GO_VER = 1.20.5
 GO_TAGS ?=
 
 RELEASE_EXES = orderer $(TOOLS_EXES)

--- a/vagrant/golang.sh
+++ b/vagrant/golang.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 GOROOT='/opt/go'
-GO_VERSION=1.20.4
+GO_VERSION=1.20.5
 
 # ----------------------------------------------------------------
 # Install Golang


### PR DESCRIPTION
Bump Go to 1.20.5.
Bump Alpine images to 3.18 (Go 1.20.5 not available on Alpine 3.16).