### PR TITLE
Simplify code by using direct return

### DIFF
--- a/common/util/net.go
+++ b/common/util/net.go
@@ -16,15 +16,14 @@ import (
 )
 
 func ExtractRemoteAddress(ctx context.Context) string {
-	var remoteAddress string
 	p, ok := peer.FromContext(ctx)
 	if !ok {
 		return ""
 	}
 	if address := p.Addr; address != nil {
-		remoteAddress = address.String()
+		return address.String()
 	}
-	return remoteAddress
+	return ""
 }
 
 // ExtractCertificateHashFromContext extracts the hash of the certificate from the given context.


### PR DESCRIPTION
The patchset simplifies the code by using direct return.

Change-Id: I3a9db0173fa0ae08adf53f3edb2d6e0a3a3e8678

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

The method ExtractRemoteAddress uses two types of return:

1. direct return of "";
2. return the variable of remoteAddress

The patchset simplify the code by using direct return.

#### Additional details

N/A

#### Related issues

N/A

#### Release Note

N/A
