### PR TITLE
Check error in the same line

### DIFF
--- a/internal/ccmetadata/validators.go
+++ b/internal/ccmetadata/validators.go
@@ -67,8 +67,7 @@ func ValidateMetadataFile(filePathName string, fileBytes []byte) error {
 	}
 
 	// If the file is not valid for the given directory-based validator, return the corresponding error
-	err := fileValidator(filePathName, fileBytes)
-	if err != nil {
+	if err := fileValidator(filePathName, fileBytes); err != nil {
 		return err
 	}
 
@@ -144,8 +143,7 @@ func couchdbIndexFileValidator(fileName string, fileBytes []byte) error {
 	}
 
 	// validate the index definition
-	err := validateIndexJSON(indexDefinition)
-	if err != nil {
+	if err := validateIndexJSON(indexDefinition); err != nil {
 		return &InvalidIndexContentError{fmt.Sprintf("Index metadata file [%s] is not a valid index definition: %s", fileName, err)}
 	}
 
@@ -173,8 +171,7 @@ func validateIndexJSON(indexDefinition map[string]interface{}) error {
 				return fmt.Errorf("Invalid entry, \"index\" must be a JSON")
 			}
 
-			err := processIndexMap(jsonValue.(map[string]interface{}))
-			if err != nil {
+			if err := processIndexMap(jsonValue.(map[string]interface{})); err != nil {
 				return err
 			}
 
@@ -243,8 +240,7 @@ func processIndexMap(jsonFragment map[string]interface{}) error {
 
 					case reflect.Map:
 						// Handle the case where a sort is included  ex: {"size":"asc"}, {"color":"desc"}
-						err := validateFieldMap(itemValue.(map[string]interface{}))
-						if err != nil {
+						if err := validateFieldMap(itemValue.(map[string]interface{})); err != nil {
 							return err
 						}
 


### PR DESCRIPTION

Change-Id: I20200cff6e7ea6f4bc508e13ea96a24d39de74f2

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

The patchset follows Go style to check error immediately after calling the method in the same line.


#### Additional details

N/A

#### Related issues

N/A

#### Release Note

N/A
