### PR TITLE
BFT chain unit tests reconfigure

### DIFF
--- a/orderer/consensus/smartbft/chain.go
+++ b/orderer/consensus/smartbft/chain.go
@@ -73,7 +73,7 @@ type BFTChain struct {
 	WALDir             string
 	consensus          *smartbft.Consensus
 	support            consensus.ConsenterSupport
-	clusterService     *cluster.ClusterService
+	ClusterService     *cluster.ClusterService
 	verifier           *Verifier
 	assembler          *Assembler
 	Metrics            *Metrics
@@ -165,17 +165,6 @@ func NewChain(
 
 	if err = c.consensus.ValidateConfiguration(rtc.Nodes); err != nil {
 		return nil, errors.Wrap(err, "failed to verify SmartBFT-Go configuration")
-	}
-
-	c.clusterService = &cluster.ClusterService{
-		StreamCountReporter:              &cluster.StreamCountReporter{},
-		Logger:                           flogging.MustGetLogger("orderer.common.cluster"),
-		StepLogger:                       flogging.MustGetLogger("orderer.common.cluster.step"),
-		MinimumExpirationWarningInterval: cluster.MinimumExpirationWarningInterval,
-		MembershipByChannel:              make(map[string]*cluster.ChannelMembersConfig),
-		RequestHandler: &Ingress{
-			Logger: logger,
-		},
 	}
 
 	logger.Infof("SmartBFT-v3 is now servicing chain")
@@ -568,7 +557,7 @@ func (c *BFTChain) updateRuntimeConfig(block *cb.Block) types.Reconfig {
 	c.RuntimeConfig.Store(newRTC)
 	if protoutil.IsConfigBlock(block) {
 		c.Comm.Configure(c.Channel, newRTC.RemoteNodes)
-		c.clusterService.ConfigureNodeCerts(c.Channel, newRTC.consenters)
+		c.ClusterService.ConfigureNodeCerts(c.Channel, newRTC.consenters)
 		c.pruneBadRequests()
 	}
 

--- a/orderer/consensus/smartbft/chain_test.go
+++ b/orderer/consensus/smartbft/chain_test.go
@@ -8,8 +8,16 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"os"
 	"testing"
 	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/common/channelconfig"
+	"github.com/hyperledger/fabric/common/crypto/tlsgen"
+	"github.com/hyperledger/fabric/internal/configtxlator/update"
+	smartBFTMocks "github.com/hyperledger/fabric/orderer/consensus/smartbft/mocks"
+	"github.com/stretchr/testify/mock"
 
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/msp"
@@ -168,7 +176,7 @@ func TestSyncNode(t *testing.T) {
 	}
 
 	// restart the old leader
-	nodeMap[leaderId].Restart()
+	nodeMap[leaderId].Restart(networkSetupInfo.configInfo)
 
 	// make sure the old leader has synced with the nodes in the network
 	nodeMap[leaderId].State.WaitLedgerHeightToBe(7)
@@ -179,6 +187,56 @@ func TestSyncNode(t *testing.T) {
 	require.NoError(t, err)
 	for _, node := range nodeMap {
 		node.State.WaitLedgerHeightToBe(8)
+	}
+}
+
+// Scenario:
+// 1. Start a network of 4 nodes
+// 2. Submit a TX and wait for the TX to be received by all nodes
+// 3. Add new node to the network
+// 4. Submit a TX and wait for the TX to be received by all nodes
+func TestAddNode(t *testing.T) {
+	dir := t.TempDir()
+	channelId := "testchannel"
+
+	// start a network
+	networkSetupInfo := NewNetworkSetupInfo(t, channelId, dir)
+	nodeMap := networkSetupInfo.CreateNodes(4)
+	networkSetupInfo.StartAllNodes()
+
+	// wait until all nodes have the genesis block in their ledger
+	for _, node := range nodeMap {
+		node.State.WaitLedgerHeightToBe(1)
+	}
+
+	// send a tx to all nodes and wait the tx will be added to each ledger
+	env := createEndorserTxEnvelope("TEST_MESSAGE #1", channelId)
+	err := networkSetupInfo.SendTxToAllAvailableNodes(env)
+	require.NoError(t, err)
+	for _, node := range nodeMap {
+		node.State.WaitLedgerHeightToBe(2)
+	}
+
+	// send a new config block to all nodes, to notice them about the new node
+	env = addNodeToConfig(t, networkSetupInfo.genesisBlock, 5, networkSetupInfo.tlsCA, networkSetupInfo.dir, networkSetupInfo.channelId)
+	err = networkSetupInfo.SendTxToAllAvailableNodes(env)
+	require.NoError(t, err)
+	for _, node := range nodeMap {
+		node.State.WaitLedgerHeightToBe(3)
+	}
+
+	// add new node to the network
+	nodesMap, newNode := networkSetupInfo.AddNewNode()
+	newNode.Start()
+	require.Equal(t, len(nodesMap), 5)
+	require.Equal(t, len(networkSetupInfo.nodeIdToNode), 5)
+
+	// send a tx to all nodes again and wait the tx will be added to each ledger
+	env = createEndorserTxEnvelope("TEST_ADDITION_OF_NODE", channelId)
+	err = networkSetupInfo.SendTxToAllAvailableNodes(env)
+	require.NoError(t, err)
+	for _, node := range nodeMap {
+		node.State.WaitLedgerHeightToBe(4)
 	}
 }
 
@@ -212,4 +270,90 @@ func generateNonce() []byte {
 	}
 	nonce++
 	return nonceBuf.Bytes()
+}
+
+// addNodeToConfig creates a config block based on the last config block. It is useful for addition or removal of a node
+func addNodeToConfig(t *testing.T, lastConfigBlock *cb.Block, nodeId uint32, tlsCA tlsgen.CA, certDir string, channelId string) *cb.Envelope {
+	// copy the last config block
+	clonedLastConfigBlock := proto.Clone(lastConfigBlock).(*cb.Block)
+
+	// fetch the ConfigEnvelope from the block
+	env := protoutil.UnmarshalEnvelopeOrPanic(clonedLastConfigBlock.Data.Data[0])
+	payload := protoutil.UnmarshalPayloadOrPanic(env.Payload)
+	configEnv, err := protoutil.UnmarshalConfigEnvelope(payload.Data)
+	require.NoError(t, err)
+	originalConfigEnv := proto.Clone(configEnv).(*cb.ConfigEnvelope)
+
+	// create the crypto material for the new node
+	host := fmt.Sprintf("bft%d.example.com", nodeId-1)
+	srvP, clnP := generateSingleCertificateSmartBFT(t, tlsCA, certDir, int(nodeId), host)
+	clientCert, err := os.ReadFile(clnP)
+	require.NoError(t, err)
+	serverCert, err := os.ReadFile(srvP)
+	require.NoError(t, err)
+
+	// update the consenter mapping to include the new node
+	newOrderer := &cb.Consenter{
+		Id:            nodeId,
+		Host:          host,
+		Port:          7050,
+		MspId:         "SampleOrg",
+		Identity:      clientCert,
+		ClientTlsCert: clientCert,
+		ServerTlsCert: serverCert,
+	}
+
+	currentOrderers := &cb.Orderers{}
+	err = proto.Unmarshal(configEnv.Config.ChannelGroup.Groups[channelconfig.OrdererGroupKey].Values[channelconfig.OrderersKey].Value, currentOrderers)
+	require.NoError(t, err)
+	currentOrderers.ConsenterMapping = append(currentOrderers.ConsenterMapping, newOrderer)
+	configEnv.Config.ChannelGroup.Groups[channelconfig.OrdererGroupKey].Values[channelconfig.OrderersKey] = &cb.ConfigValue{
+		Version:   configEnv.Config.ChannelGroup.Groups[channelconfig.OrdererGroupKey].Values[channelconfig.OrderersKey].Version + 1,
+		Value:     protoutil.MarshalOrPanic(currentOrderers),
+		ModPolicy: channelconfig.AdminsPolicyKey,
+	}
+
+	// update organization endpoints
+	ordererEndpoints := configEnv.Config.ChannelGroup.Groups[channelconfig.OrdererGroupKey].Groups["SampleOrg"].Values["Endpoints"].Value
+	ordererEndpointsVal := &cb.OrdererAddresses{}
+	proto.Unmarshal(ordererEndpoints, ordererEndpointsVal)
+	ordererAddresses := ordererEndpointsVal.Addresses
+	ordererAddresses = append(ordererAddresses, fmt.Sprintf("%s:%d", newOrderer.Host, newOrderer.Port))
+	configEnv.Config.ChannelGroup.Groups[channelconfig.OrdererGroupKey].Groups["SampleOrg"].Values["Endpoints"].Value = protoutil.MarshalOrPanic(&cb.OrdererAddresses{
+		Addresses: ordererAddresses,
+	})
+
+	// increase the sequence
+	configEnv.Config.Sequence = configEnv.Config.Sequence + 1
+
+	// calculate config update tx
+	configUpdate, err := update.Compute(originalConfigEnv.Config, configEnv.Config)
+	require.NoError(t, err)
+	signerSerializer := smartBFTMocks.NewSignerSerializer(t)
+	signerSerializer.EXPECT().Serialize().RunAndReturn(
+		func() ([]byte, error) {
+			return []byte{1, 2, 3}, nil
+		}).Maybe()
+	signerSerializer.EXPECT().Sign(mock.Anything).RunAndReturn(
+		func(message []byte) ([]byte, error) {
+			return message, nil
+		}).Maybe()
+	configUpdateTx, err := protoutil.CreateSignedEnvelope(cb.HeaderType_CONFIG_UPDATE, channelId, signerSerializer, configUpdate, 0, 0)
+	require.NoError(t, err)
+
+	// return the updated Envelope
+	return &cb.Envelope{
+		Payload: protoutil.MarshalOrPanic(&cb.Payload{
+			Data: protoutil.MarshalOrPanic(&cb.ConfigEnvelope{
+				Config:     configEnv.Config,
+				LastUpdate: configUpdateTx,
+			}),
+			Header: &cb.Header{
+				ChannelHeader: protoutil.MarshalOrPanic(&cb.ChannelHeader{
+					Type:      int32(cb.HeaderType_CONFIG),
+					ChannelId: channelId,
+				}),
+			},
+		}),
+	}
 }

--- a/orderer/consensus/smartbft/consenter.go
+++ b/orderer/consensus/smartbft/consenter.go
@@ -239,7 +239,7 @@ func (c *Consenter) HandleChain(support consensus.ConsenterSupport, metadata *cb
 
 	// refresh cluster service with updated consenters
 	c.ClusterService.ConfigureNodeCerts(chain.Channel, consenters)
-	chain.clusterService = c.ClusterService
+	chain.ClusterService = c.ClusterService
 
 	return chain, nil
 }

--- a/orderer/consensus/smartbft/util_network_test.go
+++ b/orderer/consensus/smartbft/util_network_test.go
@@ -470,9 +470,9 @@ func createBFTChainUsingMocks(t *testing.T, node *Node, configInfo *ConfigInfo) 
 		func(block *cb.Block, encodedMetadataValue []byte) {
 			node.State.AddBlock(block)
 			t.Logf("Node %d appended config block number %v to ledger", node.NodeId, block.Header.Number)
+			configInfo.lock.Lock()
+			defer configInfo.lock.Unlock()
 			if !slices.Contains(configInfo.numsOfConfigBlocks, block.Header.Number) {
-				configInfo.lock.Lock()
-				defer configInfo.lock.Unlock()
 				configInfo.numsOfConfigBlocks = append(configInfo.numsOfConfigBlocks, block.Header.Number)
 			}
 		}).Maybe()


### PR DESCRIPTION
#### Type of change

- Test update

#### Description

This PR aims to test reconfiguration cases: 
1. Add a new node to the network 
2. Configure the network while a node is down, in such case the node has to sync with other nodes in the network about the config change.

#### Related issues

issue #4008 
