### PR TITLE
Upgrade the CouchDB used to v3.3.3 as per CVE-2023-45725.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ FABRIC_VER ?= 3.0.0
 
 # 3rd party image version
 # These versions are also set in the runners in ./integration/runners/
-COUCHDB_VER ?= 3.3.2
+COUCHDB_VER ?= 3.3.3
 
 # Disable implicit rules
 .SUFFIXES:

--- a/integration/nwo/runner/couchdb.go
+++ b/integration/nwo/runner/couchdb.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	CouchDBDefaultImage = "couchdb:3.3.2"
+	CouchDBDefaultImage = "couchdb:3.3.3"
 	CouchDBUsername     = "admin"
 	CouchDBPassword     = "adminpw"
 )


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Move to CouchDB v3.3.3.  There's a [security vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45725) with CouchDB v3.3.2.  I **think** this only impacts the testing that happens to Fabric, but this PR is a good way to be sure.

#### Additional details

I have tested that CouchDB v3.3.3 is not majorly functionally different than CouchDB v3.3.2. (See its [Release Notes](https://docs.couchdb.org/en/stable/whatsnew/3.3.html#release-3-3-3)).  There have been no breaking API changes in v3.3.3, only bug fixes and security patches.

I would suggest backporting this to Fabric v2.5.x because it's only a CouchDB Patch.

#### Related issues

Tracked by https://github.com/hyperledger/fabric/issues/4594