### PR TITLE
Fix the jQuery issue in the docs on main branch

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,7 +81,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'myst_parser']
+    'myst_parser',
+    'sphinxcontrib.jquery']
 
 # -- Special API Accesses -------------------------------------------------
 # They create an instance of the Sphinx object, documented here


### PR DESCRIPTION
**This PR is for the main branch**

#### Type of change

- Documentation update

#### Description

jQuery was not loading the readthedocs menu to allow for viewing different doc versions. This commit fixes that.

#### Additional details

Found the fix here: https://github.com/readthedocs/readthedocs.org/issues/10159

#### Related issues

https://github.com/hyperledger/fabric/issues/4620.

#### Release Note
No impact on Fabric Functionality.
