### PR TITLE
Check env variable before using it

### DIFF
--- a/ci/scripts/create_binary_package.sh
+++ b/ci/scripts/create_binary_package.sh
@@ -4,6 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
+# Check TARGET is non-empty
+if [[ -z "$TARGET" ]]; then
+  echo "Error: TARGET is not set."
+  exit 1
+fi
 make "release/${TARGET}"
 mkdir -p "release/${TARGET}/config"
 


### PR DESCRIPTION

Change-Id: I5167afca9352b5bdc7d96dbe7e9ef25e2e2db69e

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

When the TARGET env variable is not set, the script will fail to run. 

This patchset adds the checking and ouputs useful hints.

#### Additional details

N/A

#### Related issues

N/A

#### Release Note

N/A
