### PR TITLE
add mutex usage comment

### DIFF
--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -59,11 +59,15 @@ type kvLedger struct {
 	historyDB              *history.DB
 	configHistoryRetriever *collectionConfigHistoryRetriever
 	snapshotMgr            *snapshotMgr
-	blockAPIsRWLock        *sync.RWMutex
-	stats                  *ledgerStats
-	commitHash             []byte
-	hashProvider           ledger.HashProvider
-	config                 *ledger.Config
+	// this RWMutex provides atomicity to commit a block to the block-storage
+	// and to apply its effects on the state database
+	//
+	// for more details see https://github.com/hyperledger/fabric/pull/4694
+	blockAPIsRWLock *sync.RWMutex
+	stats           *ledgerStats
+	commitHash      []byte
+	hashProvider    ledger.HashProvider
+	config          *ledger.Config
 
 	// isPvtDataStoreAheadOfBlockStore is read during missing pvtData
 	// reconciliation and may be updated during a regular block commit.


### PR DESCRIPTION
#### Type of change

- Improvement

#### Description

This PR adds a comment describing the mutex `blockAPIsRWLock`.

#### Additional details

It was found out that removal of some `blockAPIsRWLock` read locks gives better performance for HLF peer and reduces its resource downtime. But after clarification for what this read locks had been made, the clarifying comment was added.

#### Related issues

Initial performance improvements and discussion are available in the [PR#4694](https://github.com/hyperledger/fabric/pull/4694).
