### PR TITLE
Change evaluation method in gateway.

### DIFF
--- a/internal/pkg/gateway/api_test.go
+++ b/internal/pkg/gateway/api_test.go
@@ -498,6 +498,13 @@ func prepareTest(t *testing.T, tt *testDef) *preparedTest {
 		c.CapabilitiesReturns(cap)
 		res := &mocks.Resources{}
 		res.ChannelConfigReturns(c)
+		val := &mocks.Orderer{}
+		if tt.isBFT {
+			val.ConsensusTypeReturns("BFT")
+		} else {
+			val.ConsensusTypeReturns("etcdraft")
+		}
+		res.OrdererConfigReturns(val, true)
 		return res
 	}
 

--- a/internal/pkg/gateway/submit.go
+++ b/internal/pkg/gateway/submit.go
@@ -50,7 +50,11 @@ func (gs *Server) Submit(ctx context.Context, request *gp.SubmitRequest) (*gp.Su
 
 	logger := logger.With("txID", request.TransactionId)
 	config := gs.getChannelConfig(request.ChannelId)
-	if config.ChannelConfig().Capabilities().ConsensusTypeBFT() {
+	oc, ok := config.OrdererConfig()
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "failed to create block deliverer for channel `%s`, missing OrdererConfig", request.ChannelId)
+	}
+	if oc.ConsensusType() == "BFT" {
 		return gs.submitBFT(ctx, orderers, txn, clusterSize, logger)
 	} else {
 		return gs.submitNonBFT(ctx, orderers, txn, logger)


### PR DESCRIPTION
Since RAFT node is able to run with capability turned on, changed the gateway code to evaluate consensus type rather than evaluating channel capabilities.

#### Type of change
- Bug fix

#### Description
Since RAFT node is able to run with capability turned on, changed the gateway code to evaluate consensus type rather than evaluating channel capabilities.
Following that changed the [https://github.com/hyperledger/fabric/blob/main/internal/pkg/gateway/submit.go#L53](url) file to check the consensus type.
