### PR TITLE
Synchronizer dynamic block puller

### DIFF
--- a/orderer/consensus/smartbft/chain.go
+++ b/orderer/consensus/smartbft/chain.go
@@ -239,7 +239,6 @@ func bftSmartConsensusBuild(
 			},
 			Support:     c.support,
 			BlockPuller: c.BlockPuller, // FIXME this must be created dynamically as the cluster may change config
-			ClusterSize: clusterSize,   // FIXME this must be taken dynamically from `support` as the cluster may change in size
 			Logger:      c.Logger,
 			LatestConfig: func() (types.Configuration, []uint64) {
 				rtc := c.RuntimeConfig.Load().(RuntimeConfig)

--- a/orderer/consensus/smartbft/consenter.go
+++ b/orderer/consensus/smartbft/consenter.go
@@ -187,11 +187,6 @@ func (c *Consenter) HandleChain(support consensus.ConsenterSupport, metadata *cb
 	}
 	c.Logger.Infof("Local consenter id is %d", selfID)
 
-	puller, err := newBlockPuller(support, c.ClusterDialer, c.Conf.General.Cluster, c.BCCSP)
-	if err != nil {
-		c.Logger.Panicf("Failed initializing block puller")
-	}
-
 	config, err := util.ConfigFromMetadataOptions((uint64)(selfID), configOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed parsing smartbft configuration")
@@ -226,9 +221,8 @@ func (c *Consenter) HandleChain(support consensus.ConsenterSupport, metadata *cb
 		(uint64)(selfID),
 		config,
 		path.Join(c.WALBaseDir, support.ChannelID()),
-		puller,
-		c.ClusterDialer,        // required by the BFT-synchronizer
-		c.Conf.General.Cluster, // required by the BFT-synchronizer
+		c.ClusterDialer,
+		c.Conf.General.Cluster,
 		c.Comm,
 		c.SignerSerializer,
 		c.GetPolicyManager(support.ChannelID()),

--- a/orderer/consensus/smartbft/synchronizer.go
+++ b/orderer/consensus/smartbft/synchronizer.go
@@ -11,8 +11,11 @@ import (
 
 	"github.com/SmartBFT-Go/consensus/pkg/types"
 	"github.com/SmartBFT-Go/consensus/smartbftprotos"
+	"github.com/hyperledger/fabric-lib-go/bccsp"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	cb "github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric/orderer/common/cluster"
+	"github.com/hyperledger/fabric/orderer/common/localconfig"
 	"github.com/hyperledger/fabric/orderer/consensus"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
@@ -20,19 +23,17 @@ import (
 
 // Synchronizer implementation
 type Synchronizer struct {
-	lastReconfig    types.Reconfig
-	selfID          uint64
-	LatestConfig    func() (types.Configuration, []uint64)
-	BlockToDecision func(*cb.Block) *types.Decision
-	OnCommit        func(*cb.Block) types.Reconfig
-	Support         consensus.ConsenterSupport
-	BlockPuller     BlockPuller
-	Logger          *flogging.FabricLogger
-}
-
-// Close closes the block puller connection
-func (s *Synchronizer) Close() {
-	s.BlockPuller.Close()
+	lastReconfig       types.Reconfig
+	selfID             uint64
+	LatestConfig       func() (types.Configuration, []uint64)
+	BlockToDecision    func(*cb.Block) *types.Decision
+	OnCommit           func(*cb.Block) types.Reconfig
+	Support            consensus.ConsenterSupport
+	CryptoProvider     bccsp.BCCSP
+	ClusterDialer      *cluster.PredicateDialer
+	LocalConfigCluster localconfig.Cluster
+	BlockPullerFactory BlockPullerFactory
+	Logger             *flogging.FabricLogger
 }
 
 // Sync synchronizes blocks and returns the response
@@ -78,8 +79,13 @@ func (s *Synchronizer) getViewMetadataLastConfigSqnFromBlock(block *cb.Block) (*
 }
 
 func (s *Synchronizer) synchronize() (*types.Decision, error) {
-	defer s.BlockPuller.Close()
-	heightByEndpoint, _, err := s.BlockPuller.HeightsByEndpoints()
+	blockPuller, err := s.BlockPullerFactory.CreateBlockPuller(s.Support, s.ClusterDialer, s.LocalConfigCluster, s.CryptoProvider)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot get create BlockPuller")
+	}
+	defer blockPuller.Close()
+
+	heightByEndpoint, _, err := blockPuller.HeightsByEndpoints()
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot get HeightsByEndpoints")
 	}
@@ -110,7 +116,7 @@ func (s *Synchronizer) synchronize() (*types.Decision, error) {
 
 	var lastPulledBlock *cb.Block
 	for seq <= targetSeq {
-		block := s.BlockPuller.PullBlock(seq)
+		block := blockPuller.PullBlock(seq)
 		if block == nil {
 			s.Logger.Debugf("Failed to fetch block [%d] from cluster", seq)
 			break

--- a/orderer/consensus/smartbft/synchronizer.go
+++ b/orderer/consensus/smartbft/synchronizer.go
@@ -27,7 +27,6 @@ type Synchronizer struct {
 	OnCommit        func(*cb.Block) types.Reconfig
 	Support         consensus.ConsenterSupport
 	BlockPuller     BlockPuller
-	ClusterSize     uint64
 	Logger          *flogging.FabricLogger
 }
 
@@ -151,10 +150,11 @@ func (s *Synchronizer) synchronize() (*types.Decision, error) {
 // clusterSize: the cluster size, must be >0.
 func (s *Synchronizer) computeTargetHeight(heights []uint64) uint64 {
 	sort.Slice(heights, func(i, j int) bool { return heights[i] > heights[j] }) // Descending
-	f := uint64(s.ClusterSize-1) / 3                                            // The number of tolerated byzantine faults
+	clusterSize := len(s.Support.SharedConfig().Consenters())
+	f := uint64(clusterSize-1) / 3 // The number of tolerated byzantine faults
 	lenH := uint64(len(heights))
 
-	s.Logger.Debugf("Heights: %v", heights)
+	s.Logger.Debugf("Cluster size: %d, F: %d, Heights: %v", clusterSize, f, heights)
 
 	if lenH < f+1 {
 		s.Logger.Debugf("Returning %d", heights[0])

--- a/orderer/consensus/smartbft/synchronizer_test.go
+++ b/orderer/consensus/smartbft/synchronizer_test.go
@@ -70,7 +70,6 @@ func TestSynchronizerSync(t *testing.T) {
 			},
 			Logger:      l,
 			BlockPuller: bp,
-			ClusterSize: 4,
 			Support:     fakeCS,
 			OnCommit:    noopUpdateLastHash,
 		}
@@ -112,6 +111,11 @@ func TestSynchronizerSync(t *testing.T) {
 		fakeCS.BlockCalls(func(sqn uint64) *cb.Block {
 			return ledger[sqn]
 		})
+		fakeOrdererConfig := &mocks.OrdererConfig{}
+		fakeOrdererConfig.ConsentersReturns([]*cb.Consenter{
+			{Id: 1}, {Id: 2}, {Id: 3}, {Id: 4},
+		})
+		fakeCS.SharedConfigReturns(fakeOrdererConfig)
 
 		decision := &types.SyncResponse{
 			Latest: types.Decision{},
@@ -125,7 +129,6 @@ func TestSynchronizerSync(t *testing.T) {
 			},
 			Logger:      flogging.NewFabricLogger(zap.NewExample()),
 			BlockPuller: bp,
-			ClusterSize: 4,
 			Support:     fakeCS,
 			OnCommit:    noopUpdateLastHash,
 		}
@@ -166,6 +169,11 @@ func TestSynchronizerSync(t *testing.T) {
 		fakeCS.BlockCalls(func(sqn uint64) *cb.Block {
 			return ledger[sqn]
 		})
+		fakeOrdererConfig := &mocks.OrdererConfig{}
+		fakeOrdererConfig.ConsentersReturns([]*cb.Consenter{
+			{Id: 1}, {Id: 2}, {Id: 3}, {Id: 4},
+		})
+		fakeCS.SharedConfigReturns(fakeOrdererConfig)
 
 		decision := &types.SyncResponse{
 			Latest: types.Decision{},
@@ -179,7 +187,6 @@ func TestSynchronizerSync(t *testing.T) {
 			},
 			Logger:      flogging.NewFabricLogger(zap.NewExample()),
 			BlockPuller: bp,
-			ClusterSize: 4,
 			Support:     fakeCS,
 			OnCommit:    noopUpdateLastHash,
 		}
@@ -219,6 +226,11 @@ func TestSynchronizerSync(t *testing.T) {
 		fakeCS.BlockCalls(func(sqn uint64) *cb.Block {
 			return ledger[sqn]
 		})
+		fakeOrdererConfig := &mocks.OrdererConfig{}
+		fakeOrdererConfig.ConsentersReturns([]*cb.Consenter{
+			{Id: 1}, {Id: 2}, {Id: 3}, {Id: 4},
+		})
+		fakeCS.SharedConfigReturns(fakeOrdererConfig)
 
 		decision := &types.SyncResponse{
 			Latest: types.Decision{},
@@ -232,7 +244,6 @@ func TestSynchronizerSync(t *testing.T) {
 			},
 			Logger:      flogging.NewFabricLogger(zap.NewExample()),
 			BlockPuller: bp,
-			ClusterSize: 4,
 			Support:     fakeCS,
 			OnCommit:    noopUpdateLastHash,
 		}
@@ -271,6 +282,11 @@ func TestSynchronizerSync(t *testing.T) {
 		fakeCS.BlockCalls(func(sqn uint64) *cb.Block {
 			return ledger[sqn]
 		})
+		fakeOrdererConfig := &mocks.OrdererConfig{}
+		fakeOrdererConfig.ConsentersReturns([]*cb.Consenter{
+			{Id: 1}, {Id: 2}, {Id: 3}, {Id: 4},
+		})
+		fakeCS.SharedConfigReturns(fakeOrdererConfig)
 
 		decision := &types.SyncResponse{
 			Latest: types.Decision{},
@@ -287,7 +303,6 @@ func TestSynchronizerSync(t *testing.T) {
 			},
 			Logger:      flogging.NewFabricLogger(zap.NewExample()),
 			BlockPuller: bp,
-			ClusterSize: 4,
 			Support:     fakeCS,
 			OnCommit:    noopUpdateLastHash,
 		}

--- a/orderer/consensus/smartbft/synchronizer_test.go
+++ b/orderer/consensus/smartbft/synchronizer_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	cb "github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric/internal/pkg/comm"
+	"github.com/hyperledger/fabric/orderer/common/cluster"
+	"github.com/hyperledger/fabric/orderer/common/localconfig"
 	mocks2 "github.com/hyperledger/fabric/orderer/consensus/mocks"
 	"github.com/hyperledger/fabric/orderer/consensus/smartbft"
 	"github.com/hyperledger/fabric/orderer/consensus/smartbft/mocks"
@@ -47,6 +50,9 @@ func TestSynchronizerSync(t *testing.T) {
 
 	t.Run("no remotes", func(t *testing.T) {
 		bp := &mocks.FakeBlockPuller{}
+		bpf := &mocks.FakeBlockPullerFactory{}
+		bpf.CreateBlockPullerReturns(bp, nil)
+
 		fakeCS := &mocks2.FakeConsenterSupport{}
 		fakeCS.ChannelIDReturns("mychannel")
 		fakeCS.HeightReturns(100)
@@ -68,10 +74,12 @@ func TestSynchronizerSync(t *testing.T) {
 				}
 				return nil
 			},
-			Logger:      l,
-			BlockPuller: bp,
-			Support:     fakeCS,
-			OnCommit:    noopUpdateLastHash,
+			Logger:             l,
+			ClusterDialer:      &cluster.PredicateDialer{Config: comm.ClientConfig{}},
+			LocalConfigCluster: localconfig.Cluster{},
+			BlockPullerFactory: bpf,
+			Support:            fakeCS,
+			OnCommit:           noopUpdateLastHash,
 		}
 
 		d := syn.Sync()
@@ -92,6 +100,8 @@ func TestSynchronizerSync(t *testing.T) {
 		bp.PullBlockReturnsOnCall(0, b100)
 		bp.PullBlockReturnsOnCall(1, b101)
 		bp.PullBlockReturnsOnCall(2, b102)
+		bpf := &mocks.FakeBlockPullerFactory{}
+		bpf.CreateBlockPullerReturns(bp, nil)
 
 		height := uint64(100)
 		ledger := map[uint64]*cb.Block{99: b99}
@@ -127,10 +137,12 @@ func TestSynchronizerSync(t *testing.T) {
 				}
 				return nil
 			},
-			Logger:      flogging.NewFabricLogger(zap.NewExample()),
-			BlockPuller: bp,
-			Support:     fakeCS,
-			OnCommit:    noopUpdateLastHash,
+			Logger:             flogging.NewFabricLogger(zap.NewExample()),
+			ClusterDialer:      &cluster.PredicateDialer{Config: comm.ClientConfig{}},
+			LocalConfigCluster: localconfig.Cluster{},
+			BlockPullerFactory: bpf,
+			Support:            fakeCS,
+			OnCommit:           noopUpdateLastHash,
 		}
 
 		d := syn.Sync()
@@ -150,6 +162,8 @@ func TestSynchronizerSync(t *testing.T) {
 		bp.PullBlockReturnsOnCall(0, b100)
 		bp.PullBlockReturnsOnCall(1, b101)
 		bp.PullBlockReturnsOnCall(2, b102)
+		bpf := &mocks.FakeBlockPullerFactory{}
+		bpf.CreateBlockPullerReturns(bp, nil)
 
 		height := uint64(100)
 		ledger := map[uint64]*cb.Block{99: b99}
@@ -185,10 +199,12 @@ func TestSynchronizerSync(t *testing.T) {
 				}
 				return nil
 			},
-			Logger:      flogging.NewFabricLogger(zap.NewExample()),
-			BlockPuller: bp,
-			Support:     fakeCS,
-			OnCommit:    noopUpdateLastHash,
+			Logger:             flogging.NewFabricLogger(zap.NewExample()),
+			ClusterDialer:      &cluster.PredicateDialer{Config: comm.ClientConfig{}},
+			LocalConfigCluster: localconfig.Cluster{},
+			BlockPullerFactory: bpf,
+			Support:            fakeCS,
+			OnCommit:           noopUpdateLastHash,
 		}
 
 		d := syn.Sync()
@@ -207,6 +223,8 @@ func TestSynchronizerSync(t *testing.T) {
 		bp.PullBlockReturnsOnCall(0, b100)
 		bp.PullBlockReturnsOnCall(1, b101)
 		bp.PullBlockReturnsOnCall(2, b102)
+		bpf := &mocks.FakeBlockPullerFactory{}
+		bpf.CreateBlockPullerReturns(bp, nil)
 
 		height := uint64(100)
 		ledger := map[uint64]*cb.Block{99: b99}
@@ -242,10 +260,12 @@ func TestSynchronizerSync(t *testing.T) {
 				}
 				return nil
 			},
-			Logger:      flogging.NewFabricLogger(zap.NewExample()),
-			BlockPuller: bp,
-			Support:     fakeCS,
-			OnCommit:    noopUpdateLastHash,
+			Logger:             flogging.NewFabricLogger(zap.NewExample()),
+			ClusterDialer:      &cluster.PredicateDialer{Config: comm.ClientConfig{}},
+			LocalConfigCluster: localconfig.Cluster{},
+			BlockPullerFactory: bpf,
+			Support:            fakeCS,
+			OnCommit:           noopUpdateLastHash,
 		}
 
 		d := syn.Sync()
@@ -263,6 +283,8 @@ func TestSynchronizerSync(t *testing.T) {
 		bp.PullBlockReturnsOnCall(0, b100)
 		bp.PullBlockReturnsOnCall(1, b101)
 		bp.PullBlockReturnsOnCall(2, b102)
+		bpf := &mocks.FakeBlockPullerFactory{}
+		bpf.CreateBlockPullerReturns(bp, nil)
 
 		height := uint64(100)
 		ledger := map[uint64]*cb.Block{99: b99}
@@ -301,10 +323,12 @@ func TestSynchronizerSync(t *testing.T) {
 				}
 				return nil
 			},
-			Logger:      flogging.NewFabricLogger(zap.NewExample()),
-			BlockPuller: bp,
-			Support:     fakeCS,
-			OnCommit:    noopUpdateLastHash,
+			Logger:             flogging.NewFabricLogger(zap.NewExample()),
+			ClusterDialer:      &cluster.PredicateDialer{Config: comm.ClientConfig{}},
+			LocalConfigCluster: localconfig.Cluster{},
+			BlockPullerFactory: bpf,
+			Support:            fakeCS,
+			OnCommit:           noopUpdateLastHash,
 		}
 
 		d := syn.Sync()

--- a/orderer/consensus/smartbft/util_network_test.go
+++ b/orderer/consensus/smartbft/util_network_test.go
@@ -412,7 +412,6 @@ func createBFTChainUsingMocks(t *testing.T, node *Node) (*smartbft.BFTChain, err
 		nodeId,
 		config,
 		node.WorkingDir,
-		blockPuller,
 		nil,
 		localConfigCluster,
 		comm,


### PR DESCRIPTION
#### Type of change


- Bug fix

#### Description

The simple synchronizer uses a static block puller which does not get updated.

#### Related issues
#4696 
