### PR TITLE
Use custom gomega matcher for protobuf equality

### DIFF
--- a/common/deliver/acl_test.go
+++ b/common/deliver/acl_test.go
@@ -12,6 +12,7 @@ import (
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/common/deliver"
 	"github.com/hyperledger/fabric/common/deliver/mock"
+	. "github.com/hyperledger/fabric/internal/test"
 	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -47,7 +48,7 @@ var _ = Describe("SessionAccessControl", func() {
 
 		Expect(fakePolicyChecker.CheckPolicyCallCount()).To(Equal(1))
 		env, cid := fakePolicyChecker.CheckPolicyArgsForCall(0)
-		Expect(env).To(Equal(envelope))
+		Expect(env).To(ProtoEqual(envelope))
 		Expect(cid).To(Equal("chain-id"))
 	})
 

--- a/common/deliver/deliver_test.go
+++ b/common/deliver/deliver_test.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/hyperledger/fabric-lib-go/common/metrics/disabled"
 	"github.com/hyperledger/fabric-lib-go/common/metrics/metricsfakes"
@@ -25,6 +24,7 @@ import (
 	"github.com/hyperledger/fabric/common/deliver/mock"
 	"github.com/hyperledger/fabric/common/ledger/blockledger"
 	"github.com/hyperledger/fabric/common/util"
+	. "github.com/hyperledger/fabric/internal/test"
 	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -295,7 +295,7 @@ var _ = Describe("Deliver", func() {
 			Expect(fakeInspector.InspectCallCount()).To(Equal(1))
 			ctx, header := fakeInspector.InspectArgsForCall(0)
 			Expect(ctx).To(Equal(context.Background()))
-			Expect(proto.Equal(header, channelHeader)).To(BeTrue())
+			Expect(header).To(ProtoEqual(channelHeader))
 		})
 
 		Context("when channel header validation fails", func() {
@@ -335,7 +335,7 @@ var _ = Describe("Deliver", func() {
 
 			Expect(fakePolicyChecker.CheckPolicyCallCount()).To(BeNumerically(">=", 1))
 			e, cid := fakePolicyChecker.CheckPolicyArgsForCall(0)
-			Expect(proto.Equal(e, envelope)).To(BeTrue())
+			Expect(e).To(ProtoEqual(envelope))
 			Expect(cid).To(Equal("chain-id"))
 		})
 
@@ -345,7 +345,7 @@ var _ = Describe("Deliver", func() {
 
 			Expect(fakeBlockReader.IteratorCallCount()).To(Equal(1))
 			startPosition := fakeBlockReader.IteratorArgsForCall(0)
-			Expect(proto.Equal(startPosition, seekInfo.Start)).To(BeTrue())
+			Expect(startPosition).To(ProtoEqual(seekInfo.Start))
 		})
 
 		Context("when multiple blocks are requested", func() {
@@ -427,12 +427,12 @@ var _ = Describe("Deliver", func() {
 
 				Expect(fakeBlockReader.IteratorCallCount()).To(Equal(1))
 				start := fakeBlockReader.IteratorArgsForCall(0)
-				Expect(start).To(Equal(&ab.SeekPosition{}))
+				Expect(start).To(ProtoEqual(&ab.SeekPosition{}))
 				Expect(fakeBlockIterator.NextCallCount()).To(Equal(1))
 
 				Expect(fakeResponseSender.SendBlockResponseCallCount()).To(Equal(1))
 				b, _, _, _ := fakeResponseSender.SendBlockResponseArgsForCall(0)
-				Expect(b).To(Equal(&cb.Block{
+				Expect(b).To(ProtoEqual(&cb.Block{
 					Header: &cb.BlockHeader{Number: 100},
 				}))
 			})
@@ -457,13 +457,13 @@ var _ = Describe("Deliver", func() {
 
 				Expect(fakeBlockReader.IteratorCallCount()).To(Equal(1))
 				start := fakeBlockReader.IteratorArgsForCall(0)
-				Expect(start).To(Equal(&ab.SeekPosition{}))
+				Expect(start).To(ProtoEqual(&ab.SeekPosition{}))
 
 				Expect(fakeBlockIterator.NextCallCount()).To(Equal(2))
 				Expect(fakeResponseSender.SendBlockResponseCallCount()).To(Equal(2))
 				for i := 0; i < fakeResponseSender.SendBlockResponseCallCount(); i++ {
 					b, _, _, _ := fakeResponseSender.SendBlockResponseArgsForCall(i)
-					Expect(b).To(Equal(&cb.Block{
+					Expect(b).To(ProtoEqual(&cb.Block{
 						Header: &cb.BlockHeader{Number: uint64(i + 1)},
 					}))
 				}
@@ -494,7 +494,7 @@ var _ = Describe("Deliver", func() {
 				Expect(fakeResponseSender.SendBlockResponseCallCount()).To(Equal(1))
 				for i := 0; i < fakeResponseSender.SendBlockResponseCallCount(); i++ {
 					b, _, _, _ := fakeResponseSender.SendBlockResponseArgsForCall(i)
-					Expect(b).To(Equal(&cb.Block{
+					Expect(b).To(ProtoEqual(&cb.Block{
 						Header: &cb.BlockHeader{Number: uint64(i)},
 					}))
 				}
@@ -528,13 +528,13 @@ var _ = Describe("Deliver", func() {
 
 				Expect(fakeBlockReader.IteratorCallCount()).To(Equal(1))
 				start := fakeBlockReader.IteratorArgsForCall(0)
-				Expect(start).To(Equal(&ab.SeekPosition{}))
+				Expect(start).To(ProtoEqual(&ab.SeekPosition{}))
 
 				Expect(fakeBlockIterator.NextCallCount()).To(Equal(2))
 				Expect(fakeResponseSender.SendBlockResponseCallCount()).To(Equal(2))
 				for i := 0; i < fakeResponseSender.SendBlockResponseCallCount(); i++ {
 					b, _, _, _ := fakeResponseSender.SendBlockResponseArgsForCall(i)
-					Expect(b).To(Equal(&cb.Block{
+					Expect(b).To(ProtoEqual(&cb.Block{
 						Header:   &cb.BlockHeader{Number: uint64(i + 1)},
 						Data:     nil,
 						Metadata: &cb.BlockMetadata{Metadata: [][]byte{{3}, {4}}},
@@ -584,13 +584,13 @@ var _ = Describe("Deliver", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeBlockReader.IteratorCallCount()).To(Equal(1))
 				start := fakeBlockReader.IteratorArgsForCall(0)
-				Expect(start).To(Equal(&ab.SeekPosition{}))
+				Expect(start).To(ProtoEqual(&ab.SeekPosition{}))
 				Expect(fakeBlockIterator.NextCallCount()).To(Equal(3))
 				Expect(fakeResponseSender.SendBlockResponseCallCount()).To(Equal(3))
 				for i := 0; i < fakeResponseSender.SendBlockResponseCallCount(); i++ {
 					b, _, _, _ := fakeResponseSender.SendBlockResponseArgsForCall(i)
 					if i+1 == 1 || i+1 == 3 {
-						Expect(b).To(Equal(&cb.Block{
+						Expect(b).To(ProtoEqual(&cb.Block{
 							Header:   &cb.BlockHeader{Number: uint64(i + 1)},
 							Data:     nil,
 							Metadata: &cb.BlockMetadata{Metadata: [][]byte{{3}, {4}}},
@@ -607,7 +607,7 @@ var _ = Describe("Deliver", func() {
 							Data:     &cb.BlockData{Data: [][]byte{protoutil.MarshalOrPanic(envelope)}},
 							Metadata: &cb.BlockMetadata{Metadata: [][]byte{{3}, {4}}},
 						}
-						Expect(b).To(Equal(blk))
+						Expect(b).To(ProtoEqual(blk))
 						Expect(b.Data.Data).NotTo(BeNil())
 					}
 				}
@@ -702,7 +702,7 @@ var _ = Describe("Deliver", func() {
 				Expect(fakeResponseSender.DataTypeCallCount()).To(Equal(1))
 				Expect(fakeResponseSender.SendBlockResponseCallCount()).To(Equal(1))
 				b, _, _, _ := fakeResponseSender.SendBlockResponseArgsForCall(0)
-				Expect(b).To(Equal(&cb.Block{
+				Expect(b).To(ProtoEqual(&cb.Block{
 					Header: &cb.BlockHeader{Number: 100},
 				}))
 			})
@@ -769,7 +769,7 @@ var _ = Describe("Deliver", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fakeResponseSender.SendBlockResponseCallCount()).To(Equal(1))
 			b, _, _, _ := fakeResponseSender.SendBlockResponseArgsForCall(0)
-			Expect(b).To(Equal(&cb.Block{
+			Expect(b).To(ProtoEqual(&cb.Block{
 				Header: &cb.BlockHeader{Number: 100},
 			}))
 		})

--- a/common/deliverclient/blocksprovider/deliverer_test.go
+++ b/common/deliverclient/blocksprovider/deliverer_test.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-lib-go/bccsp"
 	"github.com/hyperledger/fabric-lib-go/bccsp/sw"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
@@ -26,6 +25,7 @@ import (
 	"github.com/hyperledger/fabric/core/config/configtest"
 	"github.com/hyperledger/fabric/internal/configtxgen/encoder"
 	"github.com/hyperledger/fabric/internal/configtxgen/genesisconfig"
+	. "github.com/hyperledger/fabric/internal/test"
 	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -575,11 +575,11 @@ var _ = Describe("CFT-Deliverer", func() {
 		It("checks the validity of the block", func() {
 			Eventually(fakeUpdatableBlockVerifier.VerifyBlockCallCount, eventuallyTO).Should(Equal(1))
 			block := fakeUpdatableBlockVerifier.VerifyBlockArgsForCall(0)
-			Expect(proto.Equal(block, &common.Block{
+			Expect(block).To(ProtoEqual(&common.Block{
 				Header: &common.BlockHeader{
 					Number: 8,
 				},
-			})).To(BeTrue())
+			}))
 		})
 
 		When("the block is invalid", func() {
@@ -679,19 +679,19 @@ var _ = Describe("CFT-Deliverer", func() {
 		It("checks the validity of the block", func() {
 			Eventually(fakeUpdatableBlockVerifier.VerifyBlockCallCount, eventuallyTO).Should(Equal(1))
 			block := fakeUpdatableBlockVerifier.VerifyBlockArgsForCall(0)
-			Expect(proto.Equal(block, &common.Block{
+			Expect(block).To(ProtoEqual(&common.Block{
 				Header: &common.BlockHeader{Number: 8},
 				Data: &common.BlockData{
 					Data: [][]byte{protoutil.MarshalOrPanic(env)},
 				},
-			})).To(BeTrue())
+			}))
 		})
 
 		It("handle the block and updates the verifier config", func() {
 			Eventually(fakeBlockHandler.HandleBlockCallCount, eventuallyTO).Should(Equal(1))
 			channelID, block := fakeBlockHandler.HandleBlockArgsForCall(0)
 			Expect(channelID).To(Equal("channel-id"))
-			Expect(block).To(Equal(&common.Block{
+			Expect(block).To(ProtoEqual(&common.Block{
 				Header: &common.BlockHeader{Number: 8},
 				Data: &common.BlockData{
 					Data: [][]byte{protoutil.MarshalOrPanic(env)},

--- a/common/grpclogging/server_test.go
+++ b/common/grpclogging/server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hyperledger/fabric/common/grpclogging"
 	"github.com/hyperledger/fabric/common/grpclogging/fakes"
 	"github.com/hyperledger/fabric/common/grpclogging/testpb"
+	. "github.com/hyperledger/fabric/internal/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
@@ -105,7 +106,7 @@ var _ = Describe("Server", func() {
 
 			resp, err := echoServiceClient.Echo(ctx, &testpb.Message{Message: "hi"})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp).To(Equal(&testpb.Message{Message: "hi", Sequence: 1}))
+			Expect(resp).To(ProtoEqual(&testpb.Message{Message: "hi", Sequence: 1}))
 
 			var logMessages []string
 			for _, entry := range observed.AllUntimed() {
@@ -332,7 +333,7 @@ var _ = Describe("Server", func() {
 
 			msg, err := streamClient.Recv()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(msg).To(Equal(&testpb.Message{Message: "hello", Sequence: 1}))
+			Expect(msg).To(ProtoEqual(&testpb.Message{Message: "hello", Sequence: 1}))
 
 			err = streamClient.CloseSend()
 			Expect(err).NotTo(HaveOccurred())
@@ -420,7 +421,7 @@ var _ = Describe("Server", func() {
 
 			msg, err := streamClient.Recv()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(msg).To(Equal(&testpb.Message{Message: "hello", Sequence: 1}))
+			Expect(msg).To(ProtoEqual(&testpb.Message{Message: "hello", Sequence: 1}))
 
 			err = streamClient.CloseSend()
 			Expect(err).NotTo(HaveOccurred())
@@ -472,7 +473,7 @@ var _ = Describe("Server", func() {
 
 				msg, err := streamClient.Recv()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(msg).To(Equal(&testpb.Message{Message: "hello", Sequence: 1}))
+				Expect(msg).To(ProtoEqual(&testpb.Message{Message: "hello", Sequence: 1}))
 
 				err = streamClient.CloseSend()
 				Expect(err).NotTo(HaveOccurred())
@@ -595,7 +596,7 @@ var _ = Describe("Server", func() {
 				Expect(err).NotTo(HaveOccurred())
 				msg, err := streamClient.Recv()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(msg).To(Equal(&testpb.Message{Message: "hello", Sequence: 1}))
+				Expect(msg).To(ProtoEqual(&testpb.Message{Message: "hello", Sequence: 1}))
 
 				err = streamClient.CloseSend()
 				Expect(err).NotTo(HaveOccurred())

--- a/common/grpcmetrics/interceptor_test.go
+++ b/common/grpcmetrics/interceptor_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hyperledger/fabric/common/grpcmetrics"
 	"github.com/hyperledger/fabric/common/grpcmetrics/fakes"
 	"github.com/hyperledger/fabric/common/grpcmetrics/testpb"
+	. "github.com/hyperledger/fabric/internal/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
@@ -120,7 +121,7 @@ var _ = Describe("Interceptor", func() {
 		It("records request duration", func() {
 			resp, err := echoServiceClient.Echo(context.Background(), &testpb.Message{Message: "yo"})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp).To(Equal(&testpb.Message{Message: "yo", Sequence: 1}))
+			Expect(resp).To(ProtoEqual(&testpb.Message{Message: "yo", Sequence: 1}))
 
 			Expect(fakeRequestDuration.WithCallCount()).To(Equal(1))
 			labelValues := fakeRequestDuration.WithArgsForCall(0)
@@ -142,7 +143,7 @@ var _ = Describe("Interceptor", func() {
 
 			resp, err := echoServiceClient.Echo(context.Background(), &testpb.Message{Message: "yo"})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp).To(Equal(&testpb.Message{Message: "yo", Sequence: 1}))
+			Expect(resp).To(ProtoEqual(&testpb.Message{Message: "yo", Sequence: 1}))
 
 			Expect(fakeRequestsReceived.WithCallCount()).To(Equal(1))
 			labelValues := fakeRequestsReceived.WithArgsForCall(0)
@@ -162,7 +163,7 @@ var _ = Describe("Interceptor", func() {
 
 			resp, err := echoServiceClient.Echo(context.Background(), &testpb.Message{Message: "yo"})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp).To(Equal(&testpb.Message{Message: "yo", Sequence: 1}))
+			Expect(resp).To(ProtoEqual(&testpb.Message{Message: "yo", Sequence: 1}))
 
 			Expect(fakeRequestsCompleted.WithCallCount()).To(Equal(1))
 			labelValues := fakeRequestsCompleted.WithArgsForCall(0)
@@ -313,10 +314,10 @@ func streamMessages(streamClient testpb.EchoService_EchoStreamClient) {
 
 	msg, err := streamClient.Recv()
 	Expect(err).NotTo(HaveOccurred())
-	Expect(msg).To(Equal(&testpb.Message{Message: "hello", Sequence: 1}))
+	Expect(msg).To(ProtoEqual(&testpb.Message{Message: "hello", Sequence: 1}))
 	msg, err = streamClient.Recv()
 	Expect(err).NotTo(HaveOccurred())
-	Expect(msg).To(Equal(&testpb.Message{Message: "hello", Sequence: 3}))
+	Expect(msg).To(ProtoEqual(&testpb.Message{Message: "hello", Sequence: 3}))
 
 	err = streamClient.CloseSend()
 	Expect(err).NotTo(HaveOccurred())

--- a/core/chaincode/handler_test.go
+++ b/core/chaincode/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hyperledger/fabric/core/common/ccprovider"
 	"github.com/hyperledger/fabric/core/common/sysccprovider"
 	"github.com/hyperledger/fabric/core/scc"
+	. "github.com/hyperledger/fabric/internal/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -176,7 +177,7 @@ var _ = Describe("Handler", func() {
 
 			Expect(fakeMessageHandler.HandleCallCount()).To(Equal(1))
 			msg, ctx := fakeMessageHandler.HandleArgsForCall(0)
-			Expect(msg).To(Equal(incomingMessage))
+			Expect(msg).To(ProtoEqual(incomingMessage))
 			Expect(ctx).To(Equal(txContext))
 		})
 
@@ -185,7 +186,7 @@ var _ = Describe("Handler", func() {
 
 			Eventually(fakeChatStream.SendCallCount).Should(Equal(1))
 			msg := fakeChatStream.SendArgsForCall(0)
-			Expect(msg).To(Equal(expectedResponse))
+			Expect(msg).To(ProtoEqual(expectedResponse))
 		})
 
 		It("deregisters the transaction ID before sending the response", func() {
@@ -210,7 +211,7 @@ var _ = Describe("Handler", func() {
 			handler.HandleTransaction(incomingMessage, fakeMessageHandler.Handle)
 			Eventually(fakeChatStream.SendCallCount).Should(Equal(1))
 			msg := fakeChatStream.SendArgsForCall(0)
-			Expect(msg).To(Equal(expectedResponse))
+			Expect(msg).To(ProtoEqual(expectedResponse))
 
 			Expect(fakeShimRequestsReceived.WithCallCount()).To(Equal(1))
 			labelValues := fakeShimRequestsReceived.WithArgsForCall(0)
@@ -324,7 +325,7 @@ var _ = Describe("Handler", func() {
 
 				Eventually(fakeChatStream.SendCallCount).Should(Equal(1))
 				msg := fakeChatStream.SendArgsForCall(0)
-				Expect(msg).To(Equal(&pb.ChaincodeMessage{
+				Expect(msg).To(ProtoEqual(&pb.ChaincodeMessage{
 					Type:      pb.ChaincodeMessage_ERROR,
 					Payload:   []byte("GET_STATE failed: transaction ID: tx-id: no ledger context"),
 					Txid:      "tx-id",
@@ -352,7 +353,7 @@ var _ = Describe("Handler", func() {
 
 				Eventually(fakeChatStream.SendCallCount).Should(Equal(1))
 				msg := fakeChatStream.SendArgsForCall(0)
-				Expect(msg).To(Equal(&pb.ChaincodeMessage{
+				Expect(msg).To(ProtoEqual(&pb.ChaincodeMessage{
 					Type:      pb.ChaincodeMessage_ERROR,
 					Payload:   []byte("GET_STATE failed: transaction ID: tx-id: no ledger context"),
 					Txid:      "tx-id",
@@ -397,7 +398,7 @@ var _ = Describe("Handler", func() {
 
 				Eventually(fakeChatStream.SendCallCount).Should(Equal(1))
 				msg := fakeChatStream.SendArgsForCall(0)
-				Expect(msg).To(Equal(&pb.ChaincodeMessage{
+				Expect(msg).To(ProtoEqual(&pb.ChaincodeMessage{
 					Type:      pb.ChaincodeMessage_ERROR,
 					Payload:   []byte("INVOKE_CHAINCODE failed: transaction ID: tx-id: could not get valid transaction"),
 					Txid:      "tx-id",
@@ -416,7 +417,7 @@ var _ = Describe("Handler", func() {
 
 					Eventually(fakeChatStream.SendCallCount).Should(Equal(1))
 					msg := fakeChatStream.SendArgsForCall(0)
-					Expect(msg).To(Equal(&pb.ChaincodeMessage{
+					Expect(msg).To(ProtoEqual(&pb.ChaincodeMessage{
 						Type:    pb.ChaincodeMessage_ERROR,
 						Payload: []byte("INVOKE_CHAINCODE failed: transaction ID: tx-id: could not get valid transaction"),
 						Txid:    "tx-id",
@@ -435,7 +436,7 @@ var _ = Describe("Handler", func() {
 						Expect(fakeContextRegistry.GetCallCount()).To(Equal(1))
 						Eventually(fakeChatStream.SendCallCount).Should(Equal(1))
 						msg := fakeChatStream.SendArgsForCall(0)
-						Expect(msg).To(Equal(expectedResponse))
+						Expect(msg).To(ProtoEqual(expectedResponse))
 					})
 
 					Context("and the transaction context is missing", func() {
@@ -445,7 +446,7 @@ var _ = Describe("Handler", func() {
 
 							Eventually(fakeChatStream.SendCallCount).Should(Equal(1))
 							msg := fakeChatStream.SendArgsForCall(0)
-							Expect(msg).To(Equal(&pb.ChaincodeMessage{
+							Expect(msg).To(ProtoEqual(&pb.ChaincodeMessage{
 								Type:    pb.ChaincodeMessage_ERROR,
 								Payload: []byte("INVOKE_CHAINCODE failed: transaction ID: tx-id: failed to get transaction context"),
 								Txid:    "tx-id",
@@ -482,7 +483,7 @@ var _ = Describe("Handler", func() {
 
 				Eventually(fakeChatStream.SendCallCount).Should(Equal(1))
 				msg := fakeChatStream.SendArgsForCall(0)
-				Expect(msg).To(Equal(&pb.ChaincodeMessage{
+				Expect(msg).To(ProtoEqual(&pb.ChaincodeMessage{
 					Type:      pb.ChaincodeMessage_ERROR,
 					Payload:   []byte("GET_STATE failed: transaction ID: tx-id: watermelon-swirl"),
 					Txid:      "tx-id",
@@ -515,7 +516,7 @@ var _ = Describe("Handler", func() {
 		It("returns a response message", func() {
 			resp, err := handler.HandlePutState(incomingMessage, txContext)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp).To(Equal(&pb.ChaincodeMessage{
+			Expect(resp).To(ProtoEqual(&pb.ChaincodeMessage{
 				Type:      pb.ChaincodeMessage_RESPONSE,
 				Txid:      "tx-id",
 				ChannelId: "channel-id",
@@ -643,7 +644,7 @@ var _ = Describe("Handler", func() {
 		It("returns a response message", func() {
 			resp, err := handler.HandlePutStateMetadata(incomingMessage, txContext)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp).To(Equal(&pb.ChaincodeMessage{
+			Expect(resp).To(ProtoEqual(&pb.ChaincodeMessage{
 				Type:      pb.ChaincodeMessage_RESPONSE,
 				Txid:      "tx-id",
 				ChannelId: "channel-id",
@@ -812,7 +813,7 @@ var _ = Describe("Handler", func() {
 		It("returns a response message", func() {
 			resp, err := handler.HandleDelState(incomingMessage, txContext)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp).To(Equal(&pb.ChaincodeMessage{
+			Expect(resp).To(ProtoEqual(&pb.ChaincodeMessage{
 				Type:      pb.ChaincodeMessage_RESPONSE,
 				Txid:      "tx-id",
 				ChannelId: "channel-id",
@@ -1031,7 +1032,7 @@ var _ = Describe("Handler", func() {
 					fakeCollectionStore.RetrieveReadWritePermissionReturns(true, false, nil) // to
 					resp, err := handler.HandleGetState(incomingMessage, txContext)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(resp).To(Equal(&pb.ChaincodeMessage{
+					Expect(resp).To(ProtoEqual(&pb.ChaincodeMessage{
 						Type:      pb.ChaincodeMessage_RESPONSE,
 						Payload:   []byte("get-private-data-response"),
 						Txid:      "tx-id",
@@ -1093,7 +1094,7 @@ var _ = Describe("Handler", func() {
 			It("returns the response from GetState", func() {
 				resp, err := handler.HandleGetState(incomingMessage, txContext)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(resp).To(Equal(&pb.ChaincodeMessage{
+				Expect(resp).To(ProtoEqual(&pb.ChaincodeMessage{
 					Type:      pb.ChaincodeMessage_RESPONSE,
 					Payload:   []byte("get-state-response"),
 					Txid:      "tx-id",
@@ -1143,7 +1144,7 @@ var _ = Describe("Handler", func() {
 			Expect(ccname).To(Equal("cc-instance-name"))
 			Expect(collection).To(Equal("collection-name"))
 			Expect(key).To(Equal("get-pvtdata-hash-key"))
-			Expect(response).To(Equal(expectedResponse))
+			Expect(response).To(ProtoEqual(expectedResponse))
 		})
 
 		Context("when unmarshalling the request fails", func() {
@@ -1288,7 +1289,7 @@ var _ = Describe("Handler", func() {
 			It("returns the response message from GetPrivateDataMetadata", func() {
 				resp, err := handler.HandleGetStateMetadata(incomingMessage, txContext)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(resp).To(Equal(expectedResponse))
+				Expect(resp).To(ProtoEqual(expectedResponse))
 			})
 
 			Context("and GetPrivateDataMetadata fails due to ledger error", func() {
@@ -1367,7 +1368,7 @@ var _ = Describe("Handler", func() {
 			It("returns the response from GetStateMetadata", func() {
 				resp, err := handler.HandleGetStateMetadata(incomingMessage, txContext)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(resp).To(Equal(expectedResponse))
+				Expect(resp).To(ProtoEqual(expectedResponse))
 			})
 
 			Context("and GetStateMetadata fails", func() {
@@ -1444,7 +1445,7 @@ var _ = Describe("Handler", func() {
 		It("returns the response message", func() {
 			resp, err := handler.HandleGetStateByRange(incomingMessage, txContext)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp).To(Equal(expectedResponse))
+			Expect(resp).To(ProtoEqual(expectedResponse))
 		})
 
 		Context("when collection is not set", func() {
@@ -1473,7 +1474,7 @@ var _ = Describe("Handler", func() {
 			It("returns the response from GetStateRangeScanIterator", func() {
 				resp, err := handler.HandleGetStateByRange(incomingMessage, txContext)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(resp).To(Equal(expectedResponse))
+				Expect(resp).To(ProtoEqual(expectedResponse))
 			})
 		})
 
@@ -1652,7 +1653,7 @@ var _ = Describe("Handler", func() {
 			expectedPayload, err := proto.Marshal(expectedQueryResponse)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(resp).To(Equal(&pb.ChaincodeMessage{
+			Expect(resp).To(ProtoEqual(&pb.ChaincodeMessage{
 				Type:      pb.ChaincodeMessage_RESPONSE,
 				Payload:   expectedPayload,
 				ChannelId: "channel-id",
@@ -1764,7 +1765,7 @@ var _ = Describe("Handler", func() {
 			expectedPayload, err := proto.Marshal(expectedQueryResponse)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(resp).To(Equal(&pb.ChaincodeMessage{
+			Expect(resp).To(ProtoEqual(&pb.ChaincodeMessage{
 				Type:      pb.ChaincodeMessage_RESPONSE,
 				Payload:   expectedPayload,
 				ChannelId: "channel-id",
@@ -2550,7 +2551,7 @@ var _ = Describe("Handler", func() {
 		})
 
 		It("sends an execute message to the chaincode with the correct proposal", func() {
-			expectedMessage := *incomingMessage
+			expectedMessage := incomingMessage
 			expectedMessage.Proposal = expectedSignedProp
 
 			close(responseNotifier)
@@ -2559,8 +2560,8 @@ var _ = Describe("Handler", func() {
 			Eventually(fakeChatStream.SendCallCount).Should(Equal(1))
 			Consistently(fakeChatStream.SendCallCount).Should(Equal(1))
 			msg := fakeChatStream.SendArgsForCall(0)
-			Expect(msg).To(Equal(&expectedMessage))
-			Expect(msg.Proposal).To(Equal(expectedSignedProp))
+			Expect(msg).To(ProtoEqual(incomingMessage))
+			Expect(msg.Proposal).To(ProtoEqual(expectedSignedProp))
 		})
 
 		It("waits for the chaincode to respond", func() {
@@ -2583,7 +2584,7 @@ var _ = Describe("Handler", func() {
 
 			resp, err := handler.Execute(txParams, "chaincode-name", incomingMessage, time.Second)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp).To(Equal(&pb.ChaincodeMessage{Txid: "a-transaction-id"}))
+			Expect(resp).To(ProtoEqual(&pb.ChaincodeMessage{Txid: "a-transaction-id"}))
 		})
 
 		It("deletes the transaction context", func() {
@@ -2778,11 +2779,11 @@ var _ = Describe("Handler", func() {
 			registeredMessage := fakeChatStream.SendArgsForCall(0)
 			readyMessage := fakeChatStream.SendArgsForCall(1)
 
-			Expect(registeredMessage).To(Equal(&pb.ChaincodeMessage{
+			Expect(registeredMessage).To(ProtoEqual(&pb.ChaincodeMessage{
 				Type: pb.ChaincodeMessage_REGISTERED,
 			}))
 
-			Expect(readyMessage).To(Equal(&pb.ChaincodeMessage{
+			Expect(readyMessage).To(ProtoEqual(&pb.ChaincodeMessage{
 				Type: pb.ChaincodeMessage_READY,
 			}))
 		})

--- a/core/chaincode/lifecycle/deployedcc_infoprovider_test.go
+++ b/core/chaincode/lifecycle/deployedcc_infoprovider_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
+	. "github.com/hyperledger/fabric/internal/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -271,7 +272,7 @@ var _ = Describe("ValidatorCommitter", func() {
 			Expect(ccInfo.Name).To(Equal("cc-name"))
 			Expect(ccInfo.IsLegacy).To(BeFalse())
 			Expect(ccInfo.Version).To(Equal(fakeChaincodeDef.EndorsementInfo.Version))
-			Expect(proto.Equal(ccInfo.ExplicitCollectionConfigPkg, fakeChaincodeDef.Collections)).To(BeTrue())
+			Expect(ccInfo.ExplicitCollectionConfigPkg).To(ProtoEqual(fakeChaincodeDef.Collections))
 		})
 
 		Context("when state range scan returns an error", func() {
@@ -343,7 +344,7 @@ var _ = Describe("ValidatorCommitter", func() {
 				Expect(newlifecycleCCInfo.Name).To(Equal("cc-name"))
 				Expect(newlifecycleCCInfo.IsLegacy).To(BeFalse())
 				Expect(newlifecycleCCInfo.Version).To(Equal(fakeChaincodeDef.EndorsementInfo.Version))
-				Expect(proto.Equal(newlifecycleCCInfo.ExplicitCollectionConfigPkg, fakeChaincodeDef.Collections)).To(BeTrue())
+				Expect(newlifecycleCCInfo.ExplicitCollectionConfigPkg).To(ProtoEqual(fakeChaincodeDef.Collections))
 
 				legacyCCInfo, ok := res["another-cc-name"]
 				Expect(ok).To(BeTrue())
@@ -379,9 +380,9 @@ var _ = Describe("ValidatorCommitter", func() {
 		It("returns the collection info as defined in the new lifecycle", func() {
 			res, err := vc.CollectionInfo("channel-name", "cc-name", "collection-name", fakeQueryExecutor)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(proto.Equal(res, &pb.StaticCollectionConfig{
+			Expect(res).To(ProtoEqual(&pb.StaticCollectionConfig{
 				Name: "collection-name",
-			})).To(BeTrue())
+			}))
 		})
 
 		Context("when no matching collection is found", func() {

--- a/core/chaincode/lifecycle/integration_test.go
+++ b/core/chaincode/lifecycle/integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hyperledger/fabric/core/dispatcher"
 	"github.com/hyperledger/fabric/protoutil"
 
+	. "github.com/hyperledger/fabric/internal/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -200,7 +201,7 @@ var _ = Describe("Integration", func() {
 			chaincodeResult := &lb.QueryChaincodeDefinitionResult{}
 			err = proto.Unmarshal(response.Payload, chaincodeResult)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(proto.Equal(chaincodeResult, &lb.QueryChaincodeDefinitionResult{
+			Expect(chaincodeResult).To(ProtoEqual(&lb.QueryChaincodeDefinitionResult{
 				Sequence:            1,
 				Version:             "1.0",
 				EndorsementPlugin:   "builtin",
@@ -210,7 +211,7 @@ var _ = Describe("Integration", func() {
 				Approvals: map[string]bool{
 					"fake-mspid": true,
 				},
-			})).To(BeTrue())
+			}))
 		})
 	})
 })

--- a/core/chaincode/lifecycle/lifecycle_test.go
+++ b/core/chaincode/lifecycle/lifecycle_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 
+	. "github.com/hyperledger/fabric/internal/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -667,11 +668,11 @@ var _ = Describe("ExternalFunctions", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(committedDefinition.EndorsementInfo.Version).To(Equal("version"))
 			Expect(committedDefinition.EndorsementInfo.EndorsementPlugin).To(Equal("my endorsement plugin"))
-			Expect(proto.Equal(committedDefinition.ValidationInfo, &lb.ChaincodeValidationInfo{
+			Expect(committedDefinition.ValidationInfo).To(ProtoEqual(&lb.ChaincodeValidationInfo{
 				ValidationPlugin:    "my validation plugin",
 				ValidationParameter: []byte("some awesome policy"),
-			})).To(BeTrue())
-			Expect(proto.Equal(committedDefinition.Collections, &pb.CollectionConfigPackage{})).To(BeTrue())
+			}))
+			Expect(committedDefinition.Collections).To(ProtoEqual(&pb.CollectionConfigPackage{}))
 
 			metadata, ok, err = resources.Serializer.DeserializeMetadata("chaincode-sources", "cc-name#5", fakeOrgState)
 			Expect(err).NotTo(HaveOccurred())
@@ -703,7 +704,7 @@ var _ = Describe("ExternalFunctions", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(committedDefinition.EndorsementInfo.Version).To(Equal("version"))
 				Expect(committedDefinition.EndorsementInfo.EndorsementPlugin).To(Equal("escc"))
-				Expect(proto.Equal(committedDefinition.ValidationInfo, &lb.ChaincodeValidationInfo{
+				Expect(committedDefinition.ValidationInfo).To(ProtoEqual(&lb.ChaincodeValidationInfo{
 					ValidationPlugin: "vscc",
 					ValidationParameter: protoutil.MarshalOrPanic(
 						&pb.ApplicationPolicy{
@@ -711,8 +712,8 @@ var _ = Describe("ExternalFunctions", func() {
 								ChannelConfigPolicyReference: "/Channel/Application/Endorsement",
 							},
 						}),
-				})).To(BeTrue())
-				Expect(proto.Equal(committedDefinition.Collections, &pb.CollectionConfigPackage{})).To(BeTrue())
+				}))
+				Expect(committedDefinition.Collections).To(ProtoEqual(&pb.CollectionConfigPackage{}))
 			})
 
 			Context("when no default endorsement policy is defined on thc channel", func() {
@@ -1202,22 +1203,22 @@ var _ = Describe("ExternalFunctions", func() {
 			cc, err := ef.QueryApprovedChaincodeDefinition("my-channel", "cc-name", 3, fakePublicState, fakeOrgStates[0])
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cc.Sequence).To(Equal(int64(3)))
-			Expect(proto.Equal(cc.EndorsementInfo, &lb.ChaincodeEndorsementInfo{
+			Expect(cc.EndorsementInfo).To(ProtoEqual(&lb.ChaincodeEndorsementInfo{
 				Version:           "version",
 				EndorsementPlugin: "endorsement-plugin",
-			})).To(BeTrue())
-			Expect(proto.Equal(cc.ValidationInfo, &lb.ChaincodeValidationInfo{
+			}))
+			Expect(cc.ValidationInfo).To(ProtoEqual(&lb.ChaincodeValidationInfo{
 				ValidationPlugin:    "validation-plugin",
 				ValidationParameter: []byte("validation-parameter"),
-			})).To(BeTrue())
-			Expect(proto.Equal(cc.Collections, &pb.CollectionConfigPackage{})).To(BeTrue())
-			Expect(proto.Equal(cc.Source, &lb.ChaincodeSource{
+			}))
+			Expect(cc.Collections).To(ProtoEqual(&pb.CollectionConfigPackage{}))
+			Expect(cc.Source).To(ProtoEqual(&lb.ChaincodeSource{
 				Type: &lb.ChaincodeSource_LocalPackage{
 					LocalPackage: &lb.ChaincodeSource_Local{
 						PackageId: "hash",
 					},
 				},
-			})).To(BeTrue())
+			}))
 		})
 
 		Context("when the next sequence is not defined and the sequence argument is not provided", func() {
@@ -1225,22 +1226,22 @@ var _ = Describe("ExternalFunctions", func() {
 				cc, err := ef.QueryApprovedChaincodeDefinition("my-channel", "cc-name", 0, fakePublicState, fakeOrgStates[0])
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cc.Sequence).To(Equal(int64(4)))
-				Expect(proto.Equal(cc.EndorsementInfo, &lb.ChaincodeEndorsementInfo{
+				Expect(cc.EndorsementInfo).To(ProtoEqual(&lb.ChaincodeEndorsementInfo{
 					Version:           "version",
 					EndorsementPlugin: "endorsement-plugin",
-				})).To(BeTrue())
-				Expect(proto.Equal(cc.ValidationInfo, &lb.ChaincodeValidationInfo{
+				}))
+				Expect(cc.ValidationInfo).To(ProtoEqual(&lb.ChaincodeValidationInfo{
 					ValidationPlugin:    "validation-plugin",
 					ValidationParameter: []byte("validation-parameter"),
-				})).To(BeTrue())
-				Expect(proto.Equal(cc.Collections, &pb.CollectionConfigPackage{})).To(BeTrue())
-				Expect(proto.Equal(cc.Source, &lb.ChaincodeSource{
+				}))
+				Expect(cc.Collections).To(ProtoEqual(&pb.CollectionConfigPackage{}))
+				Expect(cc.Source).To(ProtoEqual(&lb.ChaincodeSource{
 					Type: &lb.ChaincodeSource_LocalPackage{
 						LocalPackage: &lb.ChaincodeSource_Local{
 							PackageId: "hash",
 						},
 					},
-				})).To(BeTrue())
+				}))
 			})
 		})
 
@@ -1255,20 +1256,20 @@ var _ = Describe("ExternalFunctions", func() {
 				cc, err := ef.QueryApprovedChaincodeDefinition("my-channel", "cc-name", 0, fakePublicState, fakeOrgStates[0])
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cc.Sequence).To(Equal(int64(5)))
-				Expect(proto.Equal(cc.EndorsementInfo, &lb.ChaincodeEndorsementInfo{
+				Expect(cc.EndorsementInfo).To(ProtoEqual(&lb.ChaincodeEndorsementInfo{
 					Version:           "version",
 					EndorsementPlugin: "endorsement-plugin",
-				})).To(BeTrue())
-				Expect(proto.Equal(cc.ValidationInfo, &lb.ChaincodeValidationInfo{
+				}))
+				Expect(cc.ValidationInfo).To(ProtoEqual(&lb.ChaincodeValidationInfo{
 					ValidationPlugin:    "validation-plugin",
 					ValidationParameter: []byte("validation-parameter"),
-				})).To(BeTrue())
-				Expect(proto.Equal(cc.Collections, &pb.CollectionConfigPackage{})).To(BeTrue())
-				Expect(proto.Equal(cc.Source, &lb.ChaincodeSource{
+				}))
+				Expect(cc.Collections).To(ProtoEqual(&pb.CollectionConfigPackage{}))
+				Expect(cc.Source).To(ProtoEqual(&lb.ChaincodeSource{
 					Type: &lb.ChaincodeSource_Unavailable_{
 						Unavailable: &lb.ChaincodeSource_Unavailable{},
 					},
-				})).To(BeTrue())
+				}))
 			})
 
 			Context("and deserializing namespace metadata for next sequence fails", func() {
@@ -1296,22 +1297,22 @@ var _ = Describe("ExternalFunctions", func() {
 				cc, err := ef.QueryApprovedChaincodeDefinition("my-channel", "cc-name", 5, fakePublicState, fakeOrgStates[0])
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cc.Sequence).To(Equal(int64(5)))
-				Expect(proto.Equal(cc.EndorsementInfo, &lb.ChaincodeEndorsementInfo{
+				Expect(cc.EndorsementInfo).To(ProtoEqual(&lb.ChaincodeEndorsementInfo{
 					Version:           "version",
 					EndorsementPlugin: "endorsement-plugin",
-				})).To(BeTrue())
-				Expect(proto.Equal(cc.ValidationInfo, &lb.ChaincodeValidationInfo{
+				}))
+				Expect(cc.ValidationInfo).To(ProtoEqual(&lb.ChaincodeValidationInfo{
 					ValidationPlugin:    "validation-plugin",
 					ValidationParameter: []byte("validation-parameter"),
-				})).To(BeTrue())
-				Expect(proto.Equal(cc.Collections, &pb.CollectionConfigPackage{})).To(BeTrue())
-				Expect(proto.Equal(cc.Source, &lb.ChaincodeSource{
+				}))
+				Expect(cc.Collections).To(ProtoEqual(&pb.CollectionConfigPackage{}))
+				Expect(cc.Source).To(ProtoEqual(&lb.ChaincodeSource{
 					Type: &lb.ChaincodeSource_LocalPackage{
 						LocalPackage: &lb.ChaincodeSource_Local{
 							PackageId: "hash",
 						},
 					},
-				})).To(BeTrue())
+				}))
 			})
 		})
 
@@ -1808,15 +1809,15 @@ var _ = Describe("ExternalFunctions", func() {
 			cc, err := ef.QueryChaincodeDefinition("cc-name", fakePublicState)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cc.Sequence).To(Equal(int64(4)))
-			Expect(proto.Equal(cc.EndorsementInfo, &lb.ChaincodeEndorsementInfo{
+			Expect(cc.EndorsementInfo).To(ProtoEqual(&lb.ChaincodeEndorsementInfo{
 				Version:           "version",
 				EndorsementPlugin: "endorsement-plugin",
-			})).To(BeTrue())
-			Expect(proto.Equal(cc.ValidationInfo, &lb.ChaincodeValidationInfo{
+			}))
+			Expect(cc.ValidationInfo).To(ProtoEqual(&lb.ChaincodeValidationInfo{
 				ValidationPlugin:    "validation-plugin",
 				ValidationParameter: []byte("validation-parameter"),
-			})).To(BeTrue())
-			Expect(proto.Equal(cc.Collections, &pb.CollectionConfigPackage{})).To(BeTrue())
+			}))
+			Expect(cc.Collections).To(ProtoEqual(&pb.CollectionConfigPackage{}))
 		})
 
 		Context("when the chaincode is not defined", func() {

--- a/core/chaincode/lifecycle/scc_test.go
+++ b/core/chaincode/lifecycle/scc_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode/persistence"
 	"github.com/hyperledger/fabric/core/dispatcher"
 	"github.com/hyperledger/fabric/core/ledger"
+	. "github.com/hyperledger/fabric/internal/test"
 	"github.com/hyperledger/fabric/msp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -497,10 +498,7 @@ var _ = Describe("SCC", func() {
 					ValidationPlugin:    "validation-plugin",
 					ValidationParameter: []byte("validation-parameter"),
 				}))
-				Expect(proto.Equal(
-					cd.Collections,
-					collConfigs.toProtoCollectionConfigPackage(),
-				)).Should(BeTrue())
+				Expect(cd.Collections).To(ProtoEqual(collConfigs.toProtoCollectionConfigPackage()))
 
 				Expect(packageID).To(Equal("hash"))
 				Expect(pubState).To(Equal(fakeStub))
@@ -1354,7 +1352,7 @@ var _ = Describe("SCC", func() {
 				payload := &lb.QueryApprovedChaincodeDefinitionResult{}
 				err := proto.Unmarshal(res.Payload, payload)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(proto.Equal(payload, &lb.QueryApprovedChaincodeDefinitionResult{
+				Expect(payload).To(ProtoEqual(&lb.QueryApprovedChaincodeDefinitionResult{
 					Sequence:            7,
 					Version:             "version",
 					EndorsementPlugin:   "endorsement-plugin",
@@ -1369,7 +1367,7 @@ var _ = Describe("SCC", func() {
 							},
 						},
 					},
-				})).To(BeTrue())
+				}))
 
 				Expect(fakeSCCFuncs.QueryApprovedChaincodeDefinitionCallCount()).To(Equal(1))
 				chname, ccname, sequence, pubState, privState := fakeSCCFuncs.QueryApprovedChaincodeDefinitionArgsForCall(0)
@@ -1683,7 +1681,7 @@ var _ = Describe("SCC", func() {
 				payload := &lb.QueryChaincodeDefinitionResult{}
 				err := proto.Unmarshal(res.Payload, payload)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(proto.Equal(payload, &lb.QueryChaincodeDefinitionResult{
+				Expect(payload).To(ProtoEqual(&lb.QueryChaincodeDefinitionResult{
 					Sequence:            2,
 					Version:             "version",
 					EndorsementPlugin:   "endorsement-plugin",
@@ -1694,7 +1692,7 @@ var _ = Describe("SCC", func() {
 						"fake-mspid":  true,
 						"other-mspid": true,
 					},
-				})).To(BeTrue())
+				}))
 
 				Expect(fakeSCCFuncs.QueryChaincodeDefinitionCallCount()).To(Equal(1))
 				name, pubState := fakeSCCFuncs.QueryChaincodeDefinitionArgsForCall(0)

--- a/core/chaincode/lifecycle/serializer_test.go
+++ b/core/chaincode/lifecycle/serializer_test.go
@@ -9,6 +9,7 @@ package lifecycle_test
 import (
 	"fmt"
 
+	. "github.com/hyperledger/fabric/internal/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -402,7 +403,7 @@ var _ = Describe("Serializer", func() {
 			Expect(target.Int).To(Equal(int64(-3)))
 			Expect(target.Bytes).To(Equal([]byte("bytes")))
 			Expect(target.String).To(Equal("theory"))
-			Expect(proto.Equal(target.Proto, testStruct.Proto)).To(BeTrue())
+			Expect(target.Proto).To(ProtoEqual(testStruct.Proto))
 		})
 
 		Context("when the field encoding is bad", func() {
@@ -550,7 +551,7 @@ var _ = Describe("Serializer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(testStruct.Int).To(Equal(deserialized.Int))
-			Expect(proto.Equal(testStruct.Proto, deserialized.Proto))
+			Expect(testStruct.Proto).To(ProtoEqual(deserialized.Proto))
 
 			matched, mismatches, err := s.IsSerialized("namespace", "fake", testStruct, fakeState)
 			Expect(err).NotTo(HaveOccurred())
@@ -782,9 +783,9 @@ var _ = Describe("Serializer", func() {
 			result, err := s.DeserializeAllMetadata("namespaces", fakeState)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(result)).To(Equal(3))
-			Expect(proto.Equal(result["thing0"], &lb.StateMetadata{Datatype: "TestDatatype0"})).To(BeTrue())
-			Expect(proto.Equal(result["thing1"], &lb.StateMetadata{Datatype: "TestDatatype1"})).To(BeTrue())
-			Expect(proto.Equal(result["thing2"], &lb.StateMetadata{Datatype: "TestDatatype2"})).To(BeTrue())
+			Expect(result["thing0"]).To(ProtoEqual(&lb.StateMetadata{Datatype: "TestDatatype0"}))
+			Expect(result["thing1"]).To(ProtoEqual(&lb.StateMetadata{Datatype: "TestDatatype1"}))
+			Expect(result["thing2"]).To(ProtoEqual(&lb.StateMetadata{Datatype: "TestDatatype2"}))
 
 			Expect(fakeState.GetStateRangeCallCount()).To(Equal(1))
 			Expect(fakeState.GetStateRangeArgsForCall(0)).To(Equal("namespaces/metadata/"))
@@ -836,7 +837,7 @@ var _ = Describe("Serializer", func() {
 			result, ok, err := s.DeserializeMetadata("namespaces", "fake", fakeState)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ok).To(BeTrue())
-			Expect(proto.Equal(result, &lb.StateMetadata{Datatype: "TestDatatype"})).To(BeTrue())
+			Expect(result).To(ProtoEqual(&lb.StateMetadata{Datatype: "TestDatatype"}))
 
 			Expect(fakeState.GetStateCallCount()).To(Equal(1))
 			Expect(fakeState.GetStateArgsForCall(0)).To(Equal("namespaces/metadata/fake"))
@@ -928,7 +929,7 @@ var _ = Describe("Serializer", func() {
 			result := &lb.InstallChaincodeResult{}
 			err := s.DeserializeFieldAsProto("namespaces", "fake", "field", fakeState, result)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(proto.Equal(result, &lb.InstallChaincodeResult{PackageId: "hash"})).To(BeTrue())
+			Expect(result).To(ProtoEqual(&lb.InstallChaincodeResult{PackageId: "hash"}))
 
 			Expect(fakeState.GetStateCallCount()).To(Equal(1))
 			Expect(fakeState.GetStateArgsForCall(0)).To(Equal("namespaces/fields/fake/field"))
@@ -954,7 +955,7 @@ var _ = Describe("Serializer", func() {
 				result := &lb.InstallChaincodeResult{}
 				err := s.DeserializeFieldAsProto("namespaces", "fake", "field", fakeState, result)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(proto.Equal(result, &lb.InstallChaincodeResult{})).To(BeTrue())
+				Expect(result).To(ProtoEqual(&lb.InstallChaincodeResult{}))
 			})
 		})
 

--- a/core/dispatcher/protobuf_test.go
+++ b/core/dispatcher/protobuf_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package dispatcher_test
 
 import (
+	. "github.com/hyperledger/fabric/internal/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -37,7 +38,7 @@ var _ = Describe("ProtobufImpl", func() {
 			msg := &lc.InstallChaincodeArgs{}
 			err = proto.Unmarshal(res, msg)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(proto.Equal(msg, sampleMsg)).To(BeTrue())
+			Expect(msg).To(ProtoEqual(sampleMsg))
 		})
 	})
 
@@ -49,7 +50,7 @@ var _ = Describe("ProtobufImpl", func() {
 			msg := &lc.InstallChaincodeArgs{}
 			err = pi.Unmarshal(res, msg)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(proto.Equal(msg, sampleMsg)).To(BeTrue())
+			Expect(msg).To(ProtoEqual(sampleMsg))
 		})
 	})
 })

--- a/core/endorser/endorser_test.go
+++ b/core/endorser/endorser_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hyperledger/fabric/core/endorser/fake"
 	"github.com/hyperledger/fabric/core/ledger"
 	ledgermock "github.com/hyperledger/fabric/core/ledger/mock"
+	. "github.com/hyperledger/fabric/internal/test"
 	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -243,21 +244,21 @@ var _ = Describe("Endorser", func() {
 	It("successfully endorses the proposal", func() {
 		proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(proposalResponse.Endorsement).To(Equal(&pb.Endorsement{
+		Expect(proposalResponse.Endorsement).To(ProtoEqual(&pb.Endorsement{
 			Endorser:  []byte("endorser-identity"),
 			Signature: []byte("endorser-signature"),
 		}))
 		Expect(proposalResponse.Timestamp).To(BeNil())
 		Expect(proposalResponse.Version).To(Equal(int32(1)))
 		Expect(proposalResponse.Payload).To(Equal([]byte("endorser-modified-payload")))
-		Expect(proto.Equal(proposalResponse.Response, &pb.Response{
+		Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 			Status:  200,
 			Payload: []byte("response-payload"),
-		})).To(BeTrue())
+		}))
 
 		Expect(fakeSupport.EndorseWithPluginCallCount()).To(Equal(1))
 		pluginName, cid, propRespPayloadBytes, sp := fakeSupport.EndorseWithPluginArgsForCall(0)
-		Expect(sp).To(Equal(signedProposal))
+		Expect(sp).To(ProtoEqual(signedProposal))
 		Expect(pluginName).To(Equal("plugin-name"))
 		Expect(cid).To(Equal("channel-id"))
 
@@ -270,10 +271,10 @@ var _ = Describe("Endorser", func() {
 		err = proto.Unmarshal(prp.Extension, ccAct)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ccAct.Events).To(Equal(protoutil.MarshalOrPanic(chaincodeEvent)))
-		Expect(proto.Equal(ccAct.Response, &pb.Response{
+		Expect(ccAct.Response).To(ProtoEqual(&pb.Response{
 			Status:  200,
 			Payload: []byte("response-payload"),
-		})).To(BeTrue())
+		}))
 		Expect(fakeSupport.GetHistoryQueryExecutorCallCount()).To(Equal(1))
 		ledgerName := fakeSupport.GetHistoryQueryExecutorArgsForCall(0)
 		Expect(ledgerName).To(Equal("channel-id"))
@@ -288,7 +289,7 @@ var _ = Describe("Endorser", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(proposalResponse.Payload).To(BeNil())
-			Expect(proposalResponse.Response).To(Equal(&pb.Response{
+			Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 				Status:  500,
 				Message: "endorsing with plugin failed: fake-endorserment-error",
 			}))
@@ -339,7 +340,7 @@ var _ = Describe("Endorser", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(proposalResponse.Payload).To(BeNil())
-			Expect(proposalResponse.Response).To(Equal(&pb.Response{
+			Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 				Status:  500,
 				Message: "fake-simulator-error",
 			}))
@@ -363,7 +364,7 @@ var _ = Describe("Endorser", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(proposalResponse.Payload).To(BeNil())
-			Expect(proposalResponse.Response).To(Equal(&pb.Response{
+			Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 				Status:  500,
 				Message: "fake-history-error",
 			}))
@@ -387,7 +388,7 @@ var _ = Describe("Endorser", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(proposalResponse.Payload).To(BeNil())
-			Expect(proposalResponse.Response).To(Equal(&pb.Response{
+			Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 				Status:  500,
 				Message: "channel 'channel-id' not found",
 			}))
@@ -414,7 +415,7 @@ var _ = Describe("Endorser", func() {
 		It("wraps and returns an error and responds to the client", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
 			Expect(err).To(MatchError("error validating proposal: access denied: channel [channel-id] creator org unknown, creator is malformed"))
-			Expect(proposalResponse).To(Equal(&pb.ProposalResponse{
+			Expect(proposalResponse).To(ProtoEqual(&pb.ProposalResponse{
 				Response: &pb.Response{
 					Status:  500,
 					Message: "error validating proposal: access denied: channel [channel-id] creator org unknown, creator is malformed",
@@ -440,7 +441,7 @@ var _ = Describe("Endorser", func() {
 		It("wraps and returns an error and responds to the client", func() {
 			proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
 			Expect(err).To(MatchError("fake-acl-error"))
-			Expect(proposalResponse).To(Equal(&pb.ProposalResponse{
+			Expect(proposalResponse).To(ProtoEqual(&pb.ProposalResponse{
 				Response: &pb.Response{
 					Status:  500,
 					Message: "fake-acl-error",
@@ -479,7 +480,7 @@ var _ = Describe("Endorser", func() {
 		It("returns an error in the response", func() {
 			proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(proposalResponse.Response).To(Equal(&pb.Response{
+			Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 				Status:  500,
 				Message: "make sure the chaincode chaincode-name has been successfully defined on channel channel-id and try again: fake-definition-error",
 			}))
@@ -492,13 +493,13 @@ var _ = Describe("Endorser", func() {
 		Expect(fakeSupport.ExecuteCallCount()).To(Equal(1))
 		txParams, chaincodeName, input := fakeSupport.ExecuteArgsForCall(0)
 		Expect(txParams.ChannelID).To(Equal("channel-id"))
-		Expect(txParams.SignedProp).To(Equal(signedProposal))
+		Expect(txParams.SignedProp).To(ProtoEqual(signedProposal))
 		Expect(txParams.TXSimulator).To(Equal(fakeTxSimulator))
 		Expect(txParams.HistoryQueryExecutor).To(Equal(fakeHistoryQueryExecutor))
 		Expect(chaincodeName).To(Equal("chaincode-name"))
-		Expect(proto.Equal(input, &pb.ChaincodeInput{
+		Expect(input).To(ProtoEqual(&pb.ChaincodeInput{
 			Args: [][]byte{[]byte("arg1"), []byte("arg2"), []byte("arg3")},
-		})).To(BeTrue())
+		}))
 	})
 
 	Context("when calling the chaincode returns an error", func() {
@@ -510,7 +511,7 @@ var _ = Describe("Endorser", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(proposalResponse.Payload).To(BeNil())
-			Expect(proposalResponse.Response).To(Equal(&pb.Response{
+			Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 				Status:  500,
 				Message: "error in simulation: fake-chaincode-execution-error",
 			}))
@@ -543,7 +544,7 @@ var _ = Describe("Endorser", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(proposalResponse.Payload).To(BeNil())
-			Expect(proposalResponse.Response).To(Equal(&pb.Response{
+			Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 				Status:  500,
 				Message: "error in simulation: fake-private-data-error",
 			}))
@@ -566,7 +567,7 @@ var _ = Describe("Endorser", func() {
 			proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(proposalResponse.Payload).To(BeNil())
-			Expect(proposalResponse.Response).To(Equal(&pb.Response{
+			Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 				Status:  500,
 				Message: "error in simulation: failed to obtain ledger height for channel 'channel-id': fake-block-height-error",
 			}))
@@ -603,10 +604,10 @@ var _ = Describe("Endorser", func() {
 			Expect(proposalResponse.Timestamp).To(BeNil())
 			Expect(proposalResponse.Version).To(Equal(int32(0)))
 			Expect(proposalResponse.Payload).To(BeNil())
-			Expect(proto.Equal(proposalResponse.Response, &pb.Response{
+			Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 				Status:  200,
 				Payload: []byte("response-payload"),
-			})).To(BeTrue())
+			}))
 		})
 
 		It("does not attempt to get a history query executor", func() {
@@ -647,7 +648,7 @@ var _ = Describe("Endorser", func() {
 			It("wraps and returns an error and responds to the client", func() {
 				proposalResponse, err := e.ProcessProposal(context.Background(), signedProposal)
 				Expect(err).To(MatchError("error validating proposal: access denied: channel [] creator org unknown, creator is malformed"))
-				Expect(proposalResponse).To(Equal(&pb.ProposalResponse{
+				Expect(proposalResponse).To(ProtoEqual(&pb.ProposalResponse{
 					Response: &pb.Response{
 						Status:  500,
 						Message: "error validating proposal: access denied: channel [] creator org unknown, creator is malformed",
@@ -686,10 +687,10 @@ var _ = Describe("Endorser", func() {
 				Expect(proposalResponse.Endorsement).To(BeNil())
 				Expect(proposalResponse.Timestamp).To(BeNil())
 				Expect(proposalResponse.Version).To(Equal(int32(0)))
-				Expect(proto.Equal(proposalResponse.Response, &pb.Response{
+				Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 					Status:  500,
 					Payload: []byte("response-payload"),
-				})).To(BeTrue())
+				}))
 
 				// This is almost definitely a bug, but, adding a test in case someone is relying on this behavior.
 				// When the response is >= 500, we return a payload, but not on success.  A payload is only meaningful
@@ -702,10 +703,10 @@ var _ = Describe("Endorser", func() {
 				ccAct := &pb.ChaincodeAction{}
 				err = proto.Unmarshal(prp.Extension, ccAct)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(proto.Equal(ccAct.Response, &pb.Response{
+				Expect(ccAct.Response).To(ProtoEqual(&pb.Response{
 					Status:  500,
 					Payload: []byte("response-payload"),
-				})).To(BeTrue())
+				}))
 
 				// This is an especially weird bit of the behavior, the chaincode event is nil-ed before creating
 				// the proposal response. (That probably shouldn't be created)
@@ -724,10 +725,10 @@ var _ = Describe("Endorser", func() {
 				Expect(proposalResponse.Endorsement).To(BeNil())
 				Expect(proposalResponse.Timestamp).To(BeNil())
 				Expect(proposalResponse.Version).To(Equal(int32(0)))
-				Expect(proto.Equal(proposalResponse.Response, &pb.Response{
+				Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 					Status:  499,
 					Payload: []byte("response-payload"),
-				})).To(BeTrue())
+				}))
 				Expect(proposalResponse.Payload).To(BeNil())
 			})
 		})
@@ -760,10 +761,10 @@ var _ = Describe("Endorser", func() {
 			Expect(proposalResponse.Endorsement).To(BeNil())
 			Expect(proposalResponse.Timestamp).To(BeNil())
 			Expect(proposalResponse.Version).To(Equal(int32(0)))
-			Expect(proto.Equal(proposalResponse.Response, &pb.Response{
+			Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 				Status:  500,
 				Payload: []byte("response-payload"),
-			})).To(BeTrue())
+			}))
 			Expect(proposalResponse.Payload).NotTo(BeNil())
 		})
 	})
@@ -803,10 +804,10 @@ var _ = Describe("Endorser", func() {
 			proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(proposalResponse.Payload).To(BeNil())
-			Expect(proto.Equal(proposalResponse.Response, &pb.Response{
+			Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 				Status:  400,
 				Payload: []byte("response-payload"),
-			})).To(BeTrue())
+			}))
 		})
 	})
 
@@ -841,10 +842,10 @@ var _ = Describe("Endorser", func() {
 		It("triggers the legacy init, and returns the response from lscc", func() {
 			proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(proto.Equal(proposalResponse.Response, &pb.Response{
+			Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 				Status:  200,
 				Payload: []byte("response-payload"),
-			})).To(BeTrue())
+			}))
 
 			Expect(fakeSupport.ExecuteLegacyInitCallCount()).To(Equal(1))
 			_, name, version, input := fakeSupport.ExecuteLegacyInitArgsForCall(0)
@@ -876,7 +877,7 @@ var _ = Describe("Endorser", func() {
 			It("returns an error to the client", func() {
 				proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(proposalResponse.Response).To(Equal(&pb.Response{
+				Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 					Status:  500,
 					Message: "error in simulation: lscc upgrade/deploy should not include a code packages",
 				}))
@@ -898,7 +899,7 @@ var _ = Describe("Endorser", func() {
 			It("returns an error to the client", func() {
 				proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(proposalResponse.Response).To(Equal(&pb.Response{
+				Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 					Status:  500,
 					Message: "error in simulation: Private data is forbidden to be used in instantiate",
 				}))
@@ -920,7 +921,7 @@ var _ = Describe("Endorser", func() {
 			It("returns an error to the client", func() {
 				proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(proposalResponse.Response).To(Equal(&pb.Response{
+				Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 					Status:  500,
 					Message: "error in simulation: bad simulation",
 				}))
@@ -939,7 +940,7 @@ var _ = Describe("Endorser", func() {
 			It("returns an error to the client", func() {
 				proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(proposalResponse.Response).To(Equal(&pb.Response{
+				Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 					Status:  500,
 					Message: "error in simulation: proto: Marshal called with nil",
 				}))
@@ -955,7 +956,7 @@ var _ = Describe("Endorser", func() {
 			It("returns an error and increments the metric", func() {
 				proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(proposalResponse.Response).To(Equal(&pb.Response{
+				Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 					Status:  500,
 					Message: "error in simulation: fake-legacy-init-error",
 				}))
@@ -979,7 +980,7 @@ var _ = Describe("Endorser", func() {
 			It("triggers the legacy init, and returns the response from lscc", func() {
 				proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(proposalResponse.Response).To(Equal(&pb.Response{
+				Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 					Status:  500,
 					Message: "error in simulation: attempting to deploy a system chaincode deploy-name/channel-id",
 				}))
@@ -1035,7 +1036,7 @@ var _ = Describe("Endorser", func() {
 		It("returns an error to the client", func() {
 			proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(proposalResponse.Response).To(Equal(&pb.Response{
+			Expect(proposalResponse.Response).To(ProtoEqual(&pb.Response{
 				Status:  500,
 				Message: "error in simulation: failed to obtain collections config: no collection config for chaincode \"myCC\"",
 			}))
@@ -1133,7 +1134,7 @@ var _ = Describe("Endorser", func() {
 			proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
 			Expect(err).NotTo(HaveOccurred())
 			sort.Sort(CcInterest(*proposalResponse.Interest))
-			Expect(proposalResponse.Interest).To(Equal(&pb.ChaincodeInterest{
+			Expect(proposalResponse.Interest).To(ProtoEqual(&pb.ChaincodeInterest{
 				Chaincodes: []*pb.ChaincodeCall{{
 					Name:            "myCC",
 					CollectionNames: []string{"mycollection-1"},
@@ -1170,7 +1171,7 @@ var _ = Describe("Endorser", func() {
 			proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
 			Expect(err).NotTo(HaveOccurred())
 			sort.Sort(CcInterest(*proposalResponse.Interest))
-			Expect(proposalResponse.Interest).To(Equal(&pb.ChaincodeInterest{
+			Expect(proposalResponse.Interest).To(ProtoEqual(&pb.ChaincodeInterest{
 				Chaincodes: []*pb.ChaincodeCall{
 					{
 						Name: "myCC",
@@ -1210,7 +1211,7 @@ var _ = Describe("Endorser", func() {
 			proposalResponse, err := e.ProcessProposal(context.TODO(), signedProposal)
 			Expect(err).NotTo(HaveOccurred())
 			sort.Sort(CcInterest(*proposalResponse.Interest))
-			Expect(proposalResponse.Interest).To(Equal(&pb.ChaincodeInterest{
+			Expect(proposalResponse.Interest).To(ProtoEqual(&pb.ChaincodeInterest{
 				Chaincodes: []*pb.ChaincodeCall{{
 					Name:            "myCC",
 					CollectionNames: []string{"mycollection-1"},
@@ -1249,8 +1250,7 @@ var _ = Describe("Endorser", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			sort.Sort(CcInterest(*proposalResponse.Interest))
-			Expect(proto.Equal(
-				proposalResponse.Interest,
+			Expect(proposalResponse.Interest).To(ProtoEqual(
 				&pb.ChaincodeInterest{
 					Chaincodes: []*pb.ChaincodeCall{
 						{
@@ -1265,7 +1265,7 @@ var _ = Describe("Endorser", func() {
 						},
 					},
 				},
-			)).To(BeTrue())
+			))
 		})
 
 		It("SBE only, no chaincode policy updates", func() {
@@ -1294,8 +1294,7 @@ var _ = Describe("Endorser", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			sort.Sort(CcInterest(*proposalResponse.Interest))
-			Expect(proto.Equal(
-				proposalResponse.Interest,
+			Expect(proposalResponse.Interest).To(ProtoEqual(
 				&pb.ChaincodeInterest{
 					Chaincodes: []*pb.ChaincodeCall{{
 						Name:                     "myCC",
@@ -1303,7 +1302,7 @@ var _ = Describe("Endorser", func() {
 						DisregardNamespacePolicy: true,
 					}},
 				},
-			)).To(BeTrue())
+			))
 		})
 
 		It("chaincode to chaincode calls", func() {

--- a/core/endorser/msgvalidation_test.go
+++ b/core/endorser/msgvalidation_test.go
@@ -9,6 +9,7 @@ package endorser_test
 import (
 	"fmt"
 
+	. "github.com/hyperledger/fabric/internal/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -18,8 +19,6 @@ import (
 	"github.com/hyperledger/fabric/core/endorser"
 	"github.com/hyperledger/fabric/core/endorser/fake"
 	"github.com/hyperledger/fabric/protoutil"
-
-	"github.com/golang/protobuf/proto"
 )
 
 var _ = Describe("UnpackProposal", func() {
@@ -156,11 +155,11 @@ var _ = Describe("UnpackProposal", func() {
 		up, err := endorser.UnpackProposal(signedProposal)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(up.ChaincodeName).To(Equal("chaincode-name"))
-		Expect(up.SignedProposal).To(Equal(signedProposal))
-		Expect(proto.Equal(up.Proposal, proposal)).To(BeTrue())
-		Expect(proto.Equal(up.Input, chaincodeInput)).To(BeTrue())
-		Expect(proto.Equal(up.SignatureHeader, signatureHeader)).To(BeTrue())
-		Expect(proto.Equal(up.ChannelHeader, channelHeader)).To(BeTrue())
+		Expect(up.SignedProposal).To(ProtoEqual(signedProposal))
+		Expect(up.Proposal).To(ProtoEqual(proposal))
+		Expect(up.Input).To(ProtoEqual(chaincodeInput))
+		Expect(up.SignatureHeader).To(ProtoEqual(signatureHeader))
+		Expect(up.ChannelHeader).To(ProtoEqual(channelHeader))
 	})
 
 	Context("when the proposal bytes are invalid", func() {

--- a/integration/configtx/configtx_test.go
+++ b/integration/configtx/configtx_test.go
@@ -15,12 +15,12 @@ import (
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-config/configtx"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/integration/channelparticipation"
 	"github.com/hyperledger/fabric/integration/nwo"
 	"github.com/hyperledger/fabric/integration/ordererclient"
+	. "github.com/hyperledger/fabric/internal/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/tedsuo/ifrit"
@@ -132,7 +132,7 @@ var _ = Describe("ConfigTx", func() {
 
 		By("ensuring the active channel config matches the submitted config")
 		updatedChannelConfig := nwo.GetConfig(network, org2peer0, orderer, "testchannel")
-		Expect(proto.Equal(c.UpdatedConfig(), updatedChannelConfig)).To(BeTrue())
+		Expect(c.UpdatedConfig()).To(ProtoEqual(updatedChannelConfig))
 
 		By("checking the current application capabilities")
 		c = configtx.New(updatedChannelConfig)
@@ -190,7 +190,7 @@ var _ = Describe("ConfigTx", func() {
 
 		By("ensuring the active channel config matches the submitted config")
 		updatedChannelConfig = nwo.GetConfig(network, org2peer0, orderer, "testchannel")
-		Expect(proto.Equal(c.UpdatedConfig(), updatedChannelConfig)).To(BeTrue())
+		Expect(c.UpdatedConfig()).To(ProtoEqual(updatedChannelConfig))
 
 		By("adding the anchor peer for each org")
 		for _, peer := range testPeers {
@@ -235,7 +235,7 @@ var _ = Describe("ConfigTx", func() {
 
 			By("ensuring the active channel config matches the submitted config")
 			updatedChannelConfig = nwo.GetConfig(network, peer, orderer, "testchannel")
-			Expect(proto.Equal(c.UpdatedConfig(), updatedChannelConfig)).To(BeTrue())
+			Expect(c.UpdatedConfig()).To(ProtoEqual(updatedChannelConfig))
 		}
 	})
 })

--- a/integration/discovery/discovery_test.go
+++ b/integration/discovery/discovery_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hyperledger/fabric/integration/channelparticipation"
 	"github.com/hyperledger/fabric/integration/nwo"
 	"github.com/hyperledger/fabric/integration/nwo/commands"
+	. "github.com/hyperledger/fabric/internal/test"
 	"github.com/hyperledger/fabric/msp"
 	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/ginkgo/v2"
@@ -273,7 +274,7 @@ var _ = Describe("DiscoveryService", func() {
 			discoveredConfig2 := discoverConfiguration(network, org3Peer0)
 
 			By("comparing configuration from org1Peer0 and org3Peer0")
-			Expect(proto.Equal(discoveredConfig, discoveredConfig2)).To(BeTrue())
+			Expect(discoveredConfig).To(ProtoEqual(discoveredConfig2))
 
 			By("validating the membership data")
 			Expect(discoveredConfig.Msps).To(HaveLen(len(network.Organizations)))
@@ -281,13 +282,13 @@ var _ = Describe("DiscoveryService", func() {
 				org := network.Organization(o.Organization)
 				mspConfig, err := msp.GetVerifyingMspConfig(network.OrdererOrgMSPDir(org), org.MSPID, "bccsp")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(discoveredConfig.Msps[org.MSPID]).To(Equal(unmarshalFabricMSPConfig(mspConfig)))
+				Expect(discoveredConfig.Msps[org.MSPID]).To(ProtoEqual(unmarshalFabricMSPConfig(mspConfig)))
 			}
 			for _, p := range network.Peers {
 				org := network.Organization(p.Organization)
 				mspConfig, err := msp.GetVerifyingMspConfig(network.PeerOrgMSPDir(org), org.MSPID, "bccsp")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(discoveredConfig.Msps[org.MSPID]).To(Equal(unmarshalFabricMSPConfig(mspConfig)))
+				Expect(discoveredConfig.Msps[org.MSPID]).To(ProtoEqual(unmarshalFabricMSPConfig(mspConfig)))
 			}
 
 			By("validating the orderers")

--- a/integration/gateway/endorsing_orgs_test.go
+++ b/integration/gateway/endorsing_orgs_test.go
@@ -13,11 +13,11 @@ import (
 	"syscall"
 
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/integration/channelparticipation"
 	"github.com/hyperledger/fabric/integration/nwo"
+	. "github.com/hyperledger/fabric/internal/test"
 	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -159,5 +159,5 @@ func submitCheckEndorsingOrgsTransaction(ctx context.Context, client gateway.Gat
 		Message: "",
 		Payload: []uint8(expectedPayload),
 	}
-	Expect(proto.Equal(result, expectedResult)).To(BeTrue(), "Expected\n\t%#v\nto proto.Equal\n\t%#v", result, expectedResult)
+	Expect(result).To(ProtoEqual(expectedResult))
 }

--- a/integration/gateway/gateway_test.go
+++ b/integration/gateway/gateway_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/peer/lifecycle"
 	"github.com/hyperledger/fabric/integration/channelparticipation"
 	"github.com/hyperledger/fabric/integration/nwo"
+	. "github.com/hyperledger/fabric/internal/test"
 	"github.com/hyperledger/fabric/protoutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -273,7 +274,7 @@ var _ = Describe("GatewayService basic", func() {
 				},
 			}
 			Expect(response.Result.Payload).To(Equal(expectedResponse.Result.Payload))
-			Expect(proto.Equal(response, expectedResponse)).To(BeTrue(), "Expected\n\t%#v\nto proto.Equal\n\t%#v", response, expectedResponse)
+			Expect(response).To(ProtoEqual(expectedResponse))
 		})
 
 		It("should respond with system chaincode result", func() {
@@ -305,7 +306,7 @@ var _ = Describe("GatewayService basic", func() {
 				Payload: []byte("conga payload"),
 			}
 			Expect(result.Payload).To(Equal(expectedResult.Payload))
-			Expect(proto.Equal(result, expectedResult)).To(BeTrue(), "Expected\n\t%#v\nto proto.Equal\n\t%#v", result, expectedResult)
+			Expect(result).To(ProtoEqual(expectedResult))
 		})
 
 		It("should endorse a system chaincode transaction", func() {
@@ -402,7 +403,7 @@ var _ = Describe("GatewayService basic", func() {
 				EventName:   "EVENT_NAME",
 				Payload:     []byte("EVENT_PAYLOAD"),
 			}
-			Expect(proto.Equal(event.Events[0], expectedEvent)).To(BeTrue(), "Expected\n\t%#v\nto proto.Equal\n\t%#v", event.Events[0], expectedEvent)
+			Expect(event.Events[0]).To(ProtoEqual(expectedEvent))
 		})
 
 		It("should respond with replayed chaincode events", func() {
@@ -435,7 +436,7 @@ var _ = Describe("GatewayService basic", func() {
 				EventName:   "EVENT_NAME",
 				Payload:     []byte("EVENT_PAYLOAD"),
 			}
-			Expect(proto.Equal(event.Events[0], expectedEvent)).To(BeTrue(), "Expected\n\t%#v\nto proto.Equal\n\t%#v", event.Events[0], expectedEvent)
+			Expect(event.Events[0]).To(ProtoEqual(expectedEvent))
 		})
 
 		It("should respond with replayed chaincode events after specified transaction ID", func() {
@@ -472,7 +473,7 @@ var _ = Describe("GatewayService basic", func() {
 				EventName:   "CORRECT_EVENT_NAME",
 				Payload:     []byte("CORRECT_EVENT_PAYLOAD"),
 			}
-			Expect(proto.Equal(event.Events[0], expectedEvent)).To(BeTrue(), "Expected\n\t%#v\nto proto.Equal\n\t%#v", event.Events[0], expectedEvent)
+			Expect(event.Events[0]).To(ProtoEqual(expectedEvent))
 		})
 
 		It("should default to next commit if start position not specified", func() {
@@ -496,7 +497,7 @@ var _ = Describe("GatewayService basic", func() {
 				EventName:   "EVENT_NAME",
 				Payload:     []byte("EVENT_PAYLOAD"),
 			}
-			Expect(proto.Equal(event.Events[0], expectedEvent)).To(BeTrue(), "Expected\n\t%#v\nto proto.Equal\n\t%#v", event.Events[0], expectedEvent)
+			Expect(event.Events[0]).To(ProtoEqual(expectedEvent))
 		})
 
 		It("should fail on unauthorized identity", func() {

--- a/internal/configtxgen/encoder/encoder_test.go
+++ b/internal/configtxgen/encoder/encoder_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	. "github.com/hyperledger/fabric/internal/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -951,7 +952,7 @@ var _ = Describe("Encoder", func() {
 						},
 					},
 				}
-				Expect(proto.Equal(expected, cg)).To(BeTrue())
+				Expect(expected).To(ProtoEqual(cg))
 			})
 
 			Context("when the template configuration is not the default", func() {
@@ -1339,7 +1340,7 @@ var _ = Describe("Encoder", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(cg.Groups)).To(Equal(2))
 				Expect(cg.Groups["Orderer"]).NotTo(BeNil())
-				Expect(proto.Equal(cg.Groups["Orderer"], sysChannelGroup.Groups["Orderer"])).To(BeTrue())
+				Expect(cg.Groups["Orderer"]).To(ProtoEqual(sysChannelGroup.Groups["Orderer"]))
 				Expect(cg.Groups["Application"]).NotTo(BeNil())
 				Expect(len(cg.Groups["Application"].Policies)).To(Equal(1))
 				Expect(cg.Groups["Application"].Policies["Admins"]).NotTo(BeNil())

--- a/internal/test/matcher.go
+++ b/internal/test/matcher.go
@@ -1,0 +1,73 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/onsi/gomega/types"
+	"google.golang.org/protobuf/encoding/prototext"
+)
+
+// ProtoEqual provides a Gomega matcher that uses proto.Equal to compare actual with expected.
+func ProtoEqual(expected proto.Message) types.GomegaMatcher {
+	return &protoEqualMatcher{
+		expected: expected,
+		marshal: prototext.MarshalOptions{
+			Multiline:    true,
+			Indent:       "\t",
+			AllowPartial: true,
+		},
+	}
+}
+
+type protoEqualMatcher struct {
+	expected proto.Message
+	marshal  prototext.MarshalOptions
+}
+
+func (m *protoEqualMatcher) Match(actual interface{}) (bool, error) {
+	switch message := actual.(type) {
+	case proto.Message:
+		return proto.Equal(m.expected, message), nil
+	default:
+		return false, fmt.Errorf("ProtoEqual expects a proto.Message, got a %T", actual)
+	}
+}
+
+func (m *protoEqualMatcher) FailureMessage(actual interface{}) string {
+	switch message := actual.(type) {
+	case proto.Message:
+		return fmt.Sprintf("Expected\n%s\nto equal\n%s", m.indent(m.format(message)), m.indent(m.format(m.expected)))
+	default:
+		return fmt.Sprintf("Expected\n\t%v\nto equal\n%s", message, m.indent(m.format(m.expected)))
+	}
+}
+
+func (m *protoEqualMatcher) indent(text string) string {
+	return m.marshal.Indent + strings.ReplaceAll(text, "\n", "\n"+m.marshal.Indent)
+}
+
+func (m *protoEqualMatcher) NegatedFailureMessage(actual interface{}) string {
+	switch message := actual.(type) {
+	case proto.Message:
+		return fmt.Sprintf("Expected\n%s\nnot to equal\n%s", m.indent(m.format(message)), m.indent(m.format(m.expected)))
+	default:
+		return fmt.Sprintf("Expected\n\t%v\nnot to equal\n%s", message, m.indent(m.format(m.expected)))
+	}
+}
+
+func (m *protoEqualMatcher) format(message proto.Message) string {
+	formatted := strings.TrimSpace(m.marshal.Format(proto.MessageV2(message)))
+	return fmt.Sprintf("%s{\n%s\n}", messageType(message), m.indent(formatted))
+}
+
+func messageType(message proto.Message) string {
+	return string(proto.MessageV2(message).ProtoReflect().Descriptor().Name())
+}

--- a/orderer/common/broadcast/broadcast_test.go
+++ b/orderer/common/broadcast/broadcast_test.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/golang/protobuf/proto"
+	. "github.com/hyperledger/fabric/internal/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -125,7 +125,9 @@ var _ = Describe("Broadcast", func() {
 			Expect(fakeProcessedCounter.AddArgsForCall(0)).To(Equal(float64(1)))
 
 			Expect(fakeABServer.SendCallCount()).To(Equal(1))
-			Expect(proto.Equal(fakeABServer.SendArgsForCall(0), &ab.BroadcastResponse{Status: cb.Status_SUCCESS})).To(BeTrue())
+			Expect(fakeABServer.SendArgsForCall(0)).To(ProtoEqual(
+				&ab.BroadcastResponse{Status: cb.Status_SUCCESS},
+			))
 		})
 
 		Context("when the channel support cannot be retrieved", func() {
@@ -141,10 +143,9 @@ var _ = Describe("Broadcast", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeABServer.SendCallCount()).To(Equal(1))
-				Expect(proto.Equal(
-					fakeABServer.SendArgsForCall(0),
-					&ab.BroadcastResponse{Status: cb.Status_BAD_REQUEST, Info: "support-error"}),
-				).To(BeTrue())
+				Expect(fakeABServer.SendArgsForCall(0)).To(ProtoEqual(
+					&ab.BroadcastResponse{Status: cb.Status_BAD_REQUEST, Info: "support-error"},
+				))
 			})
 
 			Context("when the channel header is not validly decoded", func() {
@@ -189,10 +190,9 @@ var _ = Describe("Broadcast", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeABServer.SendCallCount()).To(Equal(1))
-				Expect(proto.Equal(
-					fakeABServer.SendArgsForCall(0),
-					&ab.BroadcastResponse{Status: cb.Status_SERVICE_UNAVAILABLE, Info: "not-ready"}),
-				).To(BeTrue())
+				Expect(fakeABServer.SendArgsForCall(0)).To(ProtoEqual(
+					&ab.BroadcastResponse{Status: cb.Status_SERVICE_UNAVAILABLE, Info: "not-ready"},
+				))
 			})
 		})
 
@@ -217,10 +217,9 @@ var _ = Describe("Broadcast", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeABServer.SendCallCount()).To(Equal(1))
-				Expect(proto.Equal(
-					fakeABServer.SendArgsForCall(0),
-					&ab.BroadcastResponse{Status: cb.Status_SERVICE_UNAVAILABLE, Info: "consenter-error"}),
-				).To(BeTrue())
+				Expect(fakeABServer.SendArgsForCall(0)).To(ProtoEqual(
+					&ab.BroadcastResponse{Status: cb.Status_SERVICE_UNAVAILABLE, Info: "consenter-error"},
+				))
 			})
 		})
 
@@ -234,10 +233,9 @@ var _ = Describe("Broadcast", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeABServer.SendCallCount()).To(Equal(1))
-				Expect(proto.Equal(
-					fakeABServer.SendArgsForCall(0),
+				Expect(fakeABServer.SendArgsForCall(0)).To(ProtoEqual(
 					&ab.BroadcastResponse{Status: cb.Status_BAD_REQUEST, Info: "normal-messsage-processing-error"},
-				)).To(BeTrue())
+				))
 			})
 
 			Context("when the error cause is msgprocessor.ErrChannelDoesNotExist", func() {
@@ -250,10 +248,9 @@ var _ = Describe("Broadcast", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(fakeABServer.SendCallCount()).To(Equal(1))
-					Expect(proto.Equal(
-						fakeABServer.SendArgsForCall(0),
+					Expect(fakeABServer.SendArgsForCall(0)).To(ProtoEqual(
 						&ab.BroadcastResponse{Status: cb.Status_NOT_FOUND, Info: msgprocessor.ErrChannelDoesNotExist.Error()},
-					)).To(BeTrue())
+					))
 				})
 			})
 
@@ -267,10 +264,9 @@ var _ = Describe("Broadcast", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(fakeABServer.SendCallCount()).To(Equal(1))
-					Expect(proto.Equal(
-						fakeABServer.SendArgsForCall(0),
+					Expect(fakeABServer.SendArgsForCall(0)).To(ProtoEqual(
 						&ab.BroadcastResponse{Status: cb.Status_FORBIDDEN, Info: msgprocessor.ErrPermissionDenied.Error()},
-					)).To(BeTrue())
+					))
 				})
 			})
 		})
@@ -306,7 +302,7 @@ var _ = Describe("Broadcast", func() {
 				Expect(seq).To(Equal(uint64(3)))
 
 				Expect(fakeABServer.SendCallCount()).To(Equal(1))
-				Expect(proto.Equal(fakeABServer.SendArgsForCall(0), &ab.BroadcastResponse{Status: cb.Status_SUCCESS})).To(BeTrue())
+				Expect(fakeABServer.SendArgsForCall(0)).To(ProtoEqual(&ab.BroadcastResponse{Status: cb.Status_SUCCESS}))
 			})
 
 			Context("when the consenter is not ready for the request", func() {
@@ -319,10 +315,9 @@ var _ = Describe("Broadcast", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(fakeABServer.SendCallCount()).To(Equal(1))
-					Expect(proto.Equal(
-						fakeABServer.SendArgsForCall(0),
-						&ab.BroadcastResponse{Status: cb.Status_SERVICE_UNAVAILABLE, Info: "not-ready"}),
-					).To(BeTrue())
+					Expect(fakeABServer.SendArgsForCall(0)).To(ProtoEqual(
+						&ab.BroadcastResponse{Status: cb.Status_SERVICE_UNAVAILABLE, Info: "not-ready"},
+					))
 				})
 			})
 
@@ -336,10 +331,9 @@ var _ = Describe("Broadcast", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(fakeABServer.SendCallCount()).To(Equal(1))
-					Expect(proto.Equal(
-						fakeABServer.SendArgsForCall(0),
-						&ab.BroadcastResponse{Status: cb.Status_SERVICE_UNAVAILABLE, Info: "consenter-error"}),
-					).To(BeTrue())
+					Expect(fakeABServer.SendArgsForCall(0)).To(ProtoEqual(
+						&ab.BroadcastResponse{Status: cb.Status_SERVICE_UNAVAILABLE, Info: "consenter-error"},
+					))
 				})
 			})
 
@@ -353,10 +347,9 @@ var _ = Describe("Broadcast", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(fakeABServer.SendCallCount()).To(Equal(1))
-					Expect(proto.Equal(
-						fakeABServer.SendArgsForCall(0),
+					Expect(fakeABServer.SendArgsForCall(0)).To(ProtoEqual(
 						&ab.BroadcastResponse{Status: cb.Status_BAD_REQUEST, Info: "config-processing-error"},
-					)).To(BeTrue())
+					))
 				})
 
 				Context("when the error cause is msgprocessor.ErrChannelDoesNotExist", func() {
@@ -369,10 +362,9 @@ var _ = Describe("Broadcast", func() {
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(fakeABServer.SendCallCount()).To(Equal(1))
-						Expect(proto.Equal(
-							fakeABServer.SendArgsForCall(0),
+						Expect(fakeABServer.SendArgsForCall(0)).To(ProtoEqual(
 							&ab.BroadcastResponse{Status: cb.Status_NOT_FOUND, Info: msgprocessor.ErrChannelDoesNotExist.Error()},
-						)).To(BeTrue())
+						))
 					})
 				})
 
@@ -386,10 +378,9 @@ var _ = Describe("Broadcast", func() {
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(fakeABServer.SendCallCount()).To(Equal(1))
-						Expect(proto.Equal(
-							fakeABServer.SendArgsForCall(0),
+						Expect(fakeABServer.SendArgsForCall(0)).To(ProtoEqual(
 							&ab.BroadcastResponse{Status: cb.Status_FORBIDDEN, Info: msgprocessor.ErrPermissionDenied.Error()},
-						)).To(BeTrue())
+						))
 					})
 				})
 			})


### PR DESCRIPTION
The standard gomega Equal matcher is not reliable when used with protobuf messages since they can be logically equal while containing different implementation field values. This change implements a custom ProtoEqual matcher that uses proto.Equal for reliable equality checks.

This implementation enables the following:

```go
Expect(actual).To(ProtoEqual(expected))
```

which is a more idiomatic alternative to:

```go
Expect(proto.Equal(expected, actual)).To(BeTrue())
```

In addition, a failed match produces output similar to the following, which is significantly more informative than a message simply stating that false is expected to be true:

```
[FAILED] Expected
        ChaincodeMessage{
                type:  TRANSACTION
                payload:  "\n\x04arg1\n\x04arg2"
                txid:  "tx-id"
                proposal:  {
                        proposal_bytes:  "signed-proposal-bytes"
                        signature:  "signature"
                }
                channel_id:  "channel-id"
        }
  to equal
        SignedProposal{
                proposal_bytes:  "signed-proposal-bytes"
                signature:  "signature"
        }
```