### PR TITLE
fix warnings

### DIFF
--- a/bccsp/sw/keygen.go
+++ b/bccsp/sw/keygen.go
@@ -43,7 +43,7 @@ type aesKeyGenerator struct {
 }
 
 func (kg *aesKeyGenerator) KeyGen(opts bccsp.KeyGenOpts) (bccsp.Key, error) {
-	lowLevelKey, err := GetRandomBytes(int(kg.length))
+	lowLevelKey, err := GetRandomBytes(kg.length)
 	if err != nil {
 		return nil, fmt.Errorf("Failed generating AES %d key [%s]", kg.length, err)
 	}

--- a/cmd/common/config.go
+++ b/cmd/common/config.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hyperledger/fabric/cmd/common/comm"
 	"github.com/hyperledger/fabric/cmd/common/signer"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // Config aggregates configuration of TLS and signing
@@ -30,7 +30,7 @@ func ConfigFromFile(file string) (Config, error) {
 	}
 	config := Config{}
 
-	if err := yaml.Unmarshal([]byte(configData), &config); err != nil {
+	if err := yaml.Unmarshal(configData, &config); err != nil {
 		return Config{}, errors.Errorf("error unmarshalling YAML file %s: %s", file, err)
 	}
 

--- a/cmd/common/signer/signer_test.go
+++ b/cmd/common/signer/signer_test.go
@@ -77,7 +77,7 @@ ZsQXrlIqlmNalfYPX+NDDELqlpXQBeEqnA==
 
 			defer os.Remove(tmpFile.Name())
 
-			err = ioutil.WriteFile(tmpFile.Name(), []byte(testCase.keyBytes), 0o600)
+			err = ioutil.WriteFile(tmpFile.Name(), testCase.keyBytes, 0o600)
 			require.NoError(t, err)
 
 			signer, err := NewSigner(Config{

--- a/cmd/cryptogen/main.go
+++ b/cmd/cryptogen/main.go
@@ -19,8 +19,8 @@ import (
 	"github.com/hyperledger/fabric/internal/cryptogen/metadata"
 	"github.com/hyperledger/fabric/internal/cryptogen/msp"
 
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/yaml.v2"
 )
 
 const (

--- a/common/channelconfig/msp_test.go
+++ b/common/channelconfig/msp_test.go
@@ -44,7 +44,7 @@ func TestMSPConfigManager(t *testing.T) {
 		}
 
 		for _, mspInst := range msps {
-			require.Equal(t, mspInst.GetVersion(), msp.MSPVersion(ver))
+			require.Equal(t, mspInst.GetVersion(), ver)
 		}
 	}
 }

--- a/common/channelconfig/util_test.go
+++ b/common/channelconfig/util_test.go
@@ -161,7 +161,7 @@ func createCfgBlockWithSupportedCapabilities(t *testing.T) *cb.Block {
 	}
 	configBlock := &cb.Block{
 		Data: &cb.BlockData{
-			Data: [][]byte{[]byte(protoutil.MarshalOrPanic(env))},
+			Data: [][]byte{protoutil.MarshalOrPanic(env)},
 		},
 	}
 	return configBlock
@@ -275,7 +275,7 @@ func createCfgBlockWithUnsupportedCapabilities(t *testing.T) *cb.Block {
 	}
 	configBlock := &cb.Block{
 		Data: &cb.BlockData{
-			Data: [][]byte{[]byte(protoutil.MarshalOrPanic(env))},
+			Data: [][]byte{protoutil.MarshalOrPanic(env)},
 		},
 	}
 	return configBlock
@@ -347,9 +347,8 @@ func TestMarshalEtcdRaftMetadata(t *testing.T) {
 
 	var outputCerts, inputCerts [3][]byte
 	for i := range unpacked.GetConsenters() {
-		outputCerts[i] = []byte(unpacked.GetConsenters()[i].GetClientTlsCert())
+		outputCerts[i] = unpacked.GetConsenters()[i].GetClientTlsCert()
 		inputCerts[i], _ = ioutil.ReadFile(fmt.Sprintf("testdata/tls-client-%d.pem", i+1))
-
 	}
 
 	for i := 0; i < len(inputCerts)-1; i++ {

--- a/common/deliver/binding_test.go
+++ b/common/deliver/binding_test.go
@@ -85,7 +85,7 @@ func TestBindingInspector(t *testing.T) {
 	// Scenario IV: Client sends its TLS cert hash as needed, but doesn't use mutual TLS
 	cert, _ := tls.X509KeyPair([]byte(selfSignedCertPEM), []byte(selfSignedKeyPEM))
 	h := sha256.New()
-	h.Write([]byte(cert.Certificate[0]))
+	h.Write(cert.Certificate[0])
 	chanHdr.TlsCertHash = h.Sum(nil)
 	ch, _ = proto.Marshal(chanHdr)
 	err = srv.newInspection(t).inspectBinding(envelopeWithChannelHeader(ch))

--- a/common/flogging/levels.go
+++ b/common/flogging/levels.go
@@ -20,7 +20,7 @@ const (
 
 	// PayloadLevel is used to log the extremely detailed message level debug
 	// information.
-	PayloadLevel = zapcore.Level(zapcore.DebugLevel - 1)
+	PayloadLevel = zapcore.DebugLevel - 1
 )
 
 // NameToLevel converts a level name to a zapcore.Level.  If the level name is

--- a/common/flogging/loggerlevels_test.go
+++ b/common/flogging/loggerlevels_test.go
@@ -183,9 +183,9 @@ func TestEnabled(t *testing.T) {
 
 			for i := flogging.PayloadLevel; i <= zapcore.FatalLevel; i++ {
 				if tc.enabledAt <= i {
-					require.Truef(t, ll.Enabled(i), "expected level %s and spec %s to be enabled", zapcore.Level(i), tc.spec)
+					require.Truef(t, ll.Enabled(i), "expected level %s and spec %s to be enabled", i, tc.spec)
 				} else {
-					require.False(t, ll.Enabled(i), "expected level %s and spec %s to be disabled", zapcore.Level(i), tc.spec)
+					require.False(t, ll.Enabled(i), "expected level %s and spec %s to be disabled", i, tc.spec)
 				}
 			}
 		})

--- a/common/grpclogging/grpclogging_suite_test.go
+++ b/common/grpclogging/grpclogging_suite_test.go
@@ -77,7 +77,7 @@ type echoServiceServer interface {
 
 func newTemplate(subjectCN string, hosts ...string) x509.Certificate {
 	notBefore := time.Now().Add(-1 * time.Minute)
-	notAfter := time.Now().Add(time.Duration(365 * 24 * time.Hour))
+	notAfter := time.Now().Add(365 * 24 * time.Hour)
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)

--- a/common/grpclogging/server.go
+++ b/common/grpclogging/server.go
@@ -42,7 +42,7 @@ func (l LevelerFunc) PayloadLevel(ctx context.Context, fullMethod string) zapcor
 }
 
 // DefaultPayloadLevel is default level to use when logging payloads
-const DefaultPayloadLevel = zapcore.Level(zapcore.DebugLevel - 1)
+const DefaultPayloadLevel = zapcore.DebugLevel - 1
 
 type options struct {
 	Leveler

--- a/common/ledger/blkstorage/blockindex.go
+++ b/common/ledger/blkstorage/blockindex.go
@@ -390,7 +390,7 @@ func importTxIDsFromSnapshot(
 			return err
 		}
 		batch.Put(
-			constructTxIDKey(txID, lastBlockNumInSnapshot, uint64(i)),
+			constructTxIDKey(txID, lastBlockNumInSnapshot, i),
 			[]byte{},
 		)
 		if (i+1)%importTxIDsBatchSize == 0 {

--- a/common/metrics/statsd/provider_test.go
+++ b/common/metrics/statsd/provider_test.go
@@ -133,11 +133,11 @@ var _ = Describe("Provider", func() {
 			gauge := provider.NewGauge(gaugeOpts)
 
 			for _, alpha := range []string{"x", "y", "z"} {
-				gauge.With("alpha", alpha, "beta", "b").Set(float64(1.0))
+				gauge.With("alpha", alpha, "beta", "b").Set(1.0)
 			}
 			for _, alpha := range []string{"x", "y", "z"} {
 				for i := 0; i < 5; i++ {
-					gauge.With("alpha", alpha, "beta", "b").Add(float64(1.0))
+					gauge.With("alpha", alpha, "beta", "b").Add(1.0)
 				}
 			}
 			buf := &bytes.Buffer{}

--- a/common/policies/implicitmeta.go
+++ b/common/policies/implicitmeta.go
@@ -99,7 +99,7 @@ func (imp *ImplicitMetaPolicy) EvaluateSignedData(signatureSet []*protoutil.Sign
 	if remaining == 0 {
 		return nil
 	}
-	return fmt.Errorf("implicit policy evaluation failed - %d sub-policies were satisfied, but this policy requires %d of the '%s' sub-policies to be satisfied", (imp.Threshold - remaining), imp.Threshold, imp.SubPolicyName)
+	return fmt.Errorf("implicit policy evaluation failed - %d sub-policies were satisfied, but this policy requires %d of the '%s' sub-policies to be satisfied", imp.Threshold-remaining, imp.Threshold, imp.SubPolicyName)
 }
 
 // EvaluateIdentities takes an array of identities and evaluates whether
@@ -140,5 +140,5 @@ func (imp *ImplicitMetaPolicy) EvaluateIdentities(identities []msp.Identity) err
 	if remaining == 0 {
 		return nil
 	}
-	return fmt.Errorf("implicit policy evaluation failed - %d sub-policies were satisfied, but this policy requires %d of the '%s' sub-policies to be satisfied", (imp.Threshold - remaining), imp.Threshold, imp.SubPolicyName)
+	return fmt.Errorf("implicit policy evaluation failed - %d sub-policies were satisfied, but this policy requires %d of the '%s' sub-policies to be satisfied", imp.Threshold-remaining, imp.Threshold, imp.SubPolicyName)
 }

--- a/common/policies/implicitmeta_test.go
+++ b/common/policies/implicitmeta_test.go
@@ -73,7 +73,7 @@ func runPolicyTest(t *testing.T, rule cb.ImplicitMetaPolicy_Rule, managerCount i
 
 	errI := imp.EvaluateIdentities(nil)
 
-	require.False(t, ((errI == nil && errSD != nil) || (errSD == nil && errI != nil)))
+	require.False(t, (errI == nil && errSD != nil) || (errSD == nil && errI != nil))
 	if errI != nil && errSD != nil {
 		require.Equal(t, errI.Error(), errSD.Error())
 	}

--- a/common/policies/inquire/compare_test.go
+++ b/common/policies/inquire/compare_test.go
@@ -192,7 +192,7 @@ func TestNewComparablePrincipalSet(t *testing.T) {
 		member1 := NewComparablePrincipal(member("Org1MSP"))
 		peer2 := NewComparablePrincipal(peer("Org2MSP"))
 		principals := []*msp.MSPPrincipal{member("Org1MSP"), peer("Org2MSP")}
-		cps := NewComparablePrincipalSet(policies.PrincipalSet(principals))
+		cps := NewComparablePrincipalSet(principals)
 		expected := ComparablePrincipalSet([]*ComparablePrincipal{member1, peer2})
 		require.Equal(t, expected, cps)
 	})

--- a/common/policies/policy.go
+++ b/common/policies/policy.go
@@ -214,7 +214,7 @@ func NewManagerImpl(path string, providers map[int32]Provider, root *cb.ConfigGr
 			}
 			cPolicy = imp
 		} else {
-			provider, ok := providers[int32(policy.Type)]
+			provider, ok := providers[policy.Type]
 			if !ok {
 				return nil, fmt.Errorf("policy %s at path %s has unknown policy type: %v", policyName, path, policy.Type)
 			}

--- a/core/chaincode/chaincode_support_test.go
+++ b/core/chaincode/chaincode_support_test.go
@@ -346,7 +346,7 @@ func processDone(t *testing.T, done chan error, expecterr bool) {
 }
 
 func startTx(t *testing.T, peerInstance *peer.Peer, channelID string, cis *pb.ChaincodeInvocationSpec, txId string) (*ccprovider.TransactionParams, ledger.TxSimulator) {
-	creator := []byte([]byte("Alice"))
+	creator := []byte("Alice")
 	sprop, prop := protoutil.MockSignedEndorserProposalOrPanic(channelID, cis.ChaincodeSpec, creator, []byte("msg1"))
 	txsim, hqe, err := startTxSimulation(peerInstance, channelID, txId)
 	if err != nil {
@@ -523,8 +523,8 @@ func initializeCC(t *testing.T, chainID, ccname string, ccSide *mock.MockCCComm,
 	// be triggered by the chaincode stream.  We just expect an error from fabric. Hence pass nil for done
 	execCC(t, txParams, ccSide, "badccname", false, true, nil, cis, respSet, chaincodeSupport)
 
-	//---------try a successful init at last-------
-	//everything lined up
+	// ---------try a successful init at last-------
+	// everything lined up
 	//    correct registered chaincode version
 	//    matching txid
 	//    txsim context

--- a/core/chaincode/handler.go
+++ b/core/chaincode/handler.go
@@ -958,7 +958,7 @@ func getQueryMetadataFromBytes(metadataBytes []byte) (*pb.QueryMetadata, error) 
 func (h *Handler) calculateTotalReturnLimit(metadata *pb.QueryMetadata) int32 {
 	totalReturnLimit := int32(h.TotalQueryLimit)
 	if metadata != nil {
-		pageSize := int32(metadata.PageSize)
+		pageSize := metadata.PageSize
 		if pageSize > 0 && pageSize < totalReturnLimit {
 			totalReturnLimit = pageSize
 		}
@@ -1210,7 +1210,7 @@ func (h *Handler) Execute(txParams *ccprovider.TransactionParams, namespace stri
 	defer chaincodeLogger.Debugf("Exit")
 
 	txParams.CollectionStore = h.getCollectionStore(msg.ChannelId)
-	txParams.IsInitTransaction = (msg.Type == pb.ChaincodeMessage_INIT)
+	txParams.IsInitTransaction = msg.Type == pb.ChaincodeMessage_INIT
 	txParams.NamespaceID = namespace
 
 	txctx, err := h.TXContexts.Create(txParams)

--- a/core/chaincode/lifecycle/cache_test.go
+++ b/core/chaincode/lifecycle/cache_test.go
@@ -161,8 +161,8 @@ var _ = Describe("Cache", func() {
 		lifecycle.SetChaincodeMap(c, "channel-id", channelCache)
 		lifecycle.SetLocalChaincodesMap(c, localChaincodes)
 
-		fakePublicState = MapLedgerShim(map[string][]byte{})
-		fakePrivateState = MapLedgerShim(map[string][]byte{})
+		fakePublicState = map[string][]byte{}
+		fakePrivateState = map[string][]byte{}
 		fakeQueryExecutor = &mock.SimpleQueryExecutor{}
 		fakeQueryExecutor.GetStateStub = func(namespace, key string) ([]byte, error) {
 			return fakePublicState.GetState(key)
@@ -979,14 +979,14 @@ var _ = Describe("Cache", func() {
 
 				trigger = &ledger.StateUpdateTrigger{
 					LedgerID: "channel-id",
-					StateUpdates: ledger.StateUpdates(map[string]*ledger.KVStateUpdates{
+					StateUpdates: map[string]*ledger.KVStateUpdates{
 						"_lifecycle": {
 							PublicUpdates: []*kvrwset.KVWrite{
 								{Key: "namespaces/fields/chaincode-name/Sequence"},
 							},
 							CollHashUpdates: map[string][]*kvrwset.KVWriteHash{},
 						},
-					}),
+					},
 					PostCommitQueryExecutor: fakeQueryExecutor,
 				}
 			})
@@ -1070,7 +1070,7 @@ var _ = Describe("Cache", func() {
 
 			Context("when the state update contains no updates to _lifecycle", func() {
 				BeforeEach(func() {
-					trigger.StateUpdates = ledger.StateUpdates(map[string]*ledger.KVStateUpdates{})
+					trigger.StateUpdates = map[string]*ledger.KVStateUpdates{}
 				})
 
 				It("returns an error", func() {
@@ -1136,20 +1136,20 @@ var _ = Describe("Cache", func() {
 			BeforeEach(func() {
 				definitionTrigger = &ledger.StateUpdateTrigger{
 					LedgerID: "channel-id",
-					StateUpdates: ledger.StateUpdates(map[string]*ledger.KVStateUpdates{
+					StateUpdates: map[string]*ledger.KVStateUpdates{
 						"_lifecycle": {
 							PublicUpdates: []*kvrwset.KVWrite{
 								{Key: "namespaces/fields/chaincode-name-1/Sequence"},
 							},
 							CollHashUpdates: map[string][]*kvrwset.KVWriteHash{},
 						},
-					}),
+					},
 					PostCommitQueryExecutor: fakeQueryExecutor,
 				}
 
 				approvalTrigger = &ledger.StateUpdateTrigger{
 					LedgerID: "channel-id",
-					StateUpdates: ledger.StateUpdates(map[string]*ledger.KVStateUpdates{
+					StateUpdates: map[string]*ledger.KVStateUpdates{
 						"_lifecycle": {
 							PublicUpdates: []*kvrwset.KVWrite{},
 							CollHashUpdates: map[string][]*kvrwset.KVWriteHash{
@@ -1160,7 +1160,7 @@ var _ = Describe("Cache", func() {
 								},
 							},
 						},
-					}),
+					},
 					PostCommitQueryExecutor: fakeQueryExecutor,
 				}
 

--- a/core/chaincode/lifecycle/deployedcc_infoprovider_test.go
+++ b/core/chaincode/lifecycle/deployedcc_infoprovider_test.go
@@ -85,7 +85,7 @@ var _ = Describe("ValidatorCommitter", func() {
 			LegacyDeployedCCInfoProvider: fakeLegacyProvider,
 		}
 
-		fakePublicState = MapLedgerShim(map[string][]byte{})
+		fakePublicState = map[string][]byte{}
 		fakeQueryExecutor = &mock.SimpleQueryExecutor{}
 		fakeQueryExecutor.GetStateStub = func(namespace, key string) ([]byte, error) {
 			return fakePublicState.GetState(key)
@@ -242,7 +242,7 @@ var _ = Describe("ValidatorCommitter", func() {
 	Describe("AllChaincodesInfo", func() {
 		var fakeStateIteratorKVs MapLedgerShim
 		BeforeEach(func() {
-			fakeStateIteratorKVs = MapLedgerShim(map[string][]byte{})
+			fakeStateIteratorKVs = map[string][]byte{}
 			err := resources.Serializer.Serialize("namespaces", "cc-name", &lifecycle.ChaincodeDefinition{}, fakeStateIteratorKVs)
 			Expect(err).NotTo(HaveOccurred())
 			fakeQueryExecutor.GetStateRangeScanIteratorStub = func(namespace, begin, end string) (commonledger.ResultsIterator, error) {

--- a/core/chaincode/lifecycle/endorsement_info_test.go
+++ b/core/chaincode/lifecycle/endorsement_info_test.go
@@ -50,7 +50,7 @@ var _ = Describe("ChaincodeEndorsementInfoSource", func() {
 			ChannelConfigSource: fakeChannelConfigSource,
 		}
 
-		fakePublicState = MapLedgerShim(map[string][]byte{})
+		fakePublicState = map[string][]byte{}
 		fakeQueryExecutor = &mock.SimpleQueryExecutor{}
 		fakeQueryExecutor.GetStateStub = func(namespace, key string) ([]byte, error) {
 			return fakePublicState.GetState(key)

--- a/core/chaincode/lifecycle/lifecycle_test.go
+++ b/core/chaincode/lifecycle/lifecycle_test.go
@@ -639,12 +639,12 @@ var _ = Describe("ExternalFunctions", func() {
 			}
 
 			fakePublicState = &mock.ReadWritableState{}
-			fakePublicKVStore = MapLedgerShim(map[string][]byte{})
+			fakePublicKVStore = map[string][]byte{}
 			fakePublicState = &mock.ReadWritableState{}
 			fakePublicState.PutStateStub = fakePublicKVStore.PutState
 			fakePublicState.GetStateStub = fakePublicKVStore.GetState
 
-			fakeOrgKVStore = MapLedgerShim(map[string][]byte{})
+			fakeOrgKVStore = map[string][]byte{}
 			fakeOrgState = &mock.ReadWritableState{}
 			fakeOrgState.PutStateStub = fakeOrgKVStore.PutState
 			fakeOrgState.GetStateStub = fakeOrgKVStore.GetState
@@ -983,7 +983,7 @@ var _ = Describe("ExternalFunctions", func() {
 				},
 			}
 
-			publicKVS = MapLedgerShim(map[string][]byte{})
+			publicKVS = map[string][]byte{}
 			fakePublicState = &mock.ReadWritableState{}
 			fakePublicState.GetStateStub = publicKVS.GetState
 			fakePublicState.PutStateStub = publicKVS.PutState
@@ -1000,8 +1000,8 @@ var _ = Describe("ExternalFunctions", func() {
 				},
 			}, publicKVS)
 
-			org0KVS = MapLedgerShim(map[string][]byte{})
-			org1KVS = MapLedgerShim(map[string][]byte{})
+			org0KVS = map[string][]byte{}
+			org1KVS = map[string][]byte{}
 			fakeOrg0State := &mock.ReadWritableState{}
 			fakeOrg0State.CollectionNameReturns("_implicit_org_org0")
 			fakeOrg1State := &mock.ReadWritableState{}
@@ -1156,15 +1156,15 @@ var _ = Describe("ExternalFunctions", func() {
 				PackageID: "hash",
 			}
 
-			publicKVS = MapLedgerShim(map[string][]byte{})
+			publicKVS = map[string][]byte{}
 			fakePublicState = &mock.ReadWritableState{}
 			fakePublicState.GetStateStub = publicKVS.GetState
 			fakePublicState.PutStateStub = publicKVS.PutState
 
 			resources.Serializer.Serialize("namespaces", "cc-name", testDefinition, publicKVS)
 
-			org0KVS = MapLedgerShim(map[string][]byte{})
-			org1KVS = MapLedgerShim(map[string][]byte{})
+			org0KVS = map[string][]byte{}
+			org1KVS = map[string][]byte{}
 			fakeOrg0State := &mock.ReadWritableState{}
 			fakeOrg0State.CollectionNameReturns("_implicit_org_org0")
 			fakeOrg1State := &mock.ReadWritableState{}
@@ -1442,7 +1442,7 @@ var _ = Describe("ExternalFunctions", func() {
 				},
 			}
 
-			publicKVS = MapLedgerShim(map[string][]byte{})
+			publicKVS = map[string][]byte{}
 			fakePublicState = &mock.ReadWritableState{}
 			fakePublicState.GetStateStub = publicKVS.GetState
 			fakePublicState.PutStateStub = publicKVS.PutState
@@ -1459,8 +1459,8 @@ var _ = Describe("ExternalFunctions", func() {
 				},
 			}, publicKVS)
 
-			org0KVS = MapLedgerShim(map[string][]byte{})
-			org1KVS = MapLedgerShim(map[string][]byte{})
+			org0KVS = map[string][]byte{}
+			org1KVS = map[string][]byte{}
 			fakeOrg0State := &mock.ReadWritableState{}
 			fakeOrg0State.CollectionNameReturns("_implicit_org_org0")
 			fakeOrg1State := &mock.ReadWritableState{}
@@ -1630,7 +1630,7 @@ var _ = Describe("ExternalFunctions", func() {
 		)
 
 		BeforeEach(func() {
-			publicKVS = MapLedgerShim(map[string][]byte{})
+			publicKVS = map[string][]byte{}
 			fakePublicState = &mock.ReadWritableState{}
 			fakePublicState.GetStateStub = publicKVS.GetState
 			fakePublicState.PutStateStub = publicKVS.PutState
@@ -1650,8 +1650,8 @@ var _ = Describe("ExternalFunctions", func() {
 
 			resources.Serializer.Serialize("namespaces", "cc-name", testDefinition, publicKVS)
 
-			org0KVS = MapLedgerShim(map[string][]byte{})
-			org1KVS = MapLedgerShim(map[string][]byte{})
+			org0KVS = map[string][]byte{}
+			org1KVS = map[string][]byte{}
 			fakeOrg0State := &mock.ReadWritableState{}
 			fakeOrg1State := &mock.ReadWritableState{}
 			fakeOrgStates = []*mock.ReadWritableState{
@@ -1702,7 +1702,7 @@ var _ = Describe("ExternalFunctions", func() {
 			})
 
 			It("returns an error", func() {
-				cc, err := ef.QueryChaincodeDefinition("cc-name", fakePublicState) //, nil)
+				cc, err := ef.QueryChaincodeDefinition("cc-name", fakePublicState) // , nil)
 				Expect(err).To(MatchError("could not fetch metadata for namespace cc-name: could not query metadata for namespace namespaces/cc-name: metadata-error"))
 				Expect(cc).To(BeNil())
 			})
@@ -1745,8 +1745,8 @@ var _ = Describe("ExternalFunctions", func() {
 				Collections: &pb.CollectionConfigPackage{},
 			}
 
-			org0KVS = MapLedgerShim(map[string][]byte{})
-			org1KVS = MapLedgerShim(map[string][]byte{})
+			org0KVS = map[string][]byte{}
+			org1KVS = map[string][]byte{}
 			fakeOrg0State := &mock.ReadWritableState{}
 			fakeOrg0State.CollectionNameReturns("_implicit_org_org0")
 			fakeOrg1State := &mock.ReadWritableState{}
@@ -1796,7 +1796,7 @@ var _ = Describe("ExternalFunctions", func() {
 		)
 
 		BeforeEach(func() {
-			publicKVS = MapLedgerShim(map[string][]byte{})
+			publicKVS = map[string][]byte{}
 			fakePublicState = &mock.ReadWritableState{}
 			fakePublicState.GetStateStub = publicKVS.GetState
 			fakePublicState.GetStateRangeStub = publicKVS.GetStateRange

--- a/core/chaincode/persistence/chaincode_package.go
+++ b/core/chaincode/persistence/chaincode_package.go
@@ -75,7 +75,7 @@ func (fpl *FallbackPackageLocator) GetChaincodePackage(packageID string) (*Chain
 		return metadata, mdBytes, tarStream, nil
 	}
 
-	cds, err := fpl.LegacyCCPackageLocator.GetChaincodeDepSpec(string(packageID))
+	cds, err := fpl.LegacyCCPackageLocator.GetChaincodeDepSpec(packageID)
 	if err != nil {
 		return nil, nil, nil, errors.WithMessagef(err, "could not get legacy chaincode package '%s'", packageID)
 	}

--- a/core/chaincode/query_response_generator.go
+++ b/core/chaincode/query_response_generator.go
@@ -84,6 +84,6 @@ func createQueryResponse(txContext *TransactionContext, iterID string, isPaginat
 func createResponseMetadata(returnCount int32, bookmark string) *pb.QueryResponseMetadata {
 	responseMetadata := &pb.QueryResponseMetadata{}
 	responseMetadata.Bookmark = bookmark
-	responseMetadata.FetchedRecordsCount = int32(returnCount)
+	responseMetadata.FetchedRecordsCount = returnCount
 	return responseMetadata
 }

--- a/core/chaincode/runtime_launcher.go
+++ b/core/chaincode/runtime_launcher.go
@@ -49,7 +49,7 @@ type CertGenerator interface {
 func (r *RuntimeLauncher) ChaincodeClientInfo(ccid string) (*ccintf.PeerConnection, error) {
 	var tlsConfig *ccintf.TLSConfig
 	if r.CertGenerator != nil {
-		certKeyPair, err := r.CertGenerator.Generate(string(ccid))
+		certKeyPair, err := r.CertGenerator.Generate(ccid)
 		if err != nil {
 			return nil, errors.WithMessagef(err, "failed to generate TLS certificates for %s", ccid)
 		}

--- a/core/committer/txvalidator/v14/plugin_validator.go
+++ b/core/committer/txvalidator/v14/plugin_validator.go
@@ -134,14 +134,14 @@ func (pv *PluginValidator) getOrCreatePlugin(ctx *Context) (validation.Plugin, e
 func (pv *PluginValidator) getOrCreatePluginChannelMapping(plugin vp.Name, pf validation.PluginFactory) *pluginsByChannel {
 	pv.Lock()
 	defer pv.Unlock()
-	endorserChannelMapping, exists := pv.pluginChannelMapping[vp.Name(plugin)]
+	endorserChannelMapping, exists := pv.pluginChannelMapping[plugin]
 	if !exists {
 		endorserChannelMapping = &pluginsByChannel{
 			pluginFactory:    pf,
 			channels2Plugins: make(map[string]validation.Plugin),
 			pv:               pv,
 		}
-		pv.pluginChannelMapping[vp.Name(plugin)] = endorserChannelMapping
+		pv.pluginChannelMapping[plugin] = endorserChannelMapping
 	}
 	return endorserChannelMapping
 }

--- a/core/committer/txvalidator/v14/txvalidator_test.go
+++ b/core/committer/txvalidator/v14/txvalidator_test.go
@@ -162,7 +162,7 @@ func TestBlockValidationDuplicateTXId(t *testing.T) {
 	acv.On("ForbidDuplicateTXIdInBlock").Return(true)
 	tValidator.Validate(block)
 
-	txsfltr = txflags.ValidationFlags(block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])
+	txsfltr = block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER]
 
 	require.True(t, txsfltr.IsSetTo(0, peer.TxValidationCode_VALID))
 	require.True(t, txsfltr.IsSetTo(1, peer.TxValidationCode_DUPLICATE_TXID))

--- a/core/committer/txvalidator/v20/plugindispatcher/plugin_validator.go
+++ b/core/committer/txvalidator/v20/plugindispatcher/plugin_validator.go
@@ -153,14 +153,14 @@ func (pv *PluginValidator) getOrCreatePlugin(ctx *Context) (validation.Plugin, e
 func (pv *PluginValidator) getOrCreatePluginChannelMapping(plugin txvalidatorplugin.Name, pf validation.PluginFactory) *pluginsByChannel {
 	pv.Lock()
 	defer pv.Unlock()
-	endorserChannelMapping, exists := pv.pluginChannelMapping[txvalidatorplugin.Name(plugin)]
+	endorserChannelMapping, exists := pv.pluginChannelMapping[plugin]
 	if !exists {
 		endorserChannelMapping = &pluginsByChannel{
 			pluginFactory:    pf,
 			channels2Plugins: make(map[string]validation.Plugin),
 			pv:               pv,
 		}
-		pv.pluginChannelMapping[txvalidatorplugin.Name(plugin)] = endorserChannelMapping
+		pv.pluginChannelMapping[plugin] = endorserChannelMapping
 	}
 	return endorserChannelMapping
 }

--- a/core/endorser/plugin_endorser.go
+++ b/core/endorser/plugin_endorser.go
@@ -172,21 +172,21 @@ func (pe *PluginEndorser) getOrCreatePlugin(plugin PluginName, channel string) (
 		return nil, errors.Errorf("plugin with name %s wasn't found", plugin)
 	}
 
-	pluginsByChannel := pe.getOrCreatePluginChannelMapping(PluginName(plugin), pluginFactory)
+	pluginsByChannel := pe.getOrCreatePluginChannelMapping(plugin, pluginFactory)
 	return pluginsByChannel.createPluginIfAbsent(channel)
 }
 
 func (pe *PluginEndorser) getOrCreatePluginChannelMapping(plugin PluginName, pf endorsement.PluginFactory) *pluginsByChannel {
 	pe.Lock()
 	defer pe.Unlock()
-	endorserChannelMapping, exists := pe.pluginChannelMapping[PluginName(plugin)]
+	endorserChannelMapping, exists := pe.pluginChannelMapping[plugin]
 	if !exists {
 		endorserChannelMapping = &pluginsByChannel{
 			pluginFactory:    pf,
 			channels2Plugins: make(map[string]endorsement.Plugin),
 			pe:               pe,
 		}
-		pe.pluginChannelMapping[PluginName(plugin)] = endorserChannelMapping
+		pe.pluginChannelMapping[plugin] = endorserChannelMapping
 	}
 	return endorserChannelMapping
 }

--- a/core/handlers/validation/builtin/v12/validation_logic_test.go
+++ b/core/handlers/validation/builtin/v12/validation_logic_test.go
@@ -1572,7 +1572,7 @@ var (
 	id      msp.SigningIdentity
 	sid     []byte
 	mspid   string
-	chainId string = "testchannelid"
+	chainId = "testchannelid"
 )
 
 func createCollectionConfig(collectionName string, signaturePolicyEnvelope *common.SignaturePolicyEnvelope,

--- a/core/handlers/validation/builtin/v13/validation_logic_test.go
+++ b/core/handlers/validation/builtin/v13/validation_logic_test.go
@@ -1637,7 +1637,7 @@ var (
 	id        msp.SigningIdentity
 	sid       []byte
 	mspid     string
-	channelID string = "testchannelid"
+	channelID = "testchannelid"
 )
 
 func createCollectionConfig(collectionName string, signaturePolicyEnvelope *common.SignaturePolicyEnvelope,

--- a/core/handlers/validation/builtin/v20/validation_logic_test.go
+++ b/core/handlers/validation/builtin/v20/validation_logic_test.go
@@ -246,7 +246,7 @@ var (
 	id        msp.SigningIdentity
 	sid       []byte
 	mspid     string
-	channelID string = "testchannelid"
+	channelID = "testchannelid"
 )
 
 func TestMain(m *testing.M) {

--- a/core/ledger/kvledger/benchmark/experiments/readwrite_txs_test.go
+++ b/core/ledger/kvledger/benchmark/experiments/readwrite_txs_test.go
@@ -94,9 +94,9 @@ func runReadWriteClient(chain *chainmgmt.Chain, rand *rand.Rand, numTx int, wg *
 			keyNumber := keysToOperateOn[i]
 			key := constructKey(keyNumber)
 			if useJSON {
-				value = []byte(constructJSONValue(keyNumber, kvSize))
+				value = constructJSONValue(keyNumber, kvSize)
 			} else {
-				value = []byte(constructValue(keyNumber, kvSize))
+				value = constructValue(keyNumber, kvSize)
 			}
 			panicOnError(simulator.SetState(chaincodeName, key, value))
 		}

--- a/core/ledger/kvledger/history/db.go
+++ b/core/ledger/kvledger/history/db.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
 	"github.com/hyperledger/fabric/internal/pkg/txflags"
-	protoutil "github.com/hyperledger/fabric/protoutil"
+	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 )
 

--- a/core/ledger/kvledger/history/kv_encoding.go
+++ b/core/ledger/kvledger/history/kv_encoding.go
@@ -38,7 +38,7 @@ func constructDataKey(ns string, key string, blocknum uint64, trannum uint64) da
 	k = append(k, compositeKeySep...)
 	k = append(k, util.EncodeOrderPreservingVarUint64(blocknum)...)
 	k = append(k, util.EncodeOrderPreservingVarUint64(trannum)...)
-	return dataKey(k)
+	return k
 }
 
 // constructRangescanKeys returns start and endKey for performing a range scan

--- a/core/ledger/kvledger/history/query_executer.go
+++ b/core/ledger/kvledger/history/query_executer.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hyperledger/fabric/common/ledger/blkstorage"
 	"github.com/hyperledger/fabric/common/ledger/util/leveldbhelper"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
-	protoutil "github.com/hyperledger/fabric/protoutil"
+	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
 )

--- a/core/ledger/kvledger/kv_ledger_test.go
+++ b/core/ledger/kvledger/kv_ledger_test.go
@@ -336,10 +336,10 @@ func TestKVLedgerDBRecovery(t *testing.T) {
 		},
 	)
 
-	//======================================================================================
+	// ======================================================================================
 	// SCENARIO 1: peer writes the second block to the block storage and fails
 	// before committing the block to state DB and history DB
-	//======================================================================================
+	// ======================================================================================
 	blockAndPvtdata2 := prepareNextBlockForTest(t, ledger1, bg, "SimulateForBlk2",
 		map[string]string{"key1": "value1.2", "key2": "value2.2", "key3": "value3.2"},
 		map[string]string{"key1": "pvtValue1.2", "key2": "pvtValue2.2", "key3": "pvtValue3.2"})
@@ -393,10 +393,10 @@ func TestKVLedgerDBRecovery(t *testing.T) {
 		},
 	)
 
-	//======================================================================================
+	// ======================================================================================
 	// SCENARIO 2: peer fails after committing the third block to the block storage and state DB
 	// but before committing to history DB
-	//======================================================================================
+	// ======================================================================================
 	blockAndPvtdata3 := prepareNextBlockForTest(t, ledger2, bg, "SimulateForBlk3",
 		map[string]string{"key1": "value1.3", "key2": "value2.3", "key3": "value3.3"},
 		map[string]string{"key1": "pvtValue1.3", "key2": "pvtValue2.3", "key3": "pvtValue3.3"},
@@ -453,10 +453,10 @@ func TestKVLedgerDBRecovery(t *testing.T) {
 	)
 
 	// Rare scenario
-	//======================================================================================
+	// ======================================================================================
 	// SCENARIO 3: peer fails after committing the fourth block to the block storgae
 	// and history DB but before committing to state DB
-	//======================================================================================
+	// ======================================================================================
 	blockAndPvtdata4 := prepareNextBlockForTest(t, ledger3, bg, "SimulateForBlk4",
 		map[string]string{"key1": "value1.4", "key2": "value2.4", "key3": "value3.4"},
 		map[string]string{"key1": "pvtValue1.4", "key2": "pvtValue2.4", "key3": "pvtValue3.4"},
@@ -1378,7 +1378,7 @@ func sampleDataWithPvtdataForSelectiveTx(t *testing.T, bg *testutil.BlockGenerat
 	missingData.Add(4, "ns-4", "coll-4", true)
 	missingData.Add(5, "ns-5", "coll-5", true)
 	blockAndpvtdata[5].MissingPvtData = missingData
-	txFilter = txflags.ValidationFlags(blockAndpvtdata[5].Block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])
+	txFilter = blockAndpvtdata[5].Block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER]
 	txFilter.SetFlag(5, peer.TxValidationCode_INVALID_WRITESET)
 	blockAndpvtdata[5].Block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER] = txFilter
 

--- a/core/ledger/kvledger/snapshot_mgmt_test.go
+++ b/core/ledger/kvledger/snapshot_mgmt_test.go
@@ -380,7 +380,7 @@ func testutilCommitBlocks(t *testing.T, l ledger.PeerLedger, bg *testutil.BlockG
 		require.NoError(t, err)
 		blockHash := protoutil.BlockHeaderHash(block.Header)
 		require.Equal(t, &common.BlockchainInfo{
-			Height: uint64(i + 1), CurrentBlockHash: blockHash, PreviousBlockHash: previousBlockHash,
+			Height: i + 1, CurrentBlockHash: blockHash, PreviousBlockHash: previousBlockHash,
 		}, bcInfo)
 		previousBlockHash = blockHash
 	}

--- a/core/ledger/kvledger/tests/missing_pvtdata_retrieval_test.go
+++ b/core/ledger/kvledger/tests/missing_pvtdata_retrieval_test.go
@@ -142,7 +142,7 @@ func TestGetMissingPvtData(t *testing.T) {
 		_, err := l.commitPvtDataOfOldBlocks(nil, expectedMissingPvtDataInfo)
 		require.NoError(t, err)
 		for i := 0; i < 5; i++ {
-			l.verifyMissingPvtDataSameAs(int(2), ledger.MissingPvtDataInfo{})
+			l.verifyMissingPvtDataSameAs(2, ledger.MissingPvtDataInfo{})
 		}
 
 		env.closeLedgerMgmt()

--- a/core/ledger/kvledger/tests/sample_data_helper.go
+++ b/core/ledger/kvledger/tests/sample_data_helper.go
@@ -175,7 +175,7 @@ func (d *sampleDataHelper) verifyBlockAndPvtdataUsingSubmittedData(l *testLedger
 	for _, submittedBlk := range submittedData.Blocks {
 		blkNum := submittedBlk.Block.Header.Number
 		if blkNum != 8 {
-			l.verifyBlockAndPvtDataSameAs(uint64(blkNum), submittedBlk)
+			l.verifyBlockAndPvtDataSameAs(blkNum, submittedBlk)
 		} else {
 			l.verifyBlockAndPvtData(uint64(8), nil, func(r *retrievedBlockAndPvtdata) {
 				r.sameBlockHeaderAndData(submittedBlk.Block)

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package pvtstatepurgemgmt
 
 import (
-	proto "github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/common/ledger/util"
 	"github.com/hyperledger/fabric/common/ledger/util/leveldbhelper"

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper_test.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_keeper_test.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package pvtstatepurgemgmt
 
 import (
-	fmt "fmt"
+	"fmt"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"

--- a/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_schedule_builder.go
+++ b/core/ledger/kvledger/txmgmt/pvtstatepurgemgmt/expiry_schedule_builder.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package pvtstatepurgemgmt
 
 import (
-	math "math"
+	"math"
 
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdb.go
@@ -1179,7 +1179,7 @@ func (dbclient *couchDatabase) createIndex(indexdefinition string) (*createIndex
 
 	couchDBReturn := &createIndexResponse{}
 
-	jsonBytes := []byte(respBody)
+	jsonBytes := respBody
 
 	// unmarshal the response
 	err = json.Unmarshal(jsonBytes, &couchDBReturn)
@@ -1651,7 +1651,7 @@ func (couchInstance *couchInstance) handleRequest(ctx context.Context, method, d
 				}
 				defer closeResponseBody(resp)
 
-				errorBytes := []byte(jsonError)
+				errorBytes := jsonError
 				// Unmarshal the response
 				err = json.Unmarshal(errorBytes, &couchDBReturn)
 				if err != nil {
@@ -1684,7 +1684,7 @@ func (couchInstance *couchInstance) handleRequest(ctx context.Context, method, d
 					return nil, nil, errors.Wrap(err, "error reading response body")
 				}
 
-				errorBytes := []byte(jsonError)
+				errorBytes := jsonError
 				// Unmarshal the response
 				err = json.Unmarshal(errorBytes, &couchDBReturn)
 				if err != nil {

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdbutil_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdbutil_test.go
@@ -8,7 +8,7 @@ package statecouchdb
 
 import (
 	"encoding/hex"
-	fmt "fmt"
+	"fmt"
 	"testing"
 
 	"github.com/hyperledger/fabric/common/metrics/disabled"

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdoc_conv.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdoc_conv.go
@@ -37,7 +37,7 @@ type jsonValue map[string]interface{}
 func tryCastingToJSON(b []byte) (isJSON bool, val jsonValue) {
 	var jsonVal map[string]interface{}
 	err := json.Unmarshal(b, &jsonVal)
-	return err == nil, jsonValue(jsonVal)
+	return err == nil, jsonVal
 }
 
 func castToJSON(b []byte) (jsonValue, error) {

--- a/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdoc_conv_test.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statecouchdb/couchdoc_conv_test.go
@@ -81,7 +81,7 @@ func testSortJSON(t *testing.T, filePrefix int) {
 	require.NoError(t, err)
 
 	var prettyPrintJSON bytes.Buffer
-	err = json.Indent(&prettyPrintJSON, []byte(actualKV.Value), "", "  ")
+	err = json.Indent(&prettyPrintJSON, actualKV.Value, "", "  ")
 	require.NoError(t, err)
 	expected, err := ioutil.ReadFile(
 		fmt.Sprintf("testdata/json_documents/%d_sorted.json",

--- a/core/ledger/kvledger/txmgmt/statedb/stateleveldb/value_encoding.go
+++ b/core/ledger/kvledger/txmgmt/statedb/stateleveldb/value_encoding.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package stateleveldb
 
 import (
-	proto "github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 )

--- a/core/ledger/kvledger/txmgmt/txmgr/update_batch_bytes_test.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/update_batch_bytes_test.go
@@ -9,7 +9,7 @@ package txmgr
 import (
 	"testing"
 
-	proto "github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	"github.com/stretchr/testify/require"

--- a/core/ledger/pvtdatapolicy/btlpolicy.go
+++ b/core/ledger/pvtdatapolicy/btlpolicy.go
@@ -64,7 +64,7 @@ func (p *LSCCBasedBTLPolicy) GetBTL(namespace string, collection string) (uint64
 		}
 		btlConfigured := collConfig.BlockToLive
 		if btlConfigured > 0 {
-			btl = uint64(btlConfigured)
+			btl = btlConfigured
 		} else {
 			btl = defaultBTL
 		}

--- a/core/ledger/pvtdatastorage/kv_encoding.go
+++ b/core/ledger/pvtdatastorage/kv_encoding.go
@@ -151,7 +151,7 @@ func encodeInelgMissingDataKey(key *missingDataKey) []byte {
 	encKey = append(encKey, nilByte)
 	encKey = append(encKey, []byte(key.coll)...)
 	encKey = append(encKey, nilByte)
-	return append(encKey, []byte(encodeReverseOrderVarUint64(key.blkNum))...)
+	return append(encKey, encodeReverseOrderVarUint64(key.blkNum)...)
 }
 
 func decodeInelgMissingDataKey(keyBytes []byte) *missingDataKey {
@@ -425,5 +425,5 @@ func decodeReverseOrderVarUint64(bytes []byte) (uint64, int) {
 	for i := 0; i < numFFBytes; i++ {
 		decodedBytes[i] = 0xff
 	}
-	return (math.MaxUint64 - binary.BigEndian.Uint64(decodedBytes)), numBytesConsumed
+	return math.MaxUint64 - binary.BigEndian.Uint64(decodedBytes), numBytesConsumed
 }

--- a/core/middleware/request_id_test.go
+++ b/core/middleware/request_id_test.go
@@ -29,7 +29,7 @@ var _ = Describe("WithRequestID", func() {
 	BeforeEach(func() {
 		handler = &fakes.HTTPHandler{}
 		requestID = middleware.WithRequestID(
-			middleware.GenerateIDFunc(func() string { return "generated-id" }),
+			func() string { return "generated-id" },
 		)
 		chain = requestID(handler)
 

--- a/core/scc/cscc/configure_test.go
+++ b/core/scc/cscc/configure_test.go
@@ -532,7 +532,7 @@ func TestPeerConfiger_SubmittingOrdererGenesis(t *testing.T) {
 	}
 	mockStub := &mocks.ChaincodeStub{}
 	// Failed path: wrong parameter type
-	args := [][]byte{[]byte("JoinChain"), []byte(blockBytes)}
+	args := [][]byte{[]byte("JoinChain"), blockBytes}
 	mockStub.GetArgsReturns(args)
 	mockStub.GetSignedProposalReturns(validSignedProposal(), nil)
 	res := cscc.Invoke(mockStub)

--- a/core/scc/lscc/lscc.go
+++ b/core/scc/lscc/lscc.go
@@ -137,7 +137,7 @@ type MSPIDsGetter func(string) []string
 // IDMSPManagerGetters used to get the MSP Manager for a channel.
 type MSPManagerGetter func(string) msp.MSPManager
 
-//---------- the LSCC -----------------
+// ---------- the LSCC -----------------
 
 // SCC implements chaincode lifecycle and policies around it
 type SCC struct {
@@ -198,7 +198,7 @@ func (p *PeerShim) GetApplicationConfig(cid string) (channelconfig.Application, 
 // and whether the policy manager exists
 func (p *PeerShim) PolicyManager(channelID string) (policies.Manager, bool) {
 	m := p.Peer.GetPolicyManager(channelID)
-	return m, (m != nil)
+	return m, m != nil
 }
 
 func (lscc *SCC) Name() string              { return "lscc" }
@@ -932,7 +932,7 @@ func (lscc *SCC) executeUpgrade(stub shim.ChaincodeStubInterface, chainName stri
 	return cdfs, nil
 }
 
-//-------------- the chaincode stub interface implementation ----------
+// -------------- the chaincode stub interface implementation ----------
 
 // Init is mostly useless for SCC
 func (lscc *SCC) Init(stub shim.ChaincodeStubInterface) pb.Response {

--- a/core/scc/lscc/lscc_test.go
+++ b/core/scc/lscc/lscc_test.go
@@ -241,7 +241,7 @@ func testInstall(t *testing.T, ccname string, version string, path string, creat
 			require.Equal(t, int32(shim.OK), res.Status, res.Message)
 		} else {
 			res := stub.MockInvokeWithSignedProposal("1", args, sProp)
-			require.True(t, strings.HasPrefix(string(res.Message), expectedErrorMsg), res.Message)
+			require.True(t, strings.HasPrefix(res.Message, expectedErrorMsg), res.Message)
 		}
 	})
 }
@@ -587,7 +587,7 @@ func testDeploy(t *testing.T, ccname string, version string, path string, forceB
 			})
 		}
 	} else {
-		require.Equal(t, expectedErrorMsg, string(res.Message))
+		require.Equal(t, expectedErrorMsg, res.Message)
 	}
 }
 
@@ -852,7 +852,7 @@ func testUpgrade(t *testing.T, ccname string, version string, newccname string, 
 			require.NoError(t, err)
 			require.Equal(t, newccname, lifecycleEvent.ChaincodeName)
 		} else {
-			require.Equal(t, expectedErrorMsg, string(res.Message))
+			require.Equal(t, expectedErrorMsg, res.Message)
 		}
 	})
 }
@@ -1133,7 +1133,7 @@ func TestPutChaincodeCollectionData(t *testing.T) {
 	stub := shimtest.NewMockStub("lscc", scc)
 
 	if res := stub.MockInit("1", nil); res.Status != shim.OK {
-		fmt.Println("Init failed", string(res.Message))
+		fmt.Println("Init failed", res.Message)
 		t.FailNow()
 	}
 

--- a/core/scc/qscc/query_test.go
+++ b/core/scc/qscc/query_test.go
@@ -60,7 +60,7 @@ func setupTestLedger(t *testing.T, chainid string, path string) (*shimtest.MockS
 	}
 	stub := shimtest.NewMockStub("LedgerQuerier", lq)
 	if res := stub.MockInit("1", nil); res.Status != shim.OK {
-		return nil, peerInstance, cleanup, fmt.Errorf("Init failed for test ledger [%s] with message: %s", chainid, string(res.Message))
+		return nil, peerInstance, cleanup, fmt.Errorf("Init failed for test ledger [%s] with message: %s", chainid, res.Message)
 	}
 	return stub, peerInstance, cleanup, nil
 }

--- a/discovery/client/client.go
+++ b/discovery/client/client.go
@@ -129,7 +129,7 @@ func (req *Request) AddPeersQuery(invocationChain ...*peer.ChaincodeCall) *Reque
 	})
 	var ic InvocationChain
 	if len(invocationChain) > 0 {
-		ic = InvocationChain(invocationChain)
+		ic = invocationChain
 	}
 	req.addChaincodeQueryMapping([]InvocationChain{ic})
 	req.addQueryMapping(protoext.PeerMembershipQueryType, channnelAndInvocationChain(ch, ic))
@@ -303,7 +303,7 @@ var NoFilter = NewFilter(NoPriorities, NoExclusion)
 func selectPeersForLayout(endorsersByGroups map[string][]*Peer, layout map[string]int, f Filter) (Endorsers, bool) {
 	var endorsers []*Peer
 	for grp, count := range layout {
-		endorsersOfGrp := f.Filter(Endorsers(endorsersByGroups[grp]))
+		endorsersOfGrp := f.Filter(endorsersByGroups[grp])
 
 		// We couldn't select enough peers for this layout because the current group
 		// requires more peers than we have available to be selected

--- a/discovery/client/client_test.go
+++ b/discovery/client/client_test.go
@@ -862,8 +862,8 @@ func peerIdentity(mspID string, i int) api.PeerIdentityInfo {
 	}
 	b, _ := proto.Marshal(sID)
 	return api.PeerIdentityInfo{
-		Identity:     api.PeerIdentityType(b),
-		PKIId:        gossipcommon.PKIidType(p),
+		Identity:     b,
+		PKIId:        p,
 		Organization: api.OrgIdentityType(mspID),
 	}
 }

--- a/discovery/endorsement/collection_test.go
+++ b/discovery/endorsement/collection_test.go
@@ -39,8 +39,8 @@ func TestPrincipalsFromCollectionConfig(t *testing.T) {
 		config := buildCollectionConfig(col2principals)
 		res, err := principalsFromCollectionConfig(config)
 		require.NoError(t, err)
-		assertEqualPrincipalSets(t, policies.PrincipalSet(org1AndOrg2), res["foo"])
-		assertEqualPrincipalSets(t, policies.PrincipalSet(org3AndOrg4), res["bar"])
+		assertEqualPrincipalSets(t, org1AndOrg2, res["foo"])
+		assertEqualPrincipalSets(t, org3AndOrg4, res["bar"])
 		require.Empty(t, res["baz"])
 	})
 }

--- a/discovery/endorsement/endorsement_test.go
+++ b/discovery/endorsement/endorsement_test.go
@@ -1181,7 +1181,7 @@ func identitySet(pkiID2MSPID map[string]string) api.PeerIdentitySet {
 			IdBytes: []byte(pkiID),
 		}
 		res = append(res, api.PeerIdentityInfo{
-			Identity:     api.PeerIdentityType(protoutil.MarshalOrPanic(sID)),
+			Identity:     protoutil.MarshalOrPanic(sID),
 			PKIId:        common.PKIidType(pkiID),
 			Organization: api.OrgIdentityType(mspID),
 		})
@@ -1210,13 +1210,13 @@ func newPeer(i int) *peerInfo {
 	})
 	return &peerInfo{
 		pkiID:    common.PKIidType(p),
-		identity: api.PeerIdentityType(identity),
+		identity: identity,
 		NetworkMember: discovery.NetworkMember{
 			PKIid:            common.PKIidType(p),
 			Endpoint:         p,
 			InternalEndpoint: p,
 			Envelope: &gossip.Envelope{
-				Payload: []byte(identity),
+				Payload: identity,
 			},
 		},
 	}

--- a/discovery/service.go
+++ b/discovery/service.go
@@ -185,7 +185,7 @@ func (s *Service) channelMembershipResponse(q *discovery.Query) *discovery.Query
 		membersByOrgs[org] = &discovery.Peers{}
 		for id, peer := range ids2Peers {
 			// Check if the peer is in the channel view
-			stateInfoMsg, exists := chanPeerByID[string(id)]
+			stateInfoMsg, exists := chanPeerByID[id]
 			// If the peer isn't in the channel view, skip it and don't include it in the response
 			if !exists {
 				continue

--- a/discovery/service_test.go
+++ b/discovery/service_test.go
@@ -304,11 +304,11 @@ func TestService(t *testing.T) {
 	require.Equal(t, "an error occurred", resp.Results[2].GetError().Content)
 
 	for org, responsePeers := range resp.Results[0].GetMembers().PeersByOrg {
-		err := peers(expectedChannelResponse.PeersByOrg[org].Peers).compare(peers(responsePeers.Peers))
+		err := peers(expectedChannelResponse.PeersByOrg[org].Peers).compare(responsePeers.Peers)
 		require.NoError(t, err)
 	}
 	for org, responsePeers := range resp.Results[1].GetMembers().PeersByOrg {
-		err := peers(expectedLocalResponse.PeersByOrg[org].Peers).compare(peers(responsePeers.Peers))
+		err := peers(expectedLocalResponse.PeersByOrg[org].Peers).compare(responsePeers.Peers)
 		require.NoError(t, err)
 	}
 

--- a/gossip/comm/comm_test.go
+++ b/gossip/comm/comm_test.go
@@ -338,7 +338,7 @@ func TestHandshake(t *testing.T) {
 	_, tempEndpoint, tempL := getAvailablePort(t)
 	acceptChan := handshaker(port, tempEndpoint, inst, t, mutator, none)
 	select {
-	case <-time.After(time.Duration(time.Second * 4)):
+	case <-time.After(time.Second * 4):
 		require.FailNow(t, "Didn't receive a message, seems like handshake failed")
 	case msg = <-acceptChan:
 	}
@@ -719,7 +719,7 @@ func TestResponses(t *testing.T) {
 			m.Respond(reply.GossipMessage)
 		}
 	}()
-	expectedNOnce := uint64(msg.Nonce + 1)
+	expectedNOnce := msg.Nonce + 1
 	responsesFromComm1 := comm2.Accept(acceptAll)
 
 	ticker := time.NewTicker(10 * time.Second)

--- a/gossip/discovery/discovery_test.go
+++ b/gossip/discovery/discovery_test.go
@@ -41,7 +41,7 @@ import (
 var timeout = time.Second * time.Duration(15)
 
 var (
-	aliveTimeInterval = time.Duration(time.Millisecond * 300)
+	aliveTimeInterval = time.Millisecond * 300
 	defaultTestConfig = DiscoveryConfig{
 		AliveTimeInterval:            aliveTimeInterval,
 		AliveExpirationTimeout:       10 * aliveTimeInterval,
@@ -1397,7 +1397,7 @@ func TestMsgStoreExpirationWithMembershipMessages(t *testing.T) {
 		_, exist := instances[index].discoveryImpl().aliveLastTS[string(instances[i].discoveryImpl().self.PKIid)]
 		require.True(t, exist, fmt.Sprint(step, " Data from alive msg ", i, " doesn't exist in aliveLastTS of discovery inst ", index))
 
-		_, exist = instances[index].discoveryImpl().id2Member[string(string(instances[i].discoveryImpl().self.PKIid))]
+		_, exist = instances[index].discoveryImpl().id2Member[string(instances[i].discoveryImpl().self.PKIid)]
 		require.True(t, exist, fmt.Sprint(step, " id2Member mapping doesn't exist for alive msg ", i, " of discovery inst ", index))
 
 		require.NotNil(t, instances[index].discoveryImpl().aliveMembership.MsgByID(instances[i].discoveryImpl().self.PKIid), fmt.Sprint(step, " Alive msg", i, " not exist in aliveMembership of discovery inst ", index))

--- a/gossip/election/election_test.go
+++ b/gossip/election/election_test.go
@@ -98,7 +98,7 @@ func (p *peer) Accept() <-chan Msg {
 		args := p.Called()
 		return args.Get(0).(<-chan Msg)
 	}
-	return (<-chan Msg)(p.msgChan)
+	return p.msgChan
 }
 
 func (p *peer) CreateMessage(isDeclaration bool) Msg {

--- a/gossip/gossip/certstore.go
+++ b/gossip/gossip/certstore.go
@@ -90,14 +90,14 @@ func (cs *certStore) validateIdentityMsg(msg *protoext.SignedGossipMessage) erro
 	}
 	pkiID := idMsg.PkiId
 	cert := idMsg.Cert
-	calculatedPKIID := cs.mcs.GetPKIidOfCert(api.PeerIdentityType(cert))
+	calculatedPKIID := cs.mcs.GetPKIidOfCert(cert)
 	claimedPKIID := common.PKIidType(pkiID)
 	if !bytes.Equal(calculatedPKIID, claimedPKIID) {
 		return errors.Errorf("Calculated pkiID doesn't match identity: calculated: %v, claimedPKI-ID: %v", calculatedPKIID, claimedPKIID)
 	}
 
 	verifier := func(peerIdentity []byte, signature, message []byte) error {
-		return cs.mcs.Verify(api.PeerIdentityType(peerIdentity), signature, message)
+		return cs.mcs.Verify(peerIdentity, signature, message)
 	}
 
 	err := msg.Verify(cert, verifier)
@@ -105,7 +105,7 @@ func (cs *certStore) validateIdentityMsg(msg *protoext.SignedGossipMessage) erro
 		return errors.Wrap(err, "Failed verifying message")
 	}
 
-	return cs.mcs.ValidateIdentity(api.PeerIdentityType(idMsg.Cert))
+	return cs.mcs.ValidateIdentity(idMsg.Cert)
 }
 
 func (cs *certStore) createIdentityMessage() (*protoext.SignedGossipMessage, error) {

--- a/gossip/gossip/channel/channel.go
+++ b/gossip/gossip/channel/channel.go
@@ -694,7 +694,7 @@ func (gc *gossipChannel) HandleMessage(msg protoext.ReceivedMessage) {
 					gc.logger.Warningf("Data update contains an invalid message: %+v", err)
 					return
 				}
-				if !bytes.Equal(gMsg.Channel, []byte(gc.chainID)) {
+				if !bytes.Equal(gMsg.Channel, gc.chainID) {
 					gc.logger.Warning("DataUpdate message contains item with channel", gMsg.Channel, "but should be", gc.chainID)
 					return
 				}
@@ -894,7 +894,7 @@ func (gc *gossipChannel) verifyMsg(msg protoext.ReceivedMessage) bool {
 		return true
 	}
 
-	if !bytes.Equal(m.Channel, []byte(gc.chainID)) {
+	if !bytes.Equal(m.Channel, gc.chainID) {
 		gc.logger.Warning("Message contains wrong channel(", m.Channel, "), expected", gc.chainID)
 		return false
 	}

--- a/gossip/gossip/channel/channel_test.go
+++ b/gossip/gossip/channel/channel_test.go
@@ -1994,7 +1994,7 @@ func createHelloMsg(PKIID common.PKIidType) *receivedMsg {
 
 func dataMsgOfChannel(seqnum uint64, channel common.ChannelID) *protoext.SignedGossipMessage {
 	sMsg, _ := protoext.NoopSign(&proto.GossipMessage{
-		Channel: []byte(channel),
+		Channel: channel,
 		Nonce:   0,
 		Tag:     proto.GossipMessage_CHAN_AND_ORG,
 		Content: &proto.GossipMessage_DataMsg{
@@ -2016,7 +2016,7 @@ func createStateInfoMsg(ledgerHeight int, pkiID common.PKIidType, channel common
 			StateInfo: &proto.StateInfo{
 				Channel_MAC: GenerateMAC(pkiID, channel),
 				Timestamp:   &proto.PeerTime{IncNum: uint64(time.Now().UnixNano()), SeqNum: 1},
-				PkiId:       []byte(pkiID),
+				PkiId:       pkiID,
 				Properties: &proto.Properties{
 					LedgerHeight: uint64(ledgerHeight),
 				},
@@ -2048,7 +2048,7 @@ func createDataMsg(seqnum uint64, channel common.ChannelID) *protoext.SignedGoss
 	sMsg, _ := protoext.NoopSign(&proto.GossipMessage{
 		Nonce:   0,
 		Tag:     proto.GossipMessage_CHAN_AND_ORG,
-		Channel: []byte(channel),
+		Channel: channel,
 		Content: &proto.GossipMessage_DataMsg{
 			DataMsg: &proto.DataMessage{
 				Payload: &proto.Payload{
@@ -2078,7 +2078,7 @@ func simulatePullPhaseWithVariableDigest(gc GossipChannel, t *testing.T, wg *syn
 			// Simulate a digest message an imaginary peer responds to the hello message sent
 			sMsg, _ := protoext.NoopSign(&proto.GossipMessage{
 				Tag:     proto.GossipMessage_CHAN_AND_ORG,
-				Channel: []byte(channelA),
+				Channel: channelA,
 				Content: &proto.GossipMessage_DataDig{
 					DataDig: &proto.DataDigest{
 						MsgType: proto.PullMsgType_BLOCK_MSG,

--- a/gossip/gossip/gossip_test.go
+++ b/gossip/gossip/gossip_test.go
@@ -1130,7 +1130,7 @@ func TestDataLeakage(t *testing.T) {
 				go func(instanceIndex int, channel common.ChannelID) {
 					incMsgChan, _ := peers[instanceIndex].Accept(acceptData, false)
 					msg := <-incMsgChan
-					require.Equal(t, []byte(channel), []byte(msg.Channel))
+					require.Equal(t, []byte(channel), msg.Channel)
 					wg.Done()
 				}(instanceIndex, channel)
 			}
@@ -1480,7 +1480,7 @@ func TestIdentityExpiration(t *testing.T) {
 
 func createDataMsg(seqnum uint64, data []byte, channel common.ChannelID) *proto.GossipMessage {
 	return &proto.GossipMessage{
-		Channel: []byte(channel),
+		Channel: channel,
 		Nonce:   0,
 		Tag:     proto.GossipMessage_CHAN_AND_ORG,
 		Content: &proto.GossipMessage_DataMsg{

--- a/gossip/gossip/orgs_test.go
+++ b/gossip/gossip/orgs_test.go
@@ -364,7 +364,7 @@ func TestConfidentiality(t *testing.T) {
 			externalEndpoint := ""
 			if j < externalEndpointsInOrg { // The first peers of each org would have an external endpoint
 				externalEndpoint = endpoint
-				peersWithExternalEndpoints[string(endpoint)] = struct{}{}
+				peersWithExternalEndpoints[endpoint] = struct{}{}
 			}
 			peer := newGossipInstanceWithGRPCWithExternalEndpoint(id, ports[id], grpcs[id], certs[id], secDialOpts[id],
 				cs, externalEndpoint)
@@ -509,7 +509,7 @@ func expectedMembershipSize(peersInOrg, externalEndpointsInOrg int, org string, 
 
 func extractOrgsFromMsg(msg *proto.GossipMessage, sec api.SecurityAdvisor) []string {
 	if protoext.IsAliveMsg(msg) {
-		return []string{string(sec.OrgByPeerIdentity(api.PeerIdentityType(msg.GetAliveMsg().Membership.PkiId)))}
+		return []string{string(sec.OrgByPeerIdentity(msg.GetAliveMsg().Membership.PkiId))}
 	}
 
 	orgs := map[string]struct{}{}
@@ -544,7 +544,7 @@ func extractOrgsFromMsg(msg *proto.GossipMessage, sec api.SecurityAdvisor) []str
 		dead := msg.GetMemRes().Dead
 		for _, envp := range append(alive, dead...) {
 			msg, _ := protoext.EnvelopeToGossipMessage(envp)
-			orgs[string(sec.OrgByPeerIdentity(api.PeerIdentityType(msg.GetAliveMsg().Membership.PkiId)))] = struct{}{}
+			orgs[string(sec.OrgByPeerIdentity(msg.GetAliveMsg().Membership.PkiId))] = struct{}{}
 		}
 	}
 

--- a/gossip/identity/identity.go
+++ b/gossip/identity/identity.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hyperledger/fabric/gossip/api"
 	"github.com/hyperledger/fabric/gossip/common"
-	errors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 // identityUsageThreshold sets the maximum time that an identity

--- a/gossip/privdata/coordinator_test.go
+++ b/gossip/privdata/coordinator_test.go
@@ -141,7 +141,7 @@ func (f *fetcherMock) fetch(dig2src dig2sources) (*privdatacommon.FetchedPvtData
 			uniqueEndorsements[string(endorsement.Endorser)] = struct{}{}
 		}
 	}
-	require.True(f.t, digests(f.expectedDigests).Equal(digests(dig2src.keys())))
+	require.True(f.t, digests(f.expectedDigests).Equal(dig2src.keys()))
 	require.Equal(f.t, len(f.expectedEndorsers), len(uniqueEndorsements))
 	args := f.Called(dig2src)
 	if args.Get(1) == nil {

--- a/gossip/privdata/distributor.go
+++ b/gossip/privdata/distributor.go
@@ -217,7 +217,7 @@ func (d *distributorImpl) disseminationPlanForMsg(colAP privdata.CollectionAcces
 		return colFilter(protoutil.SignedData{
 			Data:      signature.Message,
 			Signature: signature.Signature,
-			Identity:  []byte(signature.PeerIdentity),
+			Identity:  signature.PeerIdentity,
 		})
 	})
 	if err != nil {

--- a/gossip/privdata/pull.go
+++ b/gossip/privdata/pull.go
@@ -470,7 +470,7 @@ func (p *puller) computeFilters(dig2src dig2sources) (digestToFilterMapping, err
 		sources := sources
 		endorserPeer, err := p.PeerFilter(common.ChannelID(p.channel), func(peerSignature api.PeerSignature) bool {
 			for _, endorsement := range sources {
-				if bytes.Equal(endorsement.Endorser, []byte(peerSignature.PeerIdentity)) {
+				if bytes.Equal(endorsement.Endorser, peerSignature.PeerIdentity) {
 					return true
 				}
 			}

--- a/gossip/privdata/pull_test.go
+++ b/gossip/privdata/pull_test.go
@@ -306,7 +306,7 @@ func newPRWSet() []util.PrivateRWSet {
 	b2 := make([]byte, 10)
 	rand.Read(b1)
 	rand.Read(b2)
-	return []util.PrivateRWSet{util.PrivateRWSet(b1), util.PrivateRWSet(b2)}
+	return []util.PrivateRWSet{b1, b2}
 }
 
 func TestPullerFromOnly1Peer(t *testing.T) {

--- a/gossip/service/gossip_service.go
+++ b/gossip/service/gossip_service.go
@@ -442,7 +442,7 @@ func (g *GossipService) createSelfSignedData() protoutil.SignedData {
 
 // updateAnchors constructs a joinChannelMessage and sends it to the gossipSvc
 func (g *GossipService) updateAnchors(configUpdate ConfigUpdate) {
-	myOrg := string(g.secAdv.OrgByPeerIdentity(api.PeerIdentityType(g.peerIdentity)))
+	myOrg := string(g.secAdv.OrgByPeerIdentity(g.peerIdentity))
 	if !g.amIinChannel(myOrg, configUpdate) {
 		logger.Error("Tried joining channel", configUpdate.ChannelID, "but our org(", myOrg, "), isn't "+
 			"among the orgs of the channel:", orgListFromConfigUpdate(configUpdate), ", aborting.")

--- a/gossip/service/gossip_service_test.go
+++ b/gossip/service/gossip_service_test.go
@@ -914,7 +914,7 @@ func TestChannelConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	mockSignerSerializer := &mocks.SignerSerializer{}
-	mockSignerSerializer.SerializeReturns(api.PeerIdentityType(string(orgInChannelA)), nil)
+	mockSignerSerializer.SerializeReturns(api.PeerIdentityType(orgInChannelA), nil)
 	secAdv := peergossip.NewSecurityAdvisor(peergossip.NewDeserializersManager(mgmt.GetLocalMSP(cryptoProvider)))
 	gossipConfig, err := gossip.GlobalConfig(endpoint, nil)
 	require.NoError(t, err)

--- a/gossip/state/payloads_buffer_test.go
+++ b/gossip/state/payloads_buffer_test.go
@@ -108,7 +108,7 @@ func TestPayloadsBufferImpl_ConcurrentPush(t *testing.T) {
 	concurrency := 10
 
 	buffer := NewPayloadsBuffer(nextSeqNum)
-	require.Equal(t, buffer.Next(), uint64(nextSeqNum))
+	require.Equal(t, buffer.Next(), nextSeqNum)
 
 	startWG := sync.WaitGroup{}
 	startWG.Add(1)

--- a/gossip/state/state.go
+++ b/gossip/state/state.go
@@ -604,7 +604,7 @@ func (s *GossipStateProviderImpl) antiEntropy() {
 				continue
 			}
 
-			s.requestBlocksInRange(uint64(ourHeight), uint64(maxHeight)-1)
+			s.requestBlocksInRange(ourHeight, uint64(maxHeight)-1)
 		}
 	}
 }
@@ -811,5 +811,5 @@ func (s *GossipStateProviderImpl) commitBlock(block *common.Block, pvtData util.
 }
 
 func min(a uint64, b uint64) uint64 {
-	return b ^ ((a ^ b) & (-(uint64(a-b) >> 63)))
+	return b ^ ((a ^ b) & (-((a - b) >> 63)))
 }

--- a/gossip/state/state_test.go
+++ b/gossip/state/state_test.go
@@ -793,7 +793,7 @@ func TestBlockingEnqueue(t *testing.T) {
 		mc.Mock = m
 		mc.Unlock()
 		require.Equal(t, receivedBlock, uint64(receivedBlockCount))
-		if int(receivedBlockCount) == numBlocksReceived {
+		if receivedBlockCount == numBlocksReceived {
 			break
 		}
 		time.Sleep(time.Millisecond * 10)

--- a/gossip/util/privdata.go
+++ b/gossip/util/privdata.go
@@ -75,7 +75,7 @@ func (pvt *PvtDataCollections) Unmarshal(data [][]byte) error {
 func PrivateRWSets(rwsets ...PrivateRWSet) [][]byte {
 	var res [][]byte
 	for _, rws := range rwsets {
-		res = append(res, []byte(rws))
+		res = append(res, rws)
 	}
 	return res
 }

--- a/integration/chaincode/marbles/marbles_chaincode.go
+++ b/integration/chaincode/marbles/marbles_chaincode.go
@@ -52,12 +52,12 @@
 // to create the indexes in the CouchDB Fauxton interface or a curl command line utility.
 //
 
-//Example hostname:port configurations to access CouchDB.
+// Example hostname:port configurations to access CouchDB.
 //
-//To access CouchDB docker container from within another docker container or from vagrant environments:
+// To access CouchDB docker container from within another docker container or from vagrant environments:
 // http://couchdb:5984/
 //
-//Inside couchdb docker container
+// Inside couchdb docker container
 // http://127.0.0.1:5984/
 
 // Index for docType, owner.
@@ -278,7 +278,7 @@ func (t *SimpleChaincode) delete(stub shim.ChaincodeStubInterface, args []string
 		return shim.Error(jsonResp)
 	}
 
-	err = json.Unmarshal([]byte(valAsbytes), &marbleJSON)
+	err = json.Unmarshal(valAsbytes, &marbleJSON)
 	if err != nil {
 		jsonResp = "{\"Error\":\"Failed to decode JSON of: " + marbleName + "\"}"
 		return shim.Error(jsonResp)

--- a/integration/chaincode/marbles_private/chaincode.go
+++ b/integration/chaincode/marbles_private/chaincode.go
@@ -353,7 +353,7 @@ func (t *MarblesPrivateChaincode) delete(stub shim.ChaincodeStubInterface, args 
 	}
 
 	var marbleToDelete marble
-	err = json.Unmarshal([]byte(valAsbytes), &marbleToDelete)
+	err = json.Unmarshal(valAsbytes, &marbleToDelete)
 	if err != nil {
 		return shim.Error("Failed to decode JSON of: " + string(valAsbytes))
 	}
@@ -432,7 +432,7 @@ func (t *MarblesPrivateChaincode) purge(stub shim.ChaincodeStubInterface, args [
 	}
 
 	var marbleToPurge marble
-	err = json.Unmarshal([]byte(valAsbytes), &marbleToPurge)
+	err = json.Unmarshal(valAsbytes, &marbleToPurge)
 	if err != nil {
 		return shim.Error("Failed to decode JSON of: " + string(valAsbytes))
 	}

--- a/integration/channelparticipation/channel_participation.go
+++ b/integration/channelparticipation/channel_participation.go
@@ -18,7 +18,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/integration/nwo"
-	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gstruct"

--- a/integration/gateway/gateway_bft_test.go
+++ b/integration/gateway/gateway_bft_test.go
@@ -37,7 +37,7 @@ var _ = Describe("GatewayService with BFT ordering service", func() {
 		network          *nwo.Network
 		ordererProcesses map[string]ifrit.Process
 		peerProcesses    ifrit.Process
-		channel          string = "testchannel1"
+		channel          = "testchannel1"
 	)
 
 	BeforeEach(func() {

--- a/integration/gossip/gossip_test.go
+++ b/integration/gossip/gossip_test.go
@@ -181,7 +181,7 @@ var _ = Describe("Gossip State Transfer and Membership", func() {
 	When("gossip connection is lost and restored", func() {
 		var (
 			orderer       *nwo.Orderer
-			peerEndpoints map[string]string = map[string]string{}
+			peerEndpoints = map[string]string{}
 		)
 
 		BeforeEach(func() {

--- a/integration/lifecycle/chaincode/caller/chaincode.go
+++ b/integration/lifecycle/chaincode/caller/chaincode.go
@@ -32,10 +32,10 @@ func (t *CC) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
 			return shim.Error(err.Error())
 		}
 
-		return stub.InvokeChaincode(string(args[0]), [][]byte{[]byte("INVOKE")}, "")
+		return stub.InvokeChaincode(args[0], [][]byte{[]byte("INVOKE")}, "")
 
 	case "QUERYCALLEE":
-		response := stub.InvokeChaincode(string(args[0]), [][]byte{[]byte("QUERY")}, args[1])
+		response := stub.InvokeChaincode(args[0], [][]byte{[]byte("QUERY")}, args[1])
 		if response.Status >= 400 {
 			return shim.Error(response.Message)
 		}

--- a/integration/nwo/deploy.go
+++ b/integration/nwo/deploy.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hyperledger/fabric/common/util"
 	"github.com/hyperledger/fabric/integration/nwo/commands"
 	"github.com/hyperledger/fabric/protoutil"
-	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -32,7 +32,7 @@ import (
 	"github.com/hyperledger/fabric/integration/nwo/fabricconfig"
 	"github.com/hyperledger/fabric/integration/nwo/runner"
 	"github.com/hyperledger/fabric/protoutil"
-	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"

--- a/integration/nwo/runner/couchdb.go
+++ b/integration/nwo/runner/couchdb.go
@@ -68,8 +68,8 @@ func (c *CouchDB) Run(sigCh <-chan os.Signal, ready chan<- struct{}) error {
 		c.HostIP = "127.0.0.1"
 	}
 
-	if c.ContainerPort == docker.Port("") {
-		c.ContainerPort = docker.Port("5984/tcp")
+	if c.ContainerPort == ("") {
+		c.ContainerPort = "5984/tcp"
 	}
 
 	if c.StartTimeout == 0 {

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"os"
 
-	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2"
 )
 
 // TestPortRange represents a port range

--- a/integration/pvtdata/implicit_coll_test.go
+++ b/integration/pvtdata/implicit_coll_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/tedsuo/ifrit"
 )
 
-var _ bool = Describe("Pvtdata dissemination for implicit collection", func() {
+var _ = Describe("Pvtdata dissemination for implicit collection", func() {
 	var (
 		network                     *nwo.Network
 		ordererProcess, peerProcess ifrit.Process

--- a/integration/pvtdata/pvtdata_test.go
+++ b/integration/pvtdata/pvtdata_test.go
@@ -52,7 +52,7 @@ import (
 
 const channelID = "testchannel"
 
-var _ bool = Describe("PrivateData", func() {
+var _ = Describe("PrivateData", func() {
 	var (
 		network                     *nwo.Network
 		ordererProcess, peerProcess ifrit.Process

--- a/internal/ccmetadata/validators.go
+++ b/internal/ccmetadata/validators.go
@@ -155,7 +155,7 @@ func couchdbIndexFileValidator(fileName string, fileBytes []byte) error {
 // isJSON tests a string to determine if it can be parsed as valid JSON
 func isJSON(s []byte) (bool, map[string]interface{}) {
 	var js map[string]interface{}
-	return json.Unmarshal([]byte(s), &js) == nil, js
+	return json.Unmarshal(s, &js) == nil, js
 }
 
 func validateIndexJSON(indexDefinition map[string]interface{}) error {

--- a/internal/fileutil/fileutil_test.go
+++ b/internal/fileutil/fileutil_test.go
@@ -52,7 +52,7 @@ func TestFileExists(t *testing.T) {
 
 		file := filepath.Join(testPath, "empty-file")
 		contents := []byte("some random contents")
-		ioutil.WriteFile(file, []byte(contents), 0o644)
+		ioutil.WriteFile(file, contents, 0o644)
 		exists, size, err := FileExists(file)
 		require.NoError(t, err)
 		require.True(t, exists)

--- a/internal/ledgerutil/compare/compare.go
+++ b/internal/ledgerutil/compare/compare.go
@@ -497,7 +497,7 @@ func readMetadata(fpath string) (*kvledger.SnapshotSignableMetadata, error) {
 		return nil, err
 	}
 	// Unmarshal bytes
-	err = json.Unmarshal([]byte(f), &mdata)
+	err = json.Unmarshal(f, &mdata)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ledgerutil/identifytxs/identifytxs.go
+++ b/internal/ledgerutil/identifytxs/identifytxs.go
@@ -407,7 +407,7 @@ func findAndWriteTxs(blockStore *blkstorage.BlockStore, inputKeyMapWrapper *comp
 						for _, hashedWrite := range hashedWrites {
 							keyHash := hashedWrite.GetKeyHash()
 							// Get hexadecimal encoding of key hash
-							ck := compKey{namespace: namespace, collection: (collection.CollectionName), key: hex.EncodeToString(keyHash)}
+							ck := compKey{namespace: namespace, collection: collection.CollectionName, key: hex.EncodeToString(keyHash)}
 							_, exists := inputKeyMap[ck]
 							if exists {
 								// Get txValidationCode
@@ -449,7 +449,7 @@ func findAndWriteTxs(blockStore *blkstorage.BlockStore, inputKeyMapWrapper *comp
 		blockIndex++
 	}
 	// Close out any remaining open output file writers
-	err = inputKeyMap.closeAll((blockIndex - 1), txIndex, maxAvailable)
+	err = inputKeyMap.closeAll(blockIndex-1, txIndex, maxAvailable)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/internal/ledgerutil/verify/verify.go
+++ b/internal/ledgerutil/verify/verify.go
@@ -97,7 +97,7 @@ func VerifyLedger(blockStorePath string, outputDir string) (bool, error) {
 			return false, err
 		}
 
-		previousHash := []byte{}
+		var previousHash []byte
 		for i := firstBlockNumber; i < info.GetHeight(); i++ {
 			// Retrieve the next block
 			result, err := iterator.Next()

--- a/internal/peer/channel/create_test.go
+++ b/internal/peer/channel/create_test.go
@@ -60,7 +60,7 @@ func newOrderer(port int, t *testing.T) *timeoutOrderer {
 		t:                t,
 		nextExpectedSeek: uint64(1),
 		blockChannel:     make(chan uint64, 1),
-		counter:          int(1),
+		counter:          1,
 	}
 	orderer.RegisterAtomicBroadcastServer(srv, o)
 	go srv.Serve(lsnr)

--- a/internal/peer/common/mockclient.go
+++ b/internal/peer/common/mockclient.go
@@ -11,7 +11,7 @@ import (
 
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
-	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc"
 )
 
 // GetMockEndorserClient return a endorser client return specified ProposalResponse and err(nil or error)

--- a/internal/peer/common/networkconfig.go
+++ b/internal/peer/common/networkconfig.go
@@ -10,7 +10,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // NetworkConfig provides a static definition of a Hyperledger Fabric network

--- a/internal/peer/gossip/mcs.go
+++ b/internal/peer/gossip/mcs.go
@@ -262,7 +262,7 @@ func (s *MSPMessageCryptoService) VerifyByChannel(chainID common.ChannelID, peer
 	return policy.EvaluateSignedData(
 		[]*protoutil.SignedData{{
 			Data:      message,
-			Identity:  []byte(peerIdentity),
+			Identity:  peerIdentity,
 			Signature: signature,
 		}},
 	)
@@ -296,7 +296,7 @@ func (s *MSPMessageCryptoService) getValidatedIdentity(peerIdentity api.PeerIden
 	// the local MSP is required to take the final decision on the validity
 	// of the signature.
 	lDes := s.deserializer.GetLocalDeserializer()
-	identity, err := lDes.DeserializeIdentity([]byte(peerIdentity))
+	identity, err := lDes.DeserializeIdentity(peerIdentity)
 	if err == nil {
 		// No error means that the local MSP successfully deserialized the identity.
 		// We now check additional properties.
@@ -324,7 +324,7 @@ func (s *MSPMessageCryptoService) getValidatedIdentity(peerIdentity api.PeerIden
 	// Check against managers
 	for chainID, mspManager := range s.deserializer.GetChannelDeserializers() {
 		// Deserialize identity
-		identity, err := mspManager.DeserializeIdentity([]byte(peerIdentity))
+		identity, err := mspManager.DeserializeIdentity(peerIdentity)
 		if err != nil {
 			mcsLogger.Debugf("Failed deserialization identity %s on [%s]: [%s]", peerIdentity, chainID, err)
 			continue

--- a/internal/peer/gossip/mcs_test.go
+++ b/internal/peer/gossip/mcs_test.go
@@ -92,7 +92,7 @@ func TestPKIidOfCert(t *testing.T) {
 	require.NotNil(t, pkid, "PKID must be different from nil")
 	// Check that pkid is correctly computed
 	id, err := deserializersManager.Deserialize(peerIdentity)
-	require.NoError(t, err, "Failed getting validated identity from [% x]", []byte(peerIdentity))
+	require.NoError(t, err, "Failed getting validated identity from [% x]", peerIdentity)
 	idRaw := append([]byte(id.Mspid), id.IdBytes...)
 	require.NoError(t, err, "Failed marshalling identity identifier [% x]: [%s]", peerIdentity, err)
 	h := sha256.New()

--- a/internal/peer/gossip/sa.go
+++ b/internal/peer/gossip/sa.go
@@ -54,7 +54,7 @@ func (advisor *mspSecurityAdvisor) OrgByPeerIdentity(peerIdentity api.PeerIdenti
 	// namely the identity's MSP identifier be returned (Identity.GetMSPIdentifier())
 
 	// First check against the local MSP.
-	identity, err := advisor.deserializer.GetLocalDeserializer().DeserializeIdentity([]byte(peerIdentity))
+	identity, err := advisor.deserializer.GetLocalDeserializer().DeserializeIdentity(peerIdentity)
 	if err == nil {
 		return []byte(identity.GetMSPIdentifier())
 	}
@@ -62,7 +62,7 @@ func (advisor *mspSecurityAdvisor) OrgByPeerIdentity(peerIdentity api.PeerIdenti
 	// Check against managers
 	for chainID, mspManager := range advisor.deserializer.GetChannelDeserializers() {
 		// Deserialize identity
-		identity, err := mspManager.DeserializeIdentity([]byte(peerIdentity))
+		identity, err := mspManager.DeserializeIdentity(peerIdentity)
 		if err != nil {
 			saLogger.Debugf("Failed deserialization identity [% x] on [%s]: [%s]", peerIdentity, chainID, err)
 			continue

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -353,7 +353,7 @@ func serve(args []string) error {
 	// startup aclmgmt with default ACL providers (resource based and default 1.0 policies based).
 	// Users can pass in their own ACLProvider to RegisterACLProvider (currently unit tests do this)
 	aclProvider := aclmgmt.NewACLProvider(
-		aclmgmt.ResourceGetter(peerInstance.GetStableChannelConfig),
+		peerInstance.GetStableChannelConfig,
 		policyChecker,
 	)
 

--- a/internal/pkg/gateway/submit.go
+++ b/internal/pkg/gateway/submit.go
@@ -151,7 +151,7 @@ func (gs *Server) broadcastToAll(orderers []*orderer, txn *common.Envelope, wait
 // Note that this is different from N-f (the number of correct nodes), when N=3f+3. That is, we have two extra nodes
 // above the minimum required to tolerate f failures.
 func computeBFTQuorum(N uint64) (Q int, F int) {
-	F = int((int(N) - 1) / 3)
+	F = (int(N) - 1) / 3
 	Q = int(math.Ceil((float64(N) + float64(F) + 1) / 2.0))
 	return
 }

--- a/msp/cache/cache_test.go
+++ b/msp/cache/cache_test.go
@@ -175,8 +175,8 @@ func TestValidate(t *testing.T) {
 	mockMSP.AssertExpectations(t)
 	// Check the cache
 	identifier := mockIdentity.GetIdentifier()
-	key := string(identifier.Mspid + ":" + identifier.Id)
-	v, ok := i.(*cachedMSP).validateIdentityCache.get(string(key))
+	key := identifier.Mspid + ":" + identifier.Id
+	v, ok := i.(*cachedMSP).validateIdentityCache.get(key)
 	require.True(t, ok)
 	require.True(t, v.(bool))
 
@@ -194,8 +194,8 @@ func TestValidate(t *testing.T) {
 	mockMSP.AssertExpectations(t)
 	// Check the cache
 	identifier = mockIdentity.GetIdentifier()
-	key = string(identifier.Mspid + ":" + identifier.Id)
-	_, ok = i.(*cachedMSP).validateIdentityCache.get(string(key))
+	key = identifier.Mspid + ":" + identifier.Id
+	_, ok = i.(*cachedMSP).validateIdentityCache.get(key)
 	require.False(t, ok)
 }
 
@@ -276,7 +276,7 @@ func TestSatisfiesPrincipal(t *testing.T) {
 	mockMSP.AssertExpectations(t)
 	// Check the cache
 	identifier := mockIdentity.GetIdentifier()
-	identityKey := string(identifier.Mspid + ":" + identifier.Id)
+	identityKey := identifier.Mspid + ":" + identifier.Id
 	principalKey := string(mockMSPPrincipal.PrincipalClassification) + string(mockMSPPrincipal.Principal)
 	key := identityKey + principalKey
 	v, ok := i.(*cachedMSP).satisfiesPrincipalCache.get(key)
@@ -299,7 +299,7 @@ func TestSatisfiesPrincipal(t *testing.T) {
 	mockMSP.AssertExpectations(t)
 	// Check the cache
 	identifier = mockIdentity.GetIdentifier()
-	identityKey = string(identifier.Mspid + ":" + identifier.Id)
+	identityKey = identifier.Mspid + ":" + identifier.Id
 	principalKey = string(mockMSPPrincipal.PrincipalClassification) + string(mockMSPPrincipal.Principal)
 	key = identityKey + principalKey
 	v, ok = i.(*cachedMSP).satisfiesPrincipalCache.get(key)

--- a/msp/mspimplsetup.go
+++ b/msp/mspimplsetup.go
@@ -18,7 +18,7 @@ import (
 	m "github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric/bccsp"
 	"github.com/hyperledger/fabric/bccsp/utils"
-	errors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 func (msp *bccspmsp) getCertifiersIdentifier(certRaw []byte) ([]byte, error) {

--- a/msp/mspimplsetup_test.go
+++ b/msp/mspimplsetup_test.go
@@ -153,7 +153,7 @@ func TestMalformedCertsChainSetup(t *testing.T) {
 
 	// Add root CA certificate
 	// cert, err := mspImpl.getCertFromPem([]byte(ca.CertBytes()))
-	certInter, err := mspImpl.getCertFromPem([]byte(inter.CertBytes()))
+	certInter, err := mspImpl.getCertFromPem(inter.CertBytes())
 	gt.Expect(err).NotTo(gomega.HaveOccurred())
 	mspImpl.opts.Roots.AddCert(certInter)
 	mspImpl.rootCerts = []Identity{&identity{cert: certInter}}

--- a/orderer/common/cluster/interfaces.go
+++ b/orderer/common/cluster/interfaces.go
@@ -74,8 +74,9 @@ func (rm RemoteNode) String() string {
 		rm.ID, rm.Endpoint, DERtoPEM(rm.ServerTLSCert), DERtoPEM(rm.ClientTLSCert), rm.ServerRootCA)
 }
 
-// go:generate mockery --dir . --name StepClientStream --case underscore --output ./mocks/
 // StepClientStream
+//
+//go:generate mockery --dir . --name StepClientStream --case underscore --output ./mocks/
 type StepClientStream interface {
 	Send(request *orderer.StepRequest) error
 	Recv() (*orderer.StepResponse, error)

--- a/orderer/common/cluster/metrics.go
+++ b/orderer/common/cluster/metrics.go
@@ -137,7 +137,7 @@ func (m *Metrics) reportWorkerCount(channel string, count uint32) {
 }
 
 func (m *Metrics) reportMsgSendTime(host string, channel string, duration time.Duration) {
-	m.MessageSendTime.With("host", host, "channel", channel).Observe(float64(duration.Seconds()))
+	m.MessageSendTime.With("host", host, "channel", channel).Observe(duration.Seconds())
 }
 
 func (m *Metrics) reportEgressStreamCount(channel string, count uint32) {

--- a/orderer/common/cluster/util_test.go
+++ b/orderer/common/cluster/util_test.go
@@ -293,7 +293,7 @@ func createBlockChain(start, end uint64) []*common.Block {
 		return block
 	}
 	var blockchain []*common.Block
-	for seq := uint64(start); seq <= uint64(end); seq++ {
+	for seq := start; seq <= end; seq++ {
 		block := newBlock(seq)
 		block.Data.Data = append(block.Data.Data, make([]byte, 100))
 		block.Header.DataHash = protoutil.BlockDataHash(block.Data)

--- a/orderer/common/follower/options.go
+++ b/orderer/common/follower/options.go
@@ -15,14 +15,14 @@ import (
 
 const (
 	// The default minimal retry interval when pulling blocks
-	defaultPullRetryMinInterval time.Duration = 50 * time.Millisecond
+	defaultPullRetryMinInterval = 50 * time.Millisecond
 	// The default maximal retry interval when pulling blocks
-	defaultPullRetryMaxInterval time.Duration = 60 * time.Second
+	defaultPullRetryMaxInterval = 60 * time.Second
 
 	// The default minimal height polling interval when pulling blocks after the join block
-	defaultHeightPollMinInterval time.Duration = 500 * time.Millisecond
+	defaultHeightPollMinInterval = 500 * time.Millisecond
 	// The default maximal height polling interval when pulling blocks after the join block
-	defaultHeightPollMaxInterval time.Duration = 10 * time.Second
+	defaultHeightPollMaxInterval = 10 * time.Second
 )
 
 // Options contains some configuration options relevant to the follower.Chain.

--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -171,7 +171,7 @@ var Defaults = TopLevel{
 		LocalMSPID:  "SampleOrg",
 		BCCSP:       bccsp.GetDefaultOpts(),
 		Authentication: Authentication{
-			TimeWindow: time.Duration(15 * time.Minute),
+			TimeWindow: 15 * time.Minute,
 		},
 		MaxRecvMsgSize: comm.DefaultMaxRecvMsgSize,
 		MaxSendMsgSize: comm.DefaultMaxSendMsgSize,

--- a/orderer/common/server/attestationserver.go
+++ b/orderer/common/server/attestationserver.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hyperledger/fabric/common/deliver"
 	"github.com/hyperledger/fabric/common/metrics"
 	"github.com/hyperledger/fabric/common/policies"
-	localconfig "github.com/hyperledger/fabric/orderer/common/localconfig"
+	"github.com/hyperledger/fabric/orderer/common/localconfig"
 	"github.com/hyperledger/fabric/orderer/common/msgprocessor"
 	"github.com/hyperledger/fabric/orderer/common/multichannel"
 	"github.com/hyperledger/fabric/protoutil"

--- a/orderer/common/server/server.go
+++ b/orderer/common/server/server.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hyperledger/fabric/common/metrics"
 	"github.com/hyperledger/fabric/common/policies"
 	"github.com/hyperledger/fabric/orderer/common/broadcast"
-	localconfig "github.com/hyperledger/fabric/orderer/common/localconfig"
+	"github.com/hyperledger/fabric/orderer/common/localconfig"
 	"github.com/hyperledger/fabric/orderer/common/msgprocessor"
 	"github.com/hyperledger/fabric/orderer/common/multichannel"
 	"github.com/hyperledger/fabric/protoutil"

--- a/orderer/common/server/server_test.go
+++ b/orderer/common/server/server_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	ab "github.com/hyperledger/fabric-protos-go/orderer"
-	localconfig "github.com/hyperledger/fabric/orderer/common/localconfig"
+	"github.com/hyperledger/fabric/orderer/common/localconfig"
 	"github.com/hyperledger/fabric/orderer/common/multichannel"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/stretchr/testify/require"

--- a/orderer/consensus/etcdraft/chain_test.go
+++ b/orderer/consensus/etcdraft/chain_test.go
@@ -39,7 +39,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"github.com/pkg/errors"
-	raft "go.etcd.io/etcd/raft/v3"
+	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 	"go.uber.org/zap"
 )
@@ -3304,7 +3304,7 @@ func nodeConfigFromMetadata(consenterMetadata *raftprotos.ConfigMetadata) []clus
 
 func createMetadata(nodeCount int, tlsCA tlsgen.CA) *raftprotos.ConfigMetadata {
 	md := &raftprotos.ConfigMetadata{Options: &raftprotos.Options{
-		TickInterval:      time.Duration(interval).String(),
+		TickInterval:      interval.String(),
 		ElectionTick:      ELECTION_TICK,
 		HeartbeatTick:     HEARTBEAT_TICK,
 		MaxInflightBlocks: 5,
@@ -3409,7 +3409,7 @@ func newChain(
 
 	opts := etcdraft.Options{
 		RPCTimeout:          timeout,
-		RaftID:              uint64(id),
+		RaftID:              id,
 		Clock:               clock,
 		TickInterval:        interval,
 		ElectionTick:        ELECTION_TICK,

--- a/orderer/consensus/etcdraft/consenter_test.go
+++ b/orderer/consensus/etcdraft/consenter_test.go
@@ -424,7 +424,7 @@ var _ = Describe("Consenter", func() {
 		consenter := newConsenter(chainManager, tlsCA.CertBytes(), certAsPEM)
 
 		chain, err := consenter.HandleChain(support, &common.Metadata{})
-		Expect(chain).To((BeNil()))
+		Expect(chain).To(BeNil())
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("without a system channel, a follower should have been created"))
 	})
@@ -542,7 +542,7 @@ var _ = Describe("Consenter", func() {
 		consenter := newConsenter(chainManager, tlsCA.CertBytes(), certAsPEM)
 
 		chain, err := consenter.HandleChain(support, &common.Metadata{})
-		Expect(chain).To((BeNil()))
+		Expect(chain).To(BeNil())
 		Expect(err).To(MatchError("without a system channel, a follower should have been created: not in the channel"))
 	})
 })

--- a/orderer/consensus/etcdraft/membership.go
+++ b/orderer/consensus/etcdraft/membership.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/orderer/etcdraft"
 	"github.com/pkg/errors"
-	raft "go.etcd.io/etcd/raft/v3"
+	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 )
 

--- a/orderer/consensus/etcdraft/node.go
+++ b/orderer/consensus/etcdraft/node.go
@@ -142,7 +142,7 @@ func (n *node) run(campaign bool) {
 				n.logger.Panicf("Failed to persist etcd/raft data: %s", err)
 			}
 			duration := n.clock.Since(startStoring).Seconds()
-			n.metrics.DataPersistDuration.Observe(float64(duration))
+			n.metrics.DataPersistDuration.Observe(duration)
 			if duration > halfElectionTimeout {
 				n.logger.Warningf("WAL sync took %v seconds and the network is configured to start elections after %v seconds. Your disk is too slow and may cause loss of quorum and trigger leadership election.", duration, electionTimeout)
 			}

--- a/orderer/consensus/etcdraft/storage.go
+++ b/orderer/consensus/etcdraft/storage.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
-	raft "go.etcd.io/etcd/raft/v3"
+	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"
 	"go.etcd.io/etcd/server/v3/wal"

--- a/orderer/consensus/etcdraft/storage_test.go
+++ b/orderer/consensus/etcdraft/storage_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
-	raft "go.etcd.io/etcd/raft/v3"
+	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 	"go.etcd.io/etcd/server/v3/wal"
 	"go.uber.org/zap"

--- a/orderer/consensus/etcdraft/tracker.go
+++ b/orderer/consensus/etcdraft/tracker.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/common/metrics"
 	"github.com/hyperledger/fabric/protoutil"
-	raft "go.etcd.io/etcd/raft/v3"
+	"go.etcd.io/etcd/raft/v3"
 )
 
 // Tracker periodically poll Raft Status, and update disseminator

--- a/orderer/consensus/etcdraft/util.go
+++ b/orderer/consensus/etcdraft/util.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hyperledger/fabric/orderer/common/cluster"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
-	raft "go.etcd.io/etcd/raft/v3"
+	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 )
 

--- a/orderer/consensus/smartbft/egress.go
+++ b/orderer/consensus/smartbft/egress.go
@@ -44,7 +44,7 @@ func (e *Egress) Nodes() []uint64 {
 	nodes := e.RuntimeConfig.Load().(RuntimeConfig).Nodes
 	var res []uint64
 	for _, n := range nodes {
-		res = append(res, (uint64)(n))
+		res = append(res, n)
 	}
 	return res
 }

--- a/orderer/consensus/smartbft/egress.go
+++ b/orderer/consensus/smartbft/egress.go
@@ -43,9 +43,7 @@ type Egress struct {
 func (e *Egress) Nodes() []uint64 {
 	nodes := e.RuntimeConfig.Load().(RuntimeConfig).Nodes
 	var res []uint64
-	for _, n := range nodes {
-		res = append(res, n)
-	}
+	res = append(res, nodes...)
 	return res
 }
 

--- a/orderer/consensus/smartbft/signer.go
+++ b/orderer/consensus/smartbft/signer.go
@@ -51,7 +51,7 @@ func (s *Signer) SignProposal(proposal types.Proposal, _ []byte) *types.Signatur
 		BlockHeader:      protoutil.BlockHeaderBytes(block.Header),
 		IdentifierHeader: protoutil.MarshalOrPanic(s.newIdentifierHeaderOrPanic(nonce)),
 		OrdererBlockMetadata: protoutil.MarshalOrPanic(&cb.OrdererBlockMetadata{
-			LastConfig:        &cb.LastConfig{Index: uint64(s.LastConfigBlockNum(block))},
+			LastConfig:        &cb.LastConfig{Index: s.LastConfigBlockNum(block)},
 			ConsenterMetadata: proposal.Metadata,
 		}),
 	}

--- a/orderer/sample_clients/broadcast_msg/client.go
+++ b/orderer/sample_clients/broadcast_msg/client.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"sync"
 
-	pb "github.com/cheggaaa/pb"
+	"github.com/cheggaaa/pb"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	ab "github.com/hyperledger/fabric-protos-go/orderer"
 	"github.com/hyperledger/fabric/bccsp/factory"
@@ -124,7 +124,7 @@ func main() {
 			}
 
 			s := newBroadcastClient(client, channelID, signer)
-			done := make(chan (struct{}))
+			done := make(chan struct{})
 			go func() {
 				for i := uint64(0); i < msgsPerGo; i++ {
 					err = s.getAck()

--- a/protoutil/blockutils.go
+++ b/protoutil/blockutils.go
@@ -216,7 +216,7 @@ func InitBlockMetadata(block *cb.Block) {
 	if block.Metadata == nil {
 		block.Metadata = &cb.BlockMetadata{Metadata: [][]byte{{}, {}, {}, {}, {}}}
 	} else if len(block.Metadata.Metadata) < int(cb.BlockMetadataIndex_COMMIT_HASH+1) {
-		for i := int(len(block.Metadata.Metadata)); i <= int(cb.BlockMetadataIndex_COMMIT_HASH); i++ {
+		for i := len(block.Metadata.Metadata); i <= int(cb.BlockMetadataIndex_COMMIT_HASH); i++ {
 			block.Metadata.Metadata = append(block.Metadata.Metadata, []byte{})
 		}
 	}

--- a/protoutil/proputils_test.go
+++ b/protoutil/proputils_test.go
@@ -464,9 +464,9 @@ func TestComputeProposalTxID(t *testing.T) {
 	hashOut := hf.Sum(nil)
 	txid2 := hex.EncodeToString(hashOut)
 
-	t.Logf("% x\n", hashOut)
-	t.Logf("% s\n", txid)
-	t.Logf("% s\n", txid2)
+	t.Logf("%x\n", hashOut)
+	t.Logf("%s\n", txid)
+	t.Logf("%s\n", txid2)
 
 	require.Equal(t, txid, txid2)
 }


### PR DESCRIPTION
- Leading whitespaces before Go directives in comments.
- Incorrect usages of fmt.Printf, fmt.Println, and similar formatting and printing functions.
- Redundant parentheses in expressions and types.
- Types in variable and constant declarations that can be omitted since they can be inferred by the compiler. Such types are redundant, omitting them may improve readability of the code.
- Type conversions that may be omitted.
- Aliases of imported packages that may be omitted.