### PR TITLE
Tag docker images with release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,10 @@ $(BUILD_DIR)/images/%/$(DUMMY):
 		--build-arg TARGETARCH=$(ARCH) \
 		--build-arg TARGETOS=linux \
 		$(BUILD_ARGS) \
-		-t $(DOCKER_NS)/fabric-$* ./$(BUILD_CONTEXT)
+		-t $(DOCKER_NS)/fabric-$* \
+		-t $(DOCKER_NS)/fabric-$*:$(FABRIC_VER) \
+		-t $(DOCKER_NS)/fabric-$*:$(TWO_DIGIT_VERSION) \
+		./$(BUILD_CONTEXT)
 
 # builds release packages for the host platform
 .PHONY: release


### PR DESCRIPTION
When calling "make docker", tag the images with the Fabric version and Fabric two-digit version number. This will ensure that the correct ccenv and baseos images can be found when building chaincode images.