### PR TITLE
Set leader rotation disabled but make it possible later

### DIFF
--- a/internal/configtxgen/encoder/encoder.go
+++ b/internal/configtxgen/encoder/encoder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	cb "github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric-protos-go/orderer/smartbft"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/common/channelconfig"
 	"github.com/hyperledger/fabric/common/genesis"
@@ -219,6 +220,8 @@ func NewOrdererGroup(conf *genesisconfig.Orderer, channelCapabilities map[string
 		if consensusMetadata, err = channelconfig.MarshalBFTOptions(conf.SmartBFT); err != nil {
 			return nil, errors.Errorf("consenter options read failed with error %s for orderer type %s", err, ConsensusTypeBFT)
 		}
+		// Force leader rotation to be turned off
+		conf.SmartBFT.LeaderRotation = smartbft.Options_ROTATION_OFF
 		// Overwrite policy manually by computing it from the consenters
 		policies.EncodeBFTBlockVerificationPolicy(consenterProtos, ordererGroup)
 	default:

--- a/orderer/consensus/smartbft/util/util.go
+++ b/orderer/consensus/smartbft/util/util.go
@@ -56,8 +56,13 @@ func ConfigFromMetadataOptions(selfID uint64, options *smartbft.Options) (types.
 	config.SyncOnStart = options.SyncOnStart
 	config.SpeedUpViewChange = options.SpeedUpViewChange
 
-	config.LeaderRotation = false
-	config.DecisionsPerLeader = 0
+	if options.LeaderRotation != smartbft.Options_ROTATION_ON {
+		config.LeaderRotation = false
+		config.DecisionsPerLeader = 0
+	} else {
+		config.LeaderRotation = true
+		config.DecisionsPerLeader = options.DecisionsPerLeader
+	}
 
 	if err = config.Validate(); err != nil {
 		return config, errors.Wrap(err, "config validation failed")


### PR DESCRIPTION
The current code sets leader election disabled by hardcoding it. More specifically, it overrides leader rotation in the code section that parses the config. This means that if we choose to make it possible to enable it at a later version, it won't be possible to run mixed versions of v3.0.

This commit makes sure that if we decide to permit leader rotation later on, it will be possible if the majority of nodes desire so.

It achieves this by disabling leader rotation in two places:
- Channel creation
- Validation of config update transactions

However, the config parsing logic now honors leader election if it's enabled in the channel config.
