### PR TITLE
Increase default transientstoreMaxBlockRetention

### DIFF
--- a/core/deliverservice/testdata/core.yaml
+++ b/core/deliverservice/testdata/core.yaml
@@ -203,7 +203,7 @@ peer:
       # and the private data residing inside the transient store that is guaranteed not to be purged.
       # Private data is purged from the transient store when blocks with sequences that are multiples
       # of transientstoreMaxBlockRetention are committed.
-      transientstoreMaxBlockRetention: 1000
+      transientstoreMaxBlockRetention: 20000
       # pushAckTimeout is the maximum time to wait for an acknowledgement from each peer
       # at private data push at endorsement time.
       pushAckTimeout: 3s

--- a/gossip/service/config.go
+++ b/gossip/service/config.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	btlPullMarginDefault           = 10
-	transientBlockRetentionDefault = 1000
+	transientBlockRetentionDefault = 20000
 )
 
 // ServiceConfig is the config struct for gossip services

--- a/integration/nwo/template/core_template.go
+++ b/integration/nwo/template/core_template.go
@@ -60,7 +60,7 @@ peer:
       leaderElectionDuration: 5s
     pvtData:
       pullRetryThreshold: 7s
-      transientstoreMaxBlockRetention: 1000
+      transientstoreMaxBlockRetention: 20000
       pushAckTimeout: 3s
       btlPullMargin: 10
       reconcileBatchSize: 10

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -203,7 +203,7 @@ peer:
             # and the private data residing inside the transient store that is guaranteed not to be purged.
             # Private data is purged from the transient store when blocks with sequences that are multiples
             # of transientstoreMaxBlockRetention are committed.
-            transientstoreMaxBlockRetention: 1000
+            transientstoreMaxBlockRetention: 20000
             # pushAckTimeout is the maximum time to wait for an acknowledgement from each peer
             # at private data push at endorsement time.
             pushAckTimeout: 3s


### PR DESCRIPTION
Increase the default value of transientstoreMaxBlockRetention

Change-Id: I24eb6a6c4be38fbb964970b518d40c72e02e12ff

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

`transientstoreMaxBlockRetention` is used to trigger the purge of private data in the transient store.

The current default value is 1000, which is OK for simple cases with several blocks per second. Howerver, in our test with 10K tps case, it is possible to purge the private data too early before the peer gets a chance to commit the tx into the ledger.

With a larger retention window, the only cost is a larger transient database in the peer node, which is not a big deal.

Hence, this patchset suggest to increase the default value to a larger value of 100000, and it is open to have other reasonable value too.

#### Additional details

N/A

#### Related issues

N/A

#### Release Note

N/A
