### PR TITLE
Fix test flake in TestImpatientStreamDetectSelf

### DIFF
--- a/orderer/common/cluster/deliver_test.go
+++ b/orderer/common/cluster/deliver_test.go
@@ -1201,6 +1201,10 @@ func TestBlockPullerBadBlocks(t *testing.T) {
 
 func TestImpatientStreamDetectSelf(t *testing.T) {
 	osn := newClusterNodeWithTLS(t)
+	osn.Lock()
+	osn.err = fmt.Errorf("service unavailable")
+	osn.Unlock()
+
 	defer osn.stop()
 	var conn *grpc.ClientConn
 	var err error


### PR DESCRIPTION
The implementation of the fake/mock orderer in the unit tests reads a seek envelope and the test fails if reading fails.

When the `TestImpatientStreamDetectSelf` test ends, it shuts down the fake orderer, and as a result, reading from the stream fails and the test fails also.

This commit simply short-circuits the test to avoid reading from the stream, but planting an error before establishing the stream, as reading from the stream is not needed for the test but only establishing it in order to get the TLS certificate.
