### PR TITLE
found and fixed a bug in raft integration tests

### DIFF
--- a/orderer/common/follower/follower_chain_test.go
+++ b/orderer/common/follower/follower_chain_test.go
@@ -195,7 +195,10 @@ func TestFollowerPullUpToJoin(t *testing.T) {
 
 		wgChain = sync.WaitGroup{}
 		wgChain.Add(1)
-		mockChainCreator.SwitchFollowerToChainCalls(func(_ string) { wgChain.Done() })
+		mockChainCreator.SwitchFollowerToChainCalls(func(_ string) bool {
+			wgChain.Done()
+			return true
+		})
 
 		wgChain = sync.WaitGroup{}
 		wgChain.Add(1)
@@ -559,7 +562,10 @@ func TestFollowerPullAfterJoin(t *testing.T) {
 			}
 			return nil
 		})
-		mockChainCreator.SwitchFollowerToChainCalls(func(_ string) { wgChain.Done() }) // Stop when a new chain is created
+		mockChainCreator.SwitchFollowerToChainCalls(func(_ string) bool {
+			wgChain.Done()
+			return true
+		}) // Stop when a new chain is created
 		require.Equal(t, joinNum+1, localBlockchain.Height())
 
 		chain, err := follower.NewChain(ledgerResources, mockClusterConsenter, nil, options, pullerFactory, mockChainCreator, cryptoProvider, mockChannelParticipationMetricsReporter)
@@ -604,7 +610,10 @@ func TestFollowerPullAfterJoin(t *testing.T) {
 			}
 			return nil
 		})
-		mockChainCreator.SwitchFollowerToChainCalls(func(_ string) { wgChain.Done() }) // Stop when a new chain is created
+		mockChainCreator.SwitchFollowerToChainCalls(func(_ string) bool {
+			wgChain.Done()
+			return true
+		}) // Stop when a new chain is created
 		require.Equal(t, joinNum+1, localBlockchain.Height())
 
 		failPull := 10
@@ -794,7 +803,10 @@ func TestFollowerPullPastJoin(t *testing.T) {
 			}
 			return nil
 		})
-		mockChainCreator.SwitchFollowerToChainCalls(func(_ string) { wgChain.Done() }) // Stop when a new chain is created
+		mockChainCreator.SwitchFollowerToChainCalls(func(_ string) bool {
+			wgChain.Done()
+			return true
+		}) // Stop when a new chain is created
 		require.Equal(t, uint64(6), localBlockchain.Height())
 
 		chain, err := follower.NewChain(ledgerResources, mockClusterConsenter, joinBlockAppRaft, options, pullerFactory, mockChainCreator, cryptoProvider, mockChannelParticipationMetricsReporter)
@@ -839,7 +851,10 @@ func TestFollowerPullPastJoin(t *testing.T) {
 			}
 			return nil
 		})
-		mockChainCreator.SwitchFollowerToChainCalls(func(_ string) { wgChain.Done() }) // Stop when a new chain is created
+		mockChainCreator.SwitchFollowerToChainCalls(func(_ string) bool {
+			wgChain.Done()
+			return true
+		}) // Stop when a new chain is created
 		require.Equal(t, uint64(0), localBlockchain.Height())
 
 		failPull := 10
