### PR TITLE
Docs - Update legacy SDK references to Gateway SDK

### DIFF
--- a/docs/source/CONTRIBUTING.rst
+++ b/docs/source/CONTRIBUTING.rst
@@ -282,8 +282,7 @@ it receives a review comment(s).
 
 This policy applies to all official Fabric projects (fabric, fabric-ca,
 fabric-samples, fabric-test, fabric-sdk-node, fabric-sdk-java, fabric-sdk-go, fabric-gateway-java,
-fabric-chaincode-node, fabric-chaincode-java, fabric-chaincode-evm,
-fabric-baseimage, and fabric-amcl).
+fabric-gateway, fabric-chaincode-go, fabric-chaincode-node, fabric-chaincode-java, and fabric-amcl).
 
 Setting up development environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/cc_launcher.md
+++ b/docs/source/cc_launcher.md
@@ -6,7 +6,7 @@ This approach limited chaincode implementations to a handful of languages, requi
 
 Starting with Fabric 2.0, External Builders and Launchers address these limitations by enabling operators to extend the peer with programs that can build, launch, and discover chaincode. To leverage this capability you will need to create your own buildpack and then modify the peer core.yaml to include a new `externalBuilder` configuration element which lets the peer know an external builder is available. The following sections describe the details of this process.
 
-Note that if no configured external builder claims a chaincode package, the peer will attempt to process the package as if it were created with the standard Fabric packaging tools such as the peer CLI or node SDK.
+Note that if no configured external builder claims a chaincode package, the peer will attempt to process the package as if it were created with the standard Fabric packaging tools such as the peer CLI.
 
 **Note:** This is an advanced feature which will likely require custom packaging of the peer image with everything your builders and launchers depend on unless your builders and launchers are simple enough, such as those used in the [basic asset transfer external chaincode Fabric sample](https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/asset-transfer-basic/chaincode-external). For example, the following samples use `go` and `bash`, which are not included in the current official `fabric-peer` image.
 

--- a/docs/source/certs_management.md
+++ b/docs/source/certs_management.md
@@ -318,12 +318,9 @@ org1ca/
 1. **Organization Enrollment Certificate** - Authenticates the client identity for interactions with peers and orderers.
 2. **TLS Certificate** - Authenticates client communications, and only required if mutual TLS is configured.
 
-Client Certificates expire after one year, using the Hyperledger Fabric CA default settings. Client Certificates can be re-enrolled using either command line Hyperledger Fabric CA utilities or the Fabric CA client SDK.
+Client Certificates expire after one year, using the Hyperledger Fabric CA default settings. Client Certificates can be re-enrolled using the command line Hyperledger Fabric CA utility.
 
 **Impact if expired**: Client Certificates must be re-enrolled before expiration or the client application will not be able to interact with the Fabric nodes.
