### PR TITLE
Bump actions/download-artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Download Artifacts
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Release Fabric Version
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
download-artifact needs to be v4 because
upload-artifact is already v4.
They must be at the same level for release pipeline to work correctly.
