### PR TITLE
[WIP] delete in test "Resubmitting the same transaction", …

### DIFF
--- a/integration/gateway/gateway_bft_test.go
+++ b/integration/gateway/gateway_bft_test.go
@@ -165,9 +165,6 @@ var _ = Describe("GatewayService with BFT ordering service", func() {
 		Eventually(ordererProcesses["orderer2"].Ready(), network.EventuallyTimeout).Should(BeClosed())
 		time.Sleep(time.Second)
 
-		By("Resubmitting the same transaction")
-		_, err = gw.Submit(ctx, submitRequest)
-		Expect(err).NotTo(HaveOccurred())
 		waitForCommit(ctx, gw, signer, channel, submitRequest.TransactionId)
 
 		By("Checking the ledger state")


### PR DESCRIPTION
... but the test completes successfully

Illustration of gateway submit (broadcastToAll) malfunction returning an error when it should return success.
In my opinion, the broadcastToAll function is implemented incorrectly

https://github.com/hyperledger/fabric/issues/4415