### PR TITLE
Block Censorship Test

### DIFF
--- a/integration/smartbft/mock_orderer.go
+++ b/integration/smartbft/mock_orderer.go
@@ -252,7 +252,6 @@ func NewMockOrderer(address string, ledgerArray []*cb.Block, options comm.Secure
 
 	ab.RegisterAtomicBroadcastServer(grpcServer.Server(), mo)
 
-	mo.logger.Info("%s >>>> Beginning to serve request", address)
 	go grpcServer.Start()
 
 	return mo, nil

--- a/integration/smartbft/mock_orderer.go
+++ b/integration/smartbft/mock_orderer.go
@@ -169,7 +169,7 @@ func (mo *MockOrderer) deliverBlocks(
 			}
 			block = mo.ledgerArray[ledgerIdx]
 			status = cb.Status_SUCCESS
-			mo.logger.Infof("### <%s> extracted block %d ; %+v", mo.address, ledgerIdx, block)
+			mo.logger.Infof("### <%s> extracted block number %d ; ledgerIdx is %d", mo.address, block.Header.Number, ledgerIdx)
 			ledgerIdx++
 			close(iterCh)
 		}()

--- a/integration/smartbft/mock_orderer.go
+++ b/integration/smartbft/mock_orderer.go
@@ -108,10 +108,6 @@ func (mo *MockOrderer) deliverBlocks(
 		return cb.Status_BAD_REQUEST, nil
 	}
 
-	if chdr.ChannelId != "testchannel1" {
-		panic("WHAT CHANNEL ARE YOU TALKING ABOUT?")
-	}
-
 	seekInfo := &ab.SeekInfo{}
 	if err = proto.Unmarshal(payload.Data, seekInfo); err != nil {
 		mo.logger.Warningf("[channel: %s] Received a signed deliver request from %s with malformed seekInfo payload: %s", chdr.ChannelId, addr, err)
@@ -167,7 +163,6 @@ func (mo *MockOrderer) deliverBlocks(
 			}
 			block = mo.ledgerArray[ledgerIdx]
 			status = cb.Status_SUCCESS
-			mo.logger.Infof("### <%s> extracted block %d ; %v", mo.address, ledgerIdx, block)
 			ledgerIdx++
 			close(iterCh)
 		}()
@@ -194,7 +189,6 @@ func (mo *MockOrderer) deliverBlocks(
 		}
 
 		if seekInfo.ContentType == ab.SeekInfo_HEADER_WITH_SIG && !protoutil.IsConfigBlock(block) {
-			mo.logger.Infof("ASKED FOR HEADER WITH SIG")
 			block2send.Data = nil
 		} else if mo.censorDataMode {
 			if !mo.peerFirstTry {

--- a/integration/smartbft/smartbft_block_deliverer_test.go
+++ b/integration/smartbft/smartbft_block_deliverer_test.go
@@ -187,7 +187,6 @@ var _ = Describe("Smart BFT Block Deliverer", func() {
 	})
 
 	It("correct mock", func() {
-
 		var err error
 		channel := "testchannel1"
 
@@ -231,6 +230,5 @@ var _ = Describe("Smart BFT Block Deliverer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		nwo.WaitUntilEqualLedgerHeight(network, channel, 11, network.Peers[0])
-
 	})
 })

--- a/integration/smartbft/smartbft_block_deliverer_test.go
+++ b/integration/smartbft/smartbft_block_deliverer_test.go
@@ -10,11 +10,12 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/hyperledger/fabric/integration/nwo/commands"
 	"os"
 	"path/filepath"
 	"syscall"
 	"time"
+
+	"github.com/hyperledger/fabric/integration/nwo/commands"
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/hyperledger/fabric-protos-go/common"

--- a/integration/smartbft/smartbft_block_deliverer_test.go
+++ b/integration/smartbft/smartbft_block_deliverer_test.go
@@ -211,6 +211,7 @@ var _ = Describe("Smart BFT Block Deliverer", func() {
 
 		for _, mock := range mocksArray {
 			mock.censorDataMode = true
+			mock.stopDeliveryChannel = make(chan struct{})
 		}
 
 		/* Create peer */
@@ -226,7 +227,11 @@ var _ = Describe("Smart BFT Block Deliverer", func() {
 			ClientAuth: network.ClientAuthRequired,
 		})
 		Expect(err).NotTo(HaveOccurred())
-
+		Eventually(peerRunner.Err(), network.EventuallyTimeout).Should(gbytes.Say("Block censorship detected"))
 		nwo.WaitUntilEqualLedgerHeight(network, channel, 11, network.Peers[0])
+
+		for _, mock := range mocksArray {
+			close(mock.stopDeliveryChannel)
+		}
 	})
 })

