### PR TITLE
Enhance queryapproved cmd to query all approved chaincode definitions

### DIFF
--- a/core/chaincode/lifecycle/scc_test.go
+++ b/core/chaincode/lifecycle/scc_test.go
@@ -1496,7 +1496,8 @@ var _ = Describe("SCC", func() {
 				payload := &lb.QueryApprovedChaincodeDefinitionsResult{}
 				err := proto.Unmarshal(res.Payload, payload)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(proto.Equal(payload, &lb.QueryApprovedChaincodeDefinitionsResult{
+
+				expectedDefinitions := &lb.QueryApprovedChaincodeDefinitionsResult{
 					ApprovedChaincodeDefinitions: []*lb.QueryApprovedChaincodeDefinitionsResult_ApprovedChaincodeDefinition{
 						{
 							Name:                "cc-name1",
@@ -1550,7 +1551,8 @@ var _ = Describe("SCC", func() {
 							},
 						},
 					},
-				})).To(BeTrue())
+				}
+				Expect(payload.ApprovedChaincodeDefinitions).To(ConsistOf(expectedDefinitions.ApprovedChaincodeDefinitions))
 
 				Expect(fakeSCCFuncs.QueryApprovedChaincodeDefinitionsCallCount()).To(Equal(1))
 				chname, privState := fakeSCCFuncs.QueryApprovedChaincodeDefinitionsArgsForCall(0)

--- a/internal/peer/lifecycle/chaincode/queryapproved.go
+++ b/internal/peer/lifecycle/chaincode/queryapproved.go
@@ -138,41 +138,71 @@ func (a *ApprovedQuerier) Query() error {
 	}
 
 	if strings.ToLower(a.Input.OutputFormat) == "json" {
-		return printResponseAsJSON(proposalResponse, &lb.QueryApprovedChaincodeDefinitionResult{}, a.Writer)
+		return a.printResponseAsJSON(proposalResponse)
 	}
 	return a.printResponse(proposalResponse)
+}
+
+func (a *ApprovedQuerier) printResponseAsJSON(proposalResponse *pb.ProposalResponse) error {
+	if a.Input.Name != "" {
+		return printResponseAsJSON(proposalResponse, &lb.QueryApprovedChaincodeDefinitionResult{}, a.Writer)
+	}
+	return printResponseAsJSON(proposalResponse, &lb.QueryApprovedChaincodeDefinitionsResult{}, a.Writer)
 }
 
 // printResponse prints the information included in the response
 // from the server as human readable plain-text.
 func (a *ApprovedQuerier) printResponse(proposalResponse *pb.ProposalResponse) error {
-	result := &lb.QueryApprovedChaincodeDefinitionResult{}
-	err := proto.Unmarshal(proposalResponse.Response.Payload, result)
-	if err != nil {
+	if a.Input.Name != "" {
+		result := &lb.QueryApprovedChaincodeDefinitionResult{}
+		if err := proto.Unmarshal(proposalResponse.Response.Payload, result); err != nil {
+			return errors.Wrap(err, "failed to unmarshal proposal response's response payload")
+		}
+		fmt.Fprintf(a.Writer, "Approved chaincode definition for chaincode '%s' on channel '%s':\n", a.Input.Name, a.Input.ChannelID)
+		a.printSingleApprovedChaincodeDefinition(result)
+		fmt.Fprintf(a.Writer, "\n")
+		return nil
+	}
+
+	result := &lb.QueryApprovedChaincodeDefinitionsResult{}
+	if err := proto.Unmarshal(proposalResponse.Response.Payload, result); err != nil {
 		return errors.Wrap(err, "failed to unmarshal proposal response's response payload")
 	}
-	fmt.Fprintf(a.Writer, "Approved chaincode definition for chaincode '%s' on channel '%s':\n", a.Input.Name, a.Input.ChannelID)
+	fmt.Fprintf(a.Writer, "Approved chaincode definitions on channel '%s':\n", a.Input.ChannelID)
 
+	for _, acd := range result.ApprovedChaincodeDefinitions {
+		fmt.Fprintf(a.Writer, "name: %s, ", acd.Name)
+		a.printSingleApprovedChaincodeDefinition(acd)
+		fmt.Fprintf(a.Writer, "\n")
+	}
+	return nil
+}
+
+type ApprovedChaincodeDefinition interface {
+	GetVersion() string
+	GetSequence() int64
+	GetEndorsementPlugin() string
+	GetValidationPlugin() string
+	GetInitRequired() bool
+	GetSource() *lb.ChaincodeSource
+}
+
+func (a *ApprovedQuerier) printSingleApprovedChaincodeDefinition(acd ApprovedChaincodeDefinition) {
 	var packageID string
-	if result.Source != nil {
-		switch source := result.Source.Type.(type) {
+	if acd.GetSource() != nil {
+		switch source := acd.GetSource().Type.(type) {
 		case *lb.ChaincodeSource_LocalPackage:
 			packageID = source.LocalPackage.PackageId
 		case *lb.ChaincodeSource_Unavailable_:
 		}
 	}
-	fmt.Fprintf(a.Writer, "sequence: %d, version: %s, init-required: %t, package-id: %s, endorsement plugin: %s, validation plugin: %s\n",
-		result.Sequence, result.Version, result.InitRequired, packageID, result.EndorsementPlugin, result.ValidationPlugin)
-	return nil
+	fmt.Fprintf(a.Writer, "sequence: %d, version: %s, init-required: %t, package-id: %s, endorsement plugin: %s, validation plugin: %s",
+		acd.GetSequence(), acd.GetVersion(), acd.GetInitRequired(), packageID, acd.GetEndorsementPlugin(), acd.GetValidationPlugin())
 }
 
 func (a *ApprovedQuerier) validateInput() error {
 	if a.Input.ChannelID == "" {
 		return errors.New("The required parameter 'channelID' is empty. Rerun the command with -C flag")
-	}
-
-	if a.Input.Name == "" {
-		return errors.New("The required parameter 'name' is empty. Rerun the command with -n flag")
 	}
 
 	return nil
@@ -182,10 +212,15 @@ func (a *ApprovedQuerier) createProposal() (*pb.Proposal, error) {
 	var function string
 	var args proto.Message
 
-	function = "QueryApprovedChaincodeDefinition"
-	args = &lb.QueryApprovedChaincodeDefinitionArgs{
-		Name:     a.Input.Name,
-		Sequence: a.Input.Sequence,
+	if a.Input.Name != "" {
+		function = "QueryApprovedChaincodeDefinition"
+		args = &lb.QueryApprovedChaincodeDefinitionArgs{
+			Name:     a.Input.Name,
+			Sequence: a.Input.Sequence,
+		}
+	} else {
+		function = "QueryApprovedChaincodeDefinitions"
+		args = &lb.QueryApprovedChaincodeDefinitionsArgs{}
 	}
 
 	argsBytes, err := proto.Marshal(args)


### PR DESCRIPTION
This PR enhances queryapproved command to query all approved chaincode definitions.
See https://github.com/hyperledger/fabric/issues/4564 for the detail.

Also, this fixes an unstable test code on _lifecycle functions on queryapproved to query all approved chaincode definitions.

#### Type of change

- New feature
- Bug fix

#### Description

As a sub-task stemming from issue #4564, this enhances queryapproved command to query all approved chaincode definitions.
Also, this fixes an unstable test code on _lifecycle functions on queryapproved to query all approved chaincode definitions.

Once this patch is merged, I will submit patches to update the documantations:


#### Addtional Details

The example of output when executing the enhanced queryapproved in the implementation:

```
$ peer lifecycle chaincode queryapproved -C mychannel
Approved chaincode definition on channel 'mychannel':
name: basic2, sequence: 2, version: 1.0.1, init-required: false, package-id: basic2_1.0.1:dae4dca432d56265e87e6416b602b40e94e7f7cdc177031abda1c81d9ed4258a, endorsement plugin: escc, validation plugin: vscc
name: basic, sequence: 1, version: 1.0.1, init-required: false, package-id: basic_1.0.1:f4babb5fd92c0ab4bce8c6ac30ca7bbb4a55e6c37774582d11639b6036ae0273, endorsement plugin: escc, validation plugin: vscc
name: basic2, sequence: 1, version: 1.0.1, init-required: false, package-id: basic2_1.0.1:dae4dca432d56265e87e6416b602b40e94e7f7cdc177031abda1c81d9ed4258a, endorsement plugin: escc, validation plugin: vscc
```

```
 $ peer lifecycle chaincode queryapproved -C mychannel -O json
{
        "approved_chaincode_definitions": [
                {
                        "name": "basic2",
                        "sequence": 2,
                        "version": "1.0.1",
                        "endorsement_plugin": "escc",
                        "validation_plugin": "vscc",
                        "validation_parameter": "EiAvQ2hhbm5lbC9BcHBsaWNhdGlvbi9FbmRvcnNlbWVudA==",
                        "collections": {},
                        "source": {
                                "Type": {
                                        "LocalPackage": {
                                                "package_id": "basic2_1.0.1:dae4dca432d56265e87e6416b602b40e94e7f7cdc177031abda1c81d9ed4258a"
                                        }
                                }
                        }
                },
                {
                        "name": "basic",
                        "sequence": 1,
                        "version": "1.0.1",
                        "endorsement_plugin": "escc",
                        "validation_plugin": "vscc",
                        "validation_parameter": "EiAvQ2hhbm5lbC9BcHBsaWNhdGlvbi9FbmRvcnNlbWVudA==",
                        "collections": {},
                        "source": {
                                "Type": {
                                        "LocalPackage": {
                                                "package_id": "basic_1.0.1:f4babb5fd92c0ab4bce8c6ac30ca7bbb4a55e6c37774582d11639b6036ae0273"
                                        }
                                }
                        }
                },
                {
                        "name": "basic2",
                        "sequence": 1,
                        "version": "1.0.1",
                        "endorsement_plugin": "escc",
                        "validation_plugin": "vscc",
                        "validation_parameter": "EiAvQ2hhbm5lbC9BcHBsaWNhdGlvbi9FbmRvcnNlbWVudA==",
                        "collections": {},
                        "source": {
                                "Type": {
                                        "LocalPackage": {
                                                "package_id": "basic2_1.0.1:dae4dca432d56265e87e6416b602b40e94e7f7cdc177031abda1c81d9ed4258a"
                                        }
                                }
                        }
                }
        ]
}
```

#### Releated PRs

- https://github.com/hyperledger/fabric-protos/pull/196
- https://github.com/hyperledger/fabric/pull/4592

