### PR TITLE
Validate the request

### DIFF
--- a/internal/pkg/gateway/commitstatus.go
+++ b/internal/pkg/gateway/commitstatus.go
@@ -33,6 +33,16 @@ func (gs *Server) CommitStatus(ctx context.Context, signedRequest *gp.SignedComm
 		return nil, status.Errorf(codes.InvalidArgument, "invalid status request: %v", err)
 	}
 
+	// Validate the request has valid channel id and transaction id
+	switch {
+	case request.GetIdentity() == nil:
+		return nil, status.Error(codes.InvalidArgument, "no identity provided")
+	case request.GetChannelId() == "":
+		return nil, status.Error(codes.InvalidArgument, "no channel ID provided")
+	case request.GetTransactionId() == "":
+		return nil, status.Error(codes.InvalidArgument, "transaction ID should not be empty")
+	}
+
 	signedData := &protoutil.SignedData{
 		Data:      signedRequest.GetRequest(),
 		Identity:  request.GetIdentity(),

--- a/internal/pkg/gateway/commitstatus_test.go
+++ b/internal/pkg/gateway/commitstatus_test.go
@@ -119,7 +119,7 @@ func TestCommitStatus(t *testing.T) {
 
 			request := &pb.CommitStatusRequest{
 				ChannelId:     testChannel,
-				Identity:      tt.identity,
+				Identity:      []byte("IDENTITY"),
 				TransactionId: "TX_ID",
 			}
 			requestBytes, err := proto.Marshal(request)


### PR DESCRIPTION
The patchset adds validation to the request before using it.

Change-Id: Ic6a7a65d6da289d84fe82c3f6e048e396b1f1a0e

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

The patchset adds validation to the request before using it.

This can help protect from malformed request.


#### Additional details

N/A

#### Related issues

N/A

#### Release Note

N/A
