### PR TITLE
change smartbft chain log message

### DIFF
--- a/orderer/consensus/smartbft/chain.go
+++ b/orderer/consensus/smartbft/chain.go
@@ -168,7 +168,7 @@ func NewChain(
 		return nil, errors.Wrap(err, "failed to verify SmartBFT-Go configuration")
 	}
 
-	logger.Infof("SmartBFT-v3 is now servicing chain %s", support.ChannelID())
+	logger.Infof("SmartBFT-v3 is now servicing chain")
 
 	return c, nil
 }


### PR DESCRIPTION
#### Type of change

- Log message update

#### Description

This PR aims to fix a log message that includes the channel name twice. 