### PR TITLE
Remove usage of deprecated ioutil package functions [internal]

### DIFF
--- a/core/common/ccprovider/ccprovider.go
+++ b/core/common/ccprovider/ccprovider.go
@@ -188,7 +188,7 @@ func (cifs *CCInfoFSImpl) PutChaincode(depSpec *pb.ChaincodeDeploymentSpec) (CCP
 }
 
 // DirEnumerator enumerates directories
-type DirEnumerator func(string) ([]os.FileInfo, error)
+type DirEnumerator func(string) ([]os.DirEntry, error)
 
 // ChaincodeExtractor extracts chaincode from a given path
 type ChaincodeExtractor func(ccNameVersion string, path string, getHasher GetHasher) (CCPackage, error)

--- a/core/common/ccprovider/ccprovider_test.go
+++ b/core/common/ccprovider/ccprovider_test.go
@@ -8,7 +8,6 @@ package ccprovider_test
 
 import (
 	"crypto/sha256"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -39,7 +38,7 @@ func TestInstalledCCs(t *testing.T) {
 	}{
 		{
 			name:              "Non-empty directory",
-			ls:                ioutil.ReadDir,
+			ls:                os.ReadDir,
 			extractCCFromPath: ccprovider.LoadPackage,
 			expected: []chaincode.InstalledChaincode{
 				{
@@ -57,21 +56,21 @@ func TestInstalledCCs(t *testing.T) {
 		},
 		{
 			name:              "Nonexistent directory",
-			ls:                ioutil.ReadDir,
+			ls:                os.ReadDir,
 			extractCCFromPath: ccprovider.LoadPackage,
 			expected:          nil,
 			directory:         "nonexistent",
 		},
 		{
 			name:              "Empty directory",
-			ls:                ioutil.ReadDir,
+			ls:                os.ReadDir,
 			extractCCFromPath: ccprovider.LoadPackage,
 			expected:          nil,
 			directory:         "empty",
 		},
 		{
 			name: "No permission to open directory",
-			ls: func(_ string) ([]os.FileInfo, error) {
+			ls: func(_ string) ([]os.DirEntry, error) {
 				return nil, errors.New("orange")
 			},
 			extractCCFromPath: ccprovider.LoadPackage,
@@ -81,7 +80,7 @@ func TestInstalledCCs(t *testing.T) {
 		},
 		{
 			name: "No permission on chaincode files",
-			ls:   ioutil.ReadDir,
+			ls:   os.ReadDir,
 			extractCCFromPath: func(_ string, _ string, _ ccprovider.GetHasher) (ccprovider.CCPackage, error) {
 				return nil, errors.New("banana")
 			},

--- a/internal/configtxgen/encoder/encoder.go
+++ b/internal/configtxgen/encoder/encoder.go
@@ -8,7 +8,7 @@ package encoder
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/golang/protobuf/proto"
 	cb "github.com/hyperledger/fabric-protos-go/common"
@@ -251,7 +251,7 @@ func consenterProtosFromConfig(consenterMapping []*genesisconfig.Consenter) ([]*
 		// Expect the user to set the config value for client/server certs or identity to the
 		// path where they are persisted locally, then load these files to memory.
 		if consenter.ClientTLSCert != "" {
-			clientCert, err := ioutil.ReadFile(consenter.ClientTLSCert)
+			clientCert, err := os.ReadFile(consenter.ClientTLSCert)
 			if err != nil {
 				return nil, fmt.Errorf("cannot load client cert for consenter %s:%d: %s", c.GetHost(), c.GetPort(), err)
 			}
@@ -259,7 +259,7 @@ func consenterProtosFromConfig(consenterMapping []*genesisconfig.Consenter) ([]*
 		}
 
 		if consenter.ServerTLSCert != "" {
-			serverCert, err := ioutil.ReadFile(consenter.ServerTLSCert)
+			serverCert, err := os.ReadFile(consenter.ServerTLSCert)
 			if err != nil {
 				return nil, fmt.Errorf("cannot load server cert for consenter %s:%d: %s", c.GetHost(), c.GetPort(), err)
 			}
@@ -267,7 +267,7 @@ func consenterProtosFromConfig(consenterMapping []*genesisconfig.Consenter) ([]*
 		}
 
 		if consenter.Identity != "" {
-			identity, err := ioutil.ReadFile(consenter.Identity)
+			identity, err := os.ReadFile(consenter.Identity)
 			if err != nil {
 				return nil, fmt.Errorf("cannot load identity for consenter %s:%d: %s", c.GetHost(), c.GetPort(), err)
 			}

--- a/internal/configtxlator/rest/configtxlator_handlers.go
+++ b/internal/configtxlator/rest/configtxlator_handlers.go
@@ -8,7 +8,7 @@ package rest
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/golang/protobuf/proto"
@@ -23,7 +23,7 @@ func fieldBytes(fieldName string, r *http.Request) ([]byte, error) {
 	}
 	defer fieldFile.Close()
 
-	return ioutil.ReadAll(fieldFile)
+	return io.ReadAll(fieldFile)
 }
 
 func fieldConfigProto(fieldName string, r *http.Request) (*cb.Config, error) {

--- a/internal/configtxlator/rest/protolator_handlers.go
+++ b/internal/configtxlator/rest/protolator_handlers.go
@@ -9,7 +9,7 @@ package rest
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 
@@ -37,7 +37,7 @@ func Decode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintln(w, err)

--- a/internal/peer/chaincode/package.go
+++ b/internal/peer/chaincode/package.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package chaincode
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/golang/protobuf/proto"
 	pcommon "github.com/hyperledger/fabric-protos-go/common"
@@ -164,7 +164,7 @@ func (p *Packager) packageCC() error {
 	}
 
 	logger.Debugf("Packaged chaincode into deployment spec of size %d, output file %s", len(bytesToWrite), p.Input.OutputFile)
-	err = ioutil.WriteFile(p.Input.OutputFile, bytesToWrite, 0o700)
+	err = os.WriteFile(p.Input.OutputFile, bytesToWrite, 0o700)
 	if err != nil {
 		logger.Errorf("failed writing deployment spec to file [%s]: [%s]", p.Input.OutputFile, err)
 		return err

--- a/internal/peer/chaincode/signpackage.go
+++ b/internal/peer/chaincode/signpackage.go
@@ -8,7 +8,7 @@ package chaincode
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/hyperledger/fabric/bccsp"
 	"github.com/hyperledger/fabric/core/common/ccpackage"
@@ -46,7 +46,7 @@ func signpackage(cmd *cobra.Command, ipackageFile string, opackageFile string, c
 		}
 	}
 
-	b, err := ioutil.ReadFile(ipackageFile)
+	b, err := os.ReadFile(ipackageFile)
 	if err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func signpackage(cmd *cobra.Command, ipackageFile string, opackageFile string, c
 	}
 
 	b = protoutil.MarshalOrPanic(env)
-	err = ioutil.WriteFile(opackageFile, b, 0o700)
+	err = os.WriteFile(opackageFile, b, 0o700)
 	if err != nil {
 		return err
 	}

--- a/internal/peer/channel/create.go
+++ b/internal/peer/channel/create.go
@@ -8,7 +8,7 @@ package channel
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -72,7 +72,7 @@ func createChannelFromDefaults(cf *ChannelCmdFactory) (*cb.Envelope, error) {
 }
 
 func createChannelFromConfigTx(configTxFileName string) (*cb.Envelope, error) {
-	cftx, err := ioutil.ReadFile(configTxFileName)
+	cftx, err := os.ReadFile(configTxFileName)
 	if err != nil {
 		return nil, ConfigTxFileNotFound(err.Error())
 	}
@@ -187,7 +187,7 @@ func executeCreate(cf *ChannelCmdFactory) error {
 	if outputBlock != common.UndefinedParamValue {
 		file = outputBlock
 	}
-	err = ioutil.WriteFile(file, b, 0o644)
+	err = os.WriteFile(file, b, 0o644)
 	if err != nil {
 		return err
 	}

--- a/internal/peer/channel/fetch.go
+++ b/internal/peer/channel/fetch.go
@@ -8,7 +8,7 @@ package channel
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -105,7 +105,7 @@ func fetch(cmd *cobra.Command, args []string, cf *ChannelCmdFactory) error {
 		file = args[1]
 	}
 
-	if err = ioutil.WriteFile(file, b, 0o644); err != nil {
+	if err = os.WriteFile(file, b, 0o644); err != nil {
 		return err
 	}
 

--- a/internal/peer/channel/join.go
+++ b/internal/peer/channel/join.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	pcommon "github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
@@ -59,7 +59,7 @@ func getJoinCCSpec() (*pb.ChaincodeSpec, error) {
 		return nil, errors.New("Must supply genesis block file")
 	}
 
-	gb, err := ioutil.ReadFile(genesisBlockPath)
+	gb, err := os.ReadFile(genesisBlockPath)
 	if err != nil {
 		return nil, GBFileNotFoundErr(err.Error())
 	}

--- a/internal/peer/channel/signconfigtx.go
+++ b/internal/peer/channel/signconfigtx.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package channel
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/spf13/cobra"
@@ -45,7 +45,7 @@ func sign(cmd *cobra.Command, args []string, cf *ChannelCmdFactory) error {
 		}
 	}
 
-	fileData, err := ioutil.ReadFile(channelTxFile)
+	fileData, err := os.ReadFile(channelTxFile)
 	if err != nil {
 		return ConfigTxFileNotFound(err.Error())
 	}
@@ -62,5 +62,5 @@ func sign(cmd *cobra.Command, args []string, cf *ChannelCmdFactory) error {
 
 	sCtxEnvData := protoutil.MarshalOrPanic(sCtxEnv)
 
-	return ioutil.WriteFile(channelTxFile, sCtxEnvData, 0o660)
+	return os.WriteFile(channelTxFile, sCtxEnvData, 0o660)
 }

--- a/internal/peer/channel/update.go
+++ b/internal/peer/channel/update.go
@@ -9,7 +9,7 @@ package channel
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/hyperledger/fabric/internal/peer/common"
 	"github.com/hyperledger/fabric/protoutil"
@@ -54,7 +54,7 @@ func update(cmd *cobra.Command, args []string, cf *ChannelCmdFactory) error {
 		}
 	}
 
-	fileData, err := ioutil.ReadFile(channelTxFile)
+	fileData, err := os.ReadFile(channelTxFile)
 	if err != nil {
 		return ConfigTxFileNotFound(err.Error())
 	}

--- a/internal/peer/common/common.go
+++ b/internal/peer/common/common.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -307,7 +306,7 @@ func configFromEnv(prefix string) (address string, clientConfig comm.ClientConfi
 		ServerNameOverride: viper.GetString(prefix + ".tls.serverhostoverride"),
 	}
 	if secOpts.UseTLS {
-		caPEM, res := ioutil.ReadFile(config.GetPath(prefix + ".tls.rootcert.file"))
+		caPEM, res := os.ReadFile(config.GetPath(prefix + ".tls.rootcert.file"))
 		if res != nil {
 			err = errors.WithMessagef(res, "unable to load %s.tls.rootcert.file", prefix)
 			return
@@ -334,11 +333,11 @@ func configFromEnv(prefix string) (address string, clientConfig comm.ClientConfi
 
 // getClientAuthInfoFromEnv reads client tls key file and cert file and returns the bytes for the files
 func getClientAuthInfoFromEnv(prefix string) ([]byte, []byte, error) {
-	keyPEM, err := ioutil.ReadFile(config.GetPath(prefix + ".tls.clientKey.file"))
+	keyPEM, err := os.ReadFile(config.GetPath(prefix + ".tls.clientKey.file"))
 	if err != nil {
 		return nil, nil, errors.WithMessagef(err, "unable to load %s.tls.clientKey.file", prefix)
 	}
-	certPEM, err := ioutil.ReadFile(config.GetPath(prefix + ".tls.clientCert.file"))
+	certPEM, err := os.ReadFile(config.GetPath(prefix + ".tls.clientCert.file"))
 	if err != nil {
 		return nil, nil, errors.WithMessagef(err, "unable to load %s.tls.clientCert.file", prefix)
 	}

--- a/internal/peer/common/networkconfig.go
+++ b/internal/peer/common/networkconfig.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package common
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
@@ -160,7 +160,7 @@ func GetConfig(fileName string) (*NetworkConfig, error) {
 		return nil, errors.New("filename cannot be empty")
 	}
 
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading connection profile")
 	}

--- a/internal/peer/common/peerclient.go
+++ b/internal/peer/common/peerclient.go
@@ -9,7 +9,7 @@ package common
 import (
 	"context"
 	"crypto/tls"
-	"io/ioutil"
+	"os"
 	"time"
 
 	pb "github.com/hyperledger/fabric-protos-go/peer"
@@ -66,7 +66,7 @@ func NewPeerClientForAddress(address, tlsRootCertFile string) (*PeerClient, erro
 		if tlsRootCertFile == "" {
 			return nil, errors.New("tls root cert file must be set")
 		}
-		caPEM, res := ioutil.ReadFile(tlsRootCertFile)
+		caPEM, res := os.ReadFile(tlsRootCertFile)
 		if res != nil {
 			return nil, errors.WithMessagef(res, "unable to load TLS root cert file from %s", tlsRootCertFile)
 		}

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -391,7 +390,7 @@ func serve(args []string) error {
 	legacyMetadataManager, err := cclifecycle.NewMetadataManager(
 		cclifecycle.EnumerateFunc(
 			func() ([]ccdef.InstalledChaincode, error) {
-				return ccInfoFSImpl.ListInstalledChaincodes(ccInfoFSImpl.GetChaincodeInstallPath(), ioutil.ReadDir, ccprovider.LoadPackage)
+				return ccInfoFSImpl.ListInstalledChaincodes(ccInfoFSImpl.GetChaincodeInstallPath(), os.ReadDir, ccprovider.LoadPackage)
 			},
 		),
 	)


### PR DESCRIPTION
Go std lib deprecated package ioutils since go ver 1.16, while Fabric still uses it in several places. This commit continues (https://github.com/hyperledger/fabric/pull/4367) to remove usage of ioutils from the internal package.
