### PR TITLE
fix warning during doc build

### DIFF
--- a/docs/source/chaincode4ade.rst
+++ b/docs/source/chaincode4ade.rst
@@ -25,7 +25,7 @@ visit the :doc:`deploy_chaincode` tutorial and the :doc:`chaincode_lifecycle`
 concept topic.
 
 This tutorial provides an overview of the high level APIs provided by the Fabric Contract API.
-To learn more about developing smart contracts using the Fabric contract API, visit the :doc:`developapps/smartcontract` topic.
+To learn more about developing smart contracts using the Fabric contract API, visit the :doc:`sdk_chaincode` topic.
 
 Fabric Contract API
 -------------------

--- a/docs/source/deployment_guide_overview.rst
+++ b/docs/source/deployment_guide_overview.rst
@@ -145,7 +145,7 @@ If you’ve read through the key concept topic on :doc:`peers/peers`, you should
 
 These roles are important to understand before you create a peer, as they will influence your customization and deployment decisions. For a look at the various decisions you will need to make, check out :doc:`deploypeer/peerplan`.
 
-The configuration values in a peer's ``core.yaml`` file must be customized or overridden with environment variables. You can find the default ``core.yaml`` configuration file `in the sampleconfig directory of Hyperledger Fabric <https://github.com/hyperledger/fabric/blob/main/sampleconfig/core.yaml>`_. This configuration file is bundled with the peer image and is also included with the downloadable binaries. For information about how to download the production ``core.yaml`` along with the peer image, check out :doc:`deploypeer/peerdeploy`.
+The configuration values in a peer's ``core.yaml`` file must be customized or overridden with environment variables. You can find the default ``core.yaml`` configuration file `in the sampleconfig directory of Hyperledger Fabric <https://github.com/hyperledger/fabric/blob/main/sampleconfig/core.yaml>`__. This configuration file is bundled with the peer image and is also included with the downloadable binaries. For information about how to download the production ``core.yaml`` along with the peer image, check out :doc:`deploypeer/peerdeploy`.
 
 While there are many parameters in the default ``core.yaml``, you will only need to customize a small percentage of them. In general, if you do not have the need to change a tuning value, keep the default value.
 
@@ -207,7 +207,7 @@ Note: This tutorial assumes that a system channel genesis block will not be used
 Next steps
 ----------
 
-Blockchain networks are all about connection, so once you've deployed nodes, you'll obviously want to connect them to other nodes! If you have a peer organization and a peer, you'll want to join your organization to a consortium and join or :doc:`create_channel/create_channel_participation`. If you have an ordering node, you will want to add peer organizations to your consortium. You'll also want to learn how to develop chaincode, which you can learn about in the topics :doc:`developapps/scenario` and :doc:`chaincode4ade`.
+Blockchain networks are all about connection, so once you've deployed nodes, you'll obviously want to connect them to other nodes! If you have a peer organization and a peer, you'll want to join your organization to a consortium and join or :doc:`create_channel/create_channel_participation`. If you have an ordering node, you will want to add peer organizations to your consortium. You'll also want to learn how to develop chaincode, which you can learn about in the topics :doc:`smartcontract/smartcontract` and :doc:`chaincode4ade`.
 
 Part of the process of connecting nodes and creating channels will involve modifying policies to fit the use cases of business networks. For more information about policies, check out :doc:`policies/policies`.
 

--- a/docs/source/private_data_tutorial.rst
+++ b/docs/source/private_data_tutorial.rst
@@ -764,11 +764,15 @@ By setting ``"memberOnlyRead": true`` in the collection configuration file, we
 specify that only clients from Org1 can read data from the collection. An Org2 client
 who tries to read the collection would only get the following response:
 
-.. code:: json
+.. code-block:: json
 
-    Error: endorsement failure during query. response: status:500 message:"failed to
-    read asset details: GET_STATE failed: transaction ID: d23e4bc0538c3abfb7a6bd4323fd5f52306e2723be56460fc6da0e5acaee6b23: tx
-    creator does not have read access permission on privatedata in chaincodeName:private collectionName: Org1MSPPrivateCollection"
+    {
+        "Error": "endorsement failure during query",
+        "response": {
+            "status": 500,
+            "message": "failed to read asset details: GET_STATE failed: transaction ID: d23e4bc0538c3abfb7a6bd4323fd5f52306e2723be56460fc6da0e5acaee6b23: tx creator does not have read access permission on privatedata in chaincodeName:private collectionName: Org1MSPPrivateCollection"
+        }
+    }
 
 Users from Org2 will only be able to see the public hash of the private data.
 

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -8,7 +8,7 @@ tutorial to deploy and test your smart contracts. The :doc:`write_first_app`
 tutorial provides an introduction to how to use the APIs provided by the Fabric
 SDKs to invoke smart contracts from your client applications. For an in depth
 overview of how Fabric applications and smart contracts work together, you
-can visit the :doc:`developapps/developing_applications` topic.
+can visit the :doc:`smartcontract/smartcontract` topic.
 
 Network operators can use the :doc:`deploy_chaincode` tutorial and the
 :doc:`create_channel/create_channel_overview` tutorial series to learn


### PR DESCRIPTION
fix #4617 

- Bug fix
- New feature
- Improvement (improvement to code, performance, etc)
- Test update
- Documentation update

#### Description

```
$ python -m sphinx -T -E -b html -d _build/doctrees -D language=en . ~/html
Running Sphinx v7.2.6
myst v2.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=True, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
building [mo]: targets for 0 po files that are out of date
writing output...
building [html]: targets for 124 source files that are out of date
updating environment: [new config] 124 added, 0 changed, 0 removed
reading sources... [100%] write_first_app
looking for now-outdated files... none found
pickling environment... done
checking consistency... /Users/theholygrail/hyperledger/fabric/docs/source/build_network.rst: WARNING: document isn't included in any toctree
/Users/theholygrail/hyperledger/fabric/docs/source/github/github.rst: WARNING: document isn't included in any toctree
/Users/theholygrail/hyperledger/fabric/docs/source/msp-identity-validity-rules.rst: WARNING: document isn't included in any toctree
/Users/theholygrail/hyperledger/fabric/docs/source/policies.rst: WARNING: document isn't included in any toctree
/Users/theholygrail/hyperledger/fabric/docs/source/raft_bft_migration.md: WARNING: document isn't included in any toctree
/Users/theholygrail/hyperledger/fabric/docs/source/tutorial/installxcode.md: WARNING: document isn't included in any toctree
done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [100%] write_first_app
generating indices... genindex done
highlighting module code...
writing additional pages... search done
copying images... [100%] images/AppConceptsOverview.png
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 6 warnings.

The HTML pages are in ../../../../html.
```

Only warnings related to inclusion of document in toctree left
