### PR TITLE
bug fix 4509. Configuration parameters CA and address in peer.deliver…

### DIFF
--- a/internal/pkg/peer/orderers/connection.go
+++ b/internal/pkg/peer/orderers/connection.go
@@ -50,7 +50,14 @@ func (cs *ConnectionSource) RandomEndpoint() (*Endpoint, error) {
 	if len(cs.allEndpoints) == 0 {
 		return nil, errors.Errorf("no endpoints currently defined")
 	}
-	return cs.allEndpoints[rand.Intn(len(cs.allEndpoints))], nil
+	OrderersOverridekeys := make([]string, 0, len(cs.overrides))
+	for key := range cs.overrides {
+		OrderersOverridekeys = append(OrderersOverridekeys, key)
+	}
+	random := rand.Intn(len(OrderersOverridekeys))
+	endpoint := cs.overrides[OrderersOverridekeys[random]]
+	endpoint.Address = cs.allEndpoints[random].Address
+	return endpoint, nil
 }
 
 func (cs *ConnectionSource) Update(globalAddrs []string, orgs map[string]OrdererOrg) {


### PR DESCRIPTION
<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

Fabric reads the values stored in core.yaml in the peer.deliveryclient.addressOverrides section, but when connecting to orderers through the connect method in the blocksprovider.go file (internal/pkg/peer/blocksprovider/blocksprovider.go) it is using the RandomEndpoint function (endpoint, err := d.Orderers.RandomEndpoint()) located in the connection.go file (internal/pkg/peer/orderers/connection.go) to set up the endpoint that will make the connection. However the RandomEndpoint function does not use the peer.deliveryclient.addressOverrides information read by Fabric.

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

https://github.com/hyperledger/fabric/issues/4509

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
