### PR TITLE
Return the struct directly

### DIFF
--- a/core/ledger/kvledger/benchmark/experiments/conf.go
+++ b/core/ledger/kvledger/benchmark/experiments/conf.go
@@ -47,12 +47,12 @@ type configuration struct {
 
 // emptyConf returns a an empty configuration (with nested structure only)
 func emptyConf() *configuration {
-	conf := &configuration{}
-	conf.chainMgrConf = &chainmgmt.ChainMgrConf{}
-	conf.batchConf = &chainmgmt.BatchConf{}
-	conf.txConf = &txConf{}
-	conf.dataConf = &dataConf{}
-	return conf
+	return &configuration{
+		chainMgrConf: &chainmgmt.ChainMgrConf{},
+		batchConf:    &chainmgmt.BatchConf{},
+		txConf:       &txConf{},
+		dataConf:     &dataConf{},
+	}
 }
 
 // confFromTestParams consumes the parameters passed by an experiment


### PR DESCRIPTION

Change-Id: I3e1622c0c7ee144c3164cecc49f5cf6d75b9ec32

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

No need to create an empty struct and then fill in the data.

#### Additional details

N/A

#### Related issues

N/A

#### Release Note

N/A
