### PR TITLE
Bump urllib3 from 1.26.16 to 1.26.17

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -21,4 +21,4 @@ sphinx-rtd-theme==1.2.2
 sphinxcontrib-jquery==4.1
 sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib-websupport==1.2.4
-urllib3==1.26.16
+urllib3==1.26.17


### PR DESCRIPTION
This patchset resolves the security alert of Cookie HTTP header handling.

Change-Id: I7015258f8eef9518ec7a7428d51b192aa0192b1a

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

More details can be found at
https://github.com/advisories/GHSA-v845-jxx5-vc9f.

#### Additional details

N/A

#### Related issues

N/A

#### Release Note

N/A
