### PR TITLE
Suppress scheduled jobs on personal forks

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -17,8 +17,10 @@ env:
 
 jobs:
   broken-lint-checker:
+    # Only run the scheduled job in hyperledger/fabric repository, not on personal forks
+    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'hyperledger/fabric')
     name: "Check for Broken Links"
-    runs-on: fabric-ubuntu-latest
+    runs-on: ${{ github.repository == 'hyperledger/fabric' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - name: Checkout Fabric Code
         uses: actions/checkout@v4

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -14,7 +14,9 @@ permissions:
 
 jobs:
   scan:
-    runs-on: fabric-ubuntu-latest
+    # Only run the scheduled job in hyperledger/fabric repository, not on personal forks
+    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'hyperledger/fabric')
+    runs-on: ${{ github.repository == 'hyperledger/fabric' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Suppress scheduled jobs on personal forks.

Also, enable running the jobs on-demand in personal forks by using a runner that is available on personal forks.