### PR TITLE
change flag for ginkgo exec

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -36,4 +36,4 @@ done
 
 printf "\nRunning the following test suites:\n\n%s\n\nStarting tests...\n\n" "$(echo "${dirs[@]}" | tr -s ' ' '\n')"
 
-ginkgo --keep-going --slow-spec-threshold 60s --timeout 24h "${dirs[@]}"
+ginkgo --keep-going --poll-progress-after 60s --timeout 24h "${dirs[@]}"


### PR DESCRIPTION
--slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.
