### PR TITLE
Documentation - Remove references to v1.x legacy lifecycle

### DIFF
--- a/docs/source/cc_launcher.md
+++ b/docs/source/cc_launcher.md
@@ -202,7 +202,7 @@ If you do not need to fallback to the legacy Docker build process for your chain
 
 ## Chaincode packages
 
-As part of the new lifecycle introduced with Fabric 2.0, the chaincode package format changed from serialized protocol buffer messages to a gzip compressed POSIX tape archive. Chaincode packages created with `peer lifecycle chaincode package` use this new format.
+A chaincode package contains chaincode and associated metadata in a compressed gzip file that can be installed to a peer. The peer command `peer lifecycle chaincode package` can be used to create a chaincode package. You can also create a chaincode package using third party tools.
 
 ### Lifecycle chaincode package contents
 

--- a/docs/source/chaincode_lifecycle.md
+++ b/docs/source/chaincode_lifecycle.md
@@ -29,15 +29,6 @@ A network operator would use the Fabric lifecycle to perform the following tasks
 - [Install and define a chaincode](#install-and-define-a-chaincode)
 - [Upgrade a chaincode](#upgrade-a-chaincode)
 - [Deployment Scenarios](#deployment-scenarios)
-- [Migrate to the new Fabric lifecycle](#migrate-to-the-new-fabric-lifecycle)
-
-You can use the Fabric chaincode lifecycle by creating a new channel and setting
-the channel capabilities to V2_0. You will not be able to use the old lifecycle
-to install, instantiate, or update a chaincode on channels with V2_0 capabilities
-enabled. However, you can still invoke chaincode installed using the previous
-lifecycle model after you enable V2_0 capabilities. If you are upgrading from a
-v1.4.x network and need to edit your channel configurations to enable the new
-lifecycle, check out [Enabling the new chaincode lifecycle](./enable_cc_lifecycle.html).
 
 ## Install and define a chaincode
 
@@ -476,15 +467,9 @@ different chaincode definitions. As a result, both peers have two chaincode
 containers running on their peers. MYCC1 has an endorsement policy of 1 out of 2,
 while MYCC2 has an endorsement policy of 2 out of 2.*
 
-## Migrate to the v2.x Fabric lifecycle
-
-For information about migrating to the new lifecycle, check out [Considerations for getting to v2.0](./upgrade_to_newest_version.html#chaincode-lifecycle).
-
-If you need to update your channel configurations to enable the new lifecycle, check out [Enabling the new chaincode lifecycle](./enable_cc_lifecycle.html).
-
 ## More information
 
-You can watch video below to learn more about the motivation of the new Fabric chaincode lifecycle and how it is implemented.
+You can watch video below to learn more about the motivation of the Fabric chaincode lifecycle and how it is implemented.
 
 <iframe class="embed-responsive-item" id="youtubeplayer2" title="Starter Plan videos" type="text/html" width="560" height="315" src="https://www.youtube.com/embed/XvEMDScFU2M" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen> </iframe>
 

--- a/docs/source/channel_update_tutorial.rst
+++ b/docs/source/channel_update_tutorial.rst
@@ -537,11 +537,6 @@ a chaincode on the channel. If the existing channel members have already committ
 a chaincode definition to the channel, a new organization can start using the
 chaincode by approving the chaincode definition.
 
-.. note:: These instructions use the Fabric chaincode lifecycle introduced in
-          the v2.0 release. If you would like to use the previous lifecycle to
-          install and instantiate a chaincode, visit the v1.4 version of the
-          `Adding an org to a channel tutorial <https://hyperledger-fabric.readthedocs.io/en/release-1.4/channel_update_tutorial.html>`__.
-
 Before we install a chaincode as Org3, we can use the ``./network.sh`` script to
 deploy the Basic chaincode on the channel. Open a new terminal and navigate to the ``test-network`` directory. You can then use
 the ``test-network`` script to deploy the Basic chaincode:

--- a/docs/source/commands/peerchaincode.md
+++ b/docs/source/commands/peerchaincode.md
@@ -5,34 +5,20 @@
 
 # peer chaincode
 
-The `peer chaincode` command allows administrators to perform chaincode
-related operations on a peer, such as installing, instantiating, invoking,
-packaging, querying, and upgrading chaincode.
+The `peer chaincode` command allows users to invoke and query chaincode.
 
 ## Syntax
 
 The `peer chaincode` command has the following subcommands:
 
-  * install
-  * instantiate
   * invoke
-  * list
-  * package
   * query
-  * signpackage
-  * upgrade
 
-The different subcommand options (install, instantiate...) relate to the
-different chaincode operations that are relevant to a peer. For example, use the
-`peer chaincode install` subcommand option to install a chaincode on a peer, or
-the `peer chaincode query` subcommand option to query a chaincode for the
-current value on a peer's ledger.
+The subcommands take a constructor flag (`-c` or `--ctor`) to pass arguments to a chaincode.
+The value must be a JSON string that has either key 'Args' or 'Function' and 'Args'.
+These keys are case-insensitive.
 
-Some subcommands take flag `--ctor`, of which the value must be a JSON string
-that has either key 'Args' or 'Function' and 'Args'. These keys are
-case-insensitive.
-
-If the JSON string only has the Args key, the key value is an array, where the
+If the constructor JSON string only has the Args key, the key value is an array, where the
 first array element is the target function to call, and the subsequent elements
 are arguments of the function. If the JSON string has both 'Function' and
 'Args', the value of Function is the target function to call, and the value of
@@ -155,37 +141,6 @@ Global Flags:
 
 ## Example Usage
 
-### peer chaincode instantiate examples
-
-Here are some examples of the `peer chaincode instantiate` command, which
-instantiates the chaincode named `mycc` at version `1.0` on channel
-`mychannel`:
-
-  * Using the `--tls` and `--cafile` global flags to instantiate the chaincode
-    in a network with TLS enabled:
-
-    ```
-    export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    peer chaincode instantiate -o orderer.example.com:7050 --tls --cafile $ORDERER_CA -C mychannel -n mycc -v 1.0 -c '{"Args":["init","a","100","b","200"]}' -P "AND ('Org1MSP.peer','Org2MSP.peer')"
-
-    2018-02-22 16:33:53.324 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 001 Using default escc
-    2018-02-22 16:33:53.324 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 002 Using default vscc
-    2018-02-22 16:34:08.698 UTC [main] main -> INFO 003 Exiting.....
-
-    ```
-
-  * Using only the command-specific options to instantiate the chaincode in a
-    network with TLS disabled:
-
-    ```
-    peer chaincode instantiate -o orderer.example.com:7050 -C mychannel -n mycc -v 1.0 -c '{"Args":["init","a","100","b","200"]}' -P "AND ('Org1MSP.peer','Org2MSP.peer')"
-
-
-    2018-02-22 16:34:09.324 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 001 Using default escc
-    2018-02-22 16:34:09.324 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 002 Using default vscc
-    2018-02-22 16:34:24.698 UTC [main] main -> INFO 003 Exiting.....
-    ```
-
 ### peer chaincode invoke example
 
 Here is an example of the `peer chaincode invoke` command:
@@ -232,61 +187,6 @@ Here is an example of how to format the `peer chaincode invoke` command when the
 
     ```
 
-
-### peer chaincode list example
-
-Here are some examples of the `peer chaincode list ` command:
-
-  * Using the `--installed` flag to list the chaincodes installed on a peer.
-
-    ```
-    peer chaincode list --installed
-
-    Get installed chaincodes on peer:
-    Name: mycc, Version: 1.0, Path: github.com/hyperledger/fabric-samples/chaincode/abstore/go, Id: 8cc2730fdafd0b28ef734eac12b29df5fc98ad98bdb1b7e0ef96265c3d893d61
-    2018-02-22 17:07:13.476 UTC [main] main -> INFO 001 Exiting.....
-    ```
-
-    You can see that the peer has installed a chaincode called `mycc` which is at
-    version `1.0`.
-
-  * Using the `--instantiated` in combination with the `-C` (channel ID) flag to
-    list the chaincodes instantiated on a channel.
-
-    ```
-    peer chaincode list --instantiated -C mychannel
-
-    Get instantiated chaincodes on channel mychannel:
-    Name: mycc, Version: 1.0, Path: github.com/hyperledger/fabric-samples/chaincode/abstore/go, Escc: escc, Vscc: vscc
-    2018-02-22 17:07:42.969 UTC [main] main -> INFO 001 Exiting.....
-
-    ```
-
-    You can see that chaincode `mycc` at version `1.0` is instantiated on
-    channel `mychannel`.
-
-### peer chaincode package example
-
-Here is an example of the `peer chaincode package` command, which
-packages the chaincode named `mycc` at version `1.1`, creates the chaincode
-deployment spec, signs the package using the local MSP, and outputs it as
-`ccpack.out`:
-
-  ```
-    peer chaincode package ccpack.out -n mycc -p github.com/hyperledger/fabric-samples/chaincode/abstore/go -v 1.1 -s -S
-    .
-    .
-    .
-    2018-02-22 17:27:01.404 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 003 Using default escc
-    2018-02-22 17:27:01.405 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 004 Using default vscc
-    .
-    .
-    .
-    2018-02-22 17:27:01.879 UTC [chaincodeCmd] chaincodePackage -> DEBU 011 Packaged chaincode into deployment spec of size <3426>, with args = [ccpack.out]
-    2018-02-22 17:27:01.879 UTC [main] main -> INFO 012 Exiting.....
-
-    ```
-
 ### peer chaincode query example
 
 Here is an example of the `peer chaincode query` command, which queries the
@@ -303,73 +203,6 @@ variable `a`:
     2018-02-22 16:34:30.816 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 002 Using default vscc
     Query Result: 90
 
-    ```
-
-### peer chaincode signpackage example
-
-Here is an example of the `peer chaincode signpackage` command, which accepts an
-existing signed  package and creates a new one with signature of the local MSP
-appended to it.
-
-  ```
-  peer chaincode signpackage ccwith1sig.pak ccwith2sig.pak
-  Wrote signed package to ccwith2sig.pak successfully
-  2018-02-24 19:32:47.189 EST [main] main -> INFO 002 Exiting.....
-  ```
-
-### peer chaincode upgrade example
-
-Here is an example of the `peer chaincode upgrade` command, which
-upgrades the chaincode named `mycc` at version `1.1` on channel
-`mychannel` to version `1.2`, which contains a new variable `c`:
-
-  * Using the `--tls` and `--cafile` global flags to upgrade the chaincode
-    in a network with TLS enabled:
-
-    ```
-    export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    peer chaincode upgrade -o orderer.example.com:7050 --tls --cafile $ORDERER_CA -C mychannel -n mycc -v 1.2 -c '{"Args":["init","a","100","b","200","c","300"]}' -P "AND ('Org1MSP.peer','Org2MSP.peer')"
-    .
-    .
-    .
-    2018-02-22 18:26:31.433 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 003 Using default escc
-    2018-02-22 18:26:31.434 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 004 Using default vscc
-    2018-02-22 18:26:31.435 UTC [chaincodeCmd] getChaincodeSpec -> DEBU 005 java chaincode enabled
-    2018-02-22 18:26:31.435 UTC [chaincodeCmd] upgrade -> DEBU 006 Get upgrade proposal for chaincode <name:"mycc" version:"1.1" >
-    .
-    .
-    .
-    2018-02-22 18:26:46.687 UTC [chaincodeCmd] upgrade -> DEBU 009 endorse upgrade proposal, get response <status:200 message:"OK" payload:"\n\004mycc\022\0031.1\032\004escc\"\004vscc*,\022\014\022\n\010\001\022\002\010\000\022\002\010\001\032\r\022\013\n\007Org1MSP\020\003\032\r\022\013\n\007Org2MSP\020\0032f\n \261g(^v\021\220\240\332\251\014\204V\210P\310o\231\271\036\301\022\032\205fC[|=\215\372\223\022 \311b\025?\323N\343\325\032\005\365\236\001XKj\004E\351\007\247\265fu\305j\367\331\275\253\307R\032 \014H#\014\272!#\345\306s\323\371\350\364\006.\000\356\230\353\270\263\215\217\303\256\220i^\277\305\214: \375\200zY\275\203}\375\244\205\035\340\226]l!uE\334\273\214\214\020\303\3474\360\014\234-\006\315B\031\022\010\022\006\010\001\022\002\010\000\032\r\022\013\n\007Org1MSP\020\001" >
-    .
-    .
-    .
-    2018-02-22 18:26:46.693 UTC [chaincodeCmd] upgrade -> DEBU 00c Get Signed envelope
-    2018-02-22 18:26:46.693 UTC [chaincodeCmd] chaincodeUpgrade -> DEBU 00d Send signed envelope to orderer
-    2018-02-22 18:26:46.908 UTC [main] main -> INFO 00e Exiting.....
-    ```
-
-  * Using only the command-specific options to upgrade the chaincode in a
-    network with TLS disabled:
-
-    ```
-    peer chaincode upgrade -o orderer.example.com:7050 -C mychannel -n mycc -v 1.2 -c '{"Args":["init","a","100","b","200","c","300"]}' -P "AND ('Org1MSP.peer','Org2MSP.peer')"
-    .
-    .
-    .
-    2018-02-22 18:28:31.433 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 003 Using default escc
-    2018-02-22 18:28:31.434 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 004 Using default vscc
-    2018-02-22 18:28:31.435 UTC [chaincodeCmd] getChaincodeSpec -> DEBU 005 java chaincode enabled
-    2018-02-22 18:28:31.435 UTC [chaincodeCmd] upgrade -> DEBU 006 Get upgrade proposal for chaincode <name:"mycc" version:"1.1" >
-    .
-    .
-    .
-    2018-02-22 18:28:46.687 UTC [chaincodeCmd] upgrade -> DEBU 009 endorse upgrade proposal, get response <status:200 message:"OK" payload:"\n\004mycc\022\0031.1\032\004escc\"\004vscc*,\022\014\022\n\010\001\022\002\010\000\022\002\010\001\032\r\022\013\n\007Org1MSP\020\003\032\r\022\013\n\007Org2MSP\020\0032f\n \261g(^v\021\220\240\332\251\014\204V\210P\310o\231\271\036\301\022\032\205fC[|=\215\372\223\022 \311b\025?\323N\343\325\032\005\365\236\001XKj\004E\351\007\247\265fu\305j\367\331\275\253\307R\032 \014H#\014\272!#\345\306s\323\371\350\364\006.\000\356\230\353\270\263\215\217\303\256\220i^\277\305\214: \375\200zY\275\203}\375\244\205\035\340\226]l!uE\334\273\214\214\020\303\3474\360\014\234-\006\315B\031\022\010\022\006\010\001\022\002\010\000\032\r\022\013\n\007Org1MSP\020\001" >
-    .
-    .
-    .
-    2018-02-22 18:28:46.693 UTC [chaincodeCmd] upgrade -> DEBU 00c Get Signed envelope
-    2018-02-22 18:28:46.693 UTC [chaincodeCmd] chaincodeUpgrade -> DEBU 00d Send signed envelope to orderer
-    2018-02-22 18:28:46.908 UTC [main] main -> INFO 00e Exiting.....
     ```
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -12,11 +12,6 @@ definition to a channel. The chaincode is ready to be used after the definition
 has been successfully committed to the channel. For more information, visit
 [Fabric chaincode lifecycle](../chaincode_lifecycle.html).
 
-*Note: These instructions use the Fabric chaincode lifecycle introduced in the
-v2.0 release. If you would like to use the old lifecycle to install and
-instantiate a chaincode, visit the [peer chaincode](peerchaincode.html) command
-reference.*
-
 ## Syntax
 
 The `peer lifecycle chaincode` command has the following subcommands:

--- a/docs/source/deploy_chaincode.md
+++ b/docs/source/deploy_chaincode.md
@@ -6,8 +6,6 @@ A chaincode is deployed to a channel using a process known as the Fabric chainco
 
 You can use this tutorial to learn how to use the [peer lifecycle chaincode commands](./commands/peerlifecycle.html) to deploy a chaincode to a channel of the Fabric test network. Once you have an understanding of the commands, you can use the steps in this tutorial to deploy your own chaincode to the test network, or to deploy chaincode to a production network. In this tutorial, you will deploy the asset-transfer (basic) chaincode that is used by the [Running a Fabric Application tutorial](./write_first_app.html).
 
-**Note:** These instructions use the Fabric chaincode lifecycle introduced in the v2.0 release. If you would like to use the previous lifecycle to install and instantiate a chaincode, visit the [v1.4 version of the Fabric documentation](https://hyperledger-fabric.readthedocs.io/en/release-1.4).
-
 ## Start the network
 
 We will start by deploying an instance of the Fabric test network. Before you begin, make sure that you have installed the necessary software by following the instructions on [getting_started](getting_started.html). Use the following command to navigate to the test network directory within your local clone of the `fabric-samples` repository:
@@ -777,7 +775,7 @@ CONTAINER ID        IMAGE                               COMMAND             CREA
 
 If you do not see any chaincode containers listed, use the `peer lifecycle chaincode approveformyorg` command approve a chaincode definition with the correct package ID.
 
-## Endorsement policy failure
+### Endorsement policy failure
 
 **Problem:** When I try to commit the chaincode definition to the channel, the transaction fails with the following error:
 
@@ -786,7 +784,7 @@ If you do not see any chaincode containers listed, use the `peer lifecycle chain
 Error: transaction invalidated with status (ENDORSEMENT_POLICY_FAILURE)
 ```
 
-**Solution:** This error is a result of the commit transaction not gathering enough endorsements to meet the Lifecycle endorsement policy. This problem could be a result of your transaction not targeting a sufficient number of peers to meet the policy. This could also be the result of some of the peer organizations not including the `Endorsement:` signature policy referenced by the default `/Channel/Application/Endorsement` policy in their `configtx.yaml` file:
+**Solution:** This error is a result of the commit transaction not gathering enough endorsements to meet the Lifecycle endorsement policy. This problem could be a result of your transaction not targeting a sufficient number of peers to meet the policy. This could also be the result of some of the peer organizations not including the `Endorsement:` signature policy referenced by the default `/Channel/Application/Endorsement` policy in the channel configuration:
 
 ```
 Readers:
@@ -803,7 +801,7 @@ Endorsement:
 		Rule: "OR('Org2MSP.peer')"
 ```
 
-When you [enable the Fabric chaincode lifecycle](enable_cc_lifecycle.html), you also need to use the new Fabric 2.0 channel policies in addition to upgrading your channel to the `V2_0` capability. Your channel needs to include the new `/Channel/Application/LifecycleEndorsement` and `/Channel/Application/Endorsement` policies:
+Finally, ensure your channel defines the `/Channel/Application/LifecycleEndorsement` and `/Channel/Application/Endorsement` policies:
 
 ```
 Policies:
@@ -824,7 +822,7 @@ Policies:
 				Rule: "MAJORITY Endorsement"
 ```
 
-If you do not include the new channel policies in the channel configuration, you will get the following error when you approve a chaincode definition for your organization:
+If you do not include the channel policies in the channel configuration, you will get the following error when you approve a chaincode definition for your organization:
 
 ```
 Error: proposal failed with status: 500 - failed to invoke backing implementation of 'ApproveChaincodeDefinitionForMyOrg': could not set defaults for chaincode definition in channel mychannel: policy '/Channel/Application/Endorsement' must be defined for channel 'mychannel' before chaincode operations can be attempted

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -289,32 +289,10 @@ issues PKI-based certificates to network member organizations and their users.
 The CA issues one root certificate (rootCert) to each member and one enrollment
 certificate (ECert) to each authorized user.
 
-.. _Init:
-
-Init
-----
-
-A method to initialize a chaincode application. All chaincodes need to have an
-an Init function. By default, this function is never executed. However you can
-use the chaincode definition to request the execution of the Init function in
-order to initialize the chaincode.
-
 Install
 -------
 
 The process of placing a chaincode on a peer's file system.
-
-Instantiate
------------
-
-The process of starting and initializing a chaincode application on a specific
-channel. After instantiation, peers that have the chaincode installed can accept
-chaincode invocations.
-
-**NOTE**: *This method i.e. Instantiate was used in the 1.4.x and older versions of the chaincode
-lifecycle. For the current procedure used to start a chaincode on a channel with
-the new Fabric chaincode lifecycle introduced as part of Fabric v2.0,
-see Chaincode-definition_.*
 
 .. _Invoke:
 
@@ -501,7 +479,7 @@ example: ``OR('Org1.peer', 'Org2.peer')``. They are used to restrict access to
 resources on a blockchain network. For instance, they dictate who can read from
 or write to a channel, or who can use a specific chaincode API via an ACL_.
 Policies may be defined in ``configtx.yaml`` prior to bootstrapping an ordering
-service or creating a channel, or they can be specified when instantiating
+service or creating a channel, or they can be specified when deploying
 chaincode on a channel. A default set of policies ship in the sample
 ``configtx.yaml`` which will be appropriate for most networks.
 

--- a/docs/source/peers/peers.md
+++ b/docs/source/peers/peers.md
@@ -83,7 +83,7 @@ configuration of the Fabric network.
 
 ### Multiple Chaincodes
 
-A chaincode is instantiated on a single channel. Each channel (and ledger) can
+A chaincode is deployed on a single channel. Each channel (and ledger) can
 have multiple chaincodes that interact with it.
 
 ![Peer4](./peers.diagram.4.png)

--- a/docs/source/policies/policies.md
+++ b/docs/source/policies/policies.md
@@ -300,15 +300,7 @@ Application: &ApplicationDefaults
 
 ## Fabric chaincode lifecycle
 
-In the Fabric 2.0 release, a new chaincode lifecycle process was introduced,
-whereby a more democratic process is used to govern chaincode on the network.
-The new process allows multiple organizations to vote on how a chaincode will
-be operated before it can be used on a channel. This is significant because it is
-the combination of this new lifecycle process and the policies that are
-specified during that process that dictate the security across the network. More details on
-the flow are available in the [Fabric chaincode lifecycle](../chaincode_lifecycle.html)
-concept topic, but for purposes of this topic you should understand how policies are
-used in this flow. The new flow includes two steps where policies are specified:
+The [Fabric chaincode lifecycle](../chaincode_lifecycle.html) utilizes policies
 when chaincode is **approved** by organization members, and when it is **committed**
 to the channel.
 
@@ -403,20 +395,6 @@ keys.
 
 For a deeper dive on how to write an endorsement policy refer to the topic on
 [Endorsement policies](../endorsement-policies.html) in the Operations Guide.
-
-**Note:**  Policies work differently depending on which version of Fabric you are
-  using:
-- In Fabric releases prior to 2.0, chaincode endorsement policies can be
-  updated during chaincode instantiation or by using the chaincode lifecycle
-  commands. If not specified at instantiation time, the endorsement policy
-  defaults to “any member of the organizations in the channel”. For example,
-  a channel with “Org1” and “Org2” would have a default endorsement policy of
-  “OR(‘Org1.member’, ‘Org2.member’)”.
-- Starting with Fabric 2.0, Fabric introduced a new chaincode
-  lifecycle process that allows multiple organizations to agree on how a
-  chaincode will be operated before it can be used on a channel.  The new process
-  requires that organizations agree to the parameters that define a chaincode,
-  such as name, version, and the chaincode endorsement policy.
 
 ## Overriding policy definitions
 

--- a/docs/source/private_data_tutorial.rst
+++ b/docs/source/private_data_tutorial.rst
@@ -975,8 +975,8 @@ alongside the chaincode. An example index is available `here <https://github.com
 For deployment of chaincode to production environments, it is recommended
 to define any indexes alongside chaincode so that the chaincode and supporting
 indexes are deployed automatically as a unit, once the chaincode has been
-installed on a peer and instantiated on a channel. The associated indexes are
-automatically deployed upon chaincode instantiation on the channel when
+installed on a peer and deployed on a channel. The associated indexes are
+automatically created upon chaincode deployment on the channel when
 the  ``--collections-config`` flag is specified pointing to the location of
 the collection JSON file.
 

--- a/docs/source/smartcontract/smartcontract.md
+++ b/docs/source/smartcontract/smartcontract.md
@@ -305,11 +305,6 @@ abbreviations:
   the committing of chaincode definitions to channels. You can read more about
   how `_lifecycle` implements the Fabric chaincode lifecycle [process](../chaincode_lifecycle.html).
 
-* Lifecycle system chaincode (LSCC) manages the chaincode lifecycle for the
-  1.x releases of Fabric. This version of lifecycle required that chaincode be
-  instantiated or upgraded on channels. You can still use LSCC to manage your
-  chaincode if you have the channel application capability set to V1_4_x or below.
-
 * **Configuration system chaincode (CSCC)** runs in all peers to handle changes to a
   channel configuration, such as a policy update.  You can read more about this
   process in the following chaincode

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -26,8 +26,6 @@ tutorials:
 2. :doc:`upgrading_your_components`. Components should be upgraded to the latest
    version before updating any capabilities.
 3. :doc:`updating_capabilities`. Completed after updating the versions of all nodes.
-4. :doc:`enable_cc_lifecycle`. Necessary to add organization specific endorsement
-   policies central to the new chaincode lifecycle for Fabric v2.x.
 
 As the upgrading of nodes and increasing the capability levels of channels is by
 now considered a standard Fabric process, we will not show the specific commands

--- a/docs/wrappers/peer_chaincode_postscript.md
+++ b/docs/wrappers/peer_chaincode_postscript.md
@@ -1,36 +1,5 @@
 ## Example Usage
 
-### peer chaincode instantiate examples
-
-Here are some examples of the `peer chaincode instantiate` command, which
-instantiates the chaincode named `mycc` at version `1.0` on channel
-`mychannel`:
-
-  * Using the `--tls` and `--cafile` global flags to instantiate the chaincode
-    in a network with TLS enabled:
-
-    ```
-    export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    peer chaincode instantiate -o orderer.example.com:7050 --tls --cafile $ORDERER_CA -C mychannel -n mycc -v 1.0 -c '{"Args":["init","a","100","b","200"]}' -P "AND ('Org1MSP.peer','Org2MSP.peer')"
-
-    2018-02-22 16:33:53.324 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 001 Using default escc
-    2018-02-22 16:33:53.324 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 002 Using default vscc
-    2018-02-22 16:34:08.698 UTC [main] main -> INFO 003 Exiting.....
-
-    ```
-
-  * Using only the command-specific options to instantiate the chaincode in a
-    network with TLS disabled:
-
-    ```
-    peer chaincode instantiate -o orderer.example.com:7050 -C mychannel -n mycc -v 1.0 -c '{"Args":["init","a","100","b","200"]}' -P "AND ('Org1MSP.peer','Org2MSP.peer')"
-
-
-    2018-02-22 16:34:09.324 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 001 Using default escc
-    2018-02-22 16:34:09.324 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 002 Using default vscc
-    2018-02-22 16:34:24.698 UTC [main] main -> INFO 003 Exiting.....
-    ```
-
 ### peer chaincode invoke example
 
 Here is an example of the `peer chaincode invoke` command:
@@ -77,61 +46,6 @@ Here is an example of how to format the `peer chaincode invoke` command when the
 
     ```
 
-
-### peer chaincode list example
-
-Here are some examples of the `peer chaincode list ` command:
-
-  * Using the `--installed` flag to list the chaincodes installed on a peer.
-
-    ```
-    peer chaincode list --installed
-
-    Get installed chaincodes on peer:
-    Name: mycc, Version: 1.0, Path: github.com/hyperledger/fabric-samples/chaincode/abstore/go, Id: 8cc2730fdafd0b28ef734eac12b29df5fc98ad98bdb1b7e0ef96265c3d893d61
-    2018-02-22 17:07:13.476 UTC [main] main -> INFO 001 Exiting.....
-    ```
-
-    You can see that the peer has installed a chaincode called `mycc` which is at
-    version `1.0`.
-
-  * Using the `--instantiated` in combination with the `-C` (channel ID) flag to
-    list the chaincodes instantiated on a channel.
-
-    ```
-    peer chaincode list --instantiated -C mychannel
-
-    Get instantiated chaincodes on channel mychannel:
-    Name: mycc, Version: 1.0, Path: github.com/hyperledger/fabric-samples/chaincode/abstore/go, Escc: escc, Vscc: vscc
-    2018-02-22 17:07:42.969 UTC [main] main -> INFO 001 Exiting.....
-
-    ```
-
-    You can see that chaincode `mycc` at version `1.0` is instantiated on
-    channel `mychannel`.
-
-### peer chaincode package example
-
-Here is an example of the `peer chaincode package` command, which
-packages the chaincode named `mycc` at version `1.1`, creates the chaincode
-deployment spec, signs the package using the local MSP, and outputs it as
-`ccpack.out`:
-
-  ```
-    peer chaincode package ccpack.out -n mycc -p github.com/hyperledger/fabric-samples/chaincode/abstore/go -v 1.1 -s -S
-    .
-    .
-    .
-    2018-02-22 17:27:01.404 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 003 Using default escc
-    2018-02-22 17:27:01.405 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 004 Using default vscc
-    .
-    .
-    .
-    2018-02-22 17:27:01.879 UTC [chaincodeCmd] chaincodePackage -> DEBU 011 Packaged chaincode into deployment spec of size <3426>, with args = [ccpack.out]
-    2018-02-22 17:27:01.879 UTC [main] main -> INFO 012 Exiting.....
-
-    ```
-
 ### peer chaincode query example
 
 Here is an example of the `peer chaincode query` command, which queries the
@@ -148,73 +62,6 @@ variable `a`:
     2018-02-22 16:34:30.816 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 002 Using default vscc
     Query Result: 90
 
-    ```
-
-### peer chaincode signpackage example
-
-Here is an example of the `peer chaincode signpackage` command, which accepts an
-existing signed  package and creates a new one with signature of the local MSP
-appended to it.
-
-  ```
-  peer chaincode signpackage ccwith1sig.pak ccwith2sig.pak
-  Wrote signed package to ccwith2sig.pak successfully
-  2018-02-24 19:32:47.189 EST [main] main -> INFO 002 Exiting.....
-  ```
-
-### peer chaincode upgrade example
-
-Here is an example of the `peer chaincode upgrade` command, which
-upgrades the chaincode named `mycc` at version `1.1` on channel
-`mychannel` to version `1.2`, which contains a new variable `c`:
-
-  * Using the `--tls` and `--cafile` global flags to upgrade the chaincode
-    in a network with TLS enabled:
-
-    ```
-    export ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-    peer chaincode upgrade -o orderer.example.com:7050 --tls --cafile $ORDERER_CA -C mychannel -n mycc -v 1.2 -c '{"Args":["init","a","100","b","200","c","300"]}' -P "AND ('Org1MSP.peer','Org2MSP.peer')"
-    .
-    .
-    .
-    2018-02-22 18:26:31.433 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 003 Using default escc
-    2018-02-22 18:26:31.434 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 004 Using default vscc
-    2018-02-22 18:26:31.435 UTC [chaincodeCmd] getChaincodeSpec -> DEBU 005 java chaincode enabled
-    2018-02-22 18:26:31.435 UTC [chaincodeCmd] upgrade -> DEBU 006 Get upgrade proposal for chaincode <name:"mycc" version:"1.1" >
-    .
-    .
-    .
-    2018-02-22 18:26:46.687 UTC [chaincodeCmd] upgrade -> DEBU 009 endorse upgrade proposal, get response <status:200 message:"OK" payload:"\n\004mycc\022\0031.1\032\004escc\"\004vscc*,\022\014\022\n\010\001\022\002\010\000\022\002\010\001\032\r\022\013\n\007Org1MSP\020\003\032\r\022\013\n\007Org2MSP\020\0032f\n \261g(^v\021\220\240\332\251\014\204V\210P\310o\231\271\036\301\022\032\205fC[|=\215\372\223\022 \311b\025?\323N\343\325\032\005\365\236\001XKj\004E\351\007\247\265fu\305j\367\331\275\253\307R\032 \014H#\014\272!#\345\306s\323\371\350\364\006.\000\356\230\353\270\263\215\217\303\256\220i^\277\305\214: \375\200zY\275\203}\375\244\205\035\340\226]l!uE\334\273\214\214\020\303\3474\360\014\234-\006\315B\031\022\010\022\006\010\001\022\002\010\000\032\r\022\013\n\007Org1MSP\020\001" >
-    .
-    .
-    .
-    2018-02-22 18:26:46.693 UTC [chaincodeCmd] upgrade -> DEBU 00c Get Signed envelope
-    2018-02-22 18:26:46.693 UTC [chaincodeCmd] chaincodeUpgrade -> DEBU 00d Send signed envelope to orderer
-    2018-02-22 18:26:46.908 UTC [main] main -> INFO 00e Exiting.....
-    ```
-
-  * Using only the command-specific options to upgrade the chaincode in a
-    network with TLS disabled:
-
-    ```
-    peer chaincode upgrade -o orderer.example.com:7050 -C mychannel -n mycc -v 1.2 -c '{"Args":["init","a","100","b","200","c","300"]}' -P "AND ('Org1MSP.peer','Org2MSP.peer')"
-    .
-    .
-    .
-    2018-02-22 18:28:31.433 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 003 Using default escc
-    2018-02-22 18:28:31.434 UTC [chaincodeCmd] checkChaincodeCmdParams -> INFO 004 Using default vscc
-    2018-02-22 18:28:31.435 UTC [chaincodeCmd] getChaincodeSpec -> DEBU 005 java chaincode enabled
-    2018-02-22 18:28:31.435 UTC [chaincodeCmd] upgrade -> DEBU 006 Get upgrade proposal for chaincode <name:"mycc" version:"1.1" >
-    .
-    .
-    .
-    2018-02-22 18:28:46.687 UTC [chaincodeCmd] upgrade -> DEBU 009 endorse upgrade proposal, get response <status:200 message:"OK" payload:"\n\004mycc\022\0031.1\032\004escc\"\004vscc*,\022\014\022\n\010\001\022\002\010\000\022\002\010\001\032\r\022\013\n\007Org1MSP\020\003\032\r\022\013\n\007Org2MSP\020\0032f\n \261g(^v\021\220\240\332\251\014\204V\210P\310o\231\271\036\301\022\032\205fC[|=\215\372\223\022 \311b\025?\323N\343\325\032\005\365\236\001XKj\004E\351\007\247\265fu\305j\367\331\275\253\307R\032 \014H#\014\272!#\345\306s\323\371\350\364\006.\000\356\230\353\270\263\215\217\303\256\220i^\277\305\214: \375\200zY\275\203}\375\244\205\035\340\226]l!uE\334\273\214\214\020\303\3474\360\014\234-\006\315B\031\022\010\022\006\010\001\022\002\010\000\032\r\022\013\n\007Org1MSP\020\001" >
-    .
-    .
-    .
-    2018-02-22 18:28:46.693 UTC [chaincodeCmd] upgrade -> DEBU 00c Get Signed envelope
-    2018-02-22 18:28:46.693 UTC [chaincodeCmd] chaincodeUpgrade -> DEBU 00d Send signed envelope to orderer
-    2018-02-22 18:28:46.908 UTC [main] main -> INFO 00e Exiting.....
     ```
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/docs/wrappers/peer_chaincode_preamble.md
+++ b/docs/wrappers/peer_chaincode_preamble.md
@@ -1,33 +1,19 @@
 # peer chaincode
 
-The `peer chaincode` command allows administrators to perform chaincode
-related operations on a peer, such as installing, instantiating, invoking,
-packaging, querying, and upgrading chaincode.
+The `peer chaincode` command allows users to invoke and query chaincode.
 
 ## Syntax
 
 The `peer chaincode` command has the following subcommands:
 
-  * install
-  * instantiate
   * invoke
-  * list
-  * package
   * query
-  * signpackage
-  * upgrade
 
-The different subcommand options (install, instantiate...) relate to the
-different chaincode operations that are relevant to a peer. For example, use the
-`peer chaincode install` subcommand option to install a chaincode on a peer, or
-the `peer chaincode query` subcommand option to query a chaincode for the
-current value on a peer's ledger.
+The subcommands take a constructor flag (`-c` or `--ctor`) to pass arguments to a chaincode.
+The value must be a JSON string that has either key 'Args' or 'Function' and 'Args'.
+These keys are case-insensitive.
 
-Some subcommands take flag `--ctor`, of which the value must be a JSON string
-that has either key 'Args' or 'Function' and 'Args'. These keys are
-case-insensitive.
-
-If the JSON string only has the Args key, the key value is an array, where the
+If the constructor JSON string only has the Args key, the key value is an array, where the
 first array element is the target function to call, and the subsequent elements
 are arguments of the function. If the JSON string has both 'Function' and
 'Args', the value of Function is the target function to call, and the value of

--- a/docs/wrappers/peer_lifecycle_chaincode_preamble.md
+++ b/docs/wrappers/peer_lifecycle_chaincode_preamble.md
@@ -7,11 +7,6 @@ definition to a channel. The chaincode is ready to be used after the definition
 has been successfully committed to the channel. For more information, visit
 [Fabric chaincode lifecycle](../chaincode_lifecycle.html).
 
-*Note: These instructions use the Fabric chaincode lifecycle introduced in the
-v2.0 release. If you would like to use the old lifecycle to install and
-instantiate a chaincode, visit the [peer chaincode](peerchaincode.html) command
-reference.*
-
 ## Syntax
 
 The `peer lifecycle chaincode` command has the following subcommands:


### PR DESCRIPTION
v1.x legacy lifecycle is removed in Fabric v3.
This commit removes all references from the documentation.

The lifecycle upgrade docs will be removed in a separate pull request when the overall upgrade docs are refactored for v3.