### PR TITLE
change evaluate RequestId for update config

### DIFF
--- a/orderer/consensus/smartbft/chain.go
+++ b/orderer/consensus/smartbft/chain.go
@@ -107,13 +107,14 @@ func NewChain(
 	metricsWalBFT *wal.Metrics,
 	bccsp bccsp.BCCSP,
 ) (*BFTChain, error) {
+	logger := flogging.MustGetLogger("orderer.consensus.smartbft.chain").With(zap.String("channel", support.ChannelID()))
+
 	requestInspector := &RequestInspector{
 		ValidateIdentityStructure: func(_ *msp.SerializedIdentity) error {
 			return nil
 		},
+		Logger: logger,
 	}
-
-	logger := flogging.MustGetLogger("orderer.consensus.smartbft.chain").With(zap.String("channel", support.ChannelID()))
 
 	c := &BFTChain{
 		RuntimeConfig:     &atomic.Value{},

--- a/orderer/consensus/smartbft/verifier.go
+++ b/orderer/consensus/smartbft/verifier.go
@@ -190,11 +190,18 @@ func (v *Verifier) verifyRequest(rawRequest []byte, noConfigAllowed bool) (types
 	}
 
 	if req.chHdr.Type == int32(cb.HeaderType_CONFIG) {
-		err := v.ConfigValidator.ValidateConfig(req.envelope)
+		err = v.ConfigValidator.ValidateConfig(req.envelope)
 		if err != nil {
 			v.Logger.Errorf("Error verifying config update: %v", err)
 			return types.RequestInfo{}, err
 		}
+
+		reqID := v.ReqInspector.RequestID(rawRequest)
+		if v.ReqInspector.isEmpty(reqID) {
+			return types.RequestInfo{}, errors.Errorf("request id is empty")
+		}
+
+		return reqID, nil
 	}
 
 	return v.ReqInspector.requestIDFromSigHeader(req.sigHdr)

--- a/orderer/consensus/smartbft/verifier_test.go
+++ b/orderer/consensus/smartbft/verifier_test.go
@@ -111,6 +111,7 @@ func TestVerifyConsenterSig(t *testing.T) {
 		ValidateIdentityStructure: func(_ *msp.SerializedIdentity) error {
 			return nil
 		},
+		Logger: logger,
 	}
 
 	cv := &mocks.ConsenterVerifier{}
@@ -415,6 +416,7 @@ func TestVerifyProposal(t *testing.T) {
 		ValidateIdentityStructure: func(_ *msp.SerializedIdentity) error {
 			return nil
 		},
+		Logger: logger,
 	}
 
 	lastHash := hex.EncodeToString(protoutil.BlockHeaderHash(lastBlock.Header))


### PR DESCRIPTION
In the documentation and in the examples, the channel update transaction is send to one and only one orderer. Like in raft. The smartbft features are not used.

What's happening?
When an orderer receives a channel update transaction, it takes the current channel config and applies the update to it and re-signs the transaction. It then sends it to the smartbft consensus. Total 7 different transactions appear in the consensus.

My current solution fixes the error. RequestID will be calculated differently for channel update transactions.

After this change, the channel update can be sent out as a bft.