### PR TITLE
Fix prerequisites doc page for content is partly occluded by navigator

### DIFF
--- a/docs/source/prereqs.md
+++ b/docs/source/prereqs.md
@@ -4,9 +4,6 @@ The following prerequisites are required to run a Docker-based Fabric test netwo
 
 ## Mac
 
-<!--- Indent entire section -->
-<div style="margin-left: 1.5em;">
-
 ### Homebrew
 
 For macOS, we recommend using [Homebrew](https://brew.sh) to manage the prereqs.
@@ -97,12 +94,8 @@ $ brew install jq
 $ jq --version
 jq-1.6
 ```
-</div>
 
 ## **Linux**
-
-<!--- Indent entire section -->
-<div style="margin-left: 1.5em;">
 
 ### Git
 
@@ -165,12 +158,7 @@ Optional: Install the latest version of [Go](https://golang.org/doc/install) if 
 Optional: Install the latest version of [jq](https://stedolan.github.io/jq/download/) if it is not already installed
 (only required for the tutorials related to channel configuration transactions).
 
-</div>
-
 ## **Windows**
-
-<!--- Indent entire section -->
-<div style="margin-left: 1.5em;">
 
 ### Docker
 
@@ -207,8 +195,6 @@ git config --get core.autocrlf
 git config --get core.longpaths
 ```
 These output from these commands should be false and true respectively.
-
-</div>
 
 ## **Notes**
 


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description
The change is intended to fix #4745 that the prerequisites page's content is partly occluded by navigator. As analyzed in the discussion of the issue, embedded div elements cause the issue. Therefore the change is going to remove all `<div>` elements 

(Due to accidentally closing the PR for Mergeify's backport(#4796), I am resolving the conflict and submitting it as a new PR.)

#### Additional details

#### Related issues
#4745 

