### PR TITLE
Add SmartBFT consensus knobs to configtx.yaml

### DIFF
--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -682,9 +682,9 @@ Profiles:
             <<: *OrdererDefaults
             OrdererType: BFT
             SmartBFT:
-                RequestBatchMaxCount: 100
-                RequestBatchMaxInterval: 50ms
-                RequestForwardTimeout: 2s
+                RequestBatchMaxCount: 5000
+                RequestBatchMaxInterval: 200ms
+                RequestForwardTimeout: 5s
                 RequestComplainTimeout: 20s
                 RequestAutoRemoveTimeout: 3m0s
                 ViewChangeResendInterval: 5s

--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -681,6 +681,20 @@ Profiles:
         Orderer:
             <<: *OrdererDefaults
             OrdererType: BFT
+            SmartBFT:
+                RequestBatchMaxCount: 100
+                RequestBatchMaxInterval: 50ms
+                RequestForwardTimeout: 2s
+                RequestComplainTimeout: 20s
+                RequestAutoRemoveTimeout: 3m0s
+                ViewChangeResendInterval: 5s
+                ViewChangeTimeout: 20s
+                LeaderHeartbeatTimeout: 1m0s
+                CollectTimeout: 1s
+                RequestBatchMaxBytes: 10485760
+                IncomingMessageBufferSize: 200
+                RequestPoolSize: 100000
+                LeaderHeartbeatCount: 10
             Organizations:
                 - <<: *SampleOrg
                   Policies:


### PR DESCRIPTION
The configtx.yaml now has the SmartBFT consensus knobs as in the Fabric samples

#### Related issues

https://github.com/hyperledger/fabric/issues/4295
