### PR TITLE
replaced reference from 'BRANCH' variable to 'main' value as 'fabric-…

### DIFF
--- a/docs/source/cc_launcher.md
+++ b/docs/source/cc_launcher.md
@@ -8,7 +8,7 @@ Starting with Fabric 2.0, External Builders and Launchers address these limitati
 
 Note that if no configured external builder claims a chaincode package, the peer will attempt to process the package as if it were created with the standard Fabric packaging tools such as the peer CLI.
 
-**Note:** This is an advanced feature which will likely require custom packaging of the peer image with everything your builders and launchers depend on unless your builders and launchers are simple enough, such as those used in the [basic asset transfer external chaincode Fabric sample](https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/asset-transfer-basic/chaincode-external). For example, the following samples use `go` and `bash`, which are not included in the current official `fabric-peer` image.
+**Note:** This is an advanced feature which will likely require custom packaging of the peer image with everything your builders and launchers depend on unless your builders and launchers are simple enough, such as those used in the [basic asset transfer external chaincode Fabric sample](https://github.com/hyperledger/fabric-samples/blob/main/asset-transfer-basic/chaincode-external). For example, the following samples use `go` and `bash`, which are not included in the current official `fabric-peer` image.
 
 ## External builder model
 

--- a/docs/source/couchdb_tutorial.rst
+++ b/docs/source/couchdb_tutorial.rst
@@ -28,7 +28,7 @@ and for more information on the Fabric ledger refer to the `Ledger <ledger/ledge
 topic. Follow the tutorial below for details on how to leverage CouchDB in your
 blockchain network.
 
-Throughout this tutorial, we will use the `Asset transfer ledger queries sample <https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/asset-transfer-ledger-queries/chaincode-go>`__
+Throughout this tutorial, we will use the `Asset transfer ledger queries sample <https://github.com/hyperledger/fabric-samples/blob/main/asset-transfer-ledger-queries/chaincode-go>`__
 as our use case to demonstrate how to use CouchDB with Fabric, including the
 execution of JSON queries against the state database. You should have completed the task
 :doc:`install`.
@@ -102,7 +102,7 @@ in a query, CouchDB requires an index that includes the sorted fields.
    otherwise, the query will fail and an error will be thrown.
 
 To demonstrate building an index, we will use the data from the `Asset transfer ledger queries
-sample <https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/asset-transfer-ledger-queries/chaincode-go/asset_transfer_ledger_chaincode.go>`__.
+sample <https://github.com/hyperledger/fabric-samples/blob/main/asset-transfer-ledger-queries/chaincode-go/asset_transfer_ledger_chaincode.go>`__.
 In this example, the Asset data structure is defined as:
 
 .. code:: javascript
@@ -264,7 +264,7 @@ chaincode using the :doc:`commands/peerlifecycle` commands. The JSON index files
 must be located under the path ``META-INF/statedb/couchdb/indexes`` which is
 located inside the directory where the chaincode resides.
 
-The `Asset transfer ledger queries sample <https://github.com/hyperledger/fabric-samples/tree/{BRANCH}/asset-transfer-ledger-queries/chaincode-go>`__  below illustrates how the index
+The `Asset transfer ledger queries sample <https://github.com/hyperledger/fabric-samples/tree/main/asset-transfer-ledger-queries/chaincode-go>`__  below illustrates how the index
 is packaged with the chaincode.
 
 .. image:: images/couchdb_tutorial_pkg_example.png
@@ -388,7 +388,7 @@ Build the query in chaincode
 
 You can perform JSON queries against the data on the ledger using
 queries defined within your chaincode. The `Asset transfer ledger queries sample
-<https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/asset-transfer-ledger-queries/chaincode-go/asset_transfer_ledger_chaincode.go>`__
+<https://github.com/hyperledger/fabric-samples/blob/main/asset-transfer-ledger-queries/chaincode-go/asset_transfer_ledger_chaincode.go>`__
 includes two JSON query functions:
 
   * **QueryAssets**
@@ -596,7 +596,7 @@ listener application would iterate through the block transactions and build a da
 store using the key/value writes from each valid transaction's ``rwset``. The
 :doc:`peer_event_services` provide replayable events to ensure the integrity of
 downstream data stores. For an example of how you can use an event listener to write
-data to an external database, visit the `Off chain data sample <https://github.com/hyperledger/fabric-samples/tree/{BRANCH}/off_chain_data>`__
+data to an external database, visit the `Off chain data sample <https://github.com/hyperledger/fabric-samples/tree/main/off_chain_data>`__
 in the Fabric Samples.
 
 .. _cdb-pagination:
@@ -613,7 +613,7 @@ chaincode that executes the query until no more results are returned. For more i
 this `topic on pagination with CouchDB <couchdb_as_state_database.html#couchdb-pagination>`__.
 
 
-We will use the `Asset transfer ledger queries sample <https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/asset-transfer-ledger-queries/chaincode-go/asset_transfer_ledger_chaincode.go>`__
+We will use the `Asset transfer ledger queries sample <https://github.com/hyperledger/fabric-samples/blob/main/asset-transfer-ledger-queries/chaincode-go/asset_transfer_ledger_chaincode.go>`__
 function ``QueryAssetsWithPagination`` to  demonstrate how
 pagination can be implemented in chaincode and the client application.
 
@@ -733,7 +733,7 @@ no more results will get returned.
 
 For an example of how a client application can iterate over
 JSON query result sets using pagination, search for the ``getQueryResultForQueryStringWithPagination``
-function in the `Asset transfer ledger queries sample <https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/asset-transfer-ledger-queries/chaincode-go/asset_transfer_ledger_chaincode.go>`__.
+function in the `Asset transfer ledger queries sample <https://github.com/hyperledger/fabric-samples/blob/main/asset-transfer-ledger-queries/chaincode-go/asset_transfer_ledger_chaincode.go>`__.
 
 Range Query Pagination
 ----------------------
@@ -745,7 +745,7 @@ If an ``endKey`` was specified in the range query and the results are exhausted,
 
 For an example of how a client application can iterate over
 range query result sets using pagination, search for the ``GetAssetsByRangeWithPagination``
-function in the `Asset transfer ledger queries sample <https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/asset-transfer-ledger-queries/chaincode-go/asset_transfer_ledger_chaincode.go>`__.
+function in the `Asset transfer ledger queries sample <https://github.com/hyperledger/fabric-samples/blob/main/asset-transfer-ledger-queries/chaincode-go/asset_transfer_ledger_chaincode.go>`__.
 
 .. _cdb-update-index:
 

--- a/docs/source/private_data_tutorial.rst
+++ b/docs/source/private_data_tutorial.rst
@@ -238,7 +238,7 @@ Org1 and Org2 to have the private data in a side database, and the collection
 ``Org1MSPPrivateCollection`` allows only peers of Org1 to have their
 private data in a side database and ``Org2MSPPrivateCollection`` allows peers
 of Org2 to have their private data in a side database.
-For implementation details refer to the following two `asset transfer private data functions <https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/asset-transfer-private-data/chaincode-go/chaincode/asset_queries.go>`__:
+For implementation details refer to the following two `asset transfer private data functions <https://github.com/hyperledger/fabric-samples/blob/main/asset-transfer-private-data/chaincode-go/chaincode/asset_queries.go>`__:
 
  * **ReadAsset** for querying the values of the ``assetID, color, size and owner`` attributes.
  * **ReadAssetPrivateDetails** for querying the values of the ``appraisedValue`` attribute.
@@ -966,7 +966,7 @@ Using indexes with private data
 
 Indexes can also be applied to private data collections, by packaging indexes in
 the ``META-INF/statedb/couchdb/collections/<collection_name>/indexes`` directory
-alongside the chaincode. An example index is available `here <https://github.com/hyperledger/fabric-samples/blob/{BRANCH}//asset-transfer-private-data/chaincode-go/META-INF/statedb/couchdb/collections/assetCollection/indexes/indexOwner.json>`__ .
+alongside the chaincode. An example index is available `here <https://github.com/hyperledger/fabric-samples/blob/main/asset-transfer-private-data/chaincode-go/META-INF/statedb/couchdb/collections/assetCollection/indexes/indexOwner.json>`__ .
 
 For deployment of chaincode to production environments, it is recommended
 to define any indexes alongside chaincode so that the chaincode and supporting

--- a/docs/source/smartcontract/smartcontract.md
+++ b/docs/source/smartcontract/smartcontract.md
@@ -114,7 +114,7 @@ about chaincode; everyone else can think in terms of smart contracts.
 
 At the heart of a smart contract is a set of `transaction` definitions. For
 example, look at assetTransfer.js
-[here](https://github.com/hyperledger/fabric-samples/blob/{BRANCH}/asset-transfer-basic/chaincode-javascript/lib/assetTransfer.js#L67),
+[here](https://github.com/hyperledger/fabric-samples/blob/main/asset-transfer-basic/chaincode-javascript/lib/assetTransfer.js#L67),
 where you can see a smart contract transaction that creates a new asset:
 
 ```javascript


### PR DESCRIPTION
#### Type of change
- Documentation update

#### Description
Replaced `BRANCH` variable to `main` value in fabric-samples repo reference URLs [as `fabric-samples` branches are not created to match `fabric branches` anymore](https://github.com/hyperledger/fabric/pull/4713#discussion_r1511123305).

#### Additional details
[#4713](https://github.com/hyperledger/fabric/pull/4713#discussion_r1511123305)