### PR TITLE
Fix install-fabric.sh to pull baseos for v3.x

### DIFF
--- a/scripts/install-fabric.sh
+++ b/scripts/install-fabric.sh
@@ -227,7 +227,7 @@ pullImages() {
     if [ "${NODOCKER}" == 0 ]; then
         FABRIC_IMAGES=(peer orderer ccenv tools)
         case "$VERSION" in
-        2.*)
+        [2-3].*)
             FABRIC_IMAGES+=(baseos)
             shift
             ;;


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Fixed install-fabric.sh to pull baseos images for v3.x as well as v2.x.

#### Additional details

#### Related issues

https://github.com/hyperledger/fabric/issues/4423