### PR TITLE
Disable vulnerability scans for v2.2 and v2.4

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -21,8 +21,6 @@ jobs:
         ref:
           - main
           - release-2.5
-          - release-2.4
-          - release-2.2
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Fabric has recently ended maintenance of v2.2 and will no longer backport dependency updates to v2.2 or v2.4. 

All users are encouraged to use v2.5 at this point, therefore just run the vulnerability scan for v2.5 and main branches.