### PR TITLE
add channel to log and refactor code

### DIFF
--- a/orderer/common/cluster/deliver.go
+++ b/orderer/common/cluster/deliver.go
@@ -185,7 +185,7 @@ func (p *BlockPuller) tryFetchBlock(seq uint64) *common.Block {
 
 	if err := p.VerifyBlockSequence(p.blockBuff, p.Channel); err != nil {
 		p.Close()
-		p.Logger.Errorf("Failed verifying received blocks: %v", err)
+		p.Logger.Errorf("[channel: %s] Failed verifying received blocks: %v", p.Channel, err)
 		return nil
 	}
 
@@ -233,7 +233,7 @@ func (p *BlockPuller) pullBlocks(seq uint64, reConnected bool) error {
 		totalSize += size
 		p.blockBuff = append(p.blockBuff, block)
 		nextExpectedSequence++
-		p.Logger.Infof("Got block [%d] of size %d KB from %s", seq, size/1024, p.endpoint)
+		p.Logger.Infof("[channel: %s] Got block [%d] of size %d KB from %s", p.Channel, seq, size/1024, p.endpoint)
 	}
 	return nil
 }
@@ -306,7 +306,7 @@ func (p *BlockPuller) connectToSomeEndpoint(minRequestedSequence uint64) {
 	p.endpoint = chosenEndpoint
 	p.latestSeq = endpointsInfo[chosenEndpoint].lastBlockSeq
 
-	p.Logger.Infof("Connected to %s with last block seq of %d", p.endpoint, p.latestSeq)
+	p.Logger.Infof("[channel: %s] Connected to %s with last block seq of %d", p.Channel, p.endpoint, p.latestSeq)
 }
 
 // probeEndpoints reaches to all endpoints known and returns the latest block sequences
@@ -413,12 +413,12 @@ func (p *BlockPuller) fetchLastBlockSeq(minRequestedSequence uint64, endpoint st
 
 	seq := block.Header.Number
 	if seq < minRequestedSequence {
-		err := errors.Errorf("minimum requested sequence is %d but %s is at sequence %d", minRequestedSequence, endpoint, seq)
+		err = errors.Errorf("minimum requested sequence is %d but %s is at sequence %d", minRequestedSequence, endpoint, seq)
 		p.Logger.Infof("Skipping pulling from %s: %v", endpoint, err)
 		return 0, err
 	}
 
-	p.Logger.Infof("%s is at block sequence of %d", endpoint, seq)
+	p.Logger.Infof("[channel: %s] %s is at block sequence of %d", p.Channel, endpoint, seq)
 	return block.Header.Number, nil
 }
 
@@ -432,7 +432,7 @@ func (p *BlockPuller) requestBlocks(endpoint string, newStream ImpatientStreamCr
 		return nil, err
 	}
 
-	if err := stream.Send(env); err != nil {
+	if err = stream.Send(env); err != nil {
 		p.Logger.Errorf("Failed sending seek envelope to %s: %v", endpoint, err)
 		stream.abort()
 		return nil, err


### PR DESCRIPTION
Delivery is done within a channel. 
In the logs in these places it is very lacking to specify for which channel the delivery is done 