### PR TITLE
Disable peer.deliveryclient.blockGossipEnabled in sample core.yaml

### DIFF
--- a/core/deliverservice/testdata/core.yaml
+++ b/core/deliverservice/testdata/core.yaml
@@ -114,10 +114,12 @@ peer:
     # connection with ordering service and use delivery protocol
     # to pull ledger blocks from ordering service.
     useLeaderElection: false
-    # Statically defines peer to be an organization "leader",
-    # where this means that current peer will maintain connection
-    # with ordering service and disseminate block across peers in
-    # its own organization. Multiple peers or all peers in an organization
+    # Statically defines peer to be an organization "leader".
+    # Organization leaders maintain connection with ordering service
+    # and pulls blocks as they are created. Optionally, leader peers
+    # may disseminate pulled blocks to peers in its own organization
+    # based on the peer.deliveryclient.blockGossipEnabled setting below.
+    # Multiple peers or all peers in an organization
     # may be configured as org leaders, so that they all pull
     # blocks directly from ordering service.
     orgLeader: true
@@ -242,10 +244,10 @@ peer:
 
     # Gossip state transfer related configuration
     state:
-      # indicates whenever state transfer is enabled or not
-      # default value is false, i.e. state transfer is active
-      # and takes care to sync up missing blocks allowing
-      # lagging peer to catch up to speed with rest network.
+      # Indicates whether state transfer is enabled.
+      # State transfer enabled allows a peer that is not a leader
+      # to sync up missed blocks from other peers.
+      # Default value is false since the recommended value of peer.gossip.orgleader is true.
       # Keep in mind that when peer.gossip.useLeaderElection is true
       # and there are several peers in the organization,
       # or peer.gossip.useLeaderElection is false alongside with
@@ -369,8 +371,8 @@ peer:
 
   # Delivery service related config
   deliveryclient:
-    # Enables this peer to disseminate blocks it pulled from the ordering service
-    # via gossip.
+    # Enables this peer to disseminate blocks it pulls from the ordering service
+    # to other peers in the same organization via gossip.
     # Note that 'gossip.state.enabled' controls point to point block replication
     # of blocks committed in the past.
     blockGossipEnabled: true

--- a/docs/source/deploypeer/peerchecklist.md
+++ b/docs/source/deploypeer/peerchecklist.md
@@ -146,10 +146,12 @@ gossip:
     # to pull ledger blocks from ordering service.
     useLeaderElection: false
 
-    # Statically defines peer to be an organization "leader",
-    # where this means that current peer will maintain connection
-    # with ordering service and disseminate block across peers in
-    # its own organization. Multiple peers or all peers in an organization
+    # Statically defines peer to be an organization "leader".
+    # Organization leaders maintain connection with ordering service
+    # and pulls blocks as they are created. Optionally, leader peers
+    # may disseminate pulled blocks to peers in its own organization
+    # based on the peer.deliveryclient.blockGossipEnabled setting.
+    # Multiple peers or all peers in an organization
     # may be configured as org leaders, so that they all pull
     # blocks directly from ordering service.
     orgLeader: true
@@ -187,7 +189,7 @@ Peers leverage the Gossip data dissemination protocol to broadcast ledger and ch
 
   - **`useLeaderElection:`** (Defaults to `false` as of v2.2, which is recommended so that peers get blocks from ordering service.) When `useLeaderElection` is set to false, you must configure at least one peer to be the org leader by setting `peer.gossip.orgLeader` to true. Set `useLeaderElection` to true if you prefer that peers use Gossip for block dissemination among peers in the organization.
 
-  - **`orgLeader:`** (Defaults to `true` as of v2.2, which is recommended so that peers get blocks from ordering service.) Set this value to `false` if you want to use Gossip for block dissemination among peers in the organization.
+  - **`orgLeader:`** (Defaults to `true` as of v2.2, which is recommended so that peers get blocks from ordering service.) Set this value to `true` so that the peer retrieves blocks from the ordering service.
 
   - **`state.enabled:`** (Defaults to `false` as of v2.2 which is recommended so that peers get blocks from ordering service.) Set this value to `true` when you want to use Gossip to sync up missing blocks, which allows a lagging peer to catch up with other peers on the network.
 

--- a/docs/source/deploypeer/peerplan.md
+++ b/docs/source/deploypeer/peerplan.md
@@ -81,6 +81,7 @@ To reduce network traffic, in Fabric v2.2 the default core.yaml is configured fo
 * `peer.gossip.useLeaderElection = false`
 * `peer.gossip.orgLeader = true`
 * `peer.gossip.state.enabled = false`
+* `peer.deliveryclient.blockGossipEnabled = false`
 
 If all peers have `orgLeader=true` (recommended), then each peer will get blocks from the ordering service.
 

