### PR TITLE
Add GHA permission to broken link checker

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -15,6 +15,9 @@ on:
 env:
   GO_VER: 1.21.9
 
+permissions:
+  contents: read
+
 jobs:
   broken-lint-checker:
     # Only run the scheduled job in hyperledger/fabric repository, not on personal forks


### PR DESCRIPTION
Every github action should have top level permission set to read.