### PR TITLE
BFT: configure orderer replication policy

### DIFF
--- a/orderer/common/localconfig/config.go
+++ b/orderer/common/localconfig/config.go
@@ -68,6 +68,7 @@ type Cluster struct {
 	ReplicationPullTimeout         time.Duration
 	ReplicationRetryTimeout        time.Duration
 	ReplicationMaxRetries          int
+	ReplicationPolicy              string // BFT: "simple" | "consensus" (default); etcdraft: ignored, always "simple"
 	SendBufferSize                 int
 	CertExpirationWarningThreshold time.Duration
 	TLSHandshakeTimeShift          time.Duration
@@ -188,6 +189,7 @@ var Defaults = TopLevel{
 			ReplicationRetryTimeout:        time.Second * 5,
 			ReplicationPullTimeout:         time.Second * 5,
 			CertExpirationWarningThreshold: time.Hour * 24 * 7,
+			ReplicationPolicy:              "consensus", // BFT default; on etcdraft it is ignored
 		},
 		LocalMSPDir: "msp",
 		LocalMSPID:  "SampleOrg",
@@ -332,6 +334,9 @@ func (c *TopLevel) completeInitialization(configDir string) {
 			c.General.Cluster.ReplicationRetryTimeout = Defaults.General.Cluster.ReplicationRetryTimeout
 		case c.General.Cluster.CertExpirationWarningThreshold == 0:
 			c.General.Cluster.CertExpirationWarningThreshold = Defaults.General.Cluster.CertExpirationWarningThreshold
+		case (c.General.Cluster.ReplicationPolicy != "simple") && (c.General.Cluster.ReplicationPolicy != "consensus"):
+			logger.Infof("General.Cluster.ReplicationPolicy is `%s`, setting to `%s`", c.General.Cluster.ReplicationPolicy, Defaults.General.Cluster.ReplicationPolicy)
+			c.General.Cluster.ReplicationPolicy = Defaults.General.Cluster.ReplicationPolicy
 
 		case c.General.Profile.Enabled && c.General.Profile.Address == "":
 			logger.Infof("Profiling enabled and General.Profile.Address unset, setting to %s", Defaults.General.Profile.Address)

--- a/orderer/common/localconfig/config_test.go
+++ b/orderer/common/localconfig/config_test.go
@@ -165,6 +165,7 @@ func TestClusterDefaults(t *testing.T) {
 	cfg, err := cc.load()
 	require.NoError(t, err)
 	require.Equal(t, cfg.General.Cluster.ReplicationMaxRetries, Defaults.General.Cluster.ReplicationMaxRetries)
+	require.Equal(t, cfg.General.Cluster.ReplicationPolicy, Defaults.General.Cluster.ReplicationPolicy)
 }
 
 func TestConsensusConfig(t *testing.T) {

--- a/orderer/consensus/smartbft/consenter.go
+++ b/orderer/consensus/smartbft/consenter.go
@@ -15,8 +15,6 @@ import (
 	"path"
 	"reflect"
 
-	"github.com/hyperledger/fabric/orderer/consensus/smartbft/util"
-
 	"github.com/SmartBFT-Go/consensus/pkg/api"
 	"github.com/SmartBFT-Go/consensus/pkg/wal"
 	"github.com/golang/protobuf/proto"
@@ -34,6 +32,7 @@ import (
 	"github.com/hyperledger/fabric/orderer/common/localconfig"
 	"github.com/hyperledger/fabric/orderer/common/multichannel"
 	"github.com/hyperledger/fabric/orderer/consensus"
+	"github.com/hyperledger/fabric/orderer/consensus/smartbft/util"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -203,7 +202,23 @@ func (c *Consenter) HandleChain(support consensus.ConsenterSupport, metadata *cb
 		Logger:               c.Logger,
 	}
 
-	chain, err := NewChain(configValidator, (uint64)(selfID), config, path.Join(c.WALBaseDir, support.ChannelID()), puller, c.Comm, c.SignerSerializer, c.GetPolicyManager(support.ChannelID()), support, c.Metrics, c.MetricsBFT, c.MetricsWalBFT, c.BCCSP)
+	chain, err := NewChain(
+		configValidator,
+		(uint64)(selfID),
+		config,
+		path.Join(c.WALBaseDir, support.ChannelID()),
+		puller,
+		c.ClusterDialer,        // required by the BFT-synchronizer
+		c.Conf.General.Cluster, // required by the BFT-synchronizer
+		c.Comm,
+		c.SignerSerializer,
+		c.GetPolicyManager(support.ChannelID()),
+		support,
+		c.Metrics,
+		c.MetricsBFT,
+		c.MetricsWalBFT,
+		c.BCCSP,
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating a new BFTChain")
 	}

--- a/sampleconfig/orderer.yaml
+++ b/sampleconfig/orderer.yaml
@@ -115,6 +115,12 @@ General:
         # ServerPrivateKey defines the file location of the private key of the TLS certificate.
         ServerPrivateKey:
 
+        # ReplicationPolicy defines how blocks are replicated between orderers.
+        # Permitted values:
+        # in BFT: "simple" | "consensus" (default);
+        # in etcdraft: ignored, (always "simple", regardless of value in config).
+        ReplicationPolicy:
+
     # Bootstrap method: The method by which to obtain the bootstrap block
     # system channel is specified. The option can be one of:
     #   "file" - path to a file containing the genesis block or config block of system channel


### PR DESCRIPTION

Change-Id: I89596f5d10e636e499c36799472e593582847a9e

#### Type of change

- New feature

#### Description

Add a replication policy to the orderer.yaml that allows a BFT orderer to choose whethet it uses the "simple" synchronizer which contacts a single target orderer at a time or the BFT "consensus" synchronizer which contacts all target orderers and is resistant to censorship.

#### Related issues

Issue #4566 