### PR TITLE
Correct usage of osnadmin channel remove (release-2.5)

### DIFF
--- a/cmd/osnadmin/main.go
+++ b/cmd/osnadmin/main.go
@@ -55,7 +55,7 @@ func executeForArgs(args []string) (output string, exit int, err error) {
 	list := channel.Command("list", "List channel information for an Ordering Service Node (OSN). If the channelID flag is set, more detailed information will be provided for that channel.")
 	listChannelID := list.Flag("channelID", "Channel ID").Short('c').String()
 
-	remove := channel.Command("remove", "Remove an Ordering Service Node (OSN) from a channel.")
+	remove := channel.Command("remove", "Remove a channel from an Ordering Service Node (OSN).")
 	removeChannelID := remove.Flag("channelID", "Channel ID").Short('c').Required().String()
 
 	command, err := app.Parse(args)

--- a/docs/source/commands/osnadminchannel.md
+++ b/docs/source/commands/osnadminchannel.md
@@ -56,7 +56,7 @@ Subcommands:
     channel.
 
   channel remove --channelID=CHANNELID
-    Remove an Ordering Service Node (OSN) from a channel.
+    Remove a channel from an Ordering Service Node (OSN).
 ```
 
 
@@ -119,7 +119,7 @@ Flags:
 ```
 usage: osnadmin channel remove --channelID=CHANNELID
 
-Remove an Ordering Service Node (OSN) from a channel.
+Remove a channel from an Ordering Service Node (OSN).
 
 Flags:
       --help                     Show context-sensitive help (also try

--- a/docs/source/raft_configuration.md
+++ b/docs/source/raft_configuration.md
@@ -205,7 +205,7 @@ alive) you are effectively stuck until the original offline node is resurrected.
 To add a new node to the ordering service:
 
   1. **Ensure the orderer organization that owns the new node is one of the orderer organizations on the channel**. If the orderer organization is not an administrator, the node will be unable to pull blocks as a follower or be joined to the consenter set.
-  2. **Start the new ordering node**. For information about how to deploy an ordering node, check out [Planning for an ordering service](./deployorderer/ordererdeploy.html). Note that when you use the `osnadmin` CLI to create and join a channel, you do not need to point to a configuration block when starting the node.
+  2. **Start the new ordering node**. For information about how to deploy an ordering node, check out [Planning for an ordering service](./deployorderer/ordererdeploy.html). Note that while you use the `osnadmin` CLI to create and join a channel, you do not need to point to a configuration block when starting the node.
   3. **Use the `osnadmin` CLI to add the first orderer to the channel**. For more information, check out the [Create a channel](./create_channel/create_channel_participation.html#step-two-use-the-osnadmin-cli-to-add-the-first-orderer-to-the-channel) tutorial.
   4. **Wait for the Raft node to replicate the blocks** from existing nodes for all channels its certificates have been added to. When an ordering node is added to a channel, it is added as a "follower", a state in which it can replicate blocks but is not part of the "consenter set" actively servicing the channel. When the node finishes replicating the blocks, its status should change from "onboarding" to "active". Note that an "active" ordering node is still not part of the consenter set.
   5. **Add the new ordering node to the consenter set**. For more information, check out the [Create a channel](./create_channel/create_channel_participation.html#step-three-join-additional-ordering-nodes) tutorial.
@@ -221,7 +221,7 @@ channel, and then start the Raft instance for that chain.
 After it has successfully done so, the channel configuration can be updated to
 include the endpoint of the new Raft orderer.
 
-To remove an ordering node from the consenter set of a channel, use the `osnadmin channel remove` command to remove its endpoint and certificates from the channel. For more information, check out [Add or remove orderers from existing channels](./create_channel/create_channel_participation.html#add-or-remove-orderers-from-existing-channels).
+To remove an ordering node from the consenter set of a channel, use a channel config update transaction to remove its endpoint and certificates from the channel. For more information, check out [Add or remove orderers from existing channels](./create_channel/create_channel_participation.html#add-or-remove-orderers-from-existing-channels).
 
 Once an ordering node is removed from the channel, the other ordering nodes stop communicating with the removed orderer in the context of the removed channel. They might still be communicating on other channels.
 


### PR DESCRIPTION
The patchset corrects the usage about `osnadmin channel remove`.

The command is to remove a channel from an OSN, not conversely.