### PR TITLE
Add a doc notice that old version is no longer supported (release-2.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ open source architecture; Hyperledger Fabric is your starting point.
 
 ## Releases
 
-Fabric provides a release approximately once every four months with new features
+Fabric provides periodic releases with new features
 and improvements. Additionally, certain releases are designated as long-term
 support (LTS) releases. Important fixes will be backported to the most recent
 LTS release, and to the prior LTS release during periods of LTS release overlap.
 For more details see the [LTS strategy](https://github.com/hyperledger/fabric-rfcs/blob/master/text/0005-lts-release-strategy.md).
 
-LTS releases:
-- [v2.2.x](https://hyperledger-fabric.readthedocs.io/en/release-2.2/whatsnew.html) (current LTS release)
-- [v1.4.x](https://hyperledger-fabric.readthedocs.io/en/release-1.4/whatsnew.html) (prior LTS release, maintained through April 2021)
+Historic LTS releases:
+- [v2.2.x](https://hyperledger-fabric.readthedocs.io/en/release-2.2/whatsnew.html) (maintenance ended in February 2024 with the delivery of v2.2.15)
+- [v1.4.x](https://hyperledger-fabric.readthedocs.io/en/release-1.4/whatsnew.html) (maintenance ended in April 2021 with the delivery of v1.4.12)
 
 Unless specified otherwise, all releases will be upgradable from the prior minor release.
 Additionally, each LTS release is upgradable to the next LTS release.

--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -18,7 +18,7 @@
       {%- if hasdoc('copyright') %}
         {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
       {%- else %}
-        {% trans copyright=copyright|e %}&copy; Copyright Hyperledger 2020-2022.{% endtrans %}
+        {% trans copyright=copyright|e %}&copy; Copyright Hyperledger 2020-2024.{% endtrans %}
       {%- endif %}
     {%- endif %}
     <br>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -224,3 +224,7 @@ linkcheck_anchors = False
 
 # Increase the linkcheck timeout to 5 seconds
 linkcheck_timeout = 5
+
+rst_prolog = """.. attention::
+    This version of Hyperledger Fabric is no longer supported or maintained. You can change the documentation version using the selector at the bottom of the navigation panel.
+"""


### PR DESCRIPTION
This notice will be added to every rst page, including the welcome page. It will not be added to the md pages, but most of the landing pages are rst.

Also update the README accordingly.
