### PR TITLE
chore(ci): move to dedicated Fabric runners (release-2.2)

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   basic-checks:
     name: Basic Checks
-    runs-on: ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/setup-go@v3
         name: Install Go
@@ -31,7 +31,7 @@ jobs:
   unit-tests:
     name: Unit Tests
     needs: basic-checks
-    runs-on: ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/setup-go@v3
         name: Install Go
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         INTEGRATION_TEST_SUITE: ["raft","pvtdata","ledger","lifecycle","e2e","discovery gossip devmode pluggable","gateway idemix pkcs11 configtx configtxlator","sbe nwo msp"]
-    runs-on: ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/setup-go@v3
         name: Install Go


### PR DESCRIPTION
Utilize faster runners for verify CI jobs.
