### PR TITLE
Upgrade ubuntu from 20.04 to 22.04 LTS version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@
 #   - unit-test - runs the go-test based unit tests
 #   - verify - runs unit tests for only the changed package tree
 
-UBUNTU_VER ?= 20.04
+UBUNTU_VER ?= 22.04
 FABRIC_VER ?= 3.0.0
 
 # 3rd party image version
@@ -248,7 +248,7 @@ $(BUILD_DIR)/images/peer/$(DUMMY):    BUILD_ARGS=--build-arg GO_TAGS=${GO_TAGS}
 $(BUILD_DIR)/images/orderer/$(DUMMY): BUILD_ARGS=--build-arg GO_TAGS=${GO_TAGS}
 
 $(BUILD_DIR)/images/%/$(DUMMY):
-	@echo "Building Docker image $(DOCKER_NS)/fabric-$*"
+	@echo "Building Docker image $(DOCKER_NS)/fabric-$* with Ubuntu version $(UBUNTU_VER)"
 	@mkdir -p $(@D)
 	$(DBUILD) -f images/$*/Dockerfile \
 		--build-arg GO_VER=$(GO_VER) \

--- a/images/baseos/Dockerfile
+++ b/images/baseos/Dockerfile
@@ -24,7 +24,7 @@ FROM ubuntu:${UBUNTU_VER} as base
 RUN apt update && apt install -y \
     tzdata
 
-RUN     addgroup --gid 500 chaincode
-RUN     adduser  --disabled-password --gecos "" --uid 500 --gid 500 --home /home/chaincode chaincode
+RUN     groupadd --gid 500 chaincode
+RUN     useradd -c "" -u 500 -g 500 -d /home/chaincode -M chaincode
 
 USER    chaincode

--- a/images/ccenv/Dockerfile
+++ b/images/ccenv/Dockerfile
@@ -33,8 +33,8 @@ RUN apt update && apt install -y \
 RUN curl -sL https://go.dev/dl/go${GO_VER}.${TARGETOS}-${TARGETARCH}.tar.gz | tar zxvf - -C /usr/local
 ENV PATH="/usr/local/go/bin:$PATH"
 
-RUN addgroup --gid 500 chaincode
-RUN adduser  --disabled-password --gecos "" --uid 500 --gid 500 --home /home/chaincode chaincode
+RUN     groupadd --gid 500 chaincode
+RUN     useradd -c "" -u 500 -g 500 -d /home/chaincode -M chaincode
 
 RUN mkdir    -p /chaincode/output /chaincode/input
 RUN chown    -R chaincode:chaincode /chaincode


### PR DESCRIPTION
Moving container images from using Ubuntu 20.04 to Ubuntu 24.04, this is to reduce amount of vulnerabilities reported with 20.04 version, effectively  from this

```
    i New version 1.13.0 available (installed version is 1.11.0) at https://github.com/docker/scout-cli
          ✓ SBOM of image already cached, 218 packages indexed

  Target               │  hyperledger/fabric-peer:latest  │    1C     1H     1M    10L
    digest             │  260a5496cc95                    │
  Base image           │  ubuntu:20.04                    │    0C     0H     1M    10L
  Refreshed base image │  ubuntu:20.04                    │    0C     0H     1M    10L
                       │                                  │
  Updated base image   │  ubuntu:24.04                    │    0C     0H     1M     3L
                       │                                  │                         -7
```

to this

```
    i New version 1.13.0 available (installed version is 1.11.0) at https://github.com/docker/scout-cli
          ✓ SBOM of image already cached, 213 packages indexed

    i Base image was auto-detected. To get more accurate results, build images with max-mode provenance attestations.
      Review docs.docker.com ↗ for more information.

  Target             │  hyperledger/fabric-peer:latest  │    0C     0H     1M     3L
    digest           │  bd06340d98f4                    │
  Base image         │  ubuntu:24.04                    │    0C     0H     1M     3L
  Updated base image │  ubuntu:24.10                    │    0C     0H     0M     0L
                     │                                  │                  -1     -3
```