### PR TITLE
Re-add the RSA definitions to BCCSP - RSA implementation

### DIFF
--- a/bccsp/opts.go
+++ b/bccsp/opts.go
@@ -262,6 +262,38 @@ func (opts *SHAOpts) Algorithm() string {
 	return SHA
 }
 
+// RSAKeyGenOpts contains options for RSA key generation.
+type RSAKeyGenOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key generation algorithm identifier (to be used).
+func (opts *RSAKeyGenOpts) Algorithm() string {
+	return RSA
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *RSAKeyGenOpts) Ephemeral() bool {
+	return opts.Temporary
+}
+
+// RSAGoPublicKeyImportOpts contains options for RSA key importation from rsa.PublicKey
+type RSAGoPublicKeyImportOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key importation algorithm identifier (to be used).
+func (opts *RSAGoPublicKeyImportOpts) Algorithm() string {
+	return RSA
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *RSAGoPublicKeyImportOpts) Ephemeral() bool {
+	return opts.Temporary
+}
+
 // X509PublicKeyImportOpts contains options for importing public keys from an x509 certificate
 type X509PublicKeyImportOpts struct {
 	Temporary bool

--- a/bccsp/sw/conf.go
+++ b/bccsp/sw/conf.go
@@ -20,6 +20,7 @@ type config struct {
 	ellipticCurve elliptic.Curve
 	hashFunction  func() hash.Hash
 	aesBitLength  int
+	rsaBitLength  int
 }
 
 func (conf *config) setSecurityLevel(securityLevel int, hashFamily string) (err error) {
@@ -39,10 +40,12 @@ func (conf *config) setSecurityLevelSHA2(level int) (err error) {
 	case 256:
 		conf.ellipticCurve = elliptic.P256()
 		conf.hashFunction = sha256.New
+		conf.rsaBitLength = 2048
 		conf.aesBitLength = 32
 	case 384:
 		conf.ellipticCurve = elliptic.P384()
 		conf.hashFunction = sha512.New384
+		conf.rsaBitLength = 3072
 		conf.aesBitLength = 32
 	default:
 		err = fmt.Errorf("Security level not supported [%d]", level)
@@ -55,10 +58,12 @@ func (conf *config) setSecurityLevelSHA3(level int) (err error) {
 	case 256:
 		conf.ellipticCurve = elliptic.P256()
 		conf.hashFunction = sha3.New256
+		conf.rsaBitLength = 2048
 		conf.aesBitLength = 32
 	case 384:
 		conf.ellipticCurve = elliptic.P384()
 		conf.hashFunction = sha3.New384
+		conf.rsaBitLength = 3072
 		conf.aesBitLength = 32
 	default:
 		err = fmt.Errorf("Security level not supported [%d]", level)

--- a/bccsp/sw/keygen.go
+++ b/bccsp/sw/keygen.go
@@ -1,17 +1,7 @@
 /*
-Copyright IBM Corp. 2017 All Rights Reserved.
+Copyright IBM Corp. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-		 http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
 */
 
 package sw
@@ -20,6 +10,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"fmt"
 
 	"github.com/hyperledger/fabric/bccsp"
@@ -49,4 +40,17 @@ func (kg *aesKeyGenerator) KeyGen(opts bccsp.KeyGenOpts) (bccsp.Key, error) {
 	}
 
 	return &aesPrivateKey{lowLevelKey, false}, nil
+}
+
+type rsaKeyGenerator struct {
+	length int
+}
+
+func (kg *rsaKeyGenerator) KeyGen(opts bccsp.KeyGenOpts) (bccsp.Key, error) {
+	lowLevelKey, err := rsa.GenerateKey(rand.Reader, int(kg.length))
+	if err != nil {
+		return nil, fmt.Errorf("Failed generating RSA %d key [%s]", kg.length, err)
+	}
+
+	return &rsaPrivateKey{lowLevelKey}, nil
 }

--- a/bccsp/sw/new.go
+++ b/bccsp/sw/new.go
@@ -80,6 +80,11 @@ func NewWithParams(securityLevel int, hashFamily string, keyStore bccsp.KeyStore
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.AES256KeyGenOpts{}), &aesKeyGenerator{length: 32})
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.AES192KeyGenOpts{}), &aesKeyGenerator{length: 24})
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.AES128KeyGenOpts{}), &aesKeyGenerator{length: 16})
+	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSAKeyGenOpts{}), &rsaKeyGenerator{length: conf.rsaBitLength})
+	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSA1024KeyGenOpts{}), &rsaKeyGenerator{length: 1024})
+	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSA2048KeyGenOpts{}), &rsaKeyGenerator{length: 2048})
+	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSA3072KeyGenOpts{}), &rsaKeyGenerator{length: 3072})
+	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSA4096KeyGenOpts{}), &rsaKeyGenerator{length: 4096})
 
 	// Set the key deriver
 	swbccsp.AddWrapper(reflect.TypeOf(&ecdsaPrivateKey{}), &ecdsaPrivateKeyKeyDeriver{})

