### PR TITLE
Use the errors.Is to check error type

### DIFF
--- a/bccsp/pkcs11/pkcs11.go
+++ b/bccsp/pkcs11/pkcs11.go
@@ -664,7 +664,7 @@ func (csp *Provider) verifyP11ECDSA(ski []byte, msg []byte, R, S *big.Int, byteS
 		return false, fmt.Errorf("PKCS11: Verify-initialize [%s]", err)
 	}
 	err = csp.ctx.Verify(session, msg, sig)
-	if err == pkcs11.Error(pkcs11.CKR_SIGNATURE_INVALID) {
+	if errors.Is(err, pkcs11.Error(pkcs11.CKR_SIGNATURE_INVALID)) {
 		return false, nil
 	}
 	if err != nil {

--- a/bccsp/sw/fileks.go
+++ b/bccsp/sw/fileks.go
@@ -417,7 +417,7 @@ func dirEmpty(path string) (bool, error) {
 	defer f.Close()
 
 	_, err = f.Readdir(1)
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		return true, nil
 	}
 	return false, err

--- a/common/ledger/blkstorage/blockfile_mgr.go
+++ b/common/ledger/blkstorage/blockfile_mgr.go
@@ -374,7 +374,7 @@ func (mgr *blockfileMgr) syncIndex() error {
 	nextIndexableBlock := uint64(0)
 	lastBlockIndexed, err := mgr.index.getLastBlockIndexed()
 	if err != nil {
-		if err != errIndexSavePointKeyNotPresent {
+		if !errors.Is(err, errIndexSavePointKeyNotPresent) {
 			return err
 		}
 	} else {

--- a/common/ledger/blockledger/fileledger/factory.go
+++ b/common/ledger/blockledger/fileledger/factory.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package fileledger
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -59,7 +60,7 @@ func (f *fileLedgerFactory) Remove(channelID string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
-	if err := f.removeFileRepo.Save(channelID, []byte{}); err != nil && err != os.ErrExist {
+	if err := f.removeFileRepo.Save(channelID, []byte{}); err != nil && !errors.Is(err, os.ErrExist) {
 		return err
 	}
 

--- a/orderer/common/broadcast/broadcast.go
+++ b/orderer/common/broadcast/broadcast.go
@@ -68,7 +68,7 @@ func (bh *Handler) Handle(srv ab.AtomicBroadcast_BroadcastServer) error {
 	logger.Debugf("Starting new broadcast loop for %s", addr)
 	for {
 		msg, err := srv.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			logger.Debugf("Received EOF from %s, hangup", addr)
 			return nil
 		}

--- a/orderer/consensus/etcdraft/chain.go
+++ b/orderer/consensus/etcdraft/chain.go
@@ -952,13 +952,13 @@ func (c *Chain) ordered(msg *orderer.SubmitRequest) (batches [][]*common.Envelop
 					if err := c.Node.abdicateLeadership(); err != nil {
 						// If there is no leader, abort and do not retry.
 						// Return early to prevent re-submission of the transaction
-						if err == ErrNoLeader || err == ErrChainHalting {
+						if errors.Is(err, ErrNoLeader) || errors.Is(err, ErrChainHalting) {
 							c.logger.Warningf("Abdication attempt no.%d failed because there is no leader or chain halting, will not try again, will not submit TX, error: %s", attempt, err)
 							return
 						}
 
 						// If the error isn't any of the below, it's a programming error, so panic.
-						if err != ErrNoAvailableLeaderCandidate && err != ErrTimedOutLeaderTransfer {
+						if !errors.Is(err, ErrNoAvailableLeaderCandidate) && !errors.Is(err, ErrTimedOutLeaderTransfer) {
 							c.logger.Panicf("Programming error, abdicateLeader() returned with an unexpected error: %s", err)
 						}
 


### PR DESCRIPTION
The patchset uses errors.Is to check error type.

Change-Id: Ieae0eaa2527d05fa67aa31afdda42d150fff0980

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

errors.Is is recommened since Go 1.13 to check error type. The error may be wrapped.

More details: https://github.com/golang/go/wiki/ErrorValueFAQ.

#### Additional details

N/A

#### Related issues

N/A

#### Release Note

N/A
