### PR TITLE
Fix comment prefix

### DIFF
--- a/common/channelconfig/consortium.go
+++ b/common/channelconfig/consortium.go
@@ -54,7 +54,7 @@ func (cc *ConsortiumConfig) Organizations() map[string]Org {
 	return cc.orgs
 }
 
-// CreationPolicy returns the policy structure used to validate
+// ChannelCreationPolicy returns the policy structure used to validate
 // the channel creation
 func (cc *ConsortiumConfig) ChannelCreationPolicy() *cb.Policy {
 	return cc.protos.ChannelCreationPolicy


### PR DESCRIPTION
The comment prefix should match method name.

Change-Id: I817951e2c94db1705293709fc49f2fc67cf71373

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Fix comment prefix that is not matched with the method name.

#### Additional details

N/A

#### Related issues

N/A

#### Release Note

N/A
