### PR TITLE
Publish OpenSSF scorecard results

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,7 @@ jobs:
           # For private repositories:
           #   - `publish_results` will always be set to `false`, regardless
           #     of the value entered here.
-          publish_results: false
+          publish_results: true
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.


### PR DESCRIPTION
I've found that fabric scorecard is already published at https://scorecard.dev/viewer/?uri=github.com/hyperledger/fabric

Publishing from our own github action will at least give us control over the scorecard execution and publishing.