### PR TITLE
remove an unused parameter

### DIFF
--- a/core/ledger/pvtdatapolicy/btlpolicy.go
+++ b/core/ledger/pvtdatapolicy/btlpolicy.go
@@ -79,10 +79,10 @@ func (p *LSCCBasedBTLPolicy) GetExpiringBlock(namespace string, collection strin
 	if err != nil {
 		return 0, err
 	}
-	return ComputeExpiringBlock(namespace, collection, committingBlock, btl), nil
+	return ComputeExpiringBlock(collection, committingBlock, btl), nil
 }
 
-func ComputeExpiringBlock(namespace, collection string, committingBlock, btl uint64) uint64 {
+func ComputeExpiringBlock(collection string, committingBlock, btl uint64) uint64 {
 	expiryBlk := committingBlock + btl + uint64(1)
 	if expiryBlk <= committingBlock { // committingBlk + btl overflows uint64-max
 		expiryBlk = math.MaxUint64

--- a/core/ledger/pvtdatastorage/snapshot_data_importer.go
+++ b/core/ledger/pvtdatastorage/snapshot_data_importer.go
@@ -254,7 +254,7 @@ func (i *eligibilityAndBTLCache) hasExpiry(namespace, collection string, committ
 		coll: collection,
 	}]
 	if ok {
-		expiringBlk = pvtdatapolicy.ComputeExpiringBlock(namespace, collection, committingBlk, btl)
+		expiringBlk = pvtdatapolicy.ComputeExpiringBlock(collection, committingBlk, btl)
 	}
 	return expiringBlk < math.MaxUint64, expiringBlk
 }


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

This commit removes an unused parameter named "namespace" from a function that computes the expiring block number for a private key stored in a collection with a "block to live" policy.