--- a/integration/smartbft/smartbft_block_deliverer_test.go
+++ b/integration/smartbft/smartbft_block_deliverer_test.go
@@ -9,7 +9,6 @@ package smartbft
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -204,7 +203,6 @@ var _ = Describe("Smart BFT Block Deliverer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		nwo.WaitUntilEqualLedgerHeight(network, channel, 11, network.Peers[0])
-		fmt.Println("Hello")
 	})
 
 	It("block censorship", func() {

--- a/integration/smartbft/smartbft_block_deliverer_test.go
+++ b/integration/smartbft/smartbft_block_deliverer_test.go
@@ -9,6 +9,7 @@ package smartbft
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"github.com/hyperledger/fabric/integration/nwo/commands"
 	"os"
 	"path/filepath"
@@ -69,7 +70,7 @@ var _ = Describe("Smart BFT Block Deliverer", func() {
 		var ordererRunners []*ginkgomon.Runner
 		for _, orderer := range network.Orderers {
 			runner := network.OrdererRunner(orderer)
-			runner.Command.Env = append(runner.Command.Env, "FABRIC_LOGGING_SPEC=orderer.consensus.smartbft=debug:grpc=debug")
+			runner.Command.Env = append(runner.Command.Env, "FABRIC_LOGGING_SPEC=debug")
 			ordererRunners = append(ordererRunners, runner)
 			proc := ifrit.Invoke(runner)
 			ordererProcesses = append(ordererProcesses, proc)
@@ -203,9 +204,10 @@ var _ = Describe("Smart BFT Block Deliverer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		nwo.WaitUntilEqualLedgerHeight(network, channel, 11, network.Peers[0])
+		fmt.Println("Hello")
 	})
 
-	It("block censorship", func() {
+	FIt("block censorship", func() {
 		var err error
 		channel := "testchannel1"
 
@@ -217,6 +219,7 @@ var _ = Describe("Smart BFT Block Deliverer", func() {
 		By("Create a peer and join to channel")
 		p0 := network.Peers[0]
 		peerRunner := network.PeerRunner(p0)
+		peerRunner.Command.Env = append(peerRunner.Command.Env, "FABRIC_LOGGING_SPEC=debug")
 		peerProcesses = ifrit.Invoke(peerRunner)
 		Eventually(peerProcesses.Ready(), network.EventuallyTimeout).Should(BeClosed())
 

--- a/integration/smartbft/smartbft_block_deliverer_test.go
+++ b/integration/smartbft/smartbft_block_deliverer_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Smart BFT Block Deliverer", func() {
 		fmt.Println("Hello")
 	})
 
-	FIt("block censorship", func() {
+	It("block censorship", func() {
 		var err error
 		channel := "testchannel1"
 


### PR DESCRIPTION
* Test update: Add a test that will checkout how the block deliverer acts with a malicious orderer that censors blocks.

Description: The test creates a network, creates blocks on the chain, replaces the orderers with mocks and communicates with the peer. One of the orderers becomes malicious and after delivering a few data blocks he will stop. Afterwards the peer will ask for another orderer to deliver the data blocks, which should be successful, since he should be a honest orderer.

arkadi.piven@ibm.com
