### PR TITLE
Check the TLS.Config error immediately

### DIFF
--- a/common/fabhttp/server.go
+++ b/common/fabhttp/server.go
@@ -124,11 +124,10 @@ func (s *Server) Listen() (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	tlsConfig, err := s.options.TLS.Config()
-	if err != nil {
+
+	if tlsConfig, err := s.options.TLS.Config(); err != nil {
 		return nil, err
-	}
-	if tlsConfig != nil {
+	} else if tlsConfig != nil {
 		listener = tls.NewListener(listener, tlsConfig)
 	}
 	return listener, nil


### PR DESCRIPTION
The patchset checks the TLS.Config()'s potential return error immediately.

Change-Id: I16a39e0f0152179300d5626ffdffb5b2d16f5a6d

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

The patchset checks the TLS.Config()'s potential return error immediately after it is initialized. 

This is to follow Golang's style.

#### Additional details

N/A

#### Related issues

N/A

#### Release Note

N/A
