### PR TITLE
adding external chaincode binaries to the base peer image WIP

### DIFF
--- a/ccaas_builder/cmd/detect/main.go
+++ b/ccaas_builder/cmd/detect/main.go
@@ -26,8 +26,6 @@ func main() {
 		logger.Printf("::Error: %v\n", err)
 		os.Exit(1)
 	}
-
-	logger.Printf("::Type detected as ccaas")
 }
 
 type chaincodeMetadata struct {
@@ -59,9 +57,11 @@ func run() error {
 		return errors.WithMessage(err, "Unable to parse the metadata.json file")
 	}
 
-	if strings.ToLower(metadata.Type) != "ccaas" {
+	if strings.ToLower(metadata.Type) != "ccaas" && strings.ToLower(metadata.Type) != "remote" {
 		return fmt.Errorf("chaincode type not supported: %s", metadata.Type)
 	}
+
+	logger.Printf("::Type detected as: " + strings.ToLower(metadata.Type))
 
 	// returning nil indicates to the peer a successful detection
 	return nil

--- a/ccaas_builder/cmd/detect/main_test.go
+++ b/ccaas_builder/cmd/detect/main_test.go
@@ -34,6 +34,10 @@ func TestArugments(t *testing.T) {
 			exitCode: 0,
 			args:     []string{"na", "testdata/validtype"},
 		},
+		"validremote": {
+			exitCode: 0,
+			args:     []string{"na", "testdata/validremote"},
+		},
 		"wrongtype": {
 			exitCode: 1,
 			args:     []string{"na", "testdata/wrongtype"},

--- a/ccaas_builder/cmd/detect/testdata/validremote/metadata.json
+++ b/ccaas_builder/cmd/detect/testdata/validremote/metadata.json
@@ -1,0 +1,4 @@
+{
+    "type": "remote",
+    "label": "audit-trail"
+}


### PR DESCRIPTION
Simplify the use of external chaincodes

#### Type of change

- New feature
- Improvement (improvement to code, performance, etc)

Might be a new feature or an improvement.

#### Description

Using external chaincode as a service needs to change the peer image providing three binaries (detect/build/release). To simplify the setup for use cases where docker (podman, kubernetes, openshift to name a few) is not available you are forced to use external chaincodes.

#### Additional details

As its basically my first PR for fabric, feedback regarding tools/guidelines would be appreciated.
Maybe, the functionality could be moved into the existing tools in ccaasbuilder, but I wont risk a bug there.

#### Related issues

#### Release Note

The change wont impact existing installations

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
