### PR TITLE
Skip checking well formed-ness for config blocks

### DIFF
--- a/protoutil/blockutils.go
+++ b/protoutil/blockutils.go
@@ -305,6 +305,12 @@ func VerifyTransactionsAreWellFormed(block *cb.Block) error {
 		return fmt.Errorf("empty block")
 	}
 
+	// If we have a single transaction, and the block is a config block, then no need to check
+	// well formed-ness, because there cannot be another transaction in the original block.
+	if IsConfigBlock(block) {
+		return nil
+	}
+
 	for i, rawTx := range block.Data.Data {
 		env := &cb.Envelope{}
 		if err := proto.Unmarshal(rawTx, env); err != nil {

--- a/protoutil/blockutils_test.go
+++ b/protoutil/blockutils_test.go
@@ -518,6 +518,23 @@ func TestVerifyTransactionsAreWellFormed(t *testing.T) {
 		block         *cb.Block
 	}{
 		{
+			name: "config block",
+			block: &cb.Block{Data: &cb.BlockData{
+				Data: [][]byte{
+					protoutil.MarshalOrPanic(
+						&cb.Envelope{
+							Payload: protoutil.MarshalOrPanic(&cb.Payload{
+								Header: &cb.Header{
+									ChannelHeader: protoutil.MarshalOrPanic(&cb.ChannelHeader{
+										Type: int32(cb.HeaderType_CONFIG),
+									}),
+								},
+							}),
+						}),
+				},
+			}},
+		},
+		{
 			name:          "empty block",
 			expectedError: "empty block",
 		},


### PR DESCRIPTION
If the block is a config block, no point in checking its well formed-ness as it only can contain a single transaction.
