### PR TITLE
CouchDB index support for implicit collections

### DIFF
--- a/core/chaincode/implicitcollection/name.go
+++ b/core/chaincode/implicitcollection/name.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	prefix = "_implicit_org_"
+	prefix         = "_implicit_org_"
+	allOrgNotation = "_implicit_all_orgs"
 )
 
 // NameForOrg constructs the name of the implicit collection for the specified org
@@ -30,4 +31,8 @@ func MspIDIfImplicitCollection(collectionName string) (isImplicitCollection bool
 
 func IsImplicitCollection(collectionName string) bool {
 	return strings.HasPrefix(collectionName, prefix)
+}
+
+func IsAllOrgNotation(collectionName string) bool {
+	return collectionName == allOrgNotation
 }

--- a/core/ledger/kvledger/kv_ledger_provider.go
+++ b/core/ledger/kvledger/kv_ledger_provider.go
@@ -237,6 +237,7 @@ func (p *Provider) initStateDBProvider() error {
 		p.initializer.HealthCheckRegistry,
 		stateDBConfig,
 		sysNamespaces,
+		p.initializer.MembershipInfoProvider.MyImplicitCollectionName(),
 	)
 	return err
 }

--- a/core/ledger/kvledger/txmgmt/privacyenabledstate/db_test.go
+++ b/core/ledger/kvledger/txmgmt/privacyenabledstate/db_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/hyperledger/fabric-protos-go/peer"
@@ -438,6 +439,9 @@ func createCollectionConfig(collectionName string) *peer.CollectionConfig {
 func testHandleChainCodeDeploy(t *testing.T, env TestEnv) {
 	env.Init(t)
 	defer env.Cleanup()
+	// Set local MSP ID for DB to use
+	err := os.Setenv("CORE_PEER_LOCALMSPID", "testOrgMsp1")
+	require.NoError(t, err)
 	db := env.GetDBHandle(generateLedgerID(t))
 
 	coll1 := createCollectionConfig("collectionMarbles")
@@ -451,6 +455,9 @@ func testHandleChainCodeDeploy(t *testing.T, env TestEnv) {
 			{Name: "META-INF/statedb/couchdb/indexes/indexSizeSortName.json", Body: `{"index":{"fields":[{"size":"desc"}]},"ddoc":"indexSizeSortName","name":"indexSizeSortName","type":"json"}`},
 			{Name: "META-INF/statedb/couchdb/collections/collectionMarbles/indexes/indexCollMarbles.json", Body: `{"index":{"fields":["docType","owner"]},"ddoc":"indexCollectionMarbles", "name":"indexCollectionMarbles","type":"json"}`},
 			{Name: "META-INF/statedb/couchdb/collections/collectionMarblesPrivateDetails/indexes/indexCollPrivDetails.json", Body: `{"index":{"fields":["docType","price"]},"ddoc":"indexPrivateDetails", "name":"indexPrivateDetails","type":"json"}`},
+			{Name: "META-INF/statedb/couchdb/collections/_implicit_org_testOrgMsp1/indexes/indexCreateDate.json", Body: `{"index":{"fields":["create_date"]},"ddoc":"indexCreateDateDoc", "name":"indexCreateDate","type":"json"}`},
+			{Name: "META-INF/statedb/couchdb/collections/_implicit_org_testOrgMsp2/indexes/indexUpdateDate.json", Body: `{"index":{"fields":["update_date"]},"ddoc":"indexUpdateDateDoc", "name":"indexUpdateDate","type":"json"}`},
+			{Name: "META-INF/statedb/couchdb/collections/_implicit_org_*/indexes/indexDeleteDate.json", Body: `{"index":{"fields":["delete_date"]},"ddoc":"indexDeleteDateDoc", "name":"indexDeleteDate","type":"json"}`},
 		},
 	)
 
@@ -458,14 +465,23 @@ func testHandleChainCodeDeploy(t *testing.T, env TestEnv) {
 	fileEntries, err := ccprovider.ExtractFileEntries(dbArtifactsTarBytes, "couchdb")
 	require.NoError(t, err)
 
-	// There should be 3 entries
-	require.Len(t, fileEntries, 3)
+	// There should be 6 entries
+	require.Len(t, fileEntries, 6)
 
 	// There should be 2 entries for main
 	require.Len(t, fileEntries["META-INF/statedb/couchdb/indexes"], 2)
 
 	// There should be 1 entry for collectionMarbles
 	require.Len(t, fileEntries["META-INF/statedb/couchdb/collections/collectionMarbles/indexes"], 1)
+
+	// There should be 1 entry for _implicit_org_testOrgMsp1
+	require.Len(t, fileEntries["META-INF/statedb/couchdb/collections/_implicit_org_testOrgMsp1/indexes"], 1)
+
+	// There should be 1 entry for _implicit_org_testOrgMsp2
+	require.Len(t, fileEntries["META-INF/statedb/couchdb/collections/_implicit_org_testOrgMsp2/indexes"], 1)
+
+	// There should be 1 entry for _implicit_org_*
+	require.Len(t, fileEntries["META-INF/statedb/couchdb/collections/_implicit_org_*/indexes"], 1)
 
 	// Verify the content of the array item
 	expectedJSON := []byte(`{"index":{"fields":["docType","owner"]},"ddoc":"indexCollectionMarbles", "name":"indexCollectionMarbles","type":"json"}`)
@@ -474,6 +490,11 @@ func testHandleChainCodeDeploy(t *testing.T, env TestEnv) {
 
 	// The collection config is added to the chaincodeDef but missing collectionMarblesPrivateDetails.
 	// Hence, the index on collectionMarblesPrivateDetails cannot be created
+	//
+	// Index on _implicit_org_testOrgMsp1 will be created as it is implicit collection of this org,
+	// but _implicit_org_testOrgMsp2 will not be created as it belongs to a different org
+	//
+	// Index on _implicit_org_* will be created as it applies to all orgs' implicit collections
 	err = db.HandleChaincodeDeploy(chaincodeDef, dbArtifactsTarBytes)
 	require.NoError(t, err)
 

--- a/docs/source/private-data-arch.rst
+++ b/docs/source/private-data-arch.rst
@@ -176,9 +176,11 @@ The properties ``requiredPeerCount`` and ``maxPeerCount`` can however be set in 
 can set these properties based on the number of peers that they deploy, as described
 in the next section.
 
-.. note:: Since implicit private data collections are not explicitly defined,
-          it is not possible to associate CouchDB indexes with them. Utilize
-          key-based queries and key-range queries rather than JSON queries.
+.. note:: 
+
+CouchDB indexes can be created to organisation specific implicit collections just like explicitly defined collections with indexes directory name `_implicit_org_<MSP_ID>`. Such indexes are only effective within the respective organization to which the implicit collection belongs.
+
+To create common indexes for implicit collection of all the organisations, the indexes directory should be named "_implicit_org_*".
 
 Private data dissemination
 --------------------------
@@ -361,9 +363,6 @@ Limitations:
   chaincode function to make the updates. Note that calls to GetPrivateData() to retrieve
   individual keys can be made in the same transaction as PutPrivateData() calls, since
   all peers can validate key reads based on the hashed key version.
-* Since implicit private data collections are not explicitly defined,
-  it is not possible to associate CouchDB indexes with them.
-  It is therefore not recommended to utilize JSON queries with implicit private data collections.
 
 Using Indexes with collections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Allow CouchDB index creation on implicit collection of organisations.

Indexes can be created for specific organisation's implicit collections at:
`META-INF/statedb/couchdb/collections/_implicit_org_<MSP_ID>` directory of the chaincode package.

Common indexes for all the organisations' implicit collection can be created at:
`META-INF/statedb/couchdb/collections/_implicit_org_*` directory of the chaincode package.
( `*` acts as wildcard for all organisation MSP ids. )

#### Type of change

- New feature

#### Description
Updated chaincode deployment handler to check if the indexes are for implicit collection if given collection directory name not explicitly defined in collection config. If the implicit collection indexes belong this handling peer's organisation or passed as global implicit collection indexes (using `*` notation), then indexes are created on corresponding implicit collection.

#### Additional details
- Please review the way of fetching `localMspId` directly using `viper` at `NewDB` constructor function.
- Added few more tar file entries to represent implicit collection indexes in unit tests. (However UT `TestHandleChainCodeDeployOnCouchDB` was already failing due to some other error)

#### Related issues
- #4780 