### PR TITLE
Remove the outputAnchorPeersUpdate flag of configtxgen

### DIFF
--- a/cmd/configtxgen/main_test.go
+++ b/cmd/configtxgen/main_test.go
@@ -120,33 +120,8 @@ func TestInspectConfigTx(t *testing.T) {
 	require.NoError(t, doInspectChannelCreateTx(configTxDest), "Good configtx inspection request")
 }
 
-func TestGenerateAnchorPeersUpdate(t *testing.T) {
-	configTxDest := filepath.Join(tmpDir, "anchorPeerUpdate")
-
-	config := genesisconfig.Load(genesisconfig.SampleSingleMSPChannelProfile, configtest.GetDevConfigDir())
-
-	require.NoError(t, doOutputAnchorPeersUpdate(config, "foo", configTxDest, genesisconfig.SampleOrgName), "Good anchorPeerUpdate request")
-}
-
-func TestBadAnchorPeersUpdates(t *testing.T) {
-	configTxDest := filepath.Join(tmpDir, "anchorPeerUpdate")
-
-	config := genesisconfig.Load(genesisconfig.SampleSingleMSPChannelProfile, configtest.GetDevConfigDir())
-
-	require.EqualError(t, doOutputAnchorPeersUpdate(config, "foo", configTxDest, ""), "must specify an organization to update the anchor peer for")
-
-	backupApplication := config.Application
-	config.Application = nil
-	require.EqualError(t, doOutputAnchorPeersUpdate(config, "foo", configTxDest, genesisconfig.SampleOrgName), "cannot update anchor peers without an application section")
-	config.Application = backupApplication
-
-	config.Application.Organizations[0] = &genesisconfig.Organization{Name: "FakeOrg", ID: "FakeOrg"}
-	require.EqualError(t, doOutputAnchorPeersUpdate(config, "foo", configTxDest, genesisconfig.SampleOrgName), "error parsing profile as channel group: could not create application group: failed to create application org: 1 - Error loading MSP configuration for org FakeOrg: unknown MSP type ''")
-}
-
 func TestConfigTxFlags(t *testing.T) {
 	configTxDest := filepath.Join(tmpDir, "configtx")
-	configTxDestAnchorPeers := filepath.Join(tmpDir, "configtxAnchorPeers")
 
 	oldArgs := os.Args
 	defer func() {
@@ -164,7 +139,6 @@ func TestConfigTxFlags(t *testing.T) {
 		"-profile=" + genesisconfig.SampleSingleMSPChannelProfile,
 		"-configPath=" + devConfigDir,
 		"-inspectChannelCreateTx=" + configTxDest,
-		"-outputAnchorPeersUpdate=" + configTxDestAnchorPeers,
 		"-asOrg=" + genesisconfig.SampleOrgName,
 	}
 
@@ -172,8 +146,6 @@ func TestConfigTxFlags(t *testing.T) {
 
 	_, err := os.Stat(configTxDest)
 	require.NoError(t, err, "Configtx file is written successfully")
-	_, err = os.Stat(configTxDestAnchorPeers)
-	require.NoError(t, err, "Configtx anchor peers file is written successfully")
 }
 
 func TestBlockFlags(t *testing.T) {

--- a/docs/source/commands/configtxgen.md
+++ b/docs/source/commands/configtxgen.md
@@ -29,8 +29,6 @@ Usage of configtxgen:
     	Prints the configuration contained in the block at the specified path
   -inspectChannelCreateTx string
     	[DEPRECATED] Prints the configuration contained in the transaction at the specified path
-  -outputAnchorPeersUpdate string
-    	[DEPRECATED] Creates a config update to update an anchor peer (works only with the default channel creation, and only for the first update)
   -outputBlock string
     	The path to write the genesis block to (if set)
   -outputCreateChannelTx string
@@ -93,21 +91,6 @@ for channel reconfiguration workflows, such as adding a member).
 configtxgen -printOrg Org1
 ```
 
-### Output anchor peer tx (deprecated)
-
-**Note:** The channel creation transaction was used in order to create a new application channel using a system channel. Because the system channel is no longer supported since release v3.0, it is now deprecated.
-
-Output a channel configuration update transaction `anchor_peer_tx.pb`  based on
-the anchor peers defined for Org1 and channel profile SampleSingleMSPChannelV1_1
-in `configtx.yaml`. Transaction will set anchor peers for Org1 if no anchor peers
-have been set on the channel.
-```
-configtxgen -outputAnchorPeersUpdate anchor_peer_tx.pb -profile SampleSingleMSPChannelV1_1 -asOrg Org1
-```
-
-The `-outputAnchorPeersUpdate` output flag has been deprecated. To set anchor
-peers on the channel, use [configtxlator](configtxlator.html) to update the
-channel configuration.
 
 ## Configuration
 

--- a/docs/wrappers/configtxgen_postscript.md
+++ b/docs/wrappers/configtxgen_postscript.md
@@ -48,21 +48,6 @@ for channel reconfiguration workflows, such as adding a member).
 configtxgen -printOrg Org1
 ```
 
-### Output anchor peer tx (deprecated)
-
-**Note:** The channel creation transaction was used in order to create a new application channel using a system channel. Because the system channel is no longer supported since release v3.0, it is now deprecated.
-
-Output a channel configuration update transaction `anchor_peer_tx.pb`  based on
-the anchor peers defined for Org1 and channel profile SampleSingleMSPChannelV1_1
-in `configtx.yaml`. Transaction will set anchor peers for Org1 if no anchor peers
-have been set on the channel.
-```
-configtxgen -outputAnchorPeersUpdate anchor_peer_tx.pb -profile SampleSingleMSPChannelV1_1 -asOrg Org1
-```
-
-The `-outputAnchorPeersUpdate` output flag has been deprecated. To set anchor
-peers on the channel, use [configtxlator](configtxlator.html) to update the
-channel configuration.
 
 ## Configuration
 

--- a/integration/nwo/commands/configtxgen.go
+++ b/integration/nwo/commands/configtxgen.go
@@ -48,28 +48,6 @@ func (c CreateChannelTx) Args() []string {
 	}
 }
 
-type OutputAnchorPeersUpdate struct {
-	ChannelID               string
-	Profile                 string
-	ConfigPath              string
-	AsOrg                   string
-	OutputAnchorPeersUpdate string
-}
-
-func (o OutputAnchorPeersUpdate) SessionName() string {
-	return "configtxgen-output-anchor-peers-update"
-}
-
-func (o OutputAnchorPeersUpdate) Args() []string {
-	return []string{
-		"-channelID", o.ChannelID,
-		"-profile", o.Profile,
-		"-configPath", o.ConfigPath,
-		"-asOrg", o.AsOrg,
-		"-outputAnchorPeersUpdate", o.OutputAnchorPeersUpdate,
-	}
-}
-
 type PrintOrg struct {
 	ConfigPath string
 	ChannelID  string

--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -75,17 +75,6 @@ Organizations:
         OrdererEndpoints:
             - "127.0.0.1:7050"
 
-        # AnchorPeers defines the location of peers which can be used for
-        # cross-org gossip communication.
-        #
-        # NOTE: this value should only be set when using the deprecated
-        # `configtxgen --outputAnchorPeersUpdate` command. It is recommended
-        # to instead use the channel configuration update process to set the
-        # anchor peers for each organization.
-        AnchorPeers:
-            - Host: 127.0.0.1
-              Port: 7051
-
 ################################################################################
 #
 #   CAPABILITIES


### PR DESCRIPTION
This PR removes the configtxgen flag --outputAnchorPeersUpdate from the code.

#### Type of change

- New feature
- Documentation update

#### Description

In v3.0, we should use channel configuration updates and avoid using the "outputAnchorPeersUpdate" flag of configtxgen.
So, this PR removes the configtxgen flag --outputAnchorPeersUpdate from the code.

#### Related issues

Resolves #4765