### PR TITLE
Do not send channel name as part of each message

### DIFF
--- a/orderer/consensus/smartbft/egress.go
+++ b/orderer/consensus/smartbft/egress.go
@@ -65,7 +65,6 @@ func (e *Egress) SendTransaction(targetID uint64, request []byte) {
 		e.Logger.Panicf("Failed unmarshaling request %v to envelope: %v", request, err)
 	}
 	msg := &ab.SubmitRequest{
-		Channel: e.Channel,
 		Payload: env,
 	}
 
@@ -80,6 +79,5 @@ func (e *Egress) SendTransaction(targetID uint64, request []byte) {
 func bftMsgToClusterMsg(message *protos.Message, channel string) *ab.ConsensusRequest {
 	return &ab.ConsensusRequest{
 		Payload: protoutil.MarshalOrPanic(message),
-		Channel: channel,
 	}
 }

--- a/orderer/consensus/smartbft/egress_test.go
+++ b/orderer/consensus/smartbft/egress_test.go
@@ -42,7 +42,6 @@ func TestEgressSendConsensus(t *testing.T) {
 
 	rpc.AssertCalled(t, "SendConsensus", uint64(42), &ab.ConsensusRequest{
 		Payload: protoutil.MarshalOrPanic(viewData),
-		Channel: "test",
 	})
 }
 
@@ -70,7 +69,6 @@ func TestEgressSendTransaction(t *testing.T) {
 	})
 
 	rpc.AssertCalled(t, "SendSubmit", uint64(42), &ab.SubmitRequest{
-		Channel: "test",
 		Payload: &cb.Envelope{
 			Payload: []byte{1, 2, 3},
 		},


### PR DESCRIPTION
In the new communication infrastructure implementation, as per the RFC [0], the channel name for the entire lifetime of the gRPC stream, is determined at the time of establishing and authenticating the gRPC stream, and therefore there is no need to send the channel name in each message.

[0] https://hyperledger.github.io/fabric-rfcs/text/orderer-v3.html#orderer-to-orderer-authentication-and-communication
