### PR TITLE
CFT Block Puller: reset total sleep 

### DIFF
--- a/internal/pkg/peer/blocksprovider/bft_header_receiver_test.go
+++ b/internal/pkg/peer/blocksprovider/bft_header_receiver_test.go
@@ -263,7 +263,7 @@ func prepareBlock(seq uint64, contentType orderer.SeekInfo_SeekContentType, good
 	for i := 0; i < numTx; i++ {
 		data.Data[i] = []byte{byte(i), byte(seq)}
 	}
-	block.Header.DataHash, _ = protoutil.BlockDataHash(data)
+	block.Header.DataHash = protoutil.ComputeBlockDataHash(data)
 	if contentType == orderer.SeekInfo_BLOCK {
 		block.Data = data
 	}


### PR DESCRIPTION

#### Type of change

- Bug fix

#### Description

In internal/pkg/peer/blocksprovider/deliverer.go:150

Local variable `totalDuration` measures the total sleep during retries. If it exceeds `reconnectTotalTimeThreshold` the Deliverer may exit if `MaxRetryDurationExceededHandler` returns true. 

However, it does not reset on success (block reception), so `DeliverBlocks()` may exit eventually if the cumulative sleep time is large, but no consecutive reconnect failure sequence exceeds the threshold for stopping retries.

The solution is to reset `totalDuration` together when we reset `failureCounter`.


#### Related issues

Issue: #4394 
