### PR TITLE
Private data purge test improvements - release-2.5 backport

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        INTEGRATION_TEST_SUITE: ["raft","pvtdata","ledger","lifecycle","e2e","discovery gossip devmode pluggable","gateway idemix pkcs11 configtx configtxlator","sbe nwo msp"]
+        INTEGRATION_TEST_SUITE: ["raft","pvtdata","pvtdatapurge","ledger","lifecycle","e2e","discovery gossip devmode pluggable","gateway idemix pkcs11 configtx configtxlator","sbe nwo msp"]
     runs-on: ${{ github.repository == 'hyperledger/fabric' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/setup-go@v3

--- a/integration/nwo/template/core_template.go
+++ b/integration/nwo/template/core_template.go
@@ -64,7 +64,7 @@ peer:
       pushAckTimeout: 3s
       btlPullMargin: 10
       reconcileBatchSize: 10
-      reconcileSleepInterval: 10s
+      reconcileSleepInterval: 5s
       reconciliationEnabled: true
       skipPullingInvalidTransactionsDuringCommit: false
       implicitCollectionDisseminationPolicy:

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -38,6 +38,7 @@ const (
 	PKCS11Port
 	PluggableBasePort
 	PrivateDataBasePort
+	PrivateDataPurgeBasePort
 	RaftBasePort
 	SBEBasePort
 )

--- a/integration/pvtdatapurge/data_purge_test.go
+++ b/integration/pvtdatapurge/data_purge_test.go
@@ -321,6 +321,10 @@ var _ = Describe("Pvtdata purge", func() {
 			marblechaincodeutil.AssertDoesNotExistInCollectionMPD(network, channelID, chaincode.Name, `test-marble-9-purge`, org3Peer1)
 
 			By("Adding two marbles, removing Org3 from the collection, purging the marbles, and confirming that they still got purged from Org3")
+
+			// Make sure all peers are up and connected after prior test, before continuing with this test
+			network.VerifyMembership(network.Peers, channelID)
+
 			marblechaincodeutil.AddMarble(network, orderer, channelID, chaincode.Name, `{"name":"test-marble-10-purge-after-ineligible", "color":"white", "size":4, "owner":"liz", "price":4}`, org2Peer0)
 			marblechaincodeutil.AddMarble(network, orderer, channelID, chaincode.Name, `{"name":"test-marble-11-purge-after-ineligible", "color":"orange", "size":80, "owner":"clive", "price":88}`, org2Peer0)
 

--- a/integration/pvtdatapurge/data_purge_test.go
+++ b/integration/pvtdatapurge/data_purge_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package pvtdata
+package pvtdatapurge
 
 import (
 	"context"
@@ -33,6 +33,8 @@ import (
 	"github.com/tedsuo/ifrit"
 	ginkgomon "github.com/tedsuo/ifrit/ginkgomon_v2"
 )
+
+const channelID = "testchannel"
 
 var _ = Describe("Pvtdata purge", func() {
 	var (
@@ -560,4 +562,29 @@ func startNewPeer(network *nwo.Network, orderer *nwo.Orderer, peer *nwo.Peer, le
 
 	network.Peers = append(network.Peers, peer)
 	nwo.WaitUntilEqualLedgerHeight(network, channelID, ledgerHeight-1, network.Peers...)
+}
+
+func addPeer(n *nwo.Network, orderer *nwo.Orderer, peer *nwo.Peer) ifrit.Process {
+	process := ifrit.Invoke(n.PeerRunner(peer))
+	Eventually(process.Ready(), n.EventuallyTimeout).Should(BeClosed())
+
+	n.JoinChannel(channelID, orderer, peer)
+	ledgerHeight := nwo.GetLedgerHeight(n, n.Peers[0], channelID)
+	sess, err := n.PeerAdminSession(
+		peer,
+		commands.ChannelFetch{
+			Block:      "newest",
+			ChannelID:  channelID,
+			Orderer:    n.OrdererAddress(orderer, nwo.ListenPort),
+			OutputFile: filepath.Join(n.RootDir, "newest_block.pb"),
+		},
+	)
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
+	Expect(sess.Err).To(gbytes.Say(fmt.Sprintf("Received block: %d", ledgerHeight-1)))
+
+	n.Peers = append(n.Peers, peer)
+	nwo.WaitUntilEqualLedgerHeight(n, channelID, nwo.GetLedgerHeight(n, n.Peers[0], channelID), n.Peers...)
+
+	return process
 }

--- a/integration/pvtdatapurge/pvtdatapurge_suite_test.go
+++ b/integration/pvtdatapurge/pvtdatapurge_suite_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pvtdatapurge
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/hyperledger/fabric/integration"
+	"github.com/hyperledger/fabric/integration/nwo"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndToEnd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Private Data Purge Suite")
+}
+
+var (
+	buildServer *nwo.BuildServer
+	components  *nwo.Components
+)
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	buildServer = nwo.NewBuildServer()
+	buildServer.Serve()
+
+	components = buildServer.Components()
+	payload, err := json.Marshal(components)
+	Expect(err).NotTo(HaveOccurred())
+
+	return payload
+}, func(payload []byte) {
+	err := json.Unmarshal(payload, &components)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = SynchronizedAfterSuite(func() {
+}, func() {
+	buildServer.Shutdown()
+})
+
+func StartPort() int {
+	return integration.PrivateDataPurgeBasePort.StartPortForNode()
+}
+
+func CollectionConfig(collConfigFile string) string {
+	return filepath.Join("..", "pvtdata", "testdata", "collection_configs", collConfigFile)
+}


### PR DESCRIPTION
Backport private data purge test improvements to release-2.5.
This should resolve the flake failures in release-2.5 branch.