### PR TITLE
fix: missing tag for make docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ integration-test: integration-test-prereqs
 	./scripts/run-integration-tests.sh $(INTEGRATION_TEST_SUITE)
 
 .PHONY: integration-test-prereqs
-integration-test-prereqs: gotool.ginkgo baseos-docker ccenv-docker docker-thirdparty ccaasbuilder
+integration-test-prereqs: gotool.ginkgo baseos-docker ccenv-docker ccenv-docker-tag-latest docker-thirdparty ccaasbuilder
 
 .PHONY: unit-test
 unit-test: unit-test-clean docker-thirdparty-couchdb

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ $(BUILD_DIR)/images/%/$(DUMMY):
 		--build-arg TARGETARCH=$(ARCH) \
 		--build-arg TARGETOS=linux \
 		$(BUILD_ARGS) \
-		-t $(DOCKER_NS)/fabric-$* ./$(BUILD_CONTEXT)
+		-t $(DOCKER_NS)/fabric-$*:$(DOCKER_TAG) ./$(BUILD_CONTEXT)
 
 # builds release packages for the host platform
 .PHONY: release


### PR DESCRIPTION
# Fix missing tag for `make docker`
#### Type of change

- Bug fix

#### Description

When `make docker` make file is miss the tag. So, `make docker-tag-latest` and `make docker-tag-stable` will not work

#### Additional details

Reproduce: run `make docker-tag-latest` or `make docker-tag-stable` after run `make docker`