-
-[Reference - Re-enroll user](https://hyperledger.github.io/fabric-sdk-node/release-2.2/FabricCAClient.html#reenroll__anchor)
-
 
 ### Certificate Decoding
 

--- a/docs/source/chaincode_lifecycle.md
+++ b/docs/source/chaincode_lifecycle.md
@@ -64,20 +64,20 @@ every organization on a channel needs to complete each step.
 
 This topic provides a detailed overview of the operations of the Fabric
 chaincode lifecycle rather than the specific commands. To learn more about how
-to use the Fabric lifecycle using the Peer CLI, see the
+to use the Fabric lifecycle using the peer CLI, see the
 [Deploying a smart contract to a channel tutorial](deploy_chaincode.html)
 or the [peer lifecycle command reference](commands/peerlifecycle.html).
 
 ### Step One: Packaging the smart contract
 
 Chaincode needs to be packaged in a tar file before it can be installed on your
-peers. You can package a chaincode using the Fabric peer binaries, the Node
-Fabric SDK, or a third party tool such as GNU tar. When you create a chaincode
+peers. You can package a chaincode using the Fabric peer binary
+or a third party tool such as GNU tar. When you create a chaincode
 package, you need to provide a chaincode package label to create a succinct and
 human readable description of the package.
 
 If you use a third party tool to package the chaincode, the resulting file needs
-to be in the format below. The Fabric peer binaries and the Fabric SDKs will
+to be in the format below. The Fabric peer binary will
 automatically create a file in this format.
 - The chaincode needs to be packaged in a tar file, ending with a `.tar.gz` file
   extension.
@@ -100,8 +100,8 @@ label.*
 ### Step Two: Install the chaincode on your peers
 
 You need to install the chaincode package on every peer that will execute and
-endorse transactions. Whether using the CLI or an SDK, you need to complete this
-step using your **Peer Administrator**. Your peer will build the chaincode
+endorse transactions. You need to complete this step with the peer CLI using the
+credentials of the **Peer Administrator**. Your peer will build the chaincode
 after the chaincode is installed, and return a build error if there is a problem
 with your chaincode. It is recommended that organizations only package a chaincode
 once, and then install the same package on every peer that belongs to their org.
@@ -114,7 +114,7 @@ is the package label combined with a hash of the package. This package
 identifier is used to associate a chaincode package installed on your peers with
 a chaincode definition approved by your organization. **Save the identifier**
 for next step. You can also find the package identifier by querying the packages
-installed on your peer using the Peer CLI.
+installed on your peer using the peer CLI.
 
   ![Installing the chaincode](lifecycle/Lifecycle-install.png)
 

--- a/docs/source/channels.rst
+++ b/docs/source/channels.rst
@@ -10,7 +10,7 @@ party must be authenticated and authorized to transact on that channel.
 Each peer that joins a channel, has its own identity given by a membership services provider (MSP),
 which authenticates each peer to its channel peers and services.
 
-To create a new channel, the client SDK calls configuration system chaincode
+To create a new channel, the client calls configuration system chaincode
 and references properties such as ``anchor peers``, and members (organizations).
 This request creates a ``genesis block`` for the channel ledger, which stores configuration
 information about the channel policies, members and anchor peers. When adding a

--- a/docs/source/deployment_guide_overview.rst
+++ b/docs/source/deployment_guide_overview.rst
@@ -50,7 +50,7 @@ In addition to the above, here is a sampling of the decisions you will need to m
   Users have the option to deploy their chaincode using either the built in build and run support, a customized build and run using the :doc:`cc_launcher`, or using an :doc:`cc_service`.
 
 * **Using firewalls.**
-  In a production deployment, components belonging to one organization might need access to components from other organizations, necessitating the use of firewalls and advanced networking configuration. For example, applications using the Fabric SDK require access to all endorsing peers from all organizations and the ordering services for all channels. Similarly, peers need access to the ordering service on the channels that they are receiving new blocks from.
+  In a production deployment, components belonging to one organization might need access to components from other organizations, necessitating the use of firewalls and advanced networking configuration. For example, peers need access to the ordering service nodes on the channels that they are receiving new blocks from.
 
 However and wherever your components are deployed, you will need a high degree of expertise in your management system of choice (such as Kubernetes) in order to efficiently operate your network. Similarly, the structure of the network must be designed to fit the business use case and any relevant laws and regulations government of the industry in which the network will be designed to function.
 

--- a/docs/source/deploypeer/peerplan.md
+++ b/docs/source/deploypeer/peerplan.md
@@ -86,7 +86,8 @@ If all peers have `orgLeader=true` (recommended), then each peer will get blocks
 
 ### Service Discovery
 
-In any network it is possible that peer nodes can be down for maintenance, unreachable due to network issues, or the peer ledger has fallen behind while being offline. For this reason, Fabric includes a “discovery service” that enables client applications that use the SDK to locate good candidate peers to target with endorsement requests. If service discovery is not enabled, when a client application targets a peer that is offline, the request fails and will need to be resubmitted to another peer. The discovery service runs on peers and uses the network metadata information maintained by the gossip communication layer to find out which peers are online and can be targeted for requests.
+In any network it is possible that peer nodes can be down for maintenance, unreachable due to network issues, or the peer ledger has fallen behind while being offline. For this reason, Fabric includes a “discovery service” that enables the
+peer gateway component to locate good candidate peers to target with endorsement requests. The discovery service runs on peers and uses the network metadata information maintained by the gossip communication layer to find out which peers are online and can be targeted for requests.
 
 Service discovery (and private data) requires that gossip is enabled, therefore you should configure the `peer.gossip.bootstrap`, `peer.gossip.endpoint` , and `peer.gossip.externalEndpoint` parameters, as well as anchor peers on each channel, to take advantage of this feature.
 

--- a/docs/source/dev-setup/build.rst
+++ b/docs/source/dev-setup/build.rst
@@ -63,14 +63,6 @@ call/execute
     go test -v -run=TestGetFoo
 
 
-Running Node.js Client SDK Unit Tests
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You must also run the Node.js unit tests to ensure that the Node.js
-client SDK is not broken by your changes. To run the Node.js unit tests,
-follow the instructions
-`here <https://github.com/hyperledger/fabric-sdk-node/blob/main/README.md>`__.
-
 Configuration
 -------------
 

--- a/docs/source/dev-setup/devenv.rst
+++ b/docs/source/dev-setup/devenv.rst
@@ -164,7 +164,7 @@ few commands.
 
 If those commands completely successfully, you're ready to Go!
 
-If you plan to use the Hyperledger Fabric application SDKs then be sure to check out their prerequisites in the Node.js SDK `README <https://github.com/hyperledger/fabric-sdk-node#build-and-test>`__, Java SDK `README <https://github.com/hyperledger/fabric-gateway-java/blob/main/README.md>`__, and Go SDK `README <https://github.com/hyperledger/fabric-sdk-go/blob/main/README.md>`__.
+If you plan to use the Hyperledger Fabric Gateway application SDKs for Node.js, Java, or Go, then be sure to check out their prerequisites in the Fabric Gateway `documentation <https://hyperledger.github.io/fabric-gateway/>`__.
 
 .. Licensed under Creative Commons Attribution 4.0 International License
    https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/discovery-overview.rst
+++ b/docs/source/discovery-overview.rst
@@ -4,59 +4,39 @@ Service Discovery
 Why do we need service discovery?
 ---------------------------------
 
-In order to execute chaincode on peers, submit transactions to orderers, and to
-be updated about the status of transactions, applications connect to an API
-exposed by an SDK.
+Client applications interact with the :doc:`Fabric Gateway <gateway>` to
+execute chaincode on peers, submit transactions to orderers, and learn
+about the status of transactions. The peer gateway service must therefore
+know the relevant endorsement policies as well as which peers
+have the chaincode installed.
 
-However, the SDK needs a lot of information in order to allow applications to
-connect to the relevant network nodes. In addition to the CA and TLS certificates
-of the orderers and peers on the channel -- as well as their IP addresses and port
-numbers -- it must know the relevant endorsement policies as well as which peers
-have the chaincode installed (so the application knows which peers to send chaincode
-proposals to).
-
-Prior to v1.2, this information was statically encoded. However, this implementation
-is not dynamically reactive to network changes (such as the addition of peers who have
-installed the relevant chaincode, or peers that are temporarily offline). Static
-configurations also do not allow applications to react to changes of the
-endorsement policy itself (as might happen when a new organization joins a channel).
-
-In addition, the client application has no way of knowing which peers have updated
-ledgers and which do not. As a result, the application might submit proposals to
-peers whose ledger data is not in sync with the rest of the network, resulting
-in transaction being invalidated upon commit and wasting resources as a consequence.
-
-The **discovery service** improves this process by having the peers compute
-the needed information dynamically and present it to the SDK in a consumable
-manner.
-
-Starting with v2.4, the :doc:`Fabric Gateway <gateway>` interacts with service discovery in order to determine
+The **discovery service** is responsible for keeping this information synchronized
+across peers and then the :doc:`Fabric Gateway <gateway>` interacts with service discovery in order to determine
 which peers are required to endorse a transaction, and which orderer nodes to send
-the transaction to.  Consequently, client applications written using the new gateway
-SDKs do not interact directly with service discovery at all.
+the transaction to.
 
 How service discovery works in Fabric
 -------------------------------------
 
-The application is bootstrapped knowing about a group of peers which are
-trusted by the application developer/administrator to provide authentic responses
-to discovery queries. A good candidate peer to be used by the client application
+The application is bootstrapped knowing about one or more Gateway peers which are
+trusted by the application developer/administrator to gather endorsements
+from other peers. A good candidate peer to be used by the client application
 is one that is in the same organization. Note that in order for peers to be known
 to the discovery service, they must have a ``peer.gossip.externalEndpoint`` defined. To see
 how to do this, check out our :doc:`discovery-cli` documentation.
 
-The application issues a configuration query to the discovery service and obtains
-all the static information it would have otherwise needed to communicate with the
-rest of the nodes of the network. This information can be refreshed at any point
+A service discovery client such as the :doc:`discovery-cli` or another Gateway peer
+issues a configuration query to the discovery service to obtain information about
+peers in the channel. This information can be refreshed at any point
 by sending a subsequent query to the discovery service of a peer.
 
-The service runs on peers -- not on the application -- and uses the network metadata
+The discovery service runs on peers and uses the network metadata
 information maintained by the gossip communication layer to find out which peers
 are online. It also fetches information, such as any relevant endorsement policies,
 from the peer's state database.
 
-With service discovery, applications no longer need to specify which peers they
-need endorsements from. The SDK can simply send a query to the discovery service
+With service discovery, the peer Gateway acting on behalf of a client application
+simply sends a query to the discovery service
 asking which peers are needed given a channel and a chaincode ID. The discovery
 service will then compute a descriptor comprised of two objects:
 
@@ -87,18 +67,10 @@ In other words, the endorsement policy requires a signature from one peer in Org
 and one peer in Org2. And it provides the names of available peers in those orgs who
 can endorse (``peer0`` and ``peer1`` in both Org1 and in Org2).
 
-The SDK then selects a random layout from the list. In the example above, the
-endorsement policy is Org1 ``AND`` Org2. If instead it was an ``OR`` policy, the SDK
-would randomly select either Org1 or Org2, since a signature from a peer from either
-Org would satisfy the policy.
-
-After the SDK has selected a layout, it selects from the peers in the layout based on a
-criteria specified on the client side (the SDK can do this because it has access to
-metadata like ledger height). For example, it can prefer peers with higher ledger heights
-over others -- or to exclude peers that the application has discovered to be offline
--- according to the number of peers from each group in the layout. If no single
-peer is preferable based on the criteria, the SDK will randomly select from the peers
-that best meet the criteria.
+When coordinating a transaction, the peer Gateway selects an endorsement layout.
+In the example above, the endorsement policy is Org1 ``AND`` Org2. It then selects
+which endorsing peers to target from the layout using information such as which peers are
+currently available and their ledger heights.
 
 Capabilities of the discovery service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/endorsement-policies.rst
+++ b/docs/source/endorsement-policies.rst
@@ -100,7 +100,7 @@ For example:
 
     peer lifecycle chaincode approveformyorg --channelID mychannel --signature-policy "AND('Org1MSP.peer', 'Org2MSP.peer')" --name mycc --version 1.0 --package-id mycc_1:3a8c52d70c36313cfebbaf09d8616e7a6318ababa01c7cbe40603c373bcfe173 --sequence 1 --tls --cafile /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem --waitForEvent
 
-In addition to the specifying an endorsement policy from the CLI or SDK, a
+In addition to specifying an endorsement policy in the CLI, a
 chaincode can also use policies in the channel configuration as endorsement
 policies. You can use the ``--channel-config-policy`` flag to select a channel policy with
 format used by the channel configuration and by ACLs.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -590,10 +590,10 @@ for developers to write and test chaincode applications. The SDK is fully
 configurable and extensible through a standard interface. Components, including
 cryptographic algorithms for signatures, logging frameworks and state stores,
 are easily swapped in and out of the SDK. The SDK provides APIs for transaction
-processing, membership services, node traversal and event handling.
+processing and event handling.
 
-Currently, there are three officially supported SDKs -- for Node.js, Java, and Go. While the Python SDK
-is not yet official but can still be downloaded and tested.
+Currently, there are three officially supported SDKs -- for Node.js, Java, and Go.
+See :doc:`Application APIs <sdk_chaincode>` for more details.
 
 .. _Smart-Contract:
 

--- a/docs/source/ledger/ledger.md
+++ b/docs/source/ledger/ledger.md
@@ -124,7 +124,7 @@ complex queries.
 Applications submit transactions which capture changes to the world state, and
 these transactions end up being committed to the ledger blockchain. Applications
 are insulated from the details of this [consensus](../txflow.html) mechanism by
-the Hyperledger Fabric SDK; they merely invoke a smart contract, and are
+the Hyperledger Fabric SDK and peer Gateway; they merely request invocation of a smart contract, and are
 notified when the transaction has been included in the blockchain (whether valid
 or invalid). The key design point is that only transactions that are **signed**
 by the required set of **endorsing organizations** will result in an update to

--- a/docs/source/peers/peers.md
+++ b/docs/source/peers/peers.md
@@ -101,7 +101,7 @@ to hosting multiple ledgers and multiple chaincodes on a peer.
 Starting in Hyperledger Fabric v2.4, the [Fabric Gateway](../gateway.html) service
 is installed and enabled on each peer by default. The gateway service, as opposed
 to the client application (in Fabric v2.3 and earlier), manages transaction proposals
-and endorsements on the peer. The Gateway SDKs (v1.0.0 for Go, Node and Java) incorporate
+and endorsements on the peer. The Gateway SDKs for Go, Node and Java incorporate
 this peer-centric model of transaction processing, enabling simplified application
 development. Client applications developed with Fabric v2.3 or earlier SDKs will
 continue to run in Fabric v2.4.

--- a/docs/source/security_model.md
+++ b/docs/source/security_model.md
@@ -118,7 +118,6 @@ For more information see the [Hardware Security Module (HSM) topic](./hsm.html).
 A Fabric application can interact with a blockchain network by submitting transactions to a ledger or querying ledger content.
 An application interacts with a blockchain network using one of the Fabric SDKs.
 
-The Fabric v2.x SDKs only support transaction and query functions and event listening.
 Support for administrative functions for channels and nodes has been removed from the SDKs in favor of the CLI tools.
 
 Applications typically reside in a managed tier of an organization's infrastructure.
@@ -127,14 +126,12 @@ Client identities only have permission to submit transactions and query the ledg
 
 In some use cases the application tier may persist user credentials including the private key and sign transactions.
 In other use cases end users of the application may want to keep their private key secret.
-To support these use cases, the Node.js SDK supports offline signing of transactions.
+To support these use cases, the SDKs supports offline signing of transactions.
 In both cases, a Hardware Security Module can be used to store private keys meaning that the client application does not have access to them.
 
 Regardless of application design, the SDKs do not have any privileged access to peer or orderer services other than that provided by the client identity.
 From a security perspective, the SDKs are merely a set of language specific convenience functions for interacting with the gRPC services exposed by the Fabric peers and orderers.
 All security enforcement is carried out by Fabric nodes as highlighted earlier in this topic, not the client SDK.
-
-For more information see the [Applications topic](./developapps/application.html) and [Offline Signing tutorial](https://hyperledger.github.io/fabric-sdk-node/release-2.2/tutorial-sign-transaction-offline.html).
 
 <!--- Licensed under Creative Commons Attribution 4.0 International License
 https://creativecommons.org/licenses/by/4.0/ -->

--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -530,9 +530,7 @@ below provide a guided tour of what happens when you issue the command of
   script uses the ``docker-compose-test-net.yaml`` file in the `docker` folder
   to create the peer and orderer nodes. The `docker` folder also contains the
   ``docker-compose-e2e.yaml`` file that brings up the nodes of the network
-  alongside three Fabric CAs. This file is meant to be used to run end-to-end
-  tests by the Fabric SDK. Refer to the [Node SDK](https://github.com/hyperledger/fabric-sdk-node)
-  repo for details on running these tests.
+  alongside three Fabric CAs.
 
 - If you use the `createChannel` subcommand, `./network.sh` runs the
   `createChannel.sh` script in the `scripts` folder to create a channel

--- a/docs/source/upgrading_your_components.md
+++ b/docs/source/upgrading_your_components.md
@@ -211,19 +211,9 @@ Before you attempt this, you may want to upgrade peers from enough organizations
 
 To learn how to upgrade your Fabric CA server, click over to the [CA documentation](http://hyperledger-fabric-ca.readthedocs.io/en/latest/users-guide.html#upgrading-the-server).
 
-## Upgrade Node SDK clients
+## Upgrade SDK clients
 
-Upgrade Fabric and Fabric CA before upgrading Node SDK clients. Fabric and Fabric CA are tested for backwards compatibility with older SDK clients. While newer SDK clients often work with older Fabric and Fabric CA releases, they may expose features that are not yet available in the older Fabric and Fabric CA releases, and are not tested for full compatibility.
-
-Use NPM to upgrade any `Node.js` client by executing these commands in the root directory of your application:
-
-```
-npm install fabric-client@latest
-
-npm install fabric-ca-client@latest
-```
-
-These commands install the new version of both the Fabric client and Fabric-CA client and write the new versions to `package.json`.
+Upgrade Fabric before upgrading SDK clients. Fabric is tested for backwards compatibility with older SDK clients. While newer SDK clients often work with older Fabric releases, they may expose features that are not yet available in the older Fabric releases, and are not tested for full compatibility.
 
 ## Upgrading CouchDB
 


### PR DESCRIPTION
This documentation change updates many of the remaining references to the legacy SDKs, and replaces them with Gateway SDK references where applicable.