### PR TITLE
Remove usage of fmt.Errorf

### DIFF
--- a/common/cauthdsl/cauthdsl.go
+++ b/common/cauthdsl/cauthdsl.go
@@ -7,13 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package cauthdsl
 
 import (
-	"fmt"
 	"time"
 
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	mb "github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/msp"
+	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -23,7 +23,7 @@ var cauthdslLogger = flogging.MustGetLogger("cauthdsl")
 // passing them to this function for evaluation
 func compile(policy *cb.SignaturePolicy, identities []*mb.MSPPrincipal) (func([]msp.Identity, []bool) bool, error) {
 	if policy == nil {
-		return nil, fmt.Errorf("Empty policy element")
+		return nil, errors.Errorf("Empty policy element")
 	}
 
 	switch t := policy.Type.(type) {
@@ -60,7 +60,7 @@ func compile(policy *cb.SignaturePolicy, identities []*mb.MSPPrincipal) (func([]
 		}, nil
 	case *cb.SignaturePolicy_SignedBy:
 		if t.SignedBy < 0 || t.SignedBy >= int32(len(identities)) {
-			return nil, fmt.Errorf("identity index out of range, requested %v, but identities length is %d", t.SignedBy, len(identities))
+			return nil, errors.Errorf("identity index out of range, requested %v, but identities length is %d", t.SignedBy, len(identities))
 		}
 		signedByID := identities[t.SignedBy]
 		return func(signedData []msp.Identity, used []bool) bool {
@@ -87,6 +87,6 @@ func compile(policy *cb.SignaturePolicy, identities []*mb.MSPPrincipal) (func([]
 			return false
 		}, nil
 	default:
-		return nil, fmt.Errorf("Unknown type: %T:%v", t, t)
+		return nil, errors.Errorf("Unknown type: %T:%v", t, t)
 	}
 }

--- a/common/ledger/util/util.go
+++ b/common/ledger/util/util.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"encoding/binary"
-	"fmt"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
@@ -43,7 +42,7 @@ func EncodeOrderPreservingVarUint64(number uint64) []byte {
 	}
 	sizeBytes := proto.EncodeVarint(uint64(size))
 	if len(sizeBytes) > 1 {
-		panic(fmt.Errorf("[]sizeBytes should not be more than one byte because the max number it needs to hold is 8. size=%d", size))
+		panic(errors.Errorf("[]sizeBytes should not be more than one byte because the max number it needs to hold is 8. size=%d", size))
 	}
 	encodedBytes := make([]byte, size+1)
 	encodedBytes[0] = sizeBytes[0]


### PR DESCRIPTION
The patchset uses the errors pkg to follow the guideline at

https://hyperledger-fabric.readthedocs.io/en/latest/error-handling.html

Change-Id: I36eaac1b429c69195e4af1bb5bb25fc1a2578168

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Remove the usage of fmt.Errorf. Follow the official guideline to change
to the errors package.

#### Additional details

N/A

#### Related issues

N/A

#### Release Note

N/A
