### PR TITLE
Update documents to remove remaining descriptions on JIRA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@
 
 #### Related issues
 
-<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->
+<!--- Include a link to any associated issues, e.g. Github issue or approved rfc. -->
 
 <!---
 #### Release Note

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ If you think you have discovered a security issue in any of the Hyperledger proj
 
 There are two ways to report a security bug. The easiest is to email a description of the flaw and any related information (e.g. reproduction steps, version) to [security at hyperledger dot org](mailto:security@hyperledger.org).
 
-The other way is to file a confidential security bug in our [JIRA bug tracking system](https://jira.hyperledger.org). Be sure to set the “Security Level” to “Security issue”.
+The other way is to file a confidential security bug in the repository's [security advisories page](https://github.com/hyperledger/fabric/security/advisories). Guidance can be found in the GitHub documentation on [privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).
 
 The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://wiki.hyperledger.org/display/SEC/Defect+Response) on our [wiki](https://wiki.hyperledger.org).
 

--- a/docs/source/CONTRIBUTING.rst
+++ b/docs/source/CONTRIBUTING.rst
@@ -171,8 +171,7 @@ discussions/decisions to the `Fabric contributor meeting <https://wiki.hyperledg
 The mailing list, Discord, and GitHub each require their own login which you can request upon your first interaction.
 
 The Hyperledger Fabric `wiki <https://wiki.hyperledger.org/display/fabric>`__
-and the legacy issue management system in `Jira <https://jira.hyperledger.org/projects/FAB/issues>`__
-require a `Linux Foundation ID <https://identity.linuxfoundation.org/>`__,
+requires a `Linux Foundation ID <https://identity.linuxfoundation.org/>`__,
 but these resources are primarily for read-only reference and you will likely not need an ID.
 
 Contribution guide
@@ -207,7 +206,7 @@ issue. One of the project's maintainers should respond to your issue within 24
 hours. If not, please bump the issue with a comment and request that it be
 reviewed. You can also post to the relevant Hyperledger Fabric channel in
 `Hyperledger Discord <https://discord.com/servers/hyperledger-foundation-905194001349627914>`__.  For example, a doc bug should
-be broadcast to ``#fabric-documentation``, a database bug to ``#fabric-ledger``,
+be broadcast to ``#fabric-documentation``, a peer bug to ``#fabric-peer``,
 and so on...
 
 Submitting your fix

--- a/docs/source/cc_launcher.md
+++ b/docs/source/cc_launcher.md
@@ -101,7 +101,7 @@ When `release` completes, the peer will consume two types of metadata from `RELE
 
 If CouchDB index definitions are required for the chaincode, `release` is responsible for placing the indexes into the `statedb/couchdb/indexes` directory under `RELEASE_OUTPUT_DIR`. The indexes must have a `.json` extension.  See the [CouchDB indexes](couchdb_as_state_database.html#couchdb-indexes) documentation for details.
 
-In cases where a chaincode server implementation is used, `release` is responsible for populating `chaincode/server/connection.json` with the address of the chaincode server and any TLS assets required to communicate with the chaincode. When server connection information is provided to the peer, `run` will not be called. See the [Chaincode Server](https://jira.hyperledger.org/browse/FAB-14086) documentation for details.
+In cases where a chaincode server implementation is used, `release` is responsible for populating `chaincode/server/connection.json` with the address of the chaincode server and any TLS assets required to communicate with the chaincode. When server connection information is provided to the peer, `run` will not be called.
 
 The following is an example of a simple `release` script for go chaincode:
 

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -8,7 +8,7 @@
 cat > CHANGELOG.new << EOF
 ## "${2}"
 
-$(git log "$1..HEAD"  --oneline | grep -v Merge | sed -e "s/\[\(FAB-[0-9]*\)\]/\[\1\](https:\/\/jira.hyperledger.org\/browse\/\1\)/" -e "s/ \(FAB-[0-9]*\)/ \[\1\](https:\/\/jira.hyperledger.org\/browse\/\1\)/" -e "s/\([0-9|a-z]*\)/* \[\1\](https:\/\/github.com\/hyperledger\/fabric\/commit\/\1)/")
+$(git log "$1..HEAD"  --oneline | grep -v Merge | sed -e "s/\([0-9|a-z]*\)/* \[\1\](https:\/\/github.com\/hyperledger\/fabric\/commit\/\1)/")
 
 EOF
 cat CHANGELOG.md >> CHANGELOG.new


### PR DESCRIPTION
This patch removes remaining descriptions regarding JIRA in the repository. Also, it includes minor improvements of docs.

#### Type of change

- Documentation update

#### Description
It seems the Hyperledger JIRA instance was sunset at the end of last year.
On the other hands, there are some remaining descriptions regarding JIRA in the repository.
So, this patch removes the remaining descriptions. Also, it includes some minor improvements of docs.

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
