### PR TITLE
I change the RequestMaxBytes setting with the value from the config block

### DIFF
--- a/orderer/consensus/smartbft/util/util.go
+++ b/orderer/consensus/smartbft/util/util.go
@@ -70,6 +70,8 @@ func ConfigFromMetadataOptions(selfID uint64, options *smartbft.Options) (types.
 
 	if options.RequestMaxBytes == 0 {
 		config.RequestMaxBytes = config.RequestBatchMaxBytes
+	} else {
+		config.RequestMaxBytes = options.RequestMaxBytes
 	}
 
 	return config, nil


### PR DESCRIPTION
If the RequestMaxBytes parameter is set not equal to 0 when generating a genesis block (passed to the function in the options parameter), it will be ignored. This change corrects the situation.