### PR TITLE
Revert image FABRIC_CFG_PATH to /etc/hyperledger/fabric (release-2.5)

### DIFF
--- a/images/orderer/Dockerfile
+++ b/images/orderer/Dockerfile
@@ -57,7 +57,7 @@ ARG FABRIC_VER
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 
-ENV     FABRIC_CFG_PATH /var/hyperledger/fabric/config
+ENV     FABRIC_CFG_PATH /etc/hyperledger/fabric
 ENV     FABRIC_VER      ${FABRIC_VER}
 
 COPY    --from=builder  build/bin/orderer           /usr/local/bin

--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -60,7 +60,7 @@ ARG FABRIC_VER
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 
-ENV     FABRIC_CFG_PATH /var/hyperledger/fabric/config
+ENV     FABRIC_CFG_PATH /etc/hyperledger/fabric
 ENV     FABRIC_VER      ${FABRIC_VER}
 
 COPY    --from=builder  build/bin/peer          /usr/local/bin

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -69,7 +69,7 @@ ENV PATH="/usr/local/go/bin:$PATH"
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 
-ENV     FABRIC_CFG_PATH /var/hyperledger/fabric/config
+ENV     FABRIC_CFG_PATH /etc/hyperledger/fabric
 ENV     FABRIC_VER      ${FABRIC_VER}
 
 COPY    --from=builder  sampleconfig    ${FABRIC_CFG_PATH}


### PR DESCRIPTION
The updated image for v2.5 release set FABRIC_CFG_PATH to /var/hyperledger/fabric/config.

Historically the value has been /etc/hyperledger/fabric, and it is more typical for configs to exist in /etc than /var.

Additionally the code defaults to /etc/hyperledger/fabric and the docs still mention /etc/hyperledger/fabric, therefore this commit sets it back to /etc/hyperledger/fabric.

Ultimately, it shouldn't really matter since the core.yaml and orderer.yaml are copied to FABRIC_CFG_PATH, and the executables reference the configs using FABRIC_CFG_PATH. So the change is a noop at runtime, but better to get the image back to consistency with the code, docs, and historical precedents.