### PR TITLE
BFT Block Puller: Stop deliver service correctly

### DIFF
--- a/gossip/service/gossip_service.go
+++ b/gossip/service/gossip_service.go
@@ -491,7 +491,7 @@ func (g *GossipService) Stop() {
 		g.privateHandlers[chainID].close()
 
 		if g.deliveryService[chainID] != nil {
-			_ = g.deliveryService[chainID].StopDeliverForChannel()
+			g.deliveryService[chainID].Stop()
 		}
 	}
 	g.gossipSvc.Stop()

--- a/gossip/service/gossip_service_test.go
+++ b/gossip/service/gossip_service_test.go
@@ -387,6 +387,9 @@ func (ds *mockDeliverService) StopDeliverForChannel() error {
 	return nil
 }
 
+func (ds *mockDeliverService) Stop() {
+}
+
 type mockLedgerInfo struct {
 	Height uint64
 }

--- a/gossip/service/integration_test.go
+++ b/gossip/service/integration_test.go
@@ -73,6 +73,10 @@ func (eds *embeddingDeliveryService) StopDeliverForChannel() error {
 	return eds.DeliverService.StopDeliverForChannel()
 }
 
+func (eds *embeddingDeliveryService) Stop() {
+	eds.DeliverService.Stop()
+}
+
 type embeddingDeliveryServiceFactory struct {
 	DeliveryServiceFactory
 }
@@ -214,8 +218,8 @@ func TestLeaderYield(t *testing.T) {
 	t.Log("p1 has taken over leadership")
 	p0.chains[channelName].Stop()
 	p1.chains[channelName].Stop()
-	p0.deliveryService[channelName].StopDeliverForChannel()
-	p1.deliveryService[channelName].StopDeliverForChannel()
+	p0.deliveryService[channelName].Stop()
+	p1.deliveryService[channelName].Stop()
 }
 
 // TODO this pattern repeats itself in several places. Make it common in the 'genesisconfig' package to easily create


### PR DESCRIPTION
Change-Id: Icd1725913e3be913b3628b3f37e252c8e13a0461

#### Type of change
- Bug fix

#### Description

After the delivery service StopDeliveryForChannel is called, it should be possible to call StartDeliveryForChannel  again.
After the delivery service Stop is called, it should not be possible to call <Start/Stop>DeliveryForChannel  again.

This was introduced by #4260

#### Related issues

#4261 