### PR TITLE
BFT: skip self-endpoint when pulling blocks

### DIFF
--- a/core/deliverservice/deliveryclient.go
+++ b/core/deliverservice/deliveryclient.go
@@ -280,7 +280,7 @@ func (d *deliverServiceImpl) createBlockDelivererBFT(chainID string, ledgerInfo 
 		dcBFT.TLSCertHash = util.ComputeSHA256(cert.Certificate[0])
 	}
 
-	dcBFT.Initialize(d.conf.ChannelConfig)
+	dcBFT.Initialize(d.conf.ChannelConfig, "")
 
 	return dcBFT, nil
 }

--- a/internal/pkg/peer/blocksprovider/bft_deliverer.go
+++ b/internal/pkg/peer/blocksprovider/bft_deliverer.go
@@ -105,7 +105,7 @@ type BFTDeliverer struct {
 	censorshipMonitor CensorshipDetector
 }
 
-func (d *BFTDeliverer) Initialize(channelConfig *common.Config) {
+func (d *BFTDeliverer) Initialize(channelConfig *common.Config, selfEndpoint string) {
 	d.requester = NewDeliveryRequester(
 		d.ChannelID,
 		d.Signer,
@@ -115,7 +115,7 @@ func (d *BFTDeliverer) Initialize(channelConfig *common.Config) {
 	)
 
 	osLogger := flogging.MustGetLogger("peer.orderers")
-	ordererSource := d.OrderersSourceFactory.CreateConnectionSource(osLogger)
+	ordererSource := d.OrderersSourceFactory.CreateConnectionSource(osLogger, selfEndpoint)
 	globalAddresses, orgAddresses, err := extractAddresses(d.ChannelID, channelConfig, d.CryptoProvider)
 	if err != nil {
 		// The bundle was created prior to calling this function, so it should not fail when we recreate it here.

--- a/internal/pkg/peer/blocksprovider/bft_deliverer_test.go
+++ b/internal/pkg/peer/blocksprovider/bft_deliverer_test.go
@@ -228,7 +228,9 @@ func (s *bftDelivererTestSetup) initialize(t *testing.T) {
 		MaxRetryDuration:                600 * time.Second,
 		MaxRetryDurationExceededHandler: s.fakeDurationExceededHandler.DurationExceededHandler,
 	}
-	s.d.Initialize(s.channelConfig)
+	s.d.Initialize(s.channelConfig, "bogus-self-endpoint")
+	_, selfEP := s.fakeOrdererConnectionSourceFactory.CreateConnectionSourceArgsForCall(0)
+	require.Equal(t, "bogus-self-endpoint", selfEP)
 
 	s.fakeSleeper = &fake.Sleeper{}
 

--- a/internal/pkg/peer/blocksprovider/deliverer.go
+++ b/internal/pkg/peer/blocksprovider/deliverer.go
@@ -117,7 +117,7 @@ func (d *Deliverer) Initialize(channelConfig *cb.Config) {
 	)
 
 	osLogger := flogging.MustGetLogger("peer.orderers")
-	ordererSource := d.OrderersSourceFactory.CreateConnectionSource(osLogger)
+	ordererSource := d.OrderersSourceFactory.CreateConnectionSource(osLogger, "")
 	globalAddresses, orgAddresses, err := extractAddresses(d.ChannelID, channelConfig, d.CryptoProvider)
 	if err != nil {
 		// The bundle was created prior to calling this function, so it should not fail when we recreate it here.

--- a/internal/pkg/peer/blocksprovider/fake/orderer_connection_source_factory.go
+++ b/internal/pkg/peer/blocksprovider/fake/orderer_connection_source_factory.go
@@ -10,10 +10,11 @@ import (
 )
 
 type OrdererConnectionSourceFactory struct {
-	CreateConnectionSourceStub        func(*flogging.FabricLogger) orderers.ConnectionSourcer
+	CreateConnectionSourceStub        func(*flogging.FabricLogger, string) orderers.ConnectionSourcer
 	createConnectionSourceMutex       sync.RWMutex
 	createConnectionSourceArgsForCall []struct {
 		arg1 *flogging.FabricLogger
+		arg2 string
 	}
 	createConnectionSourceReturns struct {
 		result1 orderers.ConnectionSourcer
@@ -25,18 +26,19 @@ type OrdererConnectionSourceFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *OrdererConnectionSourceFactory) CreateConnectionSource(arg1 *flogging.FabricLogger) orderers.ConnectionSourcer {
+func (fake *OrdererConnectionSourceFactory) CreateConnectionSource(arg1 *flogging.FabricLogger, arg2 string) orderers.ConnectionSourcer {
 	fake.createConnectionSourceMutex.Lock()
 	ret, specificReturn := fake.createConnectionSourceReturnsOnCall[len(fake.createConnectionSourceArgsForCall)]
 	fake.createConnectionSourceArgsForCall = append(fake.createConnectionSourceArgsForCall, struct {
 		arg1 *flogging.FabricLogger
-	}{arg1})
+		arg2 string
+	}{arg1, arg2})
 	stub := fake.CreateConnectionSourceStub
 	fakeReturns := fake.createConnectionSourceReturns
-	fake.recordInvocation("CreateConnectionSource", []interface{}{arg1})
+	fake.recordInvocation("CreateConnectionSource", []interface{}{arg1, arg2})
 	fake.createConnectionSourceMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -50,17 +52,17 @@ func (fake *OrdererConnectionSourceFactory) CreateConnectionSourceCallCount() in
 	return len(fake.createConnectionSourceArgsForCall)
 }
 
-func (fake *OrdererConnectionSourceFactory) CreateConnectionSourceCalls(stub func(*flogging.FabricLogger) orderers.ConnectionSourcer) {
+func (fake *OrdererConnectionSourceFactory) CreateConnectionSourceCalls(stub func(*flogging.FabricLogger, string) orderers.ConnectionSourcer) {
 	fake.createConnectionSourceMutex.Lock()
 	defer fake.createConnectionSourceMutex.Unlock()
 	fake.CreateConnectionSourceStub = stub
 }
 
-func (fake *OrdererConnectionSourceFactory) CreateConnectionSourceArgsForCall(i int) *flogging.FabricLogger {
+func (fake *OrdererConnectionSourceFactory) CreateConnectionSourceArgsForCall(i int) (*flogging.FabricLogger, string) {
 	fake.createConnectionSourceMutex.RLock()
 	defer fake.createConnectionSourceMutex.RUnlock()
 	argsForCall := fake.createConnectionSourceArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *OrdererConnectionSourceFactory) CreateConnectionSourceReturns(result1 orderers.ConnectionSourcer) {

--- a/internal/pkg/peer/orderers/connection_factory.go
+++ b/internal/pkg/peer/orderers/connection_factory.go
@@ -17,13 +17,16 @@ type ConnectionSourcer interface {
 }
 
 type ConnectionSourceCreator interface {
-	CreateConnectionSource(logger *flogging.FabricLogger) ConnectionSourcer
+	// CreateConnectionSource creates a ConnectionSourcer implementation.
+	// In a peer, selfEndpoint == "";
+	// In an orderer selfEndpoint carries the (delivery service) endpoint of the orderer.
+	CreateConnectionSource(logger *flogging.FabricLogger, selfEndpoint string) ConnectionSourcer
 }
 
 type ConnectionSourceFactory struct {
 	Overrides map[string]*Endpoint
 }
 
-func (f *ConnectionSourceFactory) CreateConnectionSource(logger *flogging.FabricLogger) ConnectionSourcer {
-	return NewConnectionSource(logger, f.Overrides)
+func (f *ConnectionSourceFactory) CreateConnectionSource(logger *flogging.FabricLogger, selfEndpoint string) ConnectionSourcer {
+	return NewConnectionSource(logger, f.Overrides, selfEndpoint)
 }

--- a/internal/pkg/peer/orderers/connection_factory_test.go
+++ b/internal/pkg/peer/orderers/connection_factory_test.go
@@ -19,7 +19,7 @@ func TestCreateConnectionSource(t *testing.T) {
 	require.NotNil(t, factory)
 	require.Nil(t, factory.Overrides)
 	lg := flogging.MustGetLogger("test")
-	connSource := factory.CreateConnectionSource(lg)
+	connSource := factory.CreateConnectionSource(lg, "")
 	require.NotNil(t, connSource)
 
 	overrides := make(map[string]*orderers.Endpoint)
@@ -31,6 +31,6 @@ func TestCreateConnectionSource(t *testing.T) {
 	factory = &orderers.ConnectionSourceFactory{Overrides: overrides}
 	require.NotNil(t, factory)
 	require.Len(t, factory.Overrides, 1)
-	connSource = factory.CreateConnectionSource(lg)
+	connSource = factory.CreateConnectionSource(lg, "")
 	require.NotNil(t, connSource)
 }

--- a/internal/pkg/peer/orderers/connection_test.go
+++ b/internal/pkg/peer/orderers/connection_test.go
@@ -12,11 +12,10 @@ import (
 	"sort"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/hyperledger/fabric/internal/pkg/peer/orderers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 type comparableEndpoint struct {
@@ -83,12 +82,13 @@ var _ = Describe("Connection", func() {
 		org2Certs = [][]byte{cert3}
 		overrideCerts = [][]byte{cert2}
 
-		cs = orderers.NewConnectionSource(flogging.MustGetLogger("peer.orderers"), map[string]*orderers.Endpoint{
-			"override-address": {
-				Address:   "re-mapped-address",
-				RootCerts: overrideCerts,
-			},
-		})
+		cs = orderers.NewConnectionSource(flogging.MustGetLogger("peer.orderers"),
+			map[string]*orderers.Endpoint{
+				"override-address": {
+					Address:   "re-mapped-address",
+					RootCerts: overrideCerts,
+				},
+			}, "") // << no self endpoint, as in the peer
 		cs.Update(nil, map[string]orderers.OrdererOrg{
 			"org1": org1,
 			"org2": org2,
@@ -564,6 +564,620 @@ var _ = Describe("Connection", func() {
 				for _, endpoint := range endpoints {
 					Expect(endpoint.Refreshed).To(BeClosed())
 				}
+			})
+		})
+	})
+
+	When("a self-endpoint exists as in the orderer", func() {
+		BeforeEach(func() {
+			cs = orderers.NewConnectionSource(flogging.MustGetLogger("peer.orderers"),
+				map[string]*orderers.Endpoint{
+					"override-address": {
+						Address:   "re-mapped-address",
+						RootCerts: overrideCerts,
+					},
+				},
+				"org1-address1") //<< self-endpoint
+			cs.Update(nil, map[string]orderers.OrdererOrg{
+				"org1": org1,
+				"org2": org2,
+			})
+
+			endpoints = cs.Endpoints()
+		})
+
+		It("does not include the self-endpoint in endpoints", func() {
+			Expect(len(endpoints)).To(Equal(3))
+			Expect(stripEndpoints(endpoints)).To(ConsistOf(
+				stripEndpoints([]*orderers.Endpoint{
+					{
+						Address:   "org1-address2",
+						RootCerts: org1Certs,
+					},
+					{
+						Address:   "org2-address1",
+						RootCerts: org2Certs,
+					},
+					{
+						Address:   "org2-address2",
+						RootCerts: org2Certs,
+					},
+				}),
+			))
+		})
+
+		It("does not include the self endpoint in shuffled endpoints", func() {
+			shuffledEndpoints := cs.ShuffledEndpoints()
+			Expect(len(shuffledEndpoints)).To(Equal(3))
+			Expect(stripEndpoints(endpoints)).To(ConsistOf(
+				stripEndpoints([]*orderers.Endpoint{
+					{
+						Address:   "org1-address2",
+						RootCerts: org1Certs,
+					},
+					{
+						Address:   "org2-address1",
+						RootCerts: org2Certs,
+					},
+					{
+						Address:   "org2-address2",
+						RootCerts: org2Certs,
+					},
+				}),
+			))
+		})
+
+		It("does not include the self endpoint in random endpoint", func() { // there is a chance of failure here, but it is very small.
+			combinationMap := make(map[string]*orderers.Endpoint)
+			for i := 0; i < 10000; i++ {
+				r, _ := cs.RandomEndpoint()
+				combinationMap[r.Address] = r
+			}
+			var all []*orderers.Endpoint
+			for _, ep := range combinationMap {
+				all = append(all, ep)
+			}
+			Expect(stripEndpoints(all)).To(ConsistOf(
+				stripEndpoints(endpoints),
+			))
+		})
+
+		It("does not mark any of the endpoints as refreshed", func() {
+			for _, endpoint := range endpoints {
+				Expect(endpoint.Refreshed).NotTo(BeClosed())
+			}
+		})
+
+		When("an update does not modify the endpoint set", func() {
+			BeforeEach(func() {
+				cs.Update(nil, map[string]orderers.OrdererOrg{
+					"org1": org1,
+					"org2": org2,
+				})
+			})
+
+			It("does not update the endpoints", func() {
+				newEndpoints := cs.Endpoints()
+				Expect(newEndpoints).To(Equal(endpoints))
+			})
+
+			It("does not close any of the refresh channels", func() {
+				for _, endpoint := range endpoints {
+					Expect(endpoint.Refreshed).NotTo(BeClosed())
+				}
+			})
+		})
+
+		When("an update changes an org's TLS CA", func() {
+			BeforeEach(func() {
+				org1.RootCerts = [][]byte{cert1}
+
+				cs.Update(nil, map[string]orderers.OrdererOrg{
+					"org1": org1,
+					"org2": org2,
+				})
+			})
+
+			It("creates a new set of orderer endpoints yet skips the self-endpoint", func() {
+				newOrg1Certs := [][]byte{cert1}
+
+				newEndpoints := cs.Endpoints()
+				Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+					stripEndpoints([]*orderers.Endpoint{
+						{
+							Address:   "org1-address2",
+							RootCerts: newOrg1Certs,
+						},
+						{
+							Address:   "org2-address1",
+							RootCerts: org2Certs,
+						},
+						{
+							Address:   "org2-address2",
+							RootCerts: org2Certs,
+						},
+					}),
+				))
+			})
+
+			It("closes the refresh channel for all of the old endpoints", func() {
+				for _, endpoint := range endpoints {
+					Expect(endpoint.Refreshed).To(BeClosed())
+				}
+			})
+		})
+
+		When("an update changes an org's endpoint addresses", func() {
+			BeforeEach(func() {
+				org1.Addresses = []string{"org1-address1", "org1-address3"}
+				cs.Update(nil, map[string]orderers.OrdererOrg{
+					"org1": org1,
+					"org2": org2,
+				})
+			})
+
+			It("creates a new set of orderer endpoints, yet skips the self-endpoint", func() {
+				newEndpoints := cs.Endpoints()
+				Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+					stripEndpoints([]*orderers.Endpoint{
+						{
+							Address:   "org1-address3",
+							RootCerts: org1Certs,
+						},
+						{
+							Address:   "org2-address1",
+							RootCerts: org2Certs,
+						},
+						{
+							Address:   "org2-address2",
+							RootCerts: org2Certs,
+						},
+					}),
+				))
+			})
+
+			It("closes the refresh channel for all of the old endpoints", func() {
+				for _, endpoint := range endpoints {
+					Expect(endpoint.Refreshed).To(BeClosed())
+				}
+			})
+		})
+
+		When("an update removes an ordering organization", func() {
+			BeforeEach(func() {
+				cs.Update(nil, map[string]orderers.OrdererOrg{
+					"org2": org2,
+				})
+			})
+
+			It("creates a new set of orderer endpoints, self-endpoint matches nothing", func() {
+				newEndpoints := cs.Endpoints()
+				Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+					stripEndpoints([]*orderers.Endpoint{
+						{
+							Address:   "org2-address1",
+							RootCerts: org2Certs,
+						},
+						{
+							Address:   "org2-address2",
+							RootCerts: org2Certs,
+						},
+					}),
+				))
+			})
+
+			It("closes the refresh channel for all of the old endpoints", func() {
+				for _, endpoint := range endpoints {
+					Expect(endpoint.Refreshed).To(BeClosed())
+				}
+			})
+
+			When("the org is added back", func() {
+				BeforeEach(func() {
+					cs.Update(nil, map[string]orderers.OrdererOrg{
+						"org1": org1,
+						"org2": org2,
+					})
+				})
+
+				It("returns to the set of orderer endpoints, yet skips the self-endpoint", func() {
+					newEndpoints := cs.Endpoints()
+					Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+						stripEndpoints([]*orderers.Endpoint{
+							{
+								Address:   "org1-address2",
+								RootCerts: org1Certs,
+							},
+							{
+								Address:   "org2-address1",
+								RootCerts: org2Certs,
+							},
+							{
+								Address:   "org2-address2",
+								RootCerts: org2Certs,
+							},
+						}),
+					))
+				})
+			})
+		})
+
+		When("an update modifies the global endpoints but does not affect the org endpoints", func() {
+			BeforeEach(func() {
+				cs.Update(nil, map[string]orderers.OrdererOrg{
+					"org1": org1,
+					"org2": org2,
+				})
+			})
+
+			It("does not update the endpoints", func() {
+				newEndpoints := cs.Endpoints()
+				Expect(newEndpoints).To(Equal(endpoints))
+			})
+
+			It("does not close any of the refresh channels", func() {
+				for _, endpoint := range endpoints {
+					Expect(endpoint.Refreshed).NotTo(BeClosed())
+				}
+			})
+		})
+
+		When("the configuration does not contain orderer org endpoints", func() {
+			var globalCerts [][]byte
+
+			BeforeEach(func() {
+				org1.Addresses = nil
+				org2.Addresses = nil
+
+				globalCerts = [][]byte{cert1, cert2, cert3}
+
+				cs.Update([]string{"global-addr1", "global-addr2"}, map[string]orderers.OrdererOrg{
+					"org1": org1,
+					"org2": org2,
+				})
+			})
+
+			It("creates endpoints for the global addrs", func() {
+				newEndpoints := cs.Endpoints()
+				Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+					stripEndpoints([]*orderers.Endpoint{
+						{
+							Address:   "global-addr1",
+							RootCerts: globalCerts,
+						},
+						{
+							Address:   "global-addr2",
+							RootCerts: globalCerts,
+						},
+					}),
+				))
+			})
+
+			It("closes the refresh channel for all of the old endpoints", func() {
+				for _, endpoint := range endpoints {
+					Expect(endpoint.Refreshed).To(BeClosed())
+				}
+			})
+
+			When("the global list of addresses grows", func() {
+				BeforeEach(func() {
+					cs.Update([]string{"global-addr1", "global-addr2", "global-addr3"}, map[string]orderers.OrdererOrg{
+						"org1": org1,
+						"org2": org2,
+					})
+				})
+
+				It("creates endpoints for the global addrs", func() {
+					newEndpoints := cs.Endpoints()
+					Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+						stripEndpoints([]*orderers.Endpoint{
+							{
+								Address:   "global-addr1",
+								RootCerts: globalCerts,
+							},
+							{
+								Address:   "global-addr2",
+								RootCerts: globalCerts,
+							},
+							{
+								Address:   "global-addr3",
+								RootCerts: globalCerts,
+							},
+						}),
+					))
+				})
+
+				It("closes the refresh channel for all of the old endpoints", func() {
+					for _, endpoint := range endpoints {
+						Expect(endpoint.Refreshed).To(BeClosed())
+					}
+				})
+			})
+
+			When("the global set of addresses shrinks", func() {
+				BeforeEach(func() {
+					cs.Update([]string{"global-addr1"}, map[string]orderers.OrdererOrg{
+						"org1": org1,
+						"org2": org2,
+					})
+				})
+
+				It("creates endpoints for the global addrs", func() {
+					newEndpoints := cs.Endpoints()
+					Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+						stripEndpoints([]*orderers.Endpoint{
+							{
+								Address:   "global-addr1",
+								RootCerts: globalCerts,
+							},
+						}),
+					))
+				})
+
+				It("closes the refresh channel for all of the old endpoints", func() {
+					for _, endpoint := range endpoints {
+						Expect(endpoint.Refreshed).To(BeClosed())
+					}
+				})
+			})
+
+			When("the global set of addresses is modified", func() {
+				BeforeEach(func() {
+					cs.Update([]string{"global-addr1", "global-addr3"}, map[string]orderers.OrdererOrg{
+						"org1": org1,
+						"org2": org2,
+					})
+				})
+
+				It("creates endpoints for the global addrs", func() {
+					newEndpoints := cs.Endpoints()
+					Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+						stripEndpoints([]*orderers.Endpoint{
+							{
+								Address:   "global-addr1",
+								RootCerts: globalCerts,
+							},
+							{
+								Address:   "global-addr3",
+								RootCerts: globalCerts,
+							},
+						}),
+					))
+				})
+
+				It("closes the refresh channel for all of the old endpoints", func() {
+					for _, endpoint := range endpoints {
+						Expect(endpoint.Refreshed).To(BeClosed())
+					}
+				})
+			})
+
+			When("an update to the global addrs references an overridden org endpoint address", func() {
+				BeforeEach(func() {
+					cs.Update([]string{"global-addr1", "override-address"}, map[string]orderers.OrdererOrg{
+						"org1": org1,
+						"org2": org2,
+					},
+					)
+				})
+
+				It("creates a new set of orderer endpoints with overrides", func() {
+					newEndpoints := cs.Endpoints()
+					Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+						stripEndpoints([]*orderers.Endpoint{
+							{
+								Address:   "global-addr1",
+								RootCerts: globalCerts,
+							},
+							{
+								Address:   "re-mapped-address",
+								RootCerts: overrideCerts,
+							},
+						}),
+					))
+				})
+			})
+
+			When("an orderer org adds an endpoint", func() {
+				BeforeEach(func() {
+					org1.Addresses = []string{"new-org1-address"}
+					cs.Update([]string{"global-addr1", "global-addr2"}, map[string]orderers.OrdererOrg{
+						"org1": org1,
+						"org2": org2,
+					})
+				})
+
+				It("removes the global endpoints and uses only the org level ones", func() {
+					newEndpoints := cs.Endpoints()
+					Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+						stripEndpoints([]*orderers.Endpoint{
+							{
+								Address:   "new-org1-address",
+								RootCerts: org1Certs,
+							},
+						}),
+					))
+				})
+
+				It("closes the refresh channel for all of the old endpoints", func() {
+					for _, endpoint := range endpoints {
+						Expect(endpoint.Refreshed).To(BeClosed())
+					}
+				})
+			})
+		})
+
+		When("global endpoints are in effect and self-endpoint is from them", func() {
+			var globalCerts [][]byte
+
+			BeforeEach(func() {
+				cs = orderers.NewConnectionSource(flogging.MustGetLogger("peer.orderers"),
+					map[string]*orderers.Endpoint{
+						"override-address": {
+							Address:   "re-mapped-address",
+							RootCerts: overrideCerts,
+						},
+					},
+					"global-addr1") //<< self-endpoint from global endpoints
+
+				org1.Addresses = nil
+				org2.Addresses = nil
+
+				globalCerts = [][]byte{cert1, cert2, cert3}
+
+				cs.Update([]string{"global-addr1", "global-addr2"}, map[string]orderers.OrdererOrg{
+					"org1": org1,
+					"org2": org2,
+				})
+
+				endpoints = cs.Endpoints()
+			})
+
+			It("creates endpoints for the global endpoints, yet skips the self-endpoint", func() {
+				Expect(stripEndpoints(endpoints)).To(ConsistOf(
+					stripEndpoints([]*orderers.Endpoint{
+						{
+							Address:   "global-addr2",
+							RootCerts: globalCerts,
+						},
+					}),
+				))
+			})
+
+			When("the global list of addresses grows", func() {
+				BeforeEach(func() {
+					cs.Update([]string{"global-addr1", "global-addr2", "global-addr3"}, map[string]orderers.OrdererOrg{
+						"org1": org1,
+						"org2": org2,
+					})
+				})
+
+				It("creates endpoints for the global endpoints, yet skips the self-endpoint", func() {
+					newEndpoints := cs.Endpoints()
+					Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+						stripEndpoints([]*orderers.Endpoint{
+							{
+								Address:   "global-addr2",
+								RootCerts: globalCerts,
+							},
+							{
+								Address:   "global-addr3",
+								RootCerts: globalCerts,
+							},
+						}),
+					))
+				})
+
+				It("closes the refresh channel for all of the old endpoints", func() {
+					for _, endpoint := range endpoints {
+						Expect(endpoint.Refreshed).To(BeClosed())
+					}
+				})
+			})
+
+			When("the global set of addresses shrinks, removing self endpoint", func() {
+				flogging.ActivateSpec("debug")
+				BeforeEach(func() {
+					cs.Update([]string{"global-addr2"}, map[string]orderers.OrdererOrg{
+						"org1": org1,
+						"org2": org2,
+					})
+				})
+
+				It("creates endpoints for the global addrs", func() {
+					newEndpoints := cs.Endpoints()
+					Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+						stripEndpoints([]*orderers.Endpoint{
+							{
+								Address:   "global-addr2",
+								RootCerts: globalCerts,
+							},
+						}),
+					))
+				})
+
+				It("does not close the refresh channel for all of the old endpoints", func() {
+					for _, endpoint := range endpoints {
+						Expect(endpoint.Refreshed).NotTo(BeClosed())
+					}
+				})
+			})
+
+			When("the global set of addresses is modified", func() {
+				BeforeEach(func() {
+					cs.Update([]string{"global-addr1", "global-addr3"}, map[string]orderers.OrdererOrg{
+						"org1": org1,
+						"org2": org2,
+					})
+				})
+
+				It("creates endpoints for the global addrs", func() {
+					newEndpoints := cs.Endpoints()
+					Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+						stripEndpoints([]*orderers.Endpoint{
+							{
+								Address:   "global-addr3",
+								RootCerts: globalCerts,
+							},
+						}),
+					))
+				})
+
+				It("closes the refresh channel for all of the old endpoints", func() {
+					for _, endpoint := range endpoints {
+						Expect(endpoint.Refreshed).To(BeClosed())
+					}
+				})
+			})
+
+			When("an update to the global addrs references an overridden org endpoint address", func() {
+				BeforeEach(func() {
+					cs.Update([]string{"global-addr1", "override-address"}, map[string]orderers.OrdererOrg{
+						"org1": org1,
+						"org2": org2,
+					},
+					)
+				})
+
+				It("creates a new set of orderer endpoints with overrides", func() {
+					newEndpoints := cs.Endpoints()
+					Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+						stripEndpoints([]*orderers.Endpoint{
+							{
+								Address:   "re-mapped-address",
+								RootCerts: overrideCerts,
+							},
+						}),
+					))
+				})
+			})
+
+			When("an orderer org adds an endpoint", func() {
+				BeforeEach(func() {
+					org1.Addresses = []string{"new-org1-address"}
+					cs.Update([]string{"global-addr1", "global-addr2"}, map[string]orderers.OrdererOrg{
+						"org1": org1,
+						"org2": org2,
+					})
+				})
+
+				It("removes the global endpoints and uses only the org level ones", func() {
+					newEndpoints := cs.Endpoints()
+					Expect(stripEndpoints(newEndpoints)).To(ConsistOf(
+						stripEndpoints([]*orderers.Endpoint{
+							{
+								Address:   "new-org1-address",
+								RootCerts: org1Certs,
+							},
+						}),
+					))
+				})
+
+				It("closes the refresh channel for all of the old endpoints", func() {
+					for _, endpoint := range endpoints {
+						Expect(endpoint.Refreshed).To(BeClosed())
+					}
+				})
 			})
 		})
 	})


### PR DESCRIPTION


Change-Id: Ia183eef4f263943d5f387e8156d450790bee5cb2
#### Type of change

- New feature

#### Description

The orderer source provides a set of orderers to connect to, and is used by the BFTDeliverer. The BFTDeliverer is employed in the peer and in the orderer. When used in the orderer, it should skip the self-endpoint. In this commit we allow the orderer source to be set with the self-endpoint, and thus allow it to skip it when providing a set of orderers to pull blocks from.

#### Related issues

Issue #4566 