### PR TITLE
Update smartcontract.md

### DIFF
--- a/docs/source/smartcontract/smartcontract.md
+++ b/docs/source/smartcontract/smartcontract.md
@@ -99,7 +99,7 @@ state, and can also query the immutable blockchain record of transactions.
   current state of the ledger, but not its history.
 
 Smart contracts have many
-[APIs](../developapps/transactioncontext.html#structure) available to them.
+[APIs](../chaincode4ade.html#fabric-contract-api) available to them.
 Critically, in all cases, whether transactions create, read, update or delete
 business objects in the world state, the blockchain contains an [immutable
 record](../ledger/ledger.html) of these changes.


### PR DESCRIPTION
Fixing link to API in the context of "Smart contracts have many APIs available to them" because it is broken in current version of hyperledger fabric documentation

#### Type of change

- Documentation update

#### Description

Reading documentation, especially the current and release-2.5 version, I noticed that there is a link that leads to nowhere in such versions. It looks like release-2.2 had the linked documentation but it no longer exists. I tried to find the best replacement from the existing documentation for the previously linked and made such changes.

#### Additional details

N/A

#### Related issues

N/A
