### PR TITLE
Remove global-level endpoints from channel config - WIP

### DIFF
--- a/common/channelconfig/channel.go
+++ b/common/channelconfig/channel.go
@@ -91,6 +91,7 @@ func NewChannelConfig(channelGroup *cb.ConfigGroup, bccsp bccsp.BCCSP) (*Channel
 
 	channelCapabilities := cc.Capabilities()
 
+	// TODO: this cause conflicts in tests
 	if err := cc.Validate(channelCapabilities); err != nil {
 		return nil, err
 	}

--- a/common/channelconfig/channel.go
+++ b/common/channelconfig/channel.go
@@ -181,7 +181,7 @@ func (cc *ChannelConfig) Validate(channelCapabilities ChannelCapabilities) error
 		}
 	}
 
-	if !channelCapabilities.OrgSpecificOrdererEndpoints() {
+	if !channelCapabilities.OrgSpecificOrdererEndpoints() && !channelCapabilities.ConsensusTypeBFT() {
 		return cc.validateOrdererAddresses()
 	}
 

--- a/common/channelconfig/orderer.go
+++ b/common/channelconfig/orderer.go
@@ -140,6 +140,17 @@ func NewOrdererConfig(ordererGroup *cb.ConfigGroup, mspConfig *MSPConfigHandler,
 			return nil, err
 		}
 	}
+
+	if channelCapabilities.ConsensusTypeBFT() {
+		var someOrgHasEndpoints bool
+		for _, org := range oc.Organizations() {
+			someOrgHasEndpoints = someOrgHasEndpoints || len(org.Endpoints()) > 0
+		}
+		if !someOrgHasEndpoints {
+			return nil, errors.Errorf("all orderer organizations endpoints are empty")
+		}
+	}
+
 	return oc, nil
 }
 

