### PR TITLE
Synchronizer dynamic cluster size

### DIFF
--- a/orderer/consensus/smartbft/chain.go
+++ b/orderer/consensus/smartbft/chain.go
@@ -239,7 +239,6 @@ func bftSmartConsensusBuild(
 			},
 			Support:     c.support,
 			BlockPuller: c.BlockPuller, // FIXME this must be created dynamically as the cluster may change config
-			ClusterSize: clusterSize,   // FIXME this must be taken dynamically from `support` as the cluster may change in size
 			Logger:      c.Logger,
 			LatestConfig: func() (types.Configuration, []uint64) {
 				rtc := c.RuntimeConfig.Load().(RuntimeConfig)

--- a/orderer/consensus/smartbft/synchronizer.go
+++ b/orderer/consensus/smartbft/synchronizer.go
@@ -27,7 +27,6 @@ type Synchronizer struct {
 	OnCommit        func(*cb.Block) types.Reconfig
 	Support         consensus.ConsenterSupport
 	BlockPuller     BlockPuller
-	ClusterSize     uint64
 	Logger          *flogging.FabricLogger
 }
 
@@ -151,10 +150,11 @@ func (s *Synchronizer) synchronize() (*types.Decision, error) {
 // clusterSize: the cluster size, must be >0.
 func (s *Synchronizer) computeTargetHeight(heights []uint64) uint64 {
 	sort.Slice(heights, func(i, j int) bool { return heights[i] > heights[j] }) // Descending
-	f := uint64(s.ClusterSize-1) / 3                                            // The number of tolerated byzantine faults
+	clusterSize := len(s.Support.SharedConfig().Consenters())
+	f := uint64(clusterSize-1) / 3 // The number of tolerated byzantine faults
 	lenH := uint64(len(heights))
 
-	s.Logger.Debugf("Heights: %v", heights)
+	s.Logger.Debugf("Cluster size: %d, F: %d, Heights: %v", clusterSize, f, heights)
 
 	if lenH < f+1 {
 		s.Logger.Debugf("Returning %d", heights[0])

--- a/orderer/consensus/smartbft/synchronizer_test.go
+++ b/orderer/consensus/smartbft/synchronizer_test.go
@@ -70,7 +70,6 @@ func TestSynchronizerSync(t *testing.T) {
 			},
 			Logger:      l,
 			BlockPuller: bp,
-			ClusterSize: 4,
 			Support:     fakeCS,
 			OnCommit:    noopUpdateLastHash,
 		}
@@ -112,6 +111,11 @@ func TestSynchronizerSync(t *testing.T) {
 		fakeCS.BlockCalls(func(sqn uint64) *cb.Block {
 			return ledger[sqn]
 		})
+		fakeOrdererConfig := &mocks.OrdererConfig{}
+		fakeOrdererConfig.ConsentersReturns([]*cb.Consenter{
+			{Id: 1}, {Id: 2}, {Id: 3}, {Id: 4},
+		})
+		fakeCS.SharedConfigReturns(fakeOrdererConfig)
 
 		decision := &types.SyncResponse{
 			Latest: types.Decision{},
@@ -125,7 +129,6 @@ func TestSynchronizerSync(t *testing.T) {
 			},
 			Logger:      flogging.NewFabricLogger(zap.NewExample()),
 			BlockPuller: bp,
-			ClusterSize: 4,
 			Support:     fakeCS,
 			OnCommit:    noopUpdateLastHash,
 		}
@@ -166,6 +169,11 @@ func TestSynchronizerSync(t *testing.T) {
 		fakeCS.BlockCalls(func(sqn uint64) *cb.Block {
 			return ledger[sqn]
 		})
+		fakeOrdererConfig := &mocks.OrdererConfig{}
+		fakeOrdererConfig.ConsentersReturns([]*cb.Consenter{
+			{Id: 1}, {Id: 2}, {Id: 3}, {Id: 4},
+		})
+		fakeCS.SharedConfigReturns(fakeOrdererConfig)
 
 		decision := &types.SyncResponse{
 			Latest: types.Decision{},
@@ -179,7 +187,6 @@ func TestSynchronizerSync(t *testing.T) {
 			},
 			Logger:      flogging.NewFabricLogger(zap.NewExample()),
 			BlockPuller: bp,
-			ClusterSize: 4,
 			Support:     fakeCS,
 			OnCommit:    noopUpdateLastHash,
 		}
@@ -219,6 +226,11 @@ func TestSynchronizerSync(t *testing.T) {
 		fakeCS.BlockCalls(func(sqn uint64) *cb.Block {
 			return ledger[sqn]
 		})
+		fakeOrdererConfig := &mocks.OrdererConfig{}
+		fakeOrdererConfig.ConsentersReturns([]*cb.Consenter{
+			{Id: 1}, {Id: 2}, {Id: 3}, {Id: 4},
+		})
+		fakeCS.SharedConfigReturns(fakeOrdererConfig)
 
 		decision := &types.SyncResponse{
 			Latest: types.Decision{},
@@ -232,7 +244,6 @@ func TestSynchronizerSync(t *testing.T) {
 			},
 			Logger:      flogging.NewFabricLogger(zap.NewExample()),
 			BlockPuller: bp,
-			ClusterSize: 4,
 			Support:     fakeCS,
 			OnCommit:    noopUpdateLastHash,
 		}
@@ -271,6 +282,11 @@ func TestSynchronizerSync(t *testing.T) {
 		fakeCS.BlockCalls(func(sqn uint64) *cb.Block {
 			return ledger[sqn]
 		})
+		fakeOrdererConfig := &mocks.OrdererConfig{}
+		fakeOrdererConfig.ConsentersReturns([]*cb.Consenter{
+			{Id: 1}, {Id: 2}, {Id: 3}, {Id: 4},
+		})
+		fakeCS.SharedConfigReturns(fakeOrdererConfig)
 
 		decision := &types.SyncResponse{
 			Latest: types.Decision{},
@@ -287,7 +303,6 @@ func TestSynchronizerSync(t *testing.T) {
 			},
 			Logger:      flogging.NewFabricLogger(zap.NewExample()),
 			BlockPuller: bp,
-			ClusterSize: 4,
 			Support:     fakeCS,
 			OnCommit:    noopUpdateLastHash,
 		}


### PR DESCRIPTION

#### Type of change

- Bug fix

#### Description

The synchronizer assumes a fixed cluster size, which is wrong.
This commit fixes that.

#### Related issues

#4697 
