### PR TITLE
Update Github Actions (release-2.5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           RELEASE: ${{ env.FABRIC_VER }}
 
       - name: Publish Release Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           # <name> of the artifact must not collide between platform/arch builds
           name: release-${{ matrix.target }}-${{ matrix.arch }}
@@ -84,10 +84,10 @@ jobs:
 
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug
           config-inline: |
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Login to the ${{ env.DOCKER_REGISTRY }} Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ env.DOCKER_REGISTRY == 'docker.io' && secrets.DOCKERHUB_USERNAME || github.actor }}
@@ -106,7 +106,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKER_REGISTRY }}/${{ github.repository_owner }}/fabric-${{ matrix.COMPONENT }}
           tags: |
@@ -116,7 +116,7 @@ jobs:
 
       - name: Build and push ${{ matrix.COMPONENT }} Image
         id: push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.CONTEXT }}
           file: images/${{ matrix.COMPONENT }}/Dockerfile


### PR DESCRIPTION
Update to avoid Node 16 deprecation warnings.
