### PR TITLE
Implement 'osnadmin channel info' subcommand and update tests

### DIFF
--- a/cmd/osnadmin/main.go
+++ b/cmd/osnadmin/main.go
@@ -52,7 +52,10 @@ func executeForArgs(args []string) (output string, exit int, err error) {
 	configBlockPath := join.Flag("config-block", "Path to the file containing an up-to-date config block for the channel").Short('b').Required().String()
 
 	list := channel.Command("list", "List channel information for an Ordering Service Node (OSN). If the channelID flag is set, more detailed information will be provided for that channel.")
-	listChannelID := list.Flag("channelID", "Channel ID").Short('c').String()
+	// listChannelID := list.Flag("channelID", "Channel ID").Short('c').String()
+	// Define the new info subcommand
+	info := channel.Command("info", "Get detailed information about a specific channel.")
+	infoChannelID := info.Flag("channelID", "Channel ID").Short('c').Required().String()
 
 	remove := channel.Command("remove", "Remove a channel from an Ordering Service Node (OSN).")
 	removeChannelID := remove.Flag("channelID", "Channel ID").Short('c').Required().String()
@@ -113,11 +116,13 @@ func executeForArgs(args []string) (output string, exit int, err error) {
 	case join.FullCommand():
 		resp, err = osnadmin.Join(osnURL, marshaledConfigBlock, caCertPool, tlsClientCert)
 	case list.FullCommand():
-		if *listChannelID != "" {
-			resp, err = osnadmin.ListSingleChannel(osnURL, *listChannelID, caCertPool, tlsClientCert)
-			break
-		}
+		// if *listChannelID != "" {
+		// 	resp, err = osnadmin.ListSingleChannel(osnURL, *listChannelID, caCertPool, tlsClientCert)
+		// 	break
+		// }
 		resp, err = osnadmin.ListAllChannels(osnURL, caCertPool, tlsClientCert)
+	case info.FullCommand():
+		resp, err = osnadmin.ListSingleChannel(osnURL, *infoChannelID, caCertPool, tlsClientCert)
 	case remove.FullCommand():
 		resp, err = osnadmin.Remove(osnURL, *removeChannelID, caCertPool, tlsClientCert)
 	}

--- a/cmd/osnadmin/main.go
+++ b/cmd/osnadmin/main.go
@@ -58,7 +58,7 @@ func executeForArgs(args []string) (output string, exit int, err error) {
 	infoChannelID := info.Flag("channelID", "Channel ID").Short('c').Required().String()
 
 	remove := channel.Command("remove", "Remove a channel from an Ordering Service Node (OSN).")
-	removeChannelID := remove.Flag("channelID", "Channel ID").Short('c').Required().String()
+	removeChannelID := remove.Flag("channelID", "Channel ID").Short('c').String()
 
 	command, err := app.Parse(args)
 	if err != nil {

--- a/cmd/osnadmin/main.go
+++ b/cmd/osnadmin/main.go
@@ -58,7 +58,7 @@ func executeForArgs(args []string) (output string, exit int, err error) {
 	infoChannelID := info.Flag("channelID", "Channel ID").Short('c').Required().String()
 
 	remove := channel.Command("remove", "Remove a channel from an Ordering Service Node (OSN).")
-	removeChannelID := remove.Flag("channelID", "Channel ID").Short('c').String()
+	removeChannelID := remove.Flag("channelID", "Channel ID").Short('c').Required().String()
 
 	command, err := app.Parse(args)
 	if err != nil {

--- a/cmd/osnadmin/main.go
+++ b/cmd/osnadmin/main.go
@@ -52,8 +52,6 @@ func executeForArgs(args []string) (output string, exit int, err error) {
 	configBlockPath := join.Flag("config-block", "Path to the file containing an up-to-date config block for the channel").Short('b').Required().String()
 
 	list := channel.Command("list", "List channel information for an Ordering Service Node (OSN). If the channelID flag is set, more detailed information will be provided for that channel.")
-	// listChannelID := list.Flag("channelID", "Channel ID").Short('c').String()
-	// Define the new info subcommand
 	info := channel.Command("info", "Get detailed information about a specific channel.")
 	infoChannelID := info.Flag("channelID", "Channel ID").Short('c').Required().String()
 

--- a/cmd/osnadmin/main_test.go
+++ b/cmd/osnadmin/main_test.go
@@ -120,20 +120,6 @@ var _ = Describe("osnadmin", func() {
 			})
 		})
 
-		It("returns an error when channelID flag is not provided", func() {
-			args := []string{
-				"channel",
-				"info",
-				"--orderer-address", ordererURL,
-				"--ca-file", ordererCACert,
-				"--client-cert", clientCert,
-				"--client-key", clientKey,
-			}
-			output, exit, err := executeForArgs(args)
-			expectedErrorMessage := "required flag(s) \"channelID\" not set"
-			checkCLIError(output, exit, err, expectedErrorMessage)
-		})
-
 		It("uses the channel participation API to list all application channels and the system channel (when it exists)", func() {
 			args := []string{
 				"channel",
@@ -222,6 +208,20 @@ var _ = Describe("osnadmin", func() {
 				Height:            987,
 			}, nil)
 		})
+
+		// It("returns an error when channelID flag is not provided", func() {
+		// 	args := []string{
+		// 		"channel",
+		// 		"info",
+		// 		"--orderer-address", ordererURL,
+		// 		"--ca-file", ordererCACert,
+		// 		"--client-cert", clientCert,
+		// 		"--client-key", clientKey,
+		// 	}
+		// 	output, exit, err := executeForArgs(args)
+		// 	expectedErrorMessage := "required flag(s) \"channelID\" not set"
+		// 	checkCLIError(output, exit, err, expectedErrorMessage)
+		// })
 
 		It("uses the channel participation API to list the details of a single channel", func() {
 			args := []string{

--- a/cmd/osnadmin/main_test.go
+++ b/cmd/osnadmin/main_test.go
@@ -209,20 +209,6 @@ var _ = Describe("osnadmin", func() {
 			}, nil)
 		})
 
-		// It("returns an error when channelID flag is not provided", func() {
-		// 	args := []string{
-		// 		"channel",
-		// 		"info",
-		// 		"--orderer-address", ordererURL,
-		// 		"--ca-file", ordererCACert,
-		// 		"--client-cert", clientCert,
-		// 		"--client-key", clientKey,
-		// 	}
-		// 	output, exit, err := executeForArgs(args)
-		// 	expectedErrorMessage := "required flag(s) \"channelID\" not set"
-		// 	checkCLIError(output, exit, err, expectedErrorMessage)
-		// })
-
 		It("uses the channel participation API to list the details of a single channel", func() {
 			args := []string{
 				"channel",

--- a/cmd/osnadmin/main_test.go
+++ b/cmd/osnadmin/main_test.go
@@ -209,20 +209,6 @@ var _ = Describe("osnadmin", func() {
 			}, nil)
 		})
 
-		It("returns an error when channelID flag is not provided", func() {
-			args := []string{
-				"channel",
-				"info",
-				"--orderer-address", ordererURL,
-				"--ca-file", ordererCACert,
-				"--client-cert", clientCert,
-				"--client-key", clientKey,
-			}
-			output, exit, err := executeForArgs(args)
-			expectedErrorMessage := "required flag(s) \"channelID\" not set"
-			checkCLIError(output, exit, err, expectedErrorMessage)
-		})
-
 		It("uses the channel participation API to list the details of a single channel", func() {
 			args := []string{
 				"channel",
@@ -311,7 +297,6 @@ var _ = Describe("osnadmin", func() {
 					checkStatusOutput(output, exit, err, 404, expectedOutput)
 				})
 			})
-
 		})
 	})
 

--- a/cmd/osnadmin/main_test.go
+++ b/cmd/osnadmin/main_test.go
@@ -209,6 +209,20 @@ var _ = Describe("osnadmin", func() {
 			}, nil)
 		})
 
+		It("returns an error when channelID flag is not provided", func() {
+			args := []string{
+				"channel",
+				"info",
+				"--orderer-address", ordererURL,
+				"--ca-file", ordererCACert,
+				"--client-cert", clientCert,
+				"--client-key", clientKey,
+			}
+			output, exit, err := executeForArgs(args)
+			expectedErrorMessage := "required flag(s) \"channelID\" not set"
+			checkCLIError(output, exit, err, expectedErrorMessage)
+		})
+
 		It("uses the channel participation API to list the details of a single channel", func() {
 			args := []string{
 				"channel",


### PR DESCRIPTION


Implemented the `osnadmin channel info` subcommand to retrieve detailed information about a specific channel from an Ordering Service Node (OSN). This involved modifying the CLI commands and adding corresponding functionality to interact with the channel participation API.

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- New feature

<!--- Describe your changes in detail, including motivation. -->
Implemented the `osnadmin channel info` subcommand to retrieve detailed information about a specific channel from an Ordering Service Node (OSN). 



<!--- Additional implementation details or comments to reviewers. -->
- Introduced `info` subcommand under `osnadmin channel` to support querying individual channel details.
- Updated existing tests and added new tests to cover the new feature and edge cases.


Closes #4890

