### PR TITLE
Use the named var for build dir

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,3 +1,7 @@
+#Copyright Hyperledger. All Rights Reserved.
+
+#SPDX-License-Identifier: Apache-2.0
+
 # License for Sphinx
 # ==================
 #
@@ -45,7 +49,7 @@ help:
 # Remove all generated documentation files.
 .PHONY: clean
 clean:
-	-@rm -rf build/
+	-@rm -rf $(BUILDDIR)/
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
Use the variable instead of build path string.

Change-Id: I0c8663cdfe9c7c546694a3edfb7a09d10ba2af69

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

The file already has the build variable, hence should use it.


#### Additional details

N/A

#### Related issues

N/A

#### Release Note

N/A