### PR TITLE
Add error handle for stream

### DIFF
--- a/core/chaincode/extcc/extcc_handler.go
+++ b/core/chaincode/extcc/extcc_handler.go
@@ -58,7 +58,9 @@ func (i *ExternalChaincodeRuntime) Stream(ccid string, ccinfo *ccintf.ChaincodeS
 	}
 
 	// peer as client has to initiate the stream. Rest of the process is unchanged
-	sHandler.HandleChaincodeStream(stream)
+	if err := sHandler.HandleChaincodeStream(stream); err != nil {
+		return errors.WithMessagef(err, "error handling chaincode stream for %s", ccid)
+	}
 
 	extccLogger.Debugf("External chaincode %s client exited", ccid)
 

--- a/core/chaincode/extcc/extcc_handler_test.go
+++ b/core/chaincode/extcc/extcc_handler_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package extcc_test
 
 import (
+	"errors"
 	"net"
 	"time"
 
@@ -71,6 +72,19 @@ var _ = Describe("Extcc", func() {
 
 				streamArg := shandler.HandleChaincodeStreamArgsForCall(0)
 				Expect(streamArg).To(Not(BeNil()))
+			})
+
+			It("HandleChaincodeStream returns error", func() {
+				ccinfo := &ccintf.ChaincodeServerInfo{
+					Address: cclist.Addr().String(),
+					ClientConfig: comm.ClientConfig{
+						KaOpts:      comm.DefaultKeepaliveOptions,
+						DialTimeout: 10 * time.Second,
+					},
+				}
+				shandler.HandleChaincodeStreamReturns(errors.New("error returned by HandleChaincodeStream"))
+				err := i.Stream("ccid", ccinfo, shandler)
+				Expect(err).To(MatchError(ContainSubstring("error handling chaincode stream for ccid")))
 			})
 		})
 		Context("chaincode info incorrect", func() {


### PR DESCRIPTION

Change-Id: I8928e64ce09d6f6a0f2f411473d645c46a1b0db5

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

The patchset checks the potential returned error from the stream between peer and external chaincode.

#### Additional details

N/A

#### Related issues

N/A

#### Release Note

N/A
