### PR TITLE
Re-add the RSA definitions to BCCSP

### DIFF
--- a/bccsp/opts.go
+++ b/bccsp/opts.go
@@ -22,6 +22,19 @@ const (
 	// ECDSAReRand ECDSA key re-randomization
 	ECDSAReRand = "ECDSA_RERAND"
 
+	// RSA at the default security level.
+	// Each BCCSP may or may not support default security level. If not supported than
+	// an error will be returned.
+	RSA = "RSA"
+	// RSA at 1024 bit security level.
+	RSA1024 = "RSA1024"
+	// RSA at 2048 bit security level.
+	RSA2048 = "RSA2048"
+	// RSA at 3072 bit security level.
+	RSA3072 = "RSA3072"
+	// RSA at 4096 bit security level.
+	RSA4096 = "RSA4096"
+
 	// AES Advanced Encryption Standard at the default security level.
 	// Each BCCSP may or may not support default security level. If not supported than
 	// an error will be returned.

--- a/bccsp/rsaopts.go
+++ b/bccsp/rsaopts.go
@@ -1,0 +1,70 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bccsp
+
+// RSA1024KeyGenOpts contains options for RSA key generation at 1024 security.
+type RSA1024KeyGenOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key generation algorithm identifier (to be used).
+func (opts *RSA1024KeyGenOpts) Algorithm() string {
+	return RSA1024
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *RSA1024KeyGenOpts) Ephemeral() bool {
+	return opts.Temporary
+}
+
+// RSA2048KeyGenOpts contains options for RSA key generation at 2048 security.
+type RSA2048KeyGenOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key generation algorithm identifier (to be used).
+func (opts *RSA2048KeyGenOpts) Algorithm() string {
+	return RSA2048
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *RSA2048KeyGenOpts) Ephemeral() bool {
+	return opts.Temporary
+}
+
+// RSA3072KeyGenOpts contains options for RSA key generation at 3072 security.
+type RSA3072KeyGenOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key generation algorithm identifier (to be used).
+func (opts *RSA3072KeyGenOpts) Algorithm() string {
+	return RSA3072
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *RSA3072KeyGenOpts) Ephemeral() bool {
+	return opts.Temporary
+}
+
+// RSA4096KeyGenOpts contains options for RSA key generation at 4096 security.
+type RSA4096KeyGenOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key generation algorithm identifier (to be used).
+func (opts *RSA4096KeyGenOpts) Algorithm() string {
+	return RSA4096
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *RSA4096KeyGenOpts) Ephemeral() bool {
+	return opts.Temporary
+}


### PR DESCRIPTION
BCCSP supported RSA in version 1.4. The Fabric CA is currently using the Fabric 1.4 dependency. It is necessary to move Fabric CA off of Fabric 1.4 dependencies since they are no longer maintained. Fabric 2.X does not support RSA, however the CA still needs to support RSA for any older but not expired certificates that may be in use by older netwo

Github:
https://github.com/hyperledger/fabric/issues/4625
