### PR TITLE
Improve error msg by using the error pkg

### DIFF
--- a/common/cauthdsl/policy.go
+++ b/common/cauthdsl/policy.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package cauthdsl
 
 import (
-	"fmt"
-
 	"github.com/golang/protobuf/proto"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/common/policies"
@@ -32,11 +30,11 @@ func NewPolicyProvider(deserializer msp.IdentityDeserializer) policies.Provider 
 func (pr *provider) NewPolicy(data []byte) (policies.Policy, proto.Message, error) {
 	sigPolicy := &cb.SignaturePolicyEnvelope{}
 	if err := proto.Unmarshal(data, sigPolicy); err != nil {
-		return nil, nil, fmt.Errorf("Error unmarshalling to SignaturePolicy: %s", err)
+		return nil, nil, errors.Wrap(err, "error unmarshalling to SignaturePolicy")
 	}
 
 	if sigPolicy.Version != 0 {
-		return nil, nil, fmt.Errorf("This evaluator only understands messages of version 0, but version was %d", sigPolicy.Version)
+		return nil, nil, errors.Errorf("this evaluator only understands messages of version 0, but version was %d", sigPolicy.Version)
 	}
 
 	compiled, err := compile(sigPolicy.Rule, sigPolicy.Identities)
@@ -97,7 +95,7 @@ func (p *policy) EvaluateSignedData(signatureSet []*protoutil.SignedData) error 
 // they satisfy the policy
 func (p *policy) EvaluateIdentities(identities []msp.Identity) error {
 	if p == nil {
-		return fmt.Errorf("No such policy")
+		return errors.New("no such policy")
 	}
 
 	ok := p.evaluator(identities, make([]bool, len(identities)))

--- a/common/cauthdsl/policy_test.go
+++ b/common/cauthdsl/policy_test.go
@@ -103,14 +103,14 @@ func TestNewPolicyErrorCase(t *testing.T) {
 	pol1, msg1, err1 := provider.NewPolicy([]byte{0})
 	require.Nil(t, pol1)
 	require.Nil(t, msg1)
-	require.ErrorContains(t, err1, "Error unmarshalling to SignaturePolicy")
+	require.ErrorContains(t, err1, "error unmarshalling to SignaturePolicy")
 
 	sigPolicy2 := &cb.SignaturePolicyEnvelope{Version: -1}
 	data2 := marshalOrPanic(sigPolicy2)
 	pol2, msg2, err2 := provider.NewPolicy(data2)
 	require.Nil(t, pol2)
 	require.Nil(t, msg2)
-	require.EqualError(t, err2, "This evaluator only understands messages of version 0, but version was -1")
+	require.EqualError(t, err2, "this evaluator only understands messages of version 0, but version was -1")
 
 	pol3, msg3, err3 := provider.NewPolicy([]byte{})
 	require.Nil(t, pol3)


### PR DESCRIPTION
The patchset improves the error message.

Change-Id: I7d7bb084d0ba9d6d33a2b583a763752fca530b9b

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

The errors package has better features than the fmt package in terms of error processing. E.g., errors.Errorf records the stack trace at the point it is called.

On the other hand, the patchset eliminates the usage of fmt package.

#### Additional details

N/A

#### Related issues

N/A

#### Release Note

N/A
