### PR TITLE
docs: fix link

### DIFF
--- a/docs/source/deploypeer/peerchecklist.md
+++ b/docs/source/deploypeer/peerchecklist.md
@@ -275,7 +275,7 @@ BCCSP:
 
 - **`BCCSP.Default:`** If you plan to use a Hardware Security Module (HSM), then this must be set to `PKCS11`.
 
-- **`BCCSP.PKCS11.*:`** Provide this set of parameters according to your HSM configuration. Refer to this [example]((../hsm.html) of an HSM configuration for more information.
+- **`BCCSP.PKCS11.*:`** Provide this set of parameters according to your HSM configuration. Refer to this [example](../hsm.html) of an HSM configuration for more information.
 
 ## chaincode.externalBuilders.*
 


### PR DESCRIPTION
This is a cherry-pick of this PR:
https://github.com/hyperledger/fabric-docs-i18n/pull/816

#### Type of change

- Documentation update

#### Description

There is a double paren when there should be a single paren, which breaks a link

#### Additional details

#### Related issues

#### Release Note
