### PR TITLE
Remove usage of deprecated ioutil package functions [ledger]

### DIFF
--- a/common/ledger/blkstorage/reset.go
+++ b/common/ledger/blkstorage/reset.go
@@ -8,7 +8,6 @@ package blkstorage
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -103,7 +102,7 @@ func retrieveGenesisBlkOffsetAndMakeACopy(ledgerDir string) (string, int64, erro
 		return "", -1, err
 	}
 	// just for an extra safety make a backup of genesis block
-	if err := ioutil.WriteFile(path.Join(ledgerDir, "__backupGenesisBlockBytes"), genesisBlockBytes, 0o640); err != nil {
+	if err := os.WriteFile(path.Join(ledgerDir, "__backupGenesisBlockBytes"), genesisBlockBytes, 0o640); err != nil {
 		return "", -1, err
 	}
 	logger.Infof("Genesis block backed up. Genesis block info file [%s], offset [%d]", blockfilePath, endOffsetGenesisBlock)
@@ -155,7 +154,7 @@ func recordHeightIfGreaterThanPreviousRecording(ledgerDir string) error {
 	}
 	previuoslyRecordedHt := uint64(0)
 	if exists {
-		htBytes, err := ioutil.ReadFile(preResetHtFile)
+		htBytes, err := os.ReadFile(preResetHtFile)
 		if err != nil {
 			return err
 		}
@@ -167,7 +166,7 @@ func recordHeightIfGreaterThanPreviousRecording(ledgerDir string) error {
 	currentHt := blkfilesInfo.lastPersistedBlock + 1
 	if currentHt > previuoslyRecordedHt {
 		logger.Infof("Recording current height [%d]", currentHt)
-		return ioutil.WriteFile(preResetHtFile,
+		return os.WriteFile(preResetHtFile,
 			[]byte(strconv.FormatUint(currentHt, 10)),
 			0o640,
 		)
@@ -188,7 +187,7 @@ func LoadPreResetHeight(blockStorageDir string, ledgerIDs []string) (map[string]
 	}
 	m := map[string]uint64{}
 	for ledgerID, filePath := range preResetFilesMap {
-		bytes, err := ioutil.ReadFile(filePath)
+		bytes, err := os.ReadFile(filePath)
 		if err != nil {
 			return nil, err
 		}

--- a/core/ledger/kvledger/snapshot.go
+++ b/core/ledger/kvledger/snapshot.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -98,7 +97,7 @@ func (l *kvLedger) generateSnapshot() error {
 		return err
 	}
 	lastBlockNum := bcInfo.Height - 1
-	snapshotTempDir, err := ioutil.TempDir(
+	snapshotTempDir, err := os.MkdirTemp(
 		SnapshotsTempDirPath(snapshotsRootDir),
 		fmt.Sprintf("%s-%d-", l.ledgerID, lastBlockNum),
 	)
@@ -351,12 +350,12 @@ func (p *Provider) CreateFromSnapshot(snapshotDir string) (ledger.PeerLedger, st
 
 func loadSnapshotMetadataJSONs(snapshotDir string) (*SnapshotMetadataJSONs, error) {
 	signableMetadataFilePath := filepath.Join(snapshotDir, SnapshotSignableMetadataFileName)
-	signableMetadataBytes, err := ioutil.ReadFile(signableMetadataFilePath)
+	signableMetadataBytes, err := os.ReadFile(signableMetadataFilePath)
 	if err != nil {
 		return nil, err
 	}
 	additionalMetadataFilePath := filepath.Join(snapshotDir, snapshotAdditionalMetadataFileName)
-	additionalMetadataBytes, err := ioutil.ReadFile(additionalMetadataFilePath)
+	additionalMetadataBytes, err := os.ReadFile(additionalMetadataFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime"
 	"mime/multipart"
@@ -229,7 +228,7 @@ func (d *couchDoc) len() int {
 // connection pool
 func closeResponseBody(resp *http.Response) {
 	if resp != nil {
-		io.Copy(ioutil.Discard, resp.Body) // discard whatever is remaining of body
+		io.Copy(io.Discard, resp.Body) // discard whatever is remaining of body
 		resp.Body.Close()
 	}
 }
@@ -747,7 +746,7 @@ func (dbclient *couchDatabase) readDoc(id string) (*couchDoc, string, error) {
 
 	// Handle as JSON if multipart is NOT detected
 	if !strings.HasPrefix(mediaType, "multipart/") {
-		couchDoc.jsonValue, err = ioutil.ReadAll(resp.Body)
+		couchDoc.jsonValue, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, "", errors.Wrap(err, "error reading response body")
 		}
@@ -772,7 +771,7 @@ func (dbclient *couchDatabase) readDoc(id string) (*couchDoc, string, error) {
 		couchdbLogger.Debugf("[%s] part header=%s", dbclient.dbName, p.Header)
 
 		if p.Header.Get("Content-Type") == "application/json" {
-			partdata, err := ioutil.ReadAll(p)
+			partdata, err := io.ReadAll(p)
 			if err != nil {
 				return nil, "", errors.Wrap(err, "error reading multipart data")
 			}
@@ -798,7 +797,7 @@ func (dbclient *couchDatabase) readDoc(id string) (*couchDoc, string, error) {
 			if err != nil {
 				return nil, "", errors.Wrap(err, "error creating gzip reader")
 			}
-			respBody, err = ioutil.ReadAll(gr)
+			respBody, err = io.ReadAll(gr)
 			if err != nil {
 				return nil, "", errors.Wrap(err, "error reading gzip data")
 			}
@@ -812,7 +811,7 @@ func (dbclient *couchDatabase) readDoc(id string) (*couchDoc, string, error) {
 		default:
 
 			// retrieve the data,  this is not gzip
-			partdata, err := ioutil.ReadAll(p)
+			partdata, err := io.ReadAll(p)
 			if err != nil {
 				return nil, "", errors.Wrap(err, "error reading multipart data")
 			}
@@ -887,7 +886,7 @@ func (dbclient *couchDatabase) readDocRange(startKey, endKey string, limit int32
 	}
 
 	// handle as JSON document
-	jsonResponseRaw, err := ioutil.ReadAll(resp.Body)
+	jsonResponseRaw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "error reading response body")
 	}
@@ -1021,7 +1020,7 @@ func (dbclient *couchDatabase) queryDocuments(query string) ([]*queryResult, str
 	}
 
 	// handle as JSON document
-	jsonResponseRaw, err := ioutil.ReadAll(resp.Body)
+	jsonResponseRaw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "error reading response body")
 	}
@@ -1107,7 +1106,7 @@ func (dbclient *couchDatabase) listIndex() ([]*indexResult, error) {
 	defer closeResponseBody(resp)
 
 	// handle as JSON document
-	jsonResponseRaw, err := ioutil.ReadAll(resp.Body)
+	jsonResponseRaw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading response body")
 	}
@@ -1173,7 +1172,7 @@ func (dbclient *couchDatabase) createIndex(indexdefinition string) (*createIndex
 	}
 
 	// Read the response body
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading response body")
 	}
@@ -1247,7 +1246,7 @@ func (dbclient *couchDatabase) getDatabaseSecurity() (*databaseSecurity, error) 
 	defer closeResponseBody(resp)
 
 	// handle as JSON document
-	jsonResponseRaw, err := ioutil.ReadAll(resp.Body)
+	jsonResponseRaw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading response body")
 	}
@@ -1357,7 +1356,7 @@ func (dbclient *couchDatabase) batchRetrieveDocumentMetadata(keys []string) ([]*
 	}
 
 	// handle as JSON document
-	jsonResponseRaw, err := ioutil.ReadAll(resp.Body)
+	jsonResponseRaw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading response body")
 	}
@@ -1481,7 +1480,7 @@ func (dbclient *couchDatabase) batchUpdateDocuments(documents []*couchDoc) ([]*b
 	}
 
 	// handle as JSON document
-	jsonResponseRaw, err := ioutil.ReadAll(resp.Body)
+	jsonResponseRaw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading response body")
 	}
@@ -1646,7 +1645,7 @@ func (couchInstance *couchInstance) handleRequest(ctx context.Context, method, d
 			// if this is an error, then populate the couchDBReturn
 			if resp.StatusCode >= 400 {
 				// Read the response body and close it for next attempt
-				jsonError, err := ioutil.ReadAll(resp.Body)
+				jsonError, err := io.ReadAll(resp.Body)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "error reading response body")
 				}
@@ -1679,7 +1678,7 @@ func (couchInstance *couchInstance) handleRequest(ctx context.Context, method, d
 				// otherwise this is an unexpected 500 error from CouchDB. Log the error and retry.
 			} else {
 				// Read the response body and close it for next attempt
-				jsonError, err := ioutil.ReadAll(resp.Body)
+				jsonError, err := io.ReadAll(resp.Body)
 				defer closeResponseBody(resp)
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "error reading response body")

--- a/internal/ledgerutil/compare/compare.go
+++ b/internal/ledgerutil/compare/compare.go
@@ -13,7 +13,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -493,7 +492,7 @@ func readMetadata(fpath string) (*kvledger.SnapshotSignableMetadata, error) {
 	var mdata kvledger.SnapshotSignableMetadata
 
 	// Open file
-	f, err := ioutil.ReadFile(fpath)
+	f, err := os.ReadFile(fpath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Go std lib deprecated package ioutils since go ver 1.16, while Fabric still uses it in several places. This commit removes usage of ioutils from ledger-related packages.