### PR TITLE
Use fabric-lib-go v1.1.0 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20220713164125-8f0791c989d7
 	github.com/hyperledger/fabric-config v0.2.1
-	github.com/hyperledger/fabric-lib-go v1.0.1-0.20240216124656-9f79bd087182
+	github.com/hyperledger/fabric-lib-go v1.1.0
 	github.com/hyperledger/fabric-protos-go v0.3.2
 	github.com/kr/pretty v0.3.1
 	github.com/miekg/pkcs11 v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/hyperledger/fabric-chaincode-go v0.0.0-20220713164125-8f0791c989d7 h1
 github.com/hyperledger/fabric-chaincode-go v0.0.0-20220713164125-8f0791c989d7/go.mod h1:9HhzkKkb8qteXBbHEQ3J/FHBVJRDJAgYIPtKPIl3Dt8=
 github.com/hyperledger/fabric-config v0.2.1 h1:CsReuxvi5c5NUyKKQOIVbHux32o+XtmDNceYLYjycxo=
 github.com/hyperledger/fabric-config v0.2.1/go.mod h1:1ZfjDrsuMoM4IPKezQgTByy2vXUj8bgTXaOXaGXK5O4=
-github.com/hyperledger/fabric-lib-go v1.0.1-0.20240216124656-9f79bd087182 h1:O747XXWoCBDoFqMayEwvEyyYD+LIMY/3r/B78xZsbYU=
-github.com/hyperledger/fabric-lib-go v1.0.1-0.20240216124656-9f79bd087182/go.mod h1:SHNCq8AB0VpHAmvJEtdbzabv6NNV1F48JdmDihasBjc=
+github.com/hyperledger/fabric-lib-go v1.1.0 h1:iVjRr0oxqNn2P0SH2UCiOdLak56kqn/YJ6A/wnxNNaU=
+github.com/hyperledger/fabric-lib-go v1.1.0/go.mod h1:SHNCq8AB0VpHAmvJEtdbzabv6NNV1F48JdmDihasBjc=
 github.com/hyperledger/fabric-protos-go v0.0.0-20220516090339-9685156fada6/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/hyperledger/fabric-protos-go v0.3.2 h1:mQmbHw3lyDV2+W5b0FitV/SjM4LLDjMTQJWW9taitDM=
 github.com/hyperledger/fabric-protos-go v0.3.2/go.mod h1:WWnyWP40P2roPmmvxsUXSvVI/CF6vwY1K1UFidnKBys=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/client9/misspell v0.3.4
 	github.com/go-swagger/go-swagger v0.25.0
 	github.com/golang/protobuf v1.5.3
-	github.com/hyperledger/fabric-lib-go v1.0.1-0.20240216124656-9f79bd087182
+	github.com/hyperledger/fabric-lib-go v1.1.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2
 	github.com/onsi/ginkgo/v2 v2.13.2
 	github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1525,8 +1525,8 @@ github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0m
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hyperledger/fabric-lib-go v1.0.1-0.20240216124656-9f79bd087182 h1:O747XXWoCBDoFqMayEwvEyyYD+LIMY/3r/B78xZsbYU=
-github.com/hyperledger/fabric-lib-go v1.0.1-0.20240216124656-9f79bd087182/go.mod h1:SHNCq8AB0VpHAmvJEtdbzabv6NNV1F48JdmDihasBjc=
+github.com/hyperledger/fabric-lib-go v1.1.0 h1:iVjRr0oxqNn2P0SH2UCiOdLak56kqn/YJ6A/wnxNNaU=
+github.com/hyperledger/fabric-lib-go v1.1.0/go.mod h1:SHNCq8AB0VpHAmvJEtdbzabv6NNV1F48JdmDihasBjc=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -247,7 +247,7 @@ github.com/hyperledger/fabric-config/protolator/protoext/ledger/rwsetext
 github.com/hyperledger/fabric-config/protolator/protoext/mspext
 github.com/hyperledger/fabric-config/protolator/protoext/ordererext
 github.com/hyperledger/fabric-config/protolator/protoext/peerext
-# github.com/hyperledger/fabric-lib-go v1.0.1-0.20240216124656-9f79bd087182
+# github.com/hyperledger/fabric-lib-go v1.1.0
 ## explicit; go 1.20
 github.com/hyperledger/fabric-lib-go/bccsp
 github.com/hyperledger/fabric-lib-go/bccsp/factory


### PR DESCRIPTION
Transition from the fabric-lib-go temporary branch to the actual release v1.1.0.

This is the release that includes the common
bccsp, metrics, and flogging packages that
are shared across fabric and fabric-ca.
