### PR TITLE
Excessive mutex locks were removed

### DIFF
--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -517,6 +517,8 @@ func (l *kvLedger) GetTransactionByID(txID string) (*peer.ProcessedTransaction, 
 
 // GetBlockchainInfo returns basic info about blockchain
 func (l *kvLedger) GetBlockchainInfo() (*common.BlockchainInfo, error) {
+	l.blockAPIsRWLock.RLock()
+	defer l.blockAPIsRWLock.RUnlock()
 	bcInfo, err := l.blockStore.GetBlockchainInfo()
 	return bcInfo, err
 }
@@ -543,6 +545,8 @@ func (l *kvLedger) GetBlocksIterator(startBlockNumber uint64) (commonledger.Resu
 
 // GetBlockByHash returns a block given it's hash
 func (l *kvLedger) GetBlockByHash(blockHash []byte) (*common.Block, error) {
+	l.blockAPIsRWLock.RLock()
+	defer l.blockAPIsRWLock.RUnlock()
 	block, err := l.blockStore.RetrieveBlockByHash(blockHash)
 	return block, err
 }
@@ -1020,6 +1024,8 @@ func (itr *blocksItr) Next() (commonledger.QueryResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	itr.blockAPIsRWLock.RLock()
+	defer itr.blockAPIsRWLock.RUnlock()
 	return block, nil
 }
 

--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -517,8 +517,6 @@ func (l *kvLedger) GetTransactionByID(txID string) (*peer.ProcessedTransaction, 
 
 // GetBlockchainInfo returns basic info about blockchain
 func (l *kvLedger) GetBlockchainInfo() (*common.BlockchainInfo, error) {
-	l.blockAPIsRWLock.RLock()
-	defer l.blockAPIsRWLock.RUnlock()
 	bcInfo, err := l.blockStore.GetBlockchainInfo()
 	return bcInfo, err
 }
@@ -545,8 +543,6 @@ func (l *kvLedger) GetBlocksIterator(startBlockNumber uint64) (commonledger.Resu
 
 // GetBlockByHash returns a block given it's hash
 func (l *kvLedger) GetBlockByHash(blockHash []byte) (*common.Block, error) {
-	l.blockAPIsRWLock.RLock()
-	defer l.blockAPIsRWLock.RUnlock()
 	block, err := l.blockStore.RetrieveBlockByHash(blockHash)
 	return block, err
 }
@@ -1024,8 +1020,6 @@ func (itr *blocksItr) Next() (commonledger.QueryResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	itr.blockAPIsRWLock.RLock()
-	itr.blockAPIsRWLock.RUnlock() //lint:ignore SA2001 syncpoint
 	return block, nil
 }
 


### PR DESCRIPTION
Signed-off-by fubss <ivanlaish@gmail.com>

# Removing excessive mutex locks increasing performance

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

As part of my research [Uncovering the Perfect Scalable Database for Hyperledger Fabric's Evolution](https://ieeexplore.ieee.org/document/10189331) it was discovered that the Hyperledger Fabric peer node does not use resources at 100% for some types of transactions. One of the reasons of it is the often mutexes locks in the source.

This change removes three excessive mutexes locks. Some of them were locking already atomic operations and some were locking nothing.


#### Additional details

<!--- Additional implementation details or comments to reviewers. -->

The results of the peer node performance improvement were published in the paper provided above. The change has given better CPU and Disk usage and increased transaction per second rate.

Performance benchmarks of peer node were made with hyperledger-caliper. The results for write operation are:

  * for 100 byte transactions:

    * TPS rate increased to 5% 

    * CPU usage increased to 7%

    * Disk Write rate increased to 5%

  * for 4000 byte transactions:

    * TPS rate increased to 5% 

    * CPU usage increased to 6%

    * Disk Write rate increased to 4%

  * for 64000 byte transactions:

    * TPS rate increased to 2% 

    * CPU usage stayed the same

    * Disk Write rate increased to 1%

Full Caliper reports are availiable [here](https://drive.google.com/drive/folders/15eOiYOG7QeLv-qj5A5RNHWLNRwf2xduo?usp=sharing). For read operation no performance changes were detected.

The changes were sucessfully tested locally and with GitHub CI/CD.
