### PR TITLE
Update github actions to use Node 20 (release-2.5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,12 @@ jobs:
           arch: amd64
     runs-on: ubuntu-20.04
     steps:
+      - name: Checkout Fabric Code
+        uses: actions/checkout@v4      
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VER }}
-      - name: Checkout Fabric Code
-        uses: actions/checkout@v3
       - name: Compile Binary and Create Tarball
         run: ./ci/scripts/create_binary_package.sh
         env:
@@ -95,7 +95,7 @@ jobs:
               max-parallelism = 1
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to the ${{ env.DOCKER_REGISTRY }} Container Registry
         uses: docker/login-action@v2
@@ -140,7 +140,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Fabric Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download Artifacts
         id: download
         uses: actions/download-artifact@v3

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -20,12 +20,12 @@ jobs:
     name: Basic Checks
     runs-on: ${{ github.repository == 'hyperledger/fabric' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+        name: Checkout Fabric Code      
+      - uses: actions/setup-go@v5
         name: Install Go
         with:
           go-version: ${{ env.GO_VER }}
-      - uses: actions/checkout@v3
-        name: Checkout Fabric Code
       - run: make basic-checks
         name: Run Basic Checks
   unit-tests:
@@ -33,12 +33,12 @@ jobs:
     needs: basic-checks
     runs-on: ${{ github.repository == 'hyperledger/fabric' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+        name: Checkout Fabric Code      
+      - uses: actions/setup-go@v5
         name: Install Go
         with:
           go-version: ${{ env.GO_VER }}
-      - uses: actions/checkout@v3
-        name: Checkout Fabric Code
       - run: ci/scripts/setup_hsm.sh
         name: Install SoftHSM
       - run: make unit-test
@@ -52,12 +52,12 @@ jobs:
         INTEGRATION_TEST_SUITE: ["raft","pvtdata","pvtdatapurge","ledger","lifecycle","e2e","discovery gossip devmode pluggable","gateway idemix pkcs11 configtx configtxlator","sbe nwo msp"]
     runs-on: ${{ github.repository == 'hyperledger/fabric' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+        name: Checkout Fabric Code      
+      - uses: actions/setup-go@v5
         name: Install Go
         with:
           go-version: ${{ env.GO_VER }}
-      - uses: actions/checkout@v3
-        name: Checkout Fabric Code
       - run: ci/scripts/setup_hsm.sh
         name: Install SoftHSM
       - run: make integration-test INTEGRATION_TEST_SUITE="${{matrix.INTEGRATION_TEST_SUITE}}"


### PR DESCRIPTION
- actions/setup-go@v5
- actions/checkout@v4

Need to ensure checkout is done before setup-go for cache to work.
