### PR TITLE
Clarify peer timewindow property.

### DIFF
--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -310,7 +310,8 @@ peer:
     # client messages
     authentication:
         # the acceptable difference between the current server time and the
-        # client's time as specified in a client request message
+        # client's time as specified in a client request message.
+        # timewindow is checked on requests to the delivery service only.
         timewindow: 15m
 
     # Path on the file system where peer will store data (eg ledger). This

--- a/sampleconfig/orderer.yaml
+++ b/sampleconfig/orderer.yaml
@@ -162,7 +162,8 @@ General:
     # client messages
     Authentication:
         # the acceptable difference between the current server time and the
-        # client's time as specified in a client request message
+        # client's time as specified in a client request message.
+        # TimeWindow is checked on requests to the delivery service only.
         TimeWindow: 15m
 
 


### PR DESCRIPTION
Clarify that timewindow is only used for delivery service in release-2.5.