@@ -935,7 +950,7 @@ func (mbc *memoryBlockChain) fill(numBlocks uint64) {
 	defer mbc.lock.Unlock()
 
 	height := uint64(len(mbc.chain))
-	prevHash := []byte{}
+	var prevHash []byte
 
 	for i := height; i < height+numBlocks; i++ {
 		if i > 0 {

--- a/orderer/common/follower/mocks/chain_creator.go
+++ b/orderer/common/follower/mocks/chain_creator.go
@@ -8,26 +8,37 @@ import (
 )
 
 type ChainCreator struct {
-	SwitchFollowerToChainStub        func(string)
+	SwitchFollowerToChainStub        func(string) bool
 	switchFollowerToChainMutex       sync.RWMutex
 	switchFollowerToChainArgsForCall []struct {
 		arg1 string
+	}
+	switchFollowerToChainReturns struct {
+		result1 bool
+	}
+	switchFollowerToChainReturnsOnCall map[int]struct {
+		result1 bool
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ChainCreator) SwitchFollowerToChain(arg1 string) {
+func (fake *ChainCreator) SwitchFollowerToChain(arg1 string) bool {
 	fake.switchFollowerToChainMutex.Lock()
+	ret, specificReturn := fake.switchFollowerToChainReturnsOnCall[len(fake.switchFollowerToChainArgsForCall)]
 	fake.switchFollowerToChainArgsForCall = append(fake.switchFollowerToChainArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.SwitchFollowerToChainStub
 	fake.recordInvocation("SwitchFollowerToChain", []interface{}{arg1})
 	fake.switchFollowerToChainMutex.Unlock()
-	if stub != nil {
-		fake.SwitchFollowerToChainStub(arg1)
+	if fake.SwitchFollowerToChainStub != nil {
+		return fake.SwitchFollowerToChainStub(arg1)
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.switchFollowerToChainReturns
+	return fakeReturns.result1
 }
 
 func (fake *ChainCreator) SwitchFollowerToChainCallCount() int {
@@ -36,7 +47,7 @@ func (fake *ChainCreator) SwitchFollowerToChainCallCount() int {
 	return len(fake.switchFollowerToChainArgsForCall)
 }
 
-func (fake *ChainCreator) SwitchFollowerToChainCalls(stub func(string)) {
+func (fake *ChainCreator) SwitchFollowerToChainCalls(stub func(string) bool) {
 	fake.switchFollowerToChainMutex.Lock()
 	defer fake.switchFollowerToChainMutex.Unlock()
 	fake.SwitchFollowerToChainStub = stub
@@ -47,6 +58,29 @@ func (fake *ChainCreator) SwitchFollowerToChainArgsForCall(i int) string {
 	defer fake.switchFollowerToChainMutex.RUnlock()
 	argsForCall := fake.switchFollowerToChainArgsForCall[i]
 	return argsForCall.arg1
+}
+
+func (fake *ChainCreator) SwitchFollowerToChainReturns(result1 bool) {
+	fake.switchFollowerToChainMutex.Lock()
+	defer fake.switchFollowerToChainMutex.Unlock()
+	fake.SwitchFollowerToChainStub = nil
+	fake.switchFollowerToChainReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *ChainCreator) SwitchFollowerToChainReturnsOnCall(i int, result1 bool) {
+	fake.switchFollowerToChainMutex.Lock()
+	defer fake.switchFollowerToChainMutex.Unlock()
+	fake.SwitchFollowerToChainStub = nil
+	if fake.switchFollowerToChainReturnsOnCall == nil {
+		fake.switchFollowerToChainReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.switchFollowerToChainReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
 }
 
 func (fake *ChainCreator) Invocations() map[string][][]interface{} {


### PR DESCRIPTION
Often fails this [test](https://github.com/hyperledger/fabric/blob/main/integration/raft/config_test.go#L1258) 
- https://github.com/hyperledger/fabric/actions/runs/7493668256/job/20399967195
- https://github.com/hyperledger/fabric/actions/runs/7483402876/job/20368656381
- https://github.com/hyperledger/fabric/actions/runs/7462441029/job/20304890927

Failure occurs when [waiting for the orderer to delete a channel](https://github.com/hyperledger/fabric/blob/main/integration/raft/config_test.go#L1336) 

[Here is an explanation](https://github.com/hyperledger/fabric/blob/main/integration/raft/config_test.go#L1314): why they added the removal of the channel with orderer

I'll describe what's going on:
- the orderer is in a constant cycle periodically performing the [function](https://github.com/hyperledger/fabric/blob/main/orderer/common/follower/follower_chain.go#L339)
- send a command to remove channel. It passes the following functions [serveRemove](https://github.com/hyperledger/fabric/blob/main/orderer/common/channelparticipation/restapi.go#L360), [RemoveChannel](https://github.com/hyperledger/fabric/blob/main/orderer/common/multichannel/registrar.go#L769) (`r.lock` monopole is taken in this function), [Halt](https://github.com/hyperledger/fabric/blob/main/orderer/common/follower/follower_chain.go#L226) (the actual removal of the channel is expected [here](https://github.com/hyperledger/fabric/blob/main/orderer/common/follower/follower_chain.go#L228))
- let's return to the main loop, this is where the actual deletion should take place, it wants to execute the function [SwitchFollowerToChain](https://github.com/hyperledger/fabric/blob/main/orderer/common/follower/follower_chain.go#L357), but she can't, she needs a `r.lock` monopole.

==================================

The error in the raft tests is due to the struggle for monopoly control of r.lock in the SwitchChainToFollower and RemoveChannel functions.

RemoveChannel grabs monopoly control and waits for the channel to terminate. During termination, SwitchChainToFollower tries to grab monopoly control and fails.

Here is my variant of solving the error. If someone suggests a more correct and reddish way, it would be great.