### PR TITLE
Remove usage of deprecated functions

### DIFF
--- a/cmd/common/config_test.go
+++ b/cmd/common/config_test.go
@@ -20,8 +20,8 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
-	configFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("config-%d.yaml", rand.Int()))
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	configFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("config-%d.yaml", r.Int()))
 	fmt.Println(configFilePath)
 	t.Run("save and load a config", func(t *testing.T) {
 		c := Config{

--- a/common/fabhttp/tls_test.go
+++ b/common/fabhttp/tls_test.go
@@ -61,7 +61,7 @@ var _ = Describe("TLS", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// https://go-review.googlesource.com/c/go/+/229917
-		Expect(tlsConfig.ClientCAs.Subjects()).To(Equal(clientCAPool.Subjects()))
+		Expect(tlsConfig.ClientCAs.Equal(clientCAPool)).To(BeTrue())
 		tlsConfig.ClientCAs = nil
 
 		Expect(tlsConfig).To(Equal(&tls.Config{
@@ -120,9 +120,10 @@ var _ = Describe("TLS", func() {
 		})
 
 		It("builds a TLS configuration without an empty CA pool", func() {
+			emptyPool := x509.NewCertPool()
 			tlsConfig, err := httpTLS.Config()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(tlsConfig.ClientCAs.Subjects()).To(BeEmpty())
+			Expect(tlsConfig.ClientCAs.Equal(emptyPool)).To(BeTrue())
 		})
 	})
 

--- a/common/flogging/global.go
+++ b/common/flogging/global.go
@@ -28,7 +28,7 @@ func init() {
 
 	Global = logging
 	grpcLogger := Global.ZapLogger("grpc")
-	grpclog.SetLogger(NewGRPCLogger(grpcLogger))
+	grpclog.SetLoggerV2(NewGRPCLogger(grpcLogger))
 }
 
 // Init initializes logging with the provided config.

--- a/common/flogging/zap.go
+++ b/common/flogging/zap.go
@@ -33,7 +33,7 @@ func NewZapLogger(core zapcore.Core, options ...zap.Option) *zap.Logger {
 func NewGRPCLogger(l *zap.Logger) *zapgrpc.Logger {
 	l = l.WithOptions(
 		zap.AddCaller(),
-		zap.AddCallerSkip(4),
+		zap.AddCallerSkip(3),
 	)
 	return zapgrpc.NewLogger(l, zapgrpc.WithDebug())
 }

--- a/common/flogging/zap_test.go
+++ b/common/flogging/zap_test.go
@@ -291,8 +291,8 @@ func TestIsEnabledFor(t *testing.T) {
 	require.Equal(t, 2, enablerCallCount)
 }
 
-func logCaller(l grpclog.Logger, msg string)   { l.Println(msg) }
-func callWrapper(l grpclog.Logger, msg string) { logCaller(l, msg) }
+func logCaller(l grpclog.LoggerV2, msg string)   { l.Infoln(msg) }
+func callWrapper(l grpclog.LoggerV2, msg string) { logCaller(l, msg) }
 
 func TestGRPCLogger(t *testing.T) {
 	// ensure it includes the name as module, logs at debug level, and the caller with appropriate skip level
@@ -307,7 +307,7 @@ func TestGRPCLogger(t *testing.T) {
 	gl := flogging.NewGRPCLogger(zl)
 
 	callWrapper(gl, "message")
-	require.Equal(t, "grpc DEBUG TestGRPCLogger message\n", buf.String())
+	require.Equal(t, "grpc INFO TestGRPCLogger message\n", buf.String())
 }
 
 // FAB-15432

--- a/common/graph/perm.go
+++ b/common/graph/perm.go
@@ -11,8 +11,10 @@ import (
 	"time"
 )
 
+var r *rand.Rand
+
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	r = rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 // treePermutations represents possible permutations
@@ -110,7 +112,7 @@ func (tp *treePermutations) computeDescendantPermutations() {
 		// Ensure we don't have too much combinations of descendants
 		for CombinationsExceed(len(v.Descendants), v.Threshold, tp.combinationUpperBound) {
 			// Randomly pick a descendant, and remove it
-			victim := rand.Intn(len(v.Descendants))
+			victim := r.Intn(len(v.Descendants))
 			v.Descendants = append(v.Descendants[:victim], v.Descendants[victim+1:]...)
 		}
 

--- a/common/grpclogging/server_test.go
+++ b/common/grpclogging/server_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
@@ -276,7 +277,7 @@ var _ = Describe("Server", func() {
 				serveCompleteCh = make(chan error, 1)
 				go func() { serveCompleteCh <- server.Serve(listener) }()
 
-				clientConn, err = grpc.Dial(listener.Addr().String(), grpc.WithInsecure(), grpc.WithBlock())
+				clientConn, err = grpc.Dial(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 				Expect(err).NotTo(HaveOccurred())
 				echoServiceClient = testpb.NewEchoServiceClient(clientConn)
 
@@ -584,7 +585,7 @@ var _ = Describe("Server", func() {
 				serveCompleteCh = make(chan error, 1)
 				go func() { serveCompleteCh <- server.Serve(listener) }()
 
-				clientConn, err = grpc.Dial(listener.Addr().String(), grpc.WithInsecure(), grpc.WithBlock())
+				clientConn, err = grpc.Dial(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 				Expect(err).NotTo(HaveOccurred())
 				echoServiceClient = testpb.NewEchoServiceClient(clientConn)
 

--- a/common/grpcmetrics/interceptor_test.go
+++ b/common/grpcmetrics/interceptor_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
@@ -104,7 +105,7 @@ var _ = Describe("Interceptor", func() {
 		serveCompleteCh = make(chan error, 1)
 		go func() { serveCompleteCh <- server.Serve(listener) }()
 
-		cc, err := grpc.Dial(listener.Addr().String(), grpc.WithInsecure(), grpc.WithBlock())
+		cc, err := grpc.Dial(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 		Expect(err).NotTo(HaveOccurred())
 		echoServiceClient = testpb.NewEchoServiceClient(cc)
 	})

--- a/core/common/validation/fullflow_test.go
+++ b/core/common/validation/fullflow_test.go
@@ -206,8 +206,8 @@ func TestTXWithTwoActionsRejected(t *testing.T) {
 }
 
 func corrupt(bytes []byte) {
-	rand.Seed(time.Now().UnixNano())
-	bytes[rand.Intn(len(bytes))]--
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bytes[r.Intn(len(bytes))]--
 }
 
 func TestBadTx(t *testing.T) {

--- a/core/dispatcher/dispatcher_test.go
+++ b/core/dispatcher/dispatcher_test.go
@@ -10,33 +10,31 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/hyperledger/fabric/core/dispatcher"
 	"github.com/hyperledger/fabric/core/dispatcher/mock"
-
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/timestamp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type TestReceiver struct{}
 
 func (tr TestReceiver) GoodFunc(ts *timestamp.Timestamp) (*timestamp.Timestamp, error) {
-	return ptypes.TimestampProto(time.Unix(0, 0))
+	return timestamppb.New(time.Unix(0, 0)), nil
 }
 
 func (tr TestReceiver) MissingFuncParameters() (*timestamp.Timestamp, error) {
-	return ptypes.TimestampProto(time.Unix(0, 0))
+	return timestamppb.New(time.Unix(0, 0)), nil
 }
 
 func (tr TestReceiver) NotProtoParameter(foo *string) (*timestamp.Timestamp, error) {
-	return ptypes.TimestampProto(time.Unix(0, 0))
+	return timestamppb.New(time.Unix(0, 0)), nil
 }
 
 func (tr TestReceiver) NotPointerParameter(foo string) (*timestamp.Timestamp, error) {
-	return ptypes.TimestampProto(time.Unix(0, 0))
+	return timestamppb.New(time.Unix(0, 0)), nil
 }
 
 func (tr TestReceiver) NoReturnValues(ts *timestamp.Timestamp) {}
@@ -81,7 +79,7 @@ var _ = Describe("Dispatcher", func() {
 
 		BeforeEach(func() {
 			var err error
-			inputBytes, err = proto.Marshal(ptypes.TimestampNow())
+			inputBytes, err = proto.Marshal(timestamppb.Now())
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -91,8 +89,7 @@ var _ = Describe("Dispatcher", func() {
 			ts := &timestamp.Timestamp{}
 			err = proto.Unmarshal(outputBytes, ts)
 			Expect(err).NotTo(HaveOccurred())
-			gts, err := ptypes.Timestamp(ts)
-			Expect(err).NotTo(HaveOccurred())
+			gts := ts.AsTime()
 			Expect(gts).To(Equal(time.Unix(0, 0).UTC()))
 		})
 

--- a/core/ledger/kvledger/benchmark/experiments/util.go
+++ b/core/ledger/kvledger/benchmark/experiments/util.go
@@ -8,6 +8,7 @@ package experiments
 
 import (
 	"bytes"
+	crypto "crypto/rand"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -63,10 +64,10 @@ func constructValue(keyNumber int, kvSize int) []byte {
 func constructJSONValue(keyNumber int, kvSize int) []byte {
 	prefix := constructValuePrefix(keyNumber)
 
-	rand.Seed(int64(keyNumber))
-	color := colors[rand.Intn(len(colors))]
-	size := rand.Intn(len(colors))*10 + 10
-	owner := owners[rand.Intn(len(owners))]
+	r := rand.New(rand.NewSource(int64(keyNumber)))
+	color := colors[r.Intn(len(colors))]
+	size := r.Intn(len(colors))*10 + 10
+	owner := owners[r.Intn(len(owners))]
 	assetName := "marble" + strconv.Itoa(keyNumber)
 
 	testRecord := marbleRecord{Prefix: string(prefix), AssetType: "marble", AssetName: assetName, Color: color, Size: size, Owner: owner}
@@ -126,7 +127,7 @@ func calculateShare(total int, numParts int, partNum int) int {
 
 func constructRandomBytes(length int) []byte {
 	b := make([]byte, length)
-	rand.Read(b)
+	crypto.Read(b)
 	return b
 }
 

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/cache_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/cache_test.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package statecouchdb
 
 import (
-	"math/rand"
+	"crypto/rand"
 	"testing"
 
 	"github.com/VictoriaMetrics/fastcache"

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdbutil.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdbutil.go
@@ -66,7 +66,6 @@ func createCouchInstance(config *ledger.CouchDBConfig, metricsProvider metrics.P
 		DialContext: (&net.Dialer{
 			Timeout:   5 * time.Second,
 			KeepAlive: 30 * time.Second,
-			DualStack: true,
 		}).DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          2000,

--- a/core/peer/peer_test.go
+++ b/core/peer/peer_test.go
@@ -42,6 +42,7 @@ import (
 	msptesttools "github.com/hyperledger/fabric/msp/mgmt/testtools"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestMain(m *testing.M) {
@@ -69,7 +70,9 @@ func NewTestPeer(t *testing.T) (*Peer, func()) {
 		nil,
 	)
 	secAdv := peergossip.NewSecurityAdvisor(deserManager)
-	defaultSecureDialOpts := func() []grpc.DialOption { return []grpc.DialOption{grpc.WithInsecure()} }
+	defaultSecureDialOpts := func() []grpc.DialOption {
+		return []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	}
 	gossipConfig, err := gossip.GlobalConfig("localhost:0", nil)
 	require.NoError(t, err)
 

--- a/core/scc/cscc/configure_test.go
+++ b/core/scc/cscc/configure_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 //go:generate counterfeiter -o mocks/acl_provider.go --fake-name ACLProvider . aclProvider
@@ -568,7 +569,7 @@ func newPeerConfiger(t *testing.T, ledgerMgr *ledgermgmt.LedgerMgr, grpcServer *
 	)
 	secAdv := peergossip.NewSecurityAdvisor(deserManager)
 	defaultSecureDialOpts := func() []grpc.DialOption {
-		return []grpc.DialOption{grpc.WithInsecure()}
+		return []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 	}
 	gossipConfig, err := gossip.GlobalConfig(peerEndpoint, nil)
 	require.NoError(t, err)

--- a/discovery/client/client.go
+++ b/discovery/client/client.go
@@ -13,11 +13,10 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/hyperledger/fabric-protos-go/peer"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/discovery"
 	"github.com/hyperledger/fabric-protos-go/msp"
+	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/discovery/protoext"
 	gprotoext "github.com/hyperledger/fabric/gossip/protoext"
 	"github.com/pkg/errors"
@@ -267,9 +266,9 @@ func (cr *channelResponse) Endorsers(invocationChain InvocationChain, f Filter) 
 	}
 
 	desc := res.(*endorsementDescriptor)
-	rand.Seed(time.Now().Unix())
+	r := rand.New(rand.NewSource(time.Now().Unix()))
 	// We iterate over all layouts to find one that we have enough peers to select
-	for _, index := range rand.Perm(len(desc.layouts)) {
+	for _, index := range r.Perm(len(desc.layouts)) {
 		layout := desc.layouts[index]
 		endorsers, canLayoutBeSatisfied := selectPeersForLayout(desc.endorsersByGroups, layout, f)
 		if canLayoutBeSatisfied {

--- a/discovery/client/client_test.go
+++ b/discovery/client/client_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -603,7 +604,7 @@ func TestBadResponses(t *testing.T) {
 	defer svc.shutdown()
 
 	connect := func() (*grpc.ClientConn, error) {
-		return grpc.Dial(fmt.Sprintf("localhost:%d", svc.port), grpc.WithInsecure())
+		return grpc.Dial(fmt.Sprintf("localhost:%d", svc.port), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
 	auth := &discovery.AuthInfo{

--- a/discovery/client/selection.go
+++ b/discovery/client/selection.go
@@ -120,8 +120,8 @@ func (endorsers Endorsers) Filter(f ExclusionFilter) Endorsers {
 // Shuffle sorts the endorsers in random order
 func (endorsers Endorsers) Shuffle() Endorsers {
 	res := make(Endorsers, len(endorsers))
-	rand.Seed(time.Now().UnixNano())
-	for i, index := range rand.Perm(len(endorsers)) {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i, index := range r.Perm(len(endorsers)) {
 		res[i] = endorsers[index]
 	}
 	return res

--- a/gossip/discovery/discovery_test.go
+++ b/gossip/discovery/discovery_test.go
@@ -35,6 +35,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 var timeout = time.Second * time.Duration(15)
@@ -222,7 +223,7 @@ func (comm *dummyCommModule) Ping(peer *NetworkMember) bool {
 	_, alreadyExists := comm.streams[peer.Endpoint]
 	conn := comm.conns[peer.Endpoint]
 	if !alreadyExists || conn.GetState() == connectivity.Shutdown {
-		newConn, err := grpc.Dial(peer.Endpoint, grpc.WithInsecure())
+		newConn, err := grpc.Dial(peer.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			return false
 		}

--- a/gossip/filter/filter.go
+++ b/gossip/filter/filter.go
@@ -14,8 +14,10 @@ import (
 	"github.com/hyperledger/fabric/gossip/util"
 )
 
+var r *rand.Rand
+
 func init() { // do we really need this?
-	rand.Seed(int64(util.RandomUInt64()))
+	r = rand.New(rand.NewSource(int64(util.RandomUInt64())))
 }
 
 // RoutingFilter defines a predicate on a NetworkMember
@@ -49,7 +51,7 @@ func CombineRoutingFilters(filters ...RoutingFilter) RoutingFilter {
 func SelectPeers(k int, peerPool []discovery.NetworkMember, filter RoutingFilter) []*comm.RemotePeer {
 	var res []*comm.RemotePeer
 	// Iterate over the possible candidates in random order
-	for _, index := range rand.Perm(len(peerPool)) {
+	for _, index := range r.Perm(len(peerPool)) {
 		// If we collected K peers, we can stop the iteration.
 		if len(res) == k {
 			break

--- a/gossip/gossip/gossip_test.go
+++ b/gossip/gossip/gossip_test.go
@@ -36,11 +36,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var timeout = time.Second * time.Duration(180)
+var (
+	timeout = time.Second * time.Duration(180)
+	r       *rand.Rand
+)
 
 func TestMain(m *testing.M) {
 	util.SetupTestLogging()
-	rand.Seed(int64(time.Now().Second()))
+	r = rand.New(rand.NewSource(int64(time.Now().Second())))
 	factory.InitFactories(nil)
 	os.Exit(m.Run())
 }
@@ -532,7 +535,7 @@ func TestConnectToAnchorPeers(t *testing.T) {
 	waitUntilOrFailBlocking(t, wg.Wait, "waiting until all peers join the channel")
 
 	// Now start a random anchor peer
-	index := rand.Intn(anchorPeercount)
+	index := r.Intn(anchorPeercount)
 	anchorPeer := newGossipInstanceWithGRPC(index, ports[index], grpcs[index], certs[index], secDialOpts[index], 100)
 	anchorPeer.JoinChan(jcm, common.ChannelID("A"))
 	anchorPeer.UpdateLedgerHeight(1, common.ChannelID("A"))
@@ -1436,7 +1439,7 @@ func TestIdentityExpiration(t *testing.T) {
 	// Now revoke some peer
 	var ports []int
 	ports = append(ports, port1, port2, port3, port4)
-	revokedPeerIndex := rand.Intn(4)
+	revokedPeerIndex := r.Intn(4)
 	revokedPkiID := common.PKIidType(fmt.Sprintf("127.0.0.1:%d", ports[revokedPeerIndex]))
 	for i, p := range peers {
 		if i == revokedPeerIndex {

--- a/gossip/gossip/msgstore/msgs_test.go
+++ b/gossip/gossip/msgstore/msgs_test.go
@@ -18,9 +18,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var r *rand.Rand
+
 func init() {
 	util.SetupTestLogging()
-	rand.Seed(time.Now().UnixNano())
+	r = rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 func alwaysNoAction(_ interface{}, _ interface{}) common.InvalidationResult {
@@ -85,7 +87,7 @@ func TestMessagesGet(t *testing.T) {
 	msgStore := NewMessageStore(alwaysNoAction, Noop)
 	expected := []int{}
 	for i := 0; i < 2; i++ {
-		n := rand.Int()
+		n := r.Int()
 		expected = append(expected, n)
 		msgStore.Add(n)
 	}
@@ -120,7 +122,7 @@ func TestConcurrency(t *testing.T) {
 	}
 
 	addProcess := looper(func() {
-		msgStore.Add(rand.Int())
+		msgStore.Add(r.Int())
 	})
 
 	getProcess := looper(func() {

--- a/gossip/privdata/distributor.go
+++ b/gossip/privdata/distributor.go
@@ -256,7 +256,7 @@ func (d *distributorImpl) disseminationPlanForMsg(colAP privdata.CollectionAcces
 	remainingPeersAcrossOrgs := []api.PeerIdentityInfo{}
 	selectedPeerEndpointsForDebug := []string{}
 
-	rand.Seed(time.Now().Unix())
+	r := rand.New(rand.NewSource(time.Now().Unix()))
 
 	// PHASE 1 - Select one peer from each eligible org
 	if maximumPeerRemainingCount > 0 {
@@ -269,7 +269,7 @@ func (d *distributorImpl) disseminationPlanForMsg(colAP privdata.CollectionAcces
 				acksRequired = 0
 			}
 
-			selectedPeerIndex := rand.Intn(len(selectionPeersForOrg))
+			selectedPeerIndex := r.Intn(len(selectionPeersForOrg))
 			peer2SendPerOrg := selectionPeersForOrg[selectedPeerIndex]
 			selectedPeerEndpointsForDebug = append(selectedPeerEndpointsForDebug, peerEndpoints[string(peer2SendPerOrg.PKIId)])
 			sc := gossipgossip.SendCriteria{
@@ -322,7 +322,7 @@ func (d *distributorImpl) disseminationPlanForMsg(colAP privdata.CollectionAcces
 		if requiredPeerRemainingCount == 0 {
 			required = 0
 		}
-		selectedPeerIndex := rand.Intn(len(remainingPeersAcrossOrgs))
+		selectedPeerIndex := r.Intn(len(remainingPeersAcrossOrgs))
 		peer2Send := remainingPeersAcrossOrgs[selectedPeerIndex]
 		selectedPeerEndpointsForDebug = append(selectedPeerEndpointsForDebug, peerEndpoints[string(peer2Send.PKIId)])
 		sc := gossipgossip.SendCriteria{

--- a/gossip/privdata/pull.go
+++ b/gossip/privdata/pull.go
@@ -680,9 +680,9 @@ func (p *puller) isEligibleByLatestConfig(channel string, collection string, cha
 }
 
 func randomizeMemberList(members []discovery.NetworkMember) []discovery.NetworkMember {
-	rand.Seed(time.Now().UnixNano())
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	res := make([]discovery.NetworkMember, len(members))
-	for i, j := range rand.Perm(len(members)) {
+	for i, j := range r.Perm(len(members)) {
 		res[i] = members[j]
 	}
 	return res

--- a/gossip/state/state_test.go
+++ b/gossip/state/state_test.go
@@ -766,9 +766,9 @@ func TestBlockingEnqueue(t *testing.T) {
 
 	// Get a block from gossip every 1ms too
 	go func() {
-		rand.Seed(time.Now().UnixNano())
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
 		for i := 1; i <= numBlocksReceived/2; i++ {
-			blockSeq := rand.Intn(numBlocksReceived)
+			blockSeq := r.Intn(numBlocksReceived)
 			rawblock := protoutil.NewBlock(uint64(blockSeq), []byte{})
 			b, _ := pb.Marshal(rawblock)
 			block := &proto.Payload{

--- a/gossip/util/misc.go
+++ b/gossip/util/misc.go
@@ -17,8 +17,10 @@ import (
 	"github.com/spf13/viper"
 )
 
+var r *rand.Rand
+
 func init() { // do we really need this?
-	rand.Seed(time.Now().UnixNano())
+	r = rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 // Equals returns whether a and b are the same
@@ -55,7 +57,7 @@ func GetRandomIndices(indiceCount, highestIndex int) []int {
 		return nil
 	}
 
-	return rand.Perm(highestIndex + 1)[:indiceCount]
+	return r.Perm(highestIndex + 1)[:indiceCount]
 }
 
 // Set is a generic and thread-safe
@@ -174,7 +176,7 @@ func SetVal(key string, val interface{}) {
 // RandomInt returns, as an int, a non-negative pseudo-random integer in [0,n)
 // It panics if n <= 0
 func RandomInt(n int) int {
-	return rand.Intn(n)
+	return r.Intn(n)
 }
 
 // RandomUInt64 returns a random uint64
@@ -182,7 +184,7 @@ func RandomInt(n int) int {
 // If we want a rand that's non-global and specific to gossip, we can
 // establish one. Otherwise this uses the process-global locking RNG.
 func RandomUInt64() uint64 {
-	return rand.Uint64()
+	return r.Uint64()
 }
 
 func BytesToStrings(bytes [][]byte) []string {

--- a/integration/e2e/instantiation_policy_test.go
+++ b/integration/e2e/instantiation_policy_test.go
@@ -16,7 +16,6 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
@@ -32,6 +31,7 @@ import (
 	"github.com/onsi/gomega/gexec"
 	"github.com/tedsuo/ifrit"
 	ginkgomon "github.com/tedsuo/ifrit/ginkgomon_v2"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var _ = Describe("InstantiationPolicy", func() {
@@ -193,9 +193,6 @@ func (lo *LSCCOperation) Tx(signer *nwo.SigningIdentity) *common.Envelope {
 	nonce, err := time.Now().MarshalBinary()
 	Expect(err).NotTo(HaveOccurred())
 
-	timestamp, err := ptypes.TimestampProto(time.Now().UTC())
-	Expect(err).NotTo(HaveOccurred())
-
 	hasher := sha256.New()
 	hasher.Write(nonce)
 	hasher.Write(creatorBytes)
@@ -213,7 +210,7 @@ func (lo *LSCCOperation) Tx(signer *nwo.SigningIdentity) *common.Envelope {
 				Name: "lscc",
 			},
 		}),
-		Timestamp: timestamp,
+		Timestamp: timestamppb.Now(),
 		TxId:      txid,
 		Type:      int32(common.HeaderType_ENDORSER_TRANSACTION),
 	})

--- a/integration/nwo/runner/couchdb.go
+++ b/integration/nwo/runner/couchdb.go
@@ -120,7 +120,7 @@ func (c *CouchDB) Run(sigCh <-chan os.Signal, ready chan<- struct{}) error {
 	}
 	defer c.Stop()
 
-	container, err = c.Client.InspectContainer(container.ID)
+	container, err = c.Client.InspectContainerWithOptions(docker.InspectContainerOptions{ID: container.ID})
 	if err != nil {
 		return err
 	}

--- a/integration/pvtdata/pvtdata_test.go
+++ b/integration/pvtdata/pvtdata_test.go
@@ -18,11 +18,9 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
@@ -44,6 +42,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tedsuo/ifrit"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // The chaincode used in these tests has two collections defined:
@@ -1301,10 +1300,6 @@ func createDeliverEnvelope(channelID string, signingIdentity *nwo.SigningIdentit
 }
 
 func createHeader(txType cb.HeaderType, channelID string, creator []byte) (*cb.Header, error) {
-	ts, err := ptypes.TimestampProto(time.Now())
-	if err != nil {
-		return nil, err
-	}
 	nonce, err := crypto.GetRandomNonce()
 	if err != nil {
 		return nil, err
@@ -1314,7 +1309,7 @@ func createHeader(txType cb.HeaderType, channelID string, creator []byte) (*cb.H
 		ChannelId: channelID,
 		TxId:      protoutil.ComputeTxID(nonce, creator),
 		Epoch:     0,
-		Timestamp: ts,
+		Timestamp: timestamppb.Now(),
 	}
 	chdrBytes := protoutil.MarshalOrPanic(chdr)
 

--- a/integration/smartbft/smartbft_test.go
+++ b/integration/smartbft/smartbft_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -26,34 +25,26 @@ import (
 	"syscall"
 	"time"
 
-	protosOrderer "github.com/hyperledger/fabric-protos-go/orderer"
-	"github.com/hyperledger/fabric/integration/ordererclient"
-	"github.com/hyperledger/fabric/protoutil"
-
-	"github.com/golang/protobuf/proto"
-
-	"github.com/hyperledger/fabric/integration/channelparticipation"
-
-	"github.com/tedsuo/ifrit/grouper"
-
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-config/configtx"
 	"github.com/hyperledger/fabric-config/configtx/orderer"
 	"github.com/hyperledger/fabric-protos-go/common"
+	protosOrderer "github.com/hyperledger/fabric-protos-go/orderer"
+	"github.com/hyperledger/fabric/integration/channelparticipation"
 	conftx "github.com/hyperledger/fabric/integration/configtx"
 	"github.com/hyperledger/fabric/integration/nwo"
 	"github.com/hyperledger/fabric/integration/nwo/commands"
+	"github.com/hyperledger/fabric/integration/ordererclient"
+	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"github.com/tedsuo/ifrit"
 	ginkgomon "github.com/tedsuo/ifrit/ginkgomon_v2"
+	"github.com/tedsuo/ifrit/grouper"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 var _ = Describe("EndToEnd Smart BFT configuration test", func() {
 	var (

--- a/internal/configtxlator/rest/protolator_handlers_test.go
+++ b/internal/configtxlator/rest/protolator_handlers_test.go
@@ -47,8 +47,7 @@ var (
 func TestProtolatorDecode(t *testing.T) {
 	data, err := proto.Marshal(testProto)
 	require.NoError(t, err)
-
-	url := fmt.Sprintf("/protolator/decode/%s", proto.MessageName(testProto))
+	url := fmt.Sprintf("/protolator/decode/%s", proto.MessageReflect(testProto).Descriptor().FullName())
 
 	req, _ := http.NewRequest("POST", url, bytes.NewReader(data))
 	rec := httptest.NewRecorder()
@@ -64,7 +63,7 @@ func TestProtolatorDecode(t *testing.T) {
 }
 
 func TestProtolatorEncode(t *testing.T) {
-	url := fmt.Sprintf("/protolator/encode/%s", proto.MessageName(testProto))
+	url := fmt.Sprintf("/protolator/encode/%s", proto.MessageReflect(testProto).Descriptor().FullName())
 
 	req, _ := http.NewRequest("POST", url, bytes.NewReader([]byte(testOutput)))
 	rec := httptest.NewRecorder()
@@ -99,7 +98,7 @@ func TestProtolatorEncodeNonExistantProto(t *testing.T) {
 }
 
 func TestProtolatorDecodeBadData(t *testing.T) {
-	url := fmt.Sprintf("/protolator/decode/%s", proto.MessageName(testProto))
+	url := fmt.Sprintf("/protolator/decode/%s", proto.MessageReflect(testProto).Descriptor().FullName())
 
 	req, _ := http.NewRequest("POST", url, bytes.NewReader([]byte("Garbage")))
 
@@ -111,7 +110,7 @@ func TestProtolatorDecodeBadData(t *testing.T) {
 }
 
 func TestProtolatorEncodeBadData(t *testing.T) {
-	url := fmt.Sprintf("/protolator/encode/%s", proto.MessageName(testProto))
+	url := fmt.Sprintf("/protolator/encode/%s", proto.MessageReflect(testProto).Descriptor().FullName())
 
 	req, _ := http.NewRequest("POST", url, bytes.NewReader([]byte("Garbage")))
 

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -100,6 +100,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"gopkg.in/yaml.v2"
 )
 
@@ -1192,7 +1193,7 @@ func secureDialOpts(credSupport *comm.CredentialSupport) func() []grpc.DialOptio
 		if viper.GetBool("peer.tls.enabled") {
 			dialOpts = append(dialOpts, grpc.WithTransportCredentials(credSupport.GetPeerCredentials()))
 		} else {
-			dialOpts = append(dialOpts, grpc.WithInsecure())
+			dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		}
 		return dialOpts
 	}

--- a/internal/peer/node/start_test.go
+++ b/internal/peer/node/start_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestStartCmd(t *testing.T) {
@@ -46,7 +47,7 @@ func TestStartCmd(t *testing.T) {
 	}()
 
 	grpcProbe := func(addr string) bool {
-		c, err := grpc.Dial(addr, grpc.WithBlock(), grpc.WithInsecure())
+		c, err := grpc.Dial(addr, grpc.WithBlock(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err == nil {
 			c.Close()
 			return true

--- a/internal/pkg/comm/config.go
+++ b/internal/pkg/comm/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hyperledger/fabric/common/metrics"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 )
 
@@ -131,7 +132,7 @@ func (cc ClientConfig) DialOptions() ([]grpc.DialOption, error) {
 		transportCreds := &DynamicClientCredentials{TLSConfig: tlsConfig}
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(transportCreds))
 	} else {
-		dialOpts = append(dialOpts, grpc.WithInsecure())
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
 	return dialOpts, nil

--- a/internal/pkg/comm/config_test.go
+++ b/internal/pkg/comm/config_test.go
@@ -205,10 +205,7 @@ func TestSecureOptionsTLSConfig(t *testing.T) {
 
 			if len(tt.so.ServerRootCAs) != 0 {
 				require.NotNil(t, tc.RootCAs)
-				require.Len(t, tc.RootCAs.Subjects(), len(tt.so.ServerRootCAs))
-				for _, subj := range tt.tc.RootCAs.Subjects() {
-					require.Contains(t, tc.RootCAs.Subjects(), subj, "missing subject %x", subj)
-				}
+				require.True(t, tt.tc.RootCAs.Equal(tc.RootCAs))
 				tt.tc.RootCAs, tc.RootCAs = nil, nil
 			}
 

--- a/internal/pkg/comm/creds_test.go
+++ b/internal/pkg/comm/creds_test.go
@@ -143,7 +143,7 @@ func TestAddRootCA(t *testing.T) {
 
 	// https://go-review.googlesource.com/c/go/+/229917
 	config.AddClientRootCA(cert)
-	require.Equal(t, certPool.Subjects(), expectedCertPool.Subjects(), "subjects in the pool should be equal")
+	require.True(t, certPool.Equal(expectedCertPool), "subjects in the pool should be equal")
 }
 
 func TestSetClientCAs(t *testing.T) {

--- a/internal/pkg/comm/server_test.go
+++ b/internal/pkg/comm/server_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
@@ -533,7 +534,7 @@ func TestNewGRPCServer(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// invoke the EmptyCall service
-	_, err = invokeEmptyCall(testAddress, grpc.WithInsecure())
+	_, err = invokeEmptyCall(testAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err, "failed to invoke the EmptyCall service")
 }
 
@@ -567,7 +568,7 @@ func TestNewGRPCServerFromListener(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// invoke the EmptyCall service
-	_, err = invokeEmptyCall(testAddress, grpc.WithInsecure())
+	_, err = invokeEmptyCall(testAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err, "client failed to invoke the EmptyCall service")
 }
 
@@ -1257,7 +1258,7 @@ func TestServerInterceptors(t *testing.T) {
 	_, err = invokeEmptyCall(
 		lis.Addr().String(),
 		grpc.WithBlock(),
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	require.Error(t, err)
 	require.Equal(t, status.Convert(err).Message(), msg, "Expected error from second usi")
@@ -1266,7 +1267,7 @@ func TestServerInterceptors(t *testing.T) {
 	_, err = invokeEmptyStream(
 		lis.Addr().String(),
 		grpc.WithBlock(),
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	require.Error(t, err)
 	require.Equal(t, status.Convert(err).Message(), msg, "Expected error from second ssi")

--- a/internal/pkg/comm/serverstatshandler_test.go
+++ b/internal/pkg/comm/serverstatshandler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hyperledger/fabric/internal/pkg/comm/testpb"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/stats"
 )
 
@@ -89,7 +90,7 @@ func TestConnMetricsGRPCServer(t *testing.T) {
 	// create GRPC client conn
 	var clientConns []*grpc.ClientConn
 	for i := 1; i <= 3; i++ {
-		clientConn, err := grpc.DialContext(ctx, listener.Addr().String(), grpc.WithInsecure())
+		clientConn, err := grpc.DialContext(ctx, listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		gt.Expect(err).NotTo(HaveOccurred())
 		clientConns = append(clientConns, clientConn)
 

--- a/orderer/common/cluster/clusterservice_test.go
+++ b/orderer/common/cluster/clusterservice_test.go
@@ -17,11 +17,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hyperledger/fabric/common/crypto"
-
-	"github.com/golang/protobuf/ptypes"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/orderer"
+	"github.com/hyperledger/fabric/common/crypto"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/common/metrics/disabled"
 	"github.com/hyperledger/fabric/common/util"
@@ -35,19 +33,19 @@ import (
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var (
 	sourceNodeID      uint64 = 1
 	destinationNodeID uint64 = 2
 	streamID          uint64 = 111
-	tstamp, _                = ptypes.TimestampProto(time.Now().UTC())
 	nodeAuthRequest          = orderer.NodeAuthRequest{
 		Version:   0,
 		FromId:    sourceNodeID,
 		ToId:      destinationNodeID,
 		Channel:   "mychannel",
-		Timestamp: tstamp,
+		Timestamp: timestamppb.Now(),
 	}
 	nodeConsensusRequest = &orderer.ClusterNodeServiceStepRequest{
 		Payload: &orderer.ClusterNodeServiceStepRequest_NodeConrequest{

--- a/orderer/common/cluster/commauth.go
+++ b/orderer/common/cluster/commauth.go
@@ -11,15 +11,14 @@ import (
 	"encoding/asn1"
 	"strconv"
 	"sync"
-	"time"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/hyperledger/fabric-protos-go/orderer"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/internal/pkg/identity"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // AuthCommMgr implements the Communicator
@@ -253,14 +252,9 @@ func (cs *NodeClientStream) Auth() error {
 		return errors.New("signer is nil")
 	}
 
-	timestamp, err := ptypes.TimestampProto(time.Now().UTC())
-	if err != nil {
-		return errors.Wrap(err, "failed to read timestamp")
-	}
-
 	payload := &orderer.NodeAuthRequest{
 		Version:   cs.Version,
-		Timestamp: timestamp,
+		Timestamp: timestamppb.Now(),
 		FromId:    cs.SourceNodeID,
 		ToId:      cs.DestinationNodeID,
 		Channel:   cs.Channel,

--- a/orderer/common/cluster/deliver.go
+++ b/orderer/common/cluster/deliver.go
@@ -380,8 +380,8 @@ func randomEndpoint(endpointsToHeight map[string]*endpointInfo) string {
 		candidates = append(candidates, endpoint)
 	}
 
-	rand.Seed(time.Now().UnixNano())
-	return candidates[rand.Intn(len(candidates))]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return candidates[r.Intn(len(candidates))]
 }
 
 // fetchLastBlockSeq returns the last block sequence of an endpoint with the given gRPC connection.

--- a/orderer/common/cluster/deliver_test.go
+++ b/orderer/common/cluster/deliver_test.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/roundrobin"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // protects gRPC balancer registration
@@ -115,7 +116,7 @@ func (d *countingDialer) Dial(address cluster.EndpointCriteria) (*grpc.ClientCon
 	gRPCBalancerLock.Lock()
 	balancer := grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingConfig": [{"%s":{}}]}`, d.name))
 	gRPCBalancerLock.Unlock()
-	return grpc.DialContext(ctx, address.Endpoint, grpc.WithBlock(), grpc.WithInsecure(), balancer)
+	return grpc.DialContext(ctx, address.Endpoint, grpc.WithBlock(), grpc.WithTransportCredentials(insecure.NewCredentials()), balancer)
 }
 
 func noopBlockVerifierf(_ []*common.Block, _ string) error {
@@ -1134,7 +1135,7 @@ func TestImpatientStreamFailure(t *testing.T) {
 	gt.Eventually(func() (bool, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*10)
 		defer cancel()
-		conn, _ := grpc.DialContext(ctx, osn.srv.Address(), grpc.WithBlock(), grpc.WithInsecure())
+		conn, _ := grpc.DialContext(ctx, osn.srv.Address(), grpc.WithBlock(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if conn != nil {
 			conn.Close()
 			return false, nil

--- a/orderer/sample_clients/broadcast_config/client.go
+++ b/orderer/sample_clients/broadcast_config/client.go
@@ -16,6 +16,7 @@ import (
 	mspmgmt "github.com/hyperledger/fabric/msp/mgmt"
 	"github.com/hyperledger/fabric/orderer/common/localconfig"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type broadcastClient struct {
@@ -91,7 +92,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	conn, err := grpc.Dial(srv, grpc.WithInsecure())
+	conn, err := grpc.Dial(srv, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	defer func() {
 		_ = conn.Close()
 	}()

--- a/orderer/sample_clients/broadcast_msg/client.go
+++ b/orderer/sample_clients/broadcast_msg/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger/fabric/orderer/common/localconfig"
 	"github.com/hyperledger/fabric/protoutil"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type broadcastClient struct {
@@ -91,7 +92,7 @@ func main() {
 	flag.Uint64Var(&msgSize, "size", 1024, "The size in bytes of the data section for the payload")
 	flag.Parse()
 
-	conn, err := grpc.Dial(serverAddr, grpc.WithInsecure())
+	conn, err := grpc.Dial(serverAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	defer func() {
 		_ = conn.Close()
 	}()

--- a/orderer/sample_clients/deliver_stdout/client.go
+++ b/orderer/sample_clients/deliver_stdout/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger/fabric/orderer/common/localconfig"
 	"github.com/hyperledger/fabric/protoutil"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 var (
@@ -134,7 +135,7 @@ func main() {
 		flag.PrintDefaults()
 	}
 
-	conn, err := grpc.Dial(serverAddr, grpc.WithInsecure())
+	conn, err := grpc.Dial(serverAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		fmt.Println("Error connecting:", err)
 		return

--- a/protoutil/proputils.go
+++ b/protoutil/proputils.go
@@ -9,13 +9,12 @@ package protoutil
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // CreateChaincodeProposal creates a proposal from given input.
@@ -81,17 +80,12 @@ func CreateChaincodeProposalWithTxIDNonceAndTransient(txid string, typ common.He
 	// get a more appropriate mechanism to handle it in.
 	var epoch uint64
 
-	timestamp, err := ptypes.TimestampProto(time.Now().UTC())
-	if err != nil {
-		return nil, "", errors.Wrap(err, "error validating Timestamp")
-	}
-
 	hdr := &common.Header{
 		ChannelHeader: MarshalOrPanic(
 			&common.ChannelHeader{
 				Type:      int32(typ),
 				TxId:      txid,
-				Timestamp: timestamp,
+				Timestamp: timestamppb.Now(),
 				ChannelId: channelID,
 				Extension: ccHdrExtBytes,
 				Epoch:     epoch,


### PR DESCRIPTION
Remove usage of deprecated functions:
- math/rand
- protobuf/proto
- protobuf/ptypes
- grpc
- crypto/x509
- fsouza/go-dockerclient
- net
- grpc/grpclog