### PR TITLE
add embed files to the package chaincode

### DIFF
--- a/core/chaincode/platforms/golang/list.go
+++ b/core/chaincode/platforms/golang/list.go
@@ -33,6 +33,7 @@ type PackageInfo struct {
 	HFiles         []string
 	SFiles         []string
 	IgnoredGoFiles []string
+	EmbedFiles     []string
 	Incomplete     bool
 }
 
@@ -44,6 +45,7 @@ func (p PackageInfo) Files() []string {
 	files = append(files, p.HFiles...)
 	files = append(files, p.SFiles...)
 	files = append(files, p.IgnoredGoFiles...)
+	files = append(files, p.EmbedFiles...)
 	return files
 }
 


### PR DESCRIPTION
Recently [pr](https://github.com/hyperledger/fabric/pull/4726/checks) failed tests and failed to update the `google.golang.org/protobuf` package. 
The reason is that we added go:embed to the https://github.com/protocolbuffers/protobuf-go/blob/master/internal/editiondefaults/defaults.go. When building the package we didn't copy file editions_defaults.binpb and the build of the chaincode ended with an error.

After accepting this [pr](https://github.com/hyperledger/fabric/pull/4726/checks), you can update the package again 