### PR TITLE
Replace ioutil.WriteFile with os.WriteFile

### DIFF
--- a/common/deliverclient/blocksprovider/deliverer_test.go
+++ b/common/deliverclient/blocksprovider/deliverer_test.go
@@ -8,7 +8,6 @@ package blocksprovider_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"sync"
@@ -832,7 +831,7 @@ func generateCertificatesSmartBFT(confAppSmartBFT *genesisconfig.Profile, tlsCA 
 		}
 
 		srvP := path.Join(certDir, fmt.Sprintf("server%d.crt", i))
-		err = ioutil.WriteFile(srvP, srvC.Cert, 0o644)
+		err = os.WriteFile(srvP, srvC.Cert, 0o644)
 		if err != nil {
 			return err
 		}
@@ -843,7 +842,7 @@ func generateCertificatesSmartBFT(confAppSmartBFT *genesisconfig.Profile, tlsCA 
 		}
 
 		clnP := path.Join(certDir, fmt.Sprintf("client%d.crt", i))
-		err = ioutil.WriteFile(clnP, clnC.Cert, 0o644)
+		err = os.WriteFile(clnP, clnC.Cert, 0o644)
 		if err != nil {
 			return err
 		}

--- a/core/deliverservice/deliveryclient_test.go
+++ b/core/deliverservice/deliveryclient_test.go
@@ -8,7 +8,6 @@ package deliverservice
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -456,13 +455,13 @@ func generateCertificatesSmartBFT(t *testing.T, confAppSmartBFT *genesisconfig.P
 		srvC, err := tlsCA.NewServerCertKeyPair(c.Host)
 		require.NoError(t, err)
 		srvP := path.Join(certDir, fmt.Sprintf("server%d.crt", i))
-		err = ioutil.WriteFile(srvP, srvC.Cert, 0o644)
+		err = os.WriteFile(srvP, srvC.Cert, 0o644)
 		require.NoError(t, err)
 
 		clnC, err := tlsCA.NewClientCertKeyPair()
 		require.NoError(t, err)
 		clnP := path.Join(certDir, fmt.Sprintf("client%d.crt", i))
-		err = ioutil.WriteFile(clnP, clnC.Cert, 0o644)
+		err = os.WriteFile(clnP, clnC.Cert, 0o644)
 		require.NoError(t, err)
 
 		c.Identity = srvP


### PR DESCRIPTION
<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change
This PR replaces the deprecated ioutil.WriteFile with os.WriteFile to comply with the latest Go standards and improve code maintainability.

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (improvement to code, performance, etc)
- Test update

#### Description

<!--- Describe your changes in detail, including motivation. -->
The Go standard library package `ioutil` has been deprecated, and its functions have been moved to other packages. This change updates the code to replace `ioutil.WriteFile` with `os.WriteFile` in the `core/deliverservice/deliveryclient_test.go` and `common/deliverclient/blocksprovider/deliverer_test.go` files. This ensures that the code adheres to the latest Go standards and improves maintainability.

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->
The changes were made in the test files and were tested by running the existing unit tests to ensure that the new `os.WriteFile` function works as expected without any issues.

#### Related issues

<!--- Include a link to any associated issues, e.g. Github issue or approved rfc. -->
No related issues.

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
