### PR TITLE
fix gateway integration tests

### DIFF
--- a/integration/devmode/devmode_test.go
+++ b/integration/devmode/devmode_test.go
@@ -232,6 +232,7 @@ func ApproveChaincodeForMyOrg(n *nwo.Network, channel string, orderer *nwo.Order
 				InitRequired:        chaincode.InitRequired,
 				CollectionsConfig:   chaincode.CollectionsConfig,
 				ClientAuth:          n.ClientAuthRequired,
+				WaitForEventTimeout: n.EventuallyTimeout,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))

--- a/integration/e2e/acl_test.go
+++ b/integration/e2e/acl_test.go
@@ -148,6 +148,7 @@ var _ = Describe("EndToEndACL", func() {
 			ChannelConfigPolicy: chaincode.ChannelConfigPolicy,
 			InitRequired:        chaincode.InitRequired,
 			CollectionsConfig:   chaincode.CollectionsConfig,
+			WaitForEventTimeout: network.EventuallyTimeout,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit())
@@ -166,6 +167,7 @@ var _ = Describe("EndToEndACL", func() {
 			ChannelConfigPolicy: chaincode.ChannelConfigPolicy,
 			InitRequired:        chaincode.InitRequired,
 			CollectionsConfig:   chaincode.CollectionsConfig,
+			WaitForEventTimeout: network.EventuallyTimeout,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit())
@@ -192,6 +194,7 @@ var _ = Describe("EndToEndACL", func() {
 			InitRequired:        chaincode.InitRequired,
 			CollectionsConfig:   chaincode.CollectionsConfig,
 			PeerAddresses:       []string{network.PeerAddress(org1Peer0, nwo.ListenPort)},
+			WaitForEventTimeout: network.EventuallyTimeout,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit())
@@ -279,6 +282,7 @@ var _ = Describe("EndToEndACL", func() {
 			InitRequired:        chaincode.InitRequired,
 			CollectionsConfig:   chaincode.CollectionsConfig,
 			PeerAddresses:       peerAddresses,
+			WaitForEventTimeout: network.EventuallyTimeout,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit())

--- a/integration/e2e/e2e_test.go
+++ b/integration/e2e/e2e_test.go
@@ -700,6 +700,7 @@ var _ = Describe("EndToEnd", func() {
 				InitRequired:        chaincode.InitRequired,
 				CollectionsConfig:   chaincode.CollectionsConfig,
 				ClientAuth:          network.ClientAuthRequired,
+				WaitForEventTimeout: network.EventuallyTimeout,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(sess.Err, network.EventuallyTimeout).Should(gbytes.Say(`Error: proposal failed with status: 500`))

--- a/integration/nwo/commands/peer.go
+++ b/integration/nwo/commands/peer.go
@@ -330,6 +330,7 @@ type ChaincodeApproveForMyOrg struct {
 	PeerAddresses       []string
 	WaitForEvent        bool
 	ClientAuth          bool
+	WaitForEventTimeout time.Duration
 }
 
 func (c ChaincodeApproveForMyOrg) SessionName() string {
@@ -365,6 +366,10 @@ func (c ChaincodeApproveForMyOrg) Args() []string {
 
 	for _, p := range c.PeerAddresses {
 		args = append(args, "--peerAddresses", p)
+	}
+
+	if c.WaitForEventTimeout > 30*time.Second {
+		args = append(args, "--waitForEventTimeout", c.WaitForEventTimeout.String())
 	}
 
 	return args
@@ -471,6 +476,7 @@ type ChaincodeCommit struct {
 	PeerAddresses       []string
 	WaitForEvent        bool
 	ClientAuth          bool
+	WaitForEventTimeout time.Duration
 }
 
 func (c ChaincodeCommit) SessionName() string {
@@ -501,6 +507,9 @@ func (c ChaincodeCommit) Args() []string {
 	}
 	if c.ClientAuth {
 		args = append(args, "--clientauth")
+	}
+	if c.WaitForEventTimeout > 30*time.Second {
+		args = append(args, "--waitForEventTimeout", c.WaitForEventTimeout.String())
 	}
 	return args
 }

--- a/integration/nwo/deploy.go
+++ b/integration/nwo/deploy.go
@@ -182,6 +182,7 @@ func ApproveChaincodeForMyOrg(n *Network, channel string, orderer *Orderer, chai
 				InitRequired:        chaincode.InitRequired,
 				CollectionsConfig:   chaincode.CollectionsConfig,
 				ClientAuth:          n.ClientAuthRequired,
+				WaitForEventTimeout: n.EventuallyTimeout,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
@@ -238,6 +239,7 @@ func CommitChaincode(n *Network, channel string, orderer *Orderer, chaincode Cha
 		CollectionsConfig:   chaincode.CollectionsConfig,
 		PeerAddresses:       peerAddresses,
 		ClientAuth:          n.ClientAuthRequired,
+		WaitForEventTimeout: n.EventuallyTimeout,
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))

--- a/integration/pvtdata/pvtdata_test.go
+++ b/integration/pvtdata/pvtdata_test.go
@@ -997,6 +997,7 @@ func approveChaincodeForMyOrgExpectErr(n *nwo.Network, orderer *nwo.Orderer, cha
 				ChannelConfigPolicy: chaincode.ChannelConfigPolicy,
 				InitRequired:        chaincode.InitRequired,
 				CollectionsConfig:   chaincode.CollectionsConfig,
+				WaitForEventTimeout: n.EventuallyTimeout,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit())

--- a/integration/smartbft/smartbft_test.go
+++ b/integration/smartbft/smartbft_test.go
@@ -1783,6 +1783,7 @@ var _ = Describe("EndToEnd Smart BFT configuration test", func() {
 				InitRequired:        chaincode.InitRequired,
 				CollectionsConfig:   chaincode.CollectionsConfig,
 				ClientAuth:          network.ClientAuthRequired,
+				WaitForEventTimeout: network.EventuallyTimeout,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(sess, network.EventuallyTimeout).Should(gexec.Exit(0))


### PR DESCRIPTION
The default timeout for commit and approveformyorg operations on peer cli is 30 seconds.
It often happens that peer cli does not have enough time to perform these operations.
I fixed it so that this time can be passed to peer cli from integration tests.

Probably not all bugs for gateway tests are solved, but the work will be more stable.