### PR TITLE
Add inspect option into checkcommitreadiness command to output discre…

### DIFF
--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -311,6 +311,7 @@ Flags:
   -E, --endorsement-plugin string      The name of the endorsement plugin to be used for this chaincode
   -h, --help                           help for checkcommitreadiness
       --init-required                  Whether the chaincode requires invoking 'init'
+      --inspect                        If inspect is enabled, output additional information to identify discrepancies when an organization's approval is false
   -n, --name string                    Name of the chaincode
   -O, --output string                  The output format for query results. Default is human-readable plain-text. json is currently the only supported format.
       --peerAddresses stringArray      The addresses of the peers to connect to

--- a/internal/peer/lifecycle/chaincode/chaincode.go
+++ b/internal/peer/lifecycle/chaincode/chaincode.go
@@ -70,6 +70,7 @@ var (
 	sequence              int
 	initRequired          bool
 	output                string
+	inspectionEnabled     bool
 	outputDirectory       string
 )
 
@@ -119,6 +120,7 @@ func ResetFlags() {
 	flags.IntVarP(&sequence, "sequence", "", 0, "The sequence number of the chaincode definition for the channel")
 	flags.BoolVarP(&initRequired, "init-required", "", false, "Whether the chaincode requires invoking 'init'")
 	flags.StringVarP(&output, "output", "O", "", "The output format for query results. Default is human-readable plain-text. json is currently the only supported format.")
+	flags.BoolVarP(&inspectionEnabled, "inspect", "", false, "If inspect is enabled, output additional information to identify discrepancies when an organization's approval is false")
 	flags.StringVarP(&outputDirectory, "output-directory", "", "", "The output directory to use when writing a chaincode install package to disk. Default is the current working directory.")
 }
 


### PR DESCRIPTION
This patch adds `inspect` option into checkcommitreadiness command to output discrepancy details.

#### Type of change

- New feature

#### Description
I have proposed an extension to lifecycle chaincode checkcommitreadiness to provide details of the discrepancies as shown in  https://github.com/hyperledger/fabric/issues/4428.

As a sub-task stemming from issue #4428, this patch adds `inspect` option into checkcommitreadiness command to output discrepancy details.

After this patch is merged, I will submit some patches for the integration tests and documentation.

#### Additional details

The example of output when executing checkcommitreadiness with inspect flag in the implementation:

```
peer lifecycle chaincode checkcommitreadiness --channelID mychannel --name basic --version 2.0 --sequence 2 --inspect
Chaincode definition for chaincode 'basic', version '2.0', sequence '2' on channel 'mychannel' approval status by org:
Org1MSP: false (mismatch: [EndorsementInfo, ValidationInfo, Collections])
Org2MSP: false (mismatch: [ChaincodeParameters])
```

```
peer lifecycle chaincode checkcommitreadiness --channelID mychannel --name basic --version 2.0 --sequence 2 --inspect --output json
{
        "approvals": {
                "Org1MSP": false,
                "Org2MSP": false
        },
        "mismatches": {
                "Org1MSP": {
                        "items": [
                                "EndorsementInfo (Check the Version, InitRequired, EndorsementPlugin)",
                                "ValidationInfo (Check the ValidationParameter, ValidationPlugin)",
                                "Collections (Check the Collections)"
                        ]
                },
                "Org2MSP": {
                        "items": [
                                "ChaincodeParameters (Check the Sequence, ChaincodeName)"
                        ]
                }
        }
}
```

#### Related issues

- https://github.com/hyperledger/fabric/issues/4428
