### PR TITLE
DOC / Update create_channel_test_net.md

### DIFF
--- a/docs/source/create_channel/create_channel_config.md
+++ b/docs/source/create_channel/create_channel_config.md
@@ -140,13 +140,20 @@ The test network uses the default policies provided by Fabric, which require tha
 
 The `configtxgen` tool reads the channel profiles in the **Profiles** section to build a channel configuration. Each profile uses YAML syntax to gather data from other sections of the file. The `configtxgen` tool uses this configuration to create a genesis block for joining orderers to a new channel via the channel participation API. To learn more about YAML syntax, [Wikipedia](https://en.wikipedia.org/wiki/YAML) provides a good place to get started.
 
-The `configtx.yaml` used by the test network contains one channel profile `TwoOrgsApplicationGenesis`.
-The `TwoOrgsApplicationGenesis` profile is used by the test network to create application channels:
+The `configtx.yaml` used by the test network contains one channel profile `ChannelUsingRaft`.
+The `ChannelUsingRaft` profile is used by the test network to create application channels:
 ```yaml
-TwoOrgsApplicationGenesis:
+ChannelUsingRaft:
   <<: *ChannelDefaults
   Orderer:
     <<: *OrdererDefaults
+    OrdererType: etcdraft
+    EtcdRaft:
+      Consenters:
+        - Host: orderer.example.com
+          Port: 7050
+          ClientTLSCert: ../organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt
+          ServerTLSCert: ../organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt
     Organizations:
       - *OrdererOrg
     Capabilities: *OrdererCapabilities

--- a/docs/source/create_channel/create_channel_test_net.md
+++ b/docs/source/create_channel/create_channel_test_net.md
@@ -95,12 +95,19 @@ This `configtx.yaml` file contains the following information that we will use to
           ServerTLSCert: ../organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt
     ```
 - **Channel policies** Different sections of the file work together to define the policies that will govern how organizations interact with the channel and which organizations need to approve channel updates. For the purposes of this tutorial, we will use the default policies used by Fabric.
-- **Channel profiles** Each channel profile references information from other sections of the `configtx.yaml` file to build a channel configuration. The profiles are used to create the genesis block of application channel. Notice that the `configtx.yaml` file in the test network includes a single profile named `TwoOrgsApplicationGenesis` that we will use to generate the create channel transaction.
+- **Channel profiles** Each channel profile references information from other sections of the `configtx.yaml` file to build a channel configuration. The profiles are used to create the genesis block of application channel. Notice that the `configtx.yaml` file in the test network includes a single profile named `ChannelUsingRaft` that we will use to generate the create channel transaction.
     ```yaml
-    TwoOrgsApplicationGenesis:
+    ChannelUsingRaft:
         <<: *ChannelDefaults
         Orderer:
             <<: *OrdererDefaults
+            OrdererType: etcdraft
+            EtcdRaft:
+                Consenters:
+                    - Host: orderer.example.com
+                      Port: 7050
+                      ClientTLSCert: ../organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt
+                      ServerTLSCert: ../organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt
             Organizations:
                 - *OrdererOrg
             Capabilities: *OrdererCapabilities
@@ -122,10 +129,10 @@ Because we have started the Fabric test network, we are ready to create a new ch
 
 Run the following command to create the channel genesis block for `channel1`:
 ```
-configtxgen -profile TwoOrgsApplicationGenesis -outputBlock ./channel-artifacts/channel1.block -channelID channel1
+configtxgen -profile ChannelUsingRaft -outputBlock ./channel-artifacts/channel1.block -channelID channel1
 ```
 
-- **`-profile`**: The command uses the `-profile` flag to reference the `TwoOrgsApplicationGenesis:` profile from `configtx.yaml` that is used by the test network to create application channels.
+- **`-profile`**: The command uses the `-profile` flag to reference the `ChannelUsingRaft:` profile from `configtx.yaml` that is used by the test network to create application channels.
 - **`-outputBlock`**: The output of this command is the channel genesis block that is written to `-outputBlock ./channel-artifacts/channel1.block`.
 - **`-channelID`**: The `-channelID` parameter will be the name of the future channel. You can specify any name you want for your channel but for illustration purposes in this tutorial we use `channel1`. Channel names must be all lowercase, fewer than 250 characters long and match the regular expression ``[a-z][a-z0-9.-]*``.
 

--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -537,7 +537,7 @@ below provide a guided tour of what happens when you issue the command of
 - If you use the `createChannel` subcommand, `./network.sh` runs the
   `createChannel.sh` script in the `scripts` folder to create a channel
   using the supplied channel name. The script uses the `configtxgen` tool to create the channel genesis block
-  based on the `TwoOrgsApplicationGenesis` channel profile in the `configtx/configtx.yaml` file. After creating the channel, the script uses the peer cli to join ``peer0.org1.example.com`` and ``peer0.org2.example.com`` to the channel, and make both of the peers anchor peers.
+  based on the `ChannelUsingRaft` channel profile in the `configtx/configtx.yaml` file. After creating the channel, the script uses the peer cli to join ``peer0.org1.example.com`` and ``peer0.org2.example.com`` to the channel, and make both of the peers anchor peers.
 
 - If you issue the `deployCC` command, `./network.sh` runs the ``deployCC.sh``
   script to install the **asset-transfer (basic)** chaincode on both peers and then define then


### PR DESCRIPTION
The commit exhanges *TwoOrgsApplicationGenesis* with *ChannelUsingRaft* because of commit [eb16ca](https://github.com/hyperledger/fabric-samples/commit/eb16caf3d5adf05f58bd9a63cb91707f4e97b81a) in the [fabric-sample](https://github.com/hyperledger/fabric-samples/) repository. 

- documentation update
- I opened an issue in [fabric-sample](https://github.com/hyperledger/fabric-samples/issues/1131) for it
