### PR TITLE
Extend integration tests to cover inspect option of checkcommitreadiness

### DIFF
--- a/integration/nwo/commands/peer.go
+++ b/integration/nwo/commands/peer.go
@@ -482,6 +482,7 @@ type ChaincodeCheckCommitReadiness struct {
 	SignaturePolicy     string
 	ChannelConfigPolicy string
 	InitRequired        bool
+	InspectionEnabled   bool
 	CollectionsConfig   string
 	PeerAddresses       []string
 	ClientAuth          bool
@@ -507,6 +508,10 @@ func (c ChaincodeCheckCommitReadiness) Args() []string {
 
 	if c.InitRequired {
 		args = append(args, "--init-required")
+	}
+
+	if c.InspectionEnabled {
+		args = append(args, "--inspect")
 	}
 
 	if c.CollectionsConfig != "" {


### PR DESCRIPTION
#### Type of change

- Test update

#### Description

This patch extends integration tests to cover inspect option of checkcommitreadiness.

#### Related issues

#4428

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