--- a/orderer/common/cluster/testdata/blockverification/core.yaml
+++ b/orderer/common/cluster/testdata/blockverification/core.yaml
@@ -114,10 +114,12 @@ peer:
         # connection with ordering service and use delivery protocol
         # to pull ledger blocks from ordering service.
         useLeaderElection: false
-        # Statically defines peer to be an organization "leader",
-        # where this means that current peer will maintain connection
-        # with ordering service and disseminate block across peers in
-        # its own organization. Multiple peers or all peers in an organization
+        # Statically defines peer to be an organization "leader".
+        # Organization leaders maintain connection with ordering service
+        # and pulls blocks as they are created. Optionally, leader peers
+        # may disseminate pulled blocks to peers in its own organization
+        # based on the peer.deliveryclient.blockGossipEnabled setting below.
+        # Multiple peers or all peers in an organization
         # may be configured as org leaders, so that they all pull
         # blocks directly from ordering service.
         orgLeader: true
@@ -242,10 +244,10 @@ peer:
 
         # Gossip state transfer related configuration
         state:
-            # indicates whenever state transfer is enabled or not
-            # default value is false, i.e. state transfer is active
-            # and takes care to sync up missing blocks allowing
-            # lagging peer to catch up to speed with rest network.
+            # Indicates whether state transfer is enabled.
+            # State transfer enabled allows a peer that is not a leader
+            # to sync up missed blocks from other peers.
+            # Default value is false since the recommended value of peer.gossip.orgleader is true.
             # Keep in mind that when peer.gossip.useLeaderElection is true
             # and there are several peers in the organization,
             # or peer.gossip.useLeaderElection is false alongside with
@@ -369,8 +371,8 @@ peer:
 
     # Delivery service related config
     deliveryclient:
-        # Enables this peer to disseminate blocks it pulled from the ordering service
-        # via gossip.
+        # Enables this peer to disseminate blocks it pulls from the ordering service
+        # to other peers in the same organization via gossip.
         # Note that 'gossip.state.enabled' controls point to point block replication
         # of blocks committed in the past.
         blockGossipEnabled: true

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -114,10 +114,12 @@ peer:
         # connection with ordering service and use delivery protocol
         # to pull ledger blocks from ordering service.
         useLeaderElection: false
-        # Statically defines peer to be an organization "leader",
-        # where this means that current peer will maintain connection
-        # with ordering service and disseminate block across peers in
-        # its own organization. Multiple peers or all peers in an organization
+        # Statically defines peer to be an organization "leader".
+        # Organization leaders maintain connection with ordering service
+        # and pulls blocks as they are created. Optionally, leader peers
+        # may disseminate pulled blocks to peers in its own organization
+        # based on the peer.deliveryclient.blockGossipEnabled setting below.
+        # Multiple peers or all peers in an organization
         # may be configured as org leaders, so that they all pull
         # blocks directly from ordering service.
         orgLeader: true
@@ -242,10 +244,10 @@ peer:
 
         # Gossip state transfer related configuration
         state:
-            # indicates whenever state transfer is enabled or not
-            # default value is false, i.e. state transfer is active
-            # and takes care to sync up missing blocks allowing
-            # lagging peer to catch up to speed with rest network.
+            # Indicates whether state transfer is enabled.
+            # State transfer enabled allows a peer that is not a leader
+            # to sync up missed blocks from other peers.
+            # Default value is false since the recommended value of peer.gossip.orgleader is true.
             # Keep in mind that when peer.gossip.useLeaderElection is true
             # and there are several peers in the organization,
             # or peer.gossip.useLeaderElection is false alongside with
@@ -369,11 +371,11 @@ peer:
 
     # Delivery service related config
     deliveryclient:
-        # Enables this peer to disseminate blocks it pulled from the ordering service
-        # via gossip.
+        # Enables this peer to disseminate blocks it pulls from the ordering service
+        # to other peers in the same organization via gossip.
         # Note that 'gossip.state.enabled' controls point to point block replication
         # of blocks committed in the past.
-        blockGossipEnabled: true
+        blockGossipEnabled: false
         # It sets the total time the delivery service may spend in reconnection
         # attempts until its retry logic gives up and returns an error,
         # ignored if peer is a static leader


### PR DESCRIPTION
Since v2.2 it has been recommended to configure all peers to be orgLeaders so that they pull blocks from ordering service.

In v2.4 peer.deliveryclient.blockGossipEnabled was added and recommended to be set to false so that peers don't gossip pulled blocks.

These settings simplify peer behavior and reduce communication between peers (at the expense of more connections to ordering service).

Finally in v3.0 peer.deliveryclient.blockGossipEnabled is set to false by default.

This change also updates core.yaml and documentation to make these recommendations clear and consistent.

Closes https://github.com/hyperledger/fabric/issues/3961