### PR TITLE
Nominate Tatsuya Sato as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,6 +13,7 @@ See [the documentation on Maintainers](https://hyperledger-fabric.readthedocs.io
 | Dave Enyeart            | [denyeart][denyeart] | dave.enyeart | <enyeart@us.ibm.com>
 | Manish Sethi            | [manish-sethi][manish-sethi] | manish-sethi | <manish.sethi@gmail.com>
 | Senthilnathan Natarajan | [cendhu][cendhu] | Senthil1 | <cendhu@gmail.com>
+| Tatsuya Sato            | [satota2][satota2] | satota2 | <tatsuya.sato.so@hitachi.com>
 | Yacov Manevich          | [yacovm][yacovm] | yacovm | <yacov.manevich@ibm.com>
 | Yoav Tock               | [tock-ibm][tock-ibm] | tock-ibm | <tock@il.ibm.com>
 
@@ -82,6 +83,7 @@ See [the documentation on Maintainers](https://hyperledger-fabric.readthedocs.io
 [nikhil550]: https://github.com/nikhil550
 [odowdaibm]: https://github.com/odowdaibm
 [pamandrejko]: https://github.com/pamandrejko
+[satota2]: https://github.com/satota2
 [smithbk]: https://github.com/smithbk
 [srderson]: https://github.com/srderson
 [sykesm]: https://github.com/sykesm


### PR DESCRIPTION
Tatsuya Sato has been contributing to Fabric for several years. In the last 6 months Tatsuya has increased contributions, becoming one of the most active contributors.

Tatsuya has contributed new chaincode lifecycle functions that required updating protos across Fabric repositories.
He has fixed issues with cert expiration warnings.

Beyond normal code contributions, Tatsuya has also been doing general  maintenance pull requests, for example maintaining the installation script, cleaning up Fabric docs,
and maintaining the fabric-samples repository.
He has also translated documentation into Japanese, and been active in pull request reviews.

Tatsuya has demonstrated knowledge and added value across a wide range of areas spanning new features and general maintenance. In short, Tatsuya has already been maintaining Fabric. I would welcome Tatsuya's help as an official maintainer.
