### PR TITLE
Switching to use buildx to build docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,8 @@ $(BUILD_DIR)/images/%/$(DUMMY):
 		--build-arg TARGETARCH=$(ARCH) \
 		--build-arg TARGETOS=linux \
 		$(BUILD_ARGS) \
+		--cache-to type=inline,mode=max \
+		--cache-from type=registry,ref=$(DOCKER_NS)/fabric-$*:$(FABRIC_VER) \
 		-t $(DOCKER_NS)/fabric-$* \
 		-t $(DOCKER_NS)/fabric-$*:$(FABRIC_VER) \
 		-t $(DOCKER_NS)/fabric-$*:$(TWO_DIGIT_VERSION) \

--- a/docker-env.mk
+++ b/docker-env.mk
@@ -21,7 +21,7 @@ ifneq ($(NO_PROXY),)
 DOCKER_BUILD_FLAGS+=--build-arg 'NO_PROXY=$(NO_PROXY)'
 endif
 
-DOCKER_BUILD ?= docker build --force-rm
+DOCKER_BUILD ?= docker buildx build --force-rm
 DBUILD = $(DOCKER_BUILD) $(DOCKER_BUILD_FLAGS)
 
 DOCKER_NS ?= hyperledger


### PR DESCRIPTION
This commit enables to use `docker buildx` and make use of remote cache while building new images to reuse unchanged layers instead of building them each time, thus speeding up building new Fabric container images.