--- a/common/channelconfig/realconfig_test.go
+++ b/common/channelconfig/realconfig_test.go
@@ -34,16 +34,20 @@ func TestOrgSpecificOrdererEndpoints(t *testing.T) {
 	// TODO: check how we want it to beahve
 	t.Run("Without_Capability", func(t *testing.T) {
 		conf := genesisconfig.Load(genesisconfig.SampleDevModeSoloProfile, configtest.GetDevConfigDir())
-		conf.Orderer.Addresses = []string{"127.0.0.1:7050"}
-		conf.Capabilities = map[string]bool{"V1_3": true}
+		//conf.Orderer.Addresses = []string{"127.0.0.1:7050"}
+		conf.Capabilities = map[string]bool{"V_3": true}
+
+		//fmt.Printf("----endpoints are: %v", conf.Orderer.Organizations[0].OrdererEndpoints)
 
 		cg, err := encoder.NewChannelGroup(conf)
 		require.NoError(t, err)
 
+		conf.Orderer.Organizations[0].OrdererEndpoints = nil
+
 		cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 		require.NoError(t, err)
 		_, err = channelconfig.NewChannelConfig(cg, cryptoProvider)
-		require.EqualError(t, err, "could not create channel Orderer sub-group config: Orderer Org SampleOrg cannot contain endpoints value until V1_4_2+ capabilities have been enabled")
+		require.EqualError(t, err, "all orderer organizations endpoints are empty")
 	})
 
 	t.Run("Without_Capability_NoOSNs", func(t *testing.T) {

--- a/common/channelconfig/realconfig_test.go
+++ b/common/channelconfig/realconfig_test.go
@@ -31,6 +31,7 @@ func TestWithRealConfigtx(t *testing.T) {
 }
 
 func TestOrgSpecificOrdererEndpoints(t *testing.T) {
+	// TODO: check how we want it to beahve
 	t.Run("Without_Capability", func(t *testing.T) {
 		conf := genesisconfig.Load(genesisconfig.SampleDevModeSoloProfile, configtest.GetDevConfigDir())
 		conf.Orderer.Addresses = []string{"127.0.0.1:7050"}

--- a/discovery/support/config/support_test.go
+++ b/discovery/support/config/support_test.go
@@ -65,6 +65,7 @@ func TestMSPIDMapping(t *testing.T) {
 	for _, org := range ordererConfig.Orderer.Organizations {
 		org.MSPDir = filepath.Join(cryptoConfigDir, "ordererOrganizations", "example.com", "msp")
 		org.Name = randString()
+		org.OrdererEndpoints = []string{"foo:7050", "bar:8050"}
 	}
 
 	// Randomize organization names

--- a/discovery/support/config/testdata/configtx.yaml
+++ b/discovery/support/config/testdata/configtx.yaml
@@ -243,9 +243,6 @@ Orderer: &OrdererDefaults
     # Available types are "solo" and "etcdraft"
     OrdererType: solo
 
-    Addresses:
-        - orderer.example.com:7050
-
     # Batch Timeout: The amount of time to wait before creating a batch
     BatchTimeout: 2s
 

--- a/discovery/test/integration_test.go
+++ b/discovery/test/integration_test.go
@@ -666,6 +666,7 @@ func createChannelConfig(t *testing.T, cryptoConfigDir string) *common.Config {
 	// Override the MSP directories
 	for _, org := range channelConfig.Orderer.Organizations {
 		org.MSPDir = filepath.Join(cryptoConfigDir, "ordererOrganizations", "example.com", "msp")
+		org.OrdererEndpoints = []string{"orderer.example.com:7050"}
 	}
 	for i, org := range channelConfig.Application.Organizations {
 		if org.MSPType != "bccsp" {

--- a/discovery/test/testdata/configtx.yaml
+++ b/discovery/test/testdata/configtx.yaml
@@ -221,9 +221,6 @@ Orderer: &OrdererDefaults
     # Available types are "solo" and "etcdraft"
     OrdererType: solo
 
-    Addresses:
-        - orderer.example.com:7050
-
     # Batch Timeout: The amount of time to wait before creating a batch
     BatchTimeout: 2s
 

--- a/integration/nwo/template/configtx_template.go
+++ b/integration/nwo/template/configtx_template.go
@@ -141,9 +141,6 @@ Profiles:{{ range .Profiles }}
     {{- if .Orderers }}
     Orderer:
       OrdererType: {{ $w.Consensus.Type }}
-      Addresses:{{ range .Orderers }}{{ with $w.Orderer . }}
-      - 127.0.0.1:{{ $w.OrdererPort . "Listen" }}
-      {{- end }}{{ end }}
       {{- if .Blocks}}
       BatchTimeout: {{ .Blocks.BatchTimeout }}s
       BatchSize:

--- a/integration/raft/migration_test.go
+++ b/integration/raft/migration_test.go
@@ -87,7 +87,7 @@ var _ = Describe("ConsensusTypeMigration", func() {
 			networkConfig := nwo.MultiNodeEtcdRaft()
 			networkConfig.Orderers = append(networkConfig.Orderers, &nwo.Orderer{Name: "orderer4", Organization: "OrdererOrg"})
 			networkConfig.Profiles[0].Orderers = []string{"orderer1", "orderer2", "orderer3", "orderer4"}
-
+			networkConfig.Profiles[0].ChannelCapabilities = append(networkConfig.Profiles[0].ChannelCapabilities, "V3_0")
 			network = nwo.New(networkConfig, testDir, client, StartPort(), components)
 
 			o1, o2, o3, o4 := network.Orderer("orderer1"), network.Orderer("orderer2"), network.Orderer("orderer3"), network.Orderer("orderer4")
@@ -99,6 +99,11 @@ var _ = Describe("ConsensusTypeMigration", func() {
 				o2Runner = network.OrdererRunner(o2)
 				o3Runner = network.OrdererRunner(o3)
 				o4Runner = network.OrdererRunner(o4)
+
+				o1Runner.Command.Env = append(o1Runner.Command.Env, "FABRIC_LOGGING_SPEC=debug")
+				//o2Runner.Command.Env = append(o2Runner.Command.Env, "FABRIC_LOGGING_SPEC=debug")
+				//o3Runner.Command.Env = append(o3Runner.Command.Env, "FABRIC_LOGGING_SPEC=orderer.common.cluster=debug:orderer.consensus.smartbft=debug:policies.ImplicitOrderer=debug")
+				//o4Runner.Command.Env = append(o4Runner.Command.Env, "FABRIC_LOGGING_SPEC=orderer.common.cluster=debug:orderer.consensus.smartbft=debug:policies.ImplicitOrderer=debug")
 
 				o1Proc = ifrit.Invoke(o1Runner)
 				o2Proc = ifrit.Invoke(o2Runner)
@@ -129,25 +134,18 @@ var _ = Describe("ConsensusTypeMigration", func() {
 			peer := network.Peer("Org1", "peer0")
 			peer2 := network.Peer("Org2", "peer0")
 
-			// ==========================================================================
-			// TODO: solve the err in the log:
-			// [e][peer-channel-update] Error: got unexpected status: BAD_REQUEST -- error applying config update to existing channel 'testchannel': error authorizing update: error validating DeltaSet: policy for [Group] /Channel not satisfied: implicit policy evaluation failed - 1 sub-policies were satisfied, but this policy requires 2 of the 'Admins' sub-policies to be satisfied
+			// config update that should fail
 			By("Config update with global level endpoints")
 			config := nwo.GetConfig(network, peer, o1, "testchannel")
 			updatedConfig := proto.Clone(config).(*common.Config)
 			addGlobalLevelEndpointsToConfig(updatedConfig)
-
 			updateOrdererEndpointsConfigFails(network, o1, "testchannel", config, updatedConfig, peer, peer, peer2)
 
-			// By("Config update with empty endpoints per organization")
-			// clonedConfig = proto.Clone(config).(*common.Config)
-			// cleanEndpointsPerOrgFromConfig(clonedConfig)
-			// updateOrdererConfigFailed(network, o1, "testchannel", config, clonedConfig, peer, o1)
-
-			// TODO: nwo.UpdateConfig is using the peers as additional signers, using this method leads to the same problem
-			// nwo.UpdateConfig(network, o1, "testchannel", currentConfig, updatedConfig, true, peer, peer, peer2)
-
-			// ============================================================================
+			// config update that succeeds but cause a failure during the migration step
+			By("Config update with empty endpoints per organization")
+			updatedConfig = proto.Clone(config).(*common.Config)
+			cleanEndpointsPerOrgFromConfig(updatedConfig)
+			updateOrdererOrgEndpointsConfigSucceeds(network, o1, "testchannel", config, updatedConfig, peer, peer, peer2)
 
 			// === Step 3: Config update on standard channel, State=MAINTENANCE, enter maintenance-mode ===
 			By("3) Change to maintenance mode")
@@ -161,6 +159,22 @@ var _ = Describe("ConsensusTypeMigration", func() {
 
 			bftMetadata := protoutil.MarshalOrPanic(prepareBftMetadata())
 
+			// NOTE: migration should fail since there are empty orderer organizations endpoints
+			By("Migration from Raft to BFT fails")
+			config, updatedConfig = prepareTransition(network, peer, o1, "testchannel",
+				"etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE,
+				"BFT", bftMetadata, protosorderer.ConsensusType_STATE_MAINTENANCE, 1)
+			UpdateOrdererConfigFails(network, o1, "testchannel", config, updatedConfig, peer, o1)
+
+			// config update to add orderer organizations endpoints
+			By("Config update to add orderer organizations endpoints")
+			config = nwo.GetConfig(network, peer, o1, "testchannel")
+			updatedConfig = proto.Clone(config).(*common.Config)
+			addEndpointsPerOrgInConfig(updatedConfig)
+			updateOrdererOrgEndpointsConfigSucceeds(network, o1, "testchannel", config, updatedConfig, peer, peer, peer2)
+
+			// now, we can migrate
+			By("Migration from Raft to BFT succeeds")
 			config, updatedConfig = prepareTransition(network, peer, o1, "testchannel",
 				"etcdraft", protosorderer.ConsensusType_STATE_MAINTENANCE,
 				"BFT", bftMetadata, protosorderer.ConsensusType_STATE_MAINTENANCE, 1)
@@ -662,48 +676,9 @@ func updateOrdererEndpointsConfigFails(n *nwo.Network, orderer *nwo.Orderer, cha
 		ClientAuth: n.ClientAuthRequired,
 	})
 	Expect(err).NotTo(HaveOccurred())
-	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
-	Expect(sess.Err).To(gbytes.Say("Successfully submitted channel update"))
+	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(1))
+	Expect(sess.Err).NotTo(gbytes.Say("Successfully submitted channel update"))
 }
-
-//
-//func updateEndpointsConfigFailed(n *nwo.Network, orderer *nwo.Orderer, channel string, current, updated *common.Config, peer *nwo.Peer, additionalSigners ...*nwo.Peer) {
-//	tempDir, err := os.MkdirTemp("", "updateConfig")
-//	Expect(err).NotTo(HaveOccurred())
-//	defer os.RemoveAll(tempDir)
-//
-//	// compute update
-//	configUpdate, err := update.Compute(current, updated)
-//	Expect(err).NotTo(HaveOccurred())
-//	configUpdate.ChannelId = channel
-//
-//	signedEnvelope, err := protoutil.CreateSignedEnvelope(
-//		common.HeaderType_CONFIG_UPDATE,
-//		channel,
-//		nil, // local signer
-//		&common.ConfigUpdateEnvelope{ConfigUpdate: protoutil.MarshalOrPanic(configUpdate)},
-//		0, // message version
-//		0, // epoch
-//	)
-//	Expect(err).NotTo(HaveOccurred())
-//	Expect(signedEnvelope).NotTo(BeNil())
-//
-//	updateFile := filepath.Join(tempDir, "update.pb")
-//	err = os.WriteFile(updateFile, protoutil.MarshalOrPanic(signedEnvelope), 0o600)
-//	Expect(err).NotTo(HaveOccurred())
-//
-//	var sess *gexec.Session
-//	for _, signer := range additionalSigners {
-//		sess, err = n.PeerAdminSession(signer, commands.SignConfigTx{
-//			File:       updateFile,
-//			ClientAuth: n.ClientAuthRequired,
-//		})
-//		Expect(err).NotTo(HaveOccurred())
-//	}
-//
-//	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(1))
-//	Expect(sess.Err).NotTo(gbytes.Say("Successfully submitted channel update"))
-//}
 
 func prepareTransition(
 	network *nwo.Network, peer *nwo.Peer, orderer *nwo.Orderer, channel string, // Auxiliary
@@ -948,5 +923,94 @@ func addGlobalLevelEndpointsToConfig(config *common.Config) {
 }
 
 func cleanEndpointsPerOrgFromConfig(config *common.Config) {
-	config.ChannelGroup.Groups["Orderer"].Groups["OrdererOrg"].Values[channelconfig.EndpointsKey] = &common.ConfigValue{ModPolicy: channelconfig.AdminsPolicyKey}
+	config.ChannelGroup.Groups["Orderer"].Groups["OrdererOrg"].Values[channelconfig.EndpointsKey] = &common.ConfigValue{ModPolicy: "/Channel/Admins"}
+}
+
+func addEndpointsPerOrgInConfig(config *common.Config) {
+	ordererOrgEndpoint := &common.OrdererAddresses{
+		Addresses: []string{"127.0.0.1:7050"},
+	}
+	config.ChannelGroup.Groups["Orderer"].Groups["OrdererOrg"].Values[channelconfig.EndpointsKey] = &common.ConfigValue{Value: protoutil.MarshalOrPanic(ordererOrgEndpoint), ModPolicy: "/Channel/Application/Writers"}
+	//config.ChannelGroup.Groups["Orderer"].Groups["Org1"].Values[channelconfig.EndpointsKey] = &common.ConfigValue{Value: protoutil.MarshalOrPanic(ordererOrgEndpoint), ModPolicy: "/Channel/Admins"}
+	//config.ChannelGroup.Groups["Orderer"].Groups["Org2"].Values[channelconfig.EndpointsKey] = &common.ConfigValue{Value: protoutil.MarshalOrPanic(ordererOrgEndpoint), ModPolicy: "/Channel/Admins"}
+}
+
+func updateOrdererOrgEndpointsConfigSucceeds(n *nwo.Network, orderer *nwo.Orderer, channel string, current, updated *common.Config, peer *nwo.Peer, additionalSigners ...*nwo.Peer) {
+	tempDir, err := os.MkdirTemp("", "updateConfig")
+	Expect(err).NotTo(HaveOccurred())
+	defer os.RemoveAll(tempDir)
+
+	// compute update
+	configUpdate, err := update.Compute(current, updated)
+	Expect(err).NotTo(HaveOccurred())
+	configUpdate.ChannelId = channel
+
+	signedEnvelope, err := protoutil.CreateSignedEnvelope(
+		common.HeaderType_CONFIG_UPDATE,
+		channel,
+		nil, // local signer
+		&common.ConfigUpdateEnvelope{ConfigUpdate: protoutil.MarshalOrPanic(configUpdate)},
+		0, // message version
+		0, // epoch
+	)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(signedEnvelope).NotTo(BeNil())
+
+	updateFile := filepath.Join(tempDir, "update.pb")
+	err = os.WriteFile(updateFile, protoutil.MarshalOrPanic(signedEnvelope), 0o600)
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, signer := range additionalSigners {
+		sess, err := n.PeerAdminSession(signer, commands.SignConfigTx{
+			File:       updateFile,
+			ClientAuth: n.ClientAuthRequired,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
+	}
+
+	sess, err := n.OrdererAdminSession(orderer, peer, commands.SignConfigTx{
+		File:       updateFile,
+		ClientAuth: n.ClientAuthRequired,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
+
+	sess, err = n.OrdererAdminSession(orderer, peer, commands.ChannelUpdate{
+		ChannelID:  channel,
+		Orderer:    n.OrdererAddress(orderer, nwo.ListenPort),
+		File:       updateFile,
+		ClientAuth: n.ClientAuthRequired,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(sess, n.EventuallyTimeout).Should(gexec.Exit(0))
+	Expect(sess.Err).To(gbytes.Say("Successfully submitted channel update"))
+}
+
+// UpdateOrdererConfig computes, signs, and submits a configuration update
+// which requires orderers signature. the update should fail.
+func UpdateOrdererConfigFails(n *nwo.Network, orderer *nwo.Orderer, channel string, current, updated *common.Config, submitter *nwo.Peer, additionalSigners ...*nwo.Orderer) {
+	tempDir, err := os.MkdirTemp(n.RootDir, "updateConfig")
+	Expect(err).NotTo(HaveOccurred())
+	updateFile := filepath.Join(tempDir, "update.pb")
+	defer os.RemoveAll(tempDir)
+
+	nwo.ComputeUpdateOrdererConfig(updateFile, n, channel, current, updated, submitter, additionalSigners...)
+
+	Eventually(func() bool {
+		sess, err := n.OrdererAdminSession(orderer, submitter, commands.ChannelUpdate{
+			ChannelID:  channel,
+			Orderer:    n.OrdererAddress(orderer, nwo.ListenPort),
+			File:       updateFile,
+			ClientAuth: n.ClientAuthRequired,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		sess.Wait(n.EventuallyTimeout)
+		if sess.ExitCode() != 0 {
+			return false
+		}
+
+		return strings.Contains(string(sess.Err.Contents()), "Successfully submitted channel update")
+	}, n.EventuallyTimeout).Should(BeFalse())
 }

--- a/internal/configtxgen/encoder/encoder.go
+++ b/internal/configtxgen/encoder/encoder.go
@@ -142,7 +142,7 @@ func NewChannelGroup(conf *genesisconfig.Profile) (*cb.ConfigGroup, error) {
 	addValue(channelGroup, channelconfig.HashingAlgorithmValue(), channelconfig.AdminsPolicyKey)
 	addValue(channelGroup, channelconfig.BlockDataHashingStructureValue(), channelconfig.AdminsPolicyKey)
 	if conf.Orderer != nil && len(conf.Orderer.Addresses) > 0 {
-		addValue(channelGroup, channelconfig.OrdererAddressesValue(conf.Orderer.Addresses), ordererAdminsPolicyName)
+		return nil, errors.New("error adding global level endpoints to channel group, in V3.0 global level endpoints are not supported")
 	}
 
 	if conf.Consortium != "" {
@@ -329,6 +329,8 @@ func NewOrdererOrgGroup(conf *genesisconfig.Organization) (*cb.ConfigGroup, erro
 
 	if len(conf.OrdererEndpoints) > 0 {
 		addValue(ordererOrgGroup, channelconfig.EndpointsValue(conf.OrdererEndpoints), channelconfig.AdminsPolicyKey)
+	} else {
+		return nil, errors.Errorf("orderer endpoints for organization %s are missing and must be cofigured", conf.Name)
 	}
 
 	return ordererOrgGroup, nil

--- a/internal/configtxgen/encoder/encoder_test.go
+++ b/internal/configtxgen/encoder/encoder_test.go
@@ -242,7 +242,6 @@ var _ = Describe("Encoder", func() {
 				Orderer: &genesisconfig.Orderer{
 					OrdererType: "solo",
 					Policies:    CreateStandardOrdererPolicies(),
-					Addresses:   []string{"foo.com:7050", "bar.com:8050"},
 				},
 				Consortiums: map[string]*genesisconfig.Consortium{
 					"SampleConsortium": {},
@@ -256,12 +255,12 @@ var _ = Describe("Encoder", func() {
 		It("translates the config into a config group", func() {
 			cg, err := encoder.NewChannelGroup(conf)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(cg.Values)).To(Equal(5))
+			Expect(len(cg.Values)).To(Equal(4))
 			Expect(cg.Values["BlockDataHashingStructure"]).NotTo(BeNil())
 			Expect(cg.Values["Consortium"]).NotTo(BeNil())
 			Expect(cg.Values["Capabilities"]).NotTo(BeNil())
 			Expect(cg.Values["HashingAlgorithm"]).NotTo(BeNil())
-			Expect(cg.Values["OrdererAddresses"]).NotTo(BeNil())
+			Expect(cg.Values["OrdererAddresses"]).To(BeNil())
 		})
 
 		Context("when the policy definition is bad", func() {
@@ -351,11 +350,12 @@ var _ = Describe("Encoder", func() {
 				OrdererType: "solo",
 				Organizations: []*genesisconfig.Organization{
 					{
-						MSPDir:   "../../../sampleconfig/msp",
-						ID:       "SampleMSP",
-						MSPType:  "bccsp",
-						Name:     "SampleOrg",
-						Policies: CreateStandardPolicies(),
+						MSPDir:           "../../../sampleconfig/msp",
+						ID:               "SampleMSP",
+						MSPType:          "bccsp",
+						Name:             "SampleOrg",
+						Policies:         CreateStandardPolicies(),
+						OrdererEndpoints: []string{"foo:7050", "bar:8050"},
 					},
 				},
 				Policies: CreateStandardOrdererPolicies(),
@@ -692,8 +692,8 @@ var _ = Describe("Encoder", func() {
 
 			It("does not include the endpoints in the config group", func() {
 				cg, err := encoder.NewOrdererOrgGroup(conf)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(cg.Values["Endpoints"]).To(BeNil())
+				Expect(err).To(HaveOccurred())
+				Expect(cg).To(BeNil())
 			})
 		})
 

--- a/orderer/common/multichannel/chainsupport.go
+++ b/orderer/common/multichannel/chainsupport.go
@@ -150,6 +150,14 @@ func (cs *ChainSupport) ProposeConfigUpdate(configtx *cb.Envelope) (*cb.ConfigEn
 		return nil, err
 	}
 
+	isOldV3 := cs.ChannelConfig().Capabilities().ConsensusTypeBFT()
+	isNewV3 := bundle.ChannelConfig().Capabilities().ConsensusTypeBFT()
+
+	if !isOldV3 && isNewV3 {
+		//TODO: check org endponits and check in the unit tests
+		// if someoe is empty - return err
+	}
+
 	oldOrdererConfig, ok := cs.OrdererConfig()
 	if !ok {
 		logger.Panic("old config is missing orderer group")

--- a/orderer/common/multichannel/chainsupport.go
+++ b/orderer/common/multichannel/chainsupport.go
@@ -161,6 +161,9 @@ func (cs *ChainSupport) ProposeConfigUpdate(configtx *cb.Envelope) (*cb.ConfigEn
 	}
 
 	if err = cs.ValidateConsensusMetadata(oldOrdererConfig, newOrdererConfig, false); err != nil {
+		if env.Config.ChannelGroup.Values["OrdererAddressesKey"] != nil && env.Config.ChannelGroup.Values["OrdererAddressesKey"].Value == nil {
+			return nil, errors.WithMessage(err, "consensus metadata update for channel config update is invalid since it includes global level endpoints which are not supported in V3.0")
+		}
 		return nil, errors.WithMessage(err, "consensus metadata update for channel config update is invalid")
 	}
 	return env, nil

--- a/orderer/common/multichannel/chainsupport.go
+++ b/orderer/common/multichannel/chainsupport.go
@@ -9,6 +9,7 @@ package multichannel
 import (
 	"github.com/hyperledger/fabric-lib-go/bccsp"
 	cb "github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric/common/channelconfig"
 	"github.com/hyperledger/fabric/common/ledger/blockledger"
 	"github.com/hyperledger/fabric/internal/pkg/identity"
 	"github.com/hyperledger/fabric/orderer/common/blockcutter"
@@ -161,11 +162,13 @@ func (cs *ChainSupport) ProposeConfigUpdate(configtx *cb.Envelope) (*cb.ConfigEn
 	}
 
 	if err = cs.ValidateConsensusMetadata(oldOrdererConfig, newOrdererConfig, false); err != nil {
-		if env.Config.ChannelGroup.Values["OrdererAddressesKey"] != nil && env.Config.ChannelGroup.Values["OrdererAddressesKey"].Value == nil {
-			return nil, errors.WithMessage(err, "consensus metadata update for channel config update is invalid since it includes global level endpoints which are not supported in V3.0")
-		}
 		return nil, errors.WithMessage(err, "consensus metadata update for channel config update is invalid")
 	}
+
+	if env.Config.ChannelGroup.Values[channelconfig.OrdererAddressesKey] != nil && len(env.Config.ChannelGroup.Values[channelconfig.OrdererAddressesKey].Value) > 0 {
+		return nil, errors.Errorf("consensus metadata update for channel config update is invalid since it includes global level endpoints which are not supported in V3.0")
+	}
+
 	return env, nil
 }
 

--- a/orderer/common/server/etcdraft_test.go
+++ b/orderer/common/server/etcdraft_test.go
@@ -26,6 +26,7 @@ func nextPort() int32 {
 	return atomic.AddInt32(&basePort, 1)
 }
 
+// TODO: explore why fail
 func TestSpawnEtcdRaft(t *testing.T) {
 	gt := NewGomegaWithT(t)
 
@@ -102,6 +103,7 @@ func generateBootstrapBlock(gt *GomegaWithT, tempDir, configtxgen, channel, prof
 		"-outputBlock", genesisBlockPath,
 		"--configPath", tempDir,
 	)
+
 	configtxgenProcess, err := gexec.Start(cmd, nil, nil)
 	gt.Expect(err).NotTo(HaveOccurred())
 	gt.Eventually(configtxgenProcess, time.Minute).Should(gexec.Exit(0))
@@ -290,6 +292,7 @@ func testEtcdRaftOSNNoTLSDualListener(gt *GomegaWithT, configPath, orderer strin
 		"FABRIC_LOGGING_SPEC=info",
 	}
 	ordererProcess, err := gexec.Start(cmd, nil, nil)
+	fmt.Printf("Hwlloooo 2\n")
 	gt.Expect(err).NotTo(HaveOccurred())
 	defer func() { gt.Eventually(ordererProcess.Kill(), time.Minute).Should(gexec.Exit()) }()
 

--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -360,6 +360,7 @@ func TestVerifyNoSystemChannelJoinBlock(t *testing.T) {
 		require.NotNil(t, fileRepo)
 
 		genesisBytes, err = os.ReadFile(genesisFile)
+		fmt.Printf("genesisBytes are: %v", genesisBytes)
 		require.NoError(t, err)
 		require.NotNil(t, genesisBytes)
 	}
@@ -372,7 +373,7 @@ func TestVerifyNoSystemChannelJoinBlock(t *testing.T) {
 
 	t.Run("With genesis join-block", func(t *testing.T) {
 		setup()
-
+		// TODO: why the test is affected by the changes to the produceGenesisFileEtcdRaft func that adds endpoints + remove the globals
 		err := fileRepo.Save("testchannelid", genesisBytes)
 		require.NoError(t, err)
 		require.Panics(t, func() { verifyNoSystemChannelJoinBlock(config, cryptoProvider) })
@@ -554,6 +555,7 @@ func generateCryptoMaterials(t *testing.T, cryptogen, tmpDir string) string {
 	return cryptoPath
 }
 
+// TODO: this test is in conflict with our new requirements
 func TestUpdateTrustedRoots(t *testing.T) {
 	configtest.SetDevFabricConfigPath(t)
 
@@ -968,6 +970,8 @@ func panicMsg(f func()) string {
 // produces a system channel genesis file to make sure the server detects it and refuses to start
 func produceGenesisFileEtcdRaft(t *testing.T, channelID string, tmpDir string) (string, []byte) {
 	confRaft := genesisconfig.Load("SampleEtcdRaftSystemChannel", tmpDir)
+	confRaft.Orderer.Addresses = []string{}
+	confRaft.Orderer.Organizations[0].OrdererEndpoints = []string{"127.0.0.1:7050"}
 
 	serverCert, err := os.ReadFile(string(confRaft.Orderer.EtcdRaft.Consenters[0].ServerTlsCert))
 	require.NoError(t, err)
@@ -984,6 +988,8 @@ func produceGenesisFileEtcdRaft(t *testing.T, channelID string, tmpDir string) (
 
 func produceGenesisFileEtcdRaftAppChannel(t *testing.T, channelID string, tmpDir string) (string, []byte) {
 	confRaft := genesisconfig.Load("SampleOrgChannel", tmpDir)
+	confRaft.Orderer.Addresses = []string{}
+	confRaft.Orderer.Organizations[0].OrdererEndpoints = []string{"127.0.0.1:7050"}
 
 	serverCert, err := os.ReadFile(string(confRaft.Orderer.EtcdRaft.Consenters[0].ServerTlsCert))
 	require.NoError(t, err)

--- a/orderer/consensus/etcdraft/chain.go
+++ b/orderer/consensus/etcdraft/chain.go
@@ -1469,14 +1469,14 @@ func (c *Chain) ValidateConsensusMetadata(oldOrdererConfig, newOrdererConfig cha
 		if newOrdererConfig.ConsensusType() == "BFT" {
 			// This is a migration, so we have to validate the config change and make sure that endpoints per org are configured
 			for _, org := range newOrdererConfig.Organizations() {
-				if org.Endpoints() == nil {
-					c.logger.Panicf("illegal orderer config detected during consensus metadata validation: endpoints of org %s are missing", org.Name())
+				if len(org.Endpoints()) == 0 {
+					c.logger.Warnf("illegal orderer config detected during consensus metadata validation: endpoints of org %s are missing", org.Name())
 					return errors.Errorf("illegal orderer config detected during consensus metadata validation: endpoints of org %s are missing", org.Name())
 				}
 			}
 			return nil
 		} else {
-			c.logger.Panicf("illegal consensus type detected during consensus metadata validation: %s", newOrdererConfig.ConsensusType())
+			c.logger.Warnf("illegal consensus type detected during consensus metadata validation: %s", newOrdererConfig.ConsensusType())
 			return errors.Errorf("illegal consensus type detected during consensus metadata validation: %s", newOrdererConfig.ConsensusType())
 
 		}


### PR DESCRIPTION
#### Type of change

- config update

#### Description

This PR aims to block the option to specify global-level endpoints and enforce that endpoints per org are defined. 

#### Related issues

 issue #4763 