### PR TITLE
fix: typo in documentations

### DIFF
--- a/docs/source/cc_service.md
+++ b/docs/source/cc_service.md
@@ -41,13 +41,13 @@ tar cfz myccpackage.tgz metadata.json code.tar.gz
 
 ## Configuring a peer to process external chaincode
 
-In this section we go over the configuration needed
+In this section we go over the configuration needed:
 * to detect if the chaincode package identifies an external chaincode service
 * to create the `connection.json` file in the release directory
 
 ### Modify the peer core.yaml to include the externalBuilder
 
-Assume the scripts are on the peer in the `bin` directory as follows
+Assume the scripts are on the peer in the `bin` directory as follows:
 ```
     <fully qualified path on the peer's env>
     └── bin
@@ -140,7 +140,7 @@ exit 0
 
 #### bin/release
 
-For chaincode as an external service, the `bin/release` script is responsible for providing the `connection.json` to the peer by placing it in the `RELEASE_OUTPUT_DIR`.  The `connection.json` file has the following JSON structure
+For chaincode as an external service, the `bin/release` script is responsible for providing the `connection.json` to the peer by placing it in the `RELEASE_OUTPUT_DIR`.  The `connection.json` file has the following JSON structure:
 
 * **address** - chaincode server endpoint accessible from peer. Must be specified in “<host>:<port>” format.
 * **domain** - chaincode service domain name. If the address is not authorized by the TLS certificate of the chaincode service, you can specify an authorized address through domain.

--- a/docs/source/gateway.md
+++ b/docs/source/gateway.md
@@ -40,7 +40,7 @@ Hyperledger Fabric currently supports client application development in three la
 
 In order for a transaction to be successfully committed to the ledger, a sufficient number of endorsements are required in order to satisfy
 the [endorsement policy](endorsement-policies.html). Getting an endorsement from an organization involves connecting to one
-of its peers and have it simulate (execute) the transaction proposal against its copy of the ledger. The peer simulates the transaction by invoking the chaincode function, as specified by its name and arguments in the proposal, and building (and signing) a read-write set. The read-write set contains the current ledger state and proposed changes in response to the state get/set instructions in that function.
+of its peers and having it simulate (execute) the transaction proposal against its copy of the ledger. The peer simulates the transaction by invoking the chaincode function, as specified by its name and arguments in the proposal, and building (and signing) a read-write set. The read-write set contains the current ledger state and proposed changes in response to the state get/set instructions in that function.
 
 The endorsement policy, or sum of multiple policies, that gets applied to a transaction depends on the implementation of the chaincode function that is being invoked, and could be a combination of the following:
 


### PR DESCRIPTION
#### Type of change

This PR fixes various typo in documentations.

fixes #3271 

- Documentation update

#### Description

- fixed the typo "have" ---> "having" 
- Added a number of missing colons(:)

<img width="1437" alt="Screenshot 2024-05-22 at 02 22 28" src="https://github.com/hyperledger/fabric/assets/144223699/7747d0db-0019-4154-aea3-49fc52792b38">

