### PR TITLE
Fix inter-page links with MyST options in docs.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,10 +107,12 @@ def setup(app):
 
 html_theme = 'sphinx_rtd_theme'
 
-# html_css_files = ['css/custom.css']
-
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_static_path = ['_static']
 
 html_add_permalinks = True
+
+# -- MyST-specific Options -------------------------------------------------
+# https://myst-parser.readthedocs.io/en/latest/configuration.html#sphinx-config-options
+myst_all_links_external = True


### PR DESCRIPTION
#### Type of change

**This is for the main branch**

- Documentation update

#### Description

The new parser (MyST) for Markdown files was interpreting relative links (e.g. `../../file.html`) as anchors (e.g. `#../../file.html`) which doesn't help.  This changes the docs configuration to stop doing that.

#### Additional details

Sphinx moved to MyST for parsing Markdown files. This is the config page: https://myst-parser.readthedocs.io/en/latest/configuration.html#global-configuration

#### Related issues

N/A

#### Release Note
This will have no effect on Fabric functionality, but will change how the docs link to each other.