--- a/bccsp/sw/rsa_test.go
+++ b/bccsp/sw/rsa_test.go
@@ -12,16 +12,10 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
-	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-type rsaPublicKeyASN struct {
-	N *big.Int
-	E int
-}
 
 func TestRSAPublicKey(t *testing.T) {
 	lowLevelKey, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/bccsp/sw/rsakey.go
+++ b/bccsp/sw/rsakey.go
@@ -1,0 +1,124 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sw
+
+import (
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/hyperledger/fabric/bccsp"
+)
+
+// rsaPublicKey reflects the ASN.1 structure of a PKCS#1 public key.
+type rsaPublicKeyASN struct {
+	N *big.Int
+	E int
+}
+
+type rsaPrivateKey struct {
+	privKey *rsa.PrivateKey
+}
+
+// Bytes converts this key to its byte representation,
+// if this operation is allowed.
+func (k *rsaPrivateKey) Bytes() ([]byte, error) {
+	return nil, errors.New("Not supported.")
+}
+
+// SKI returns the subject key identifier of this key.
+func (k *rsaPrivateKey) SKI() []byte {
+	if k.privKey == nil {
+		return nil
+	}
+
+	// Marshall the public key
+	raw, _ := asn1.Marshal(rsaPublicKeyASN{
+		N: k.privKey.N,
+		E: k.privKey.E,
+	})
+
+	// Hash it
+	hash := sha256.New()
+	hash.Write(raw)
+	return hash.Sum(nil)
+}
+
+// Symmetric returns true if this key is a symmetric key,
+// false is this key is asymmetric
+func (k *rsaPrivateKey) Symmetric() bool {
+	return false
+}
+
+// Private returns true if this key is an asymmetric private key,
+// false otherwise.
+func (k *rsaPrivateKey) Private() bool {
+	return true
+}
+
+// PublicKey returns the corresponding public key part of an asymmetric public/private key pair.
+// This method returns an error in symmetric key schemes.
+func (k *rsaPrivateKey) PublicKey() (bccsp.Key, error) {
+	return &rsaPublicKey{&k.privKey.PublicKey}, nil
+}
+
+type rsaPublicKey struct {
+	pubKey *rsa.PublicKey
+}
+
+// Bytes converts this key to its byte representation,
+// if this operation is allowed.
+func (k *rsaPublicKey) Bytes() (raw []byte, err error) {
+	if k.pubKey == nil {
+		return nil, errors.New("Failed marshalling key. Key is nil.")
+	}
+	raw, err = x509.MarshalPKIXPublicKey(k.pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("Failed marshalling key [%s]", err)
+	}
+	return
+}
+
+// SKI returns the subject key identifier of this key.
+func (k *rsaPublicKey) SKI() []byte {
+	if k.pubKey == nil {
+		return nil
+	}
+
+	// Marshall the public key
+	raw, _ := asn1.Marshal(rsaPublicKeyASN{
+		N: k.pubKey.N,
+		E: k.pubKey.E,
+	})
+
+	// Hash it
+	hash := sha256.New()
+	hash.Write(raw)
+	return hash.Sum(nil)
+}
+
+// Symmetric returns true if this key is a symmetric key,
+// false is this key is asymmetric
+func (k *rsaPublicKey) Symmetric() bool {
+	return false
+}
+
+// Private returns true if this key is an asymmetric private key,
+// false otherwise.
+func (k *rsaPublicKey) Private() bool {
+	return false
+}
+
+// PublicKey returns the corresponding public key part of an asymmetric public/private key pair.
+// This method returns an error in symmetric key schemes.
+func (k *rsaPublicKey) PublicKey() (bccsp.Key, error) {
+	return k, nil
+}


### PR DESCRIPTION
    BCCSP supported RSA in version 1.4. The Fabric CA is currently using the Fabric 1.4 dependency.
    It is necessary to move Fabric CA off of Fabric 1.4 dependencies since they are no longer maintained.
    Fabric 2.X does not support RSA, however the CA still needs to support RSA for any older but not expired certificates that may be in use by older netwo

    Github:
    https://github.com/hyperledger/fabric/issues/4625