### PR TITLE
Utilize 2.5 images for java chaincode and node chaincode

### DIFF
--- a/core/chaincode/chaincodetest.yaml
+++ b/core/chaincode/chaincodetest.yaml
@@ -294,7 +294,8 @@ chaincode:
         path:
         name:
 
-    # Generic builder environment, suitable for most chaincode types
+    # Generic builder image with Go pre-installed.
+    # TWO_DIGIT_VERSION represents Fabric major.minor version.
     builder: $(DOCKER_NS)/fabric-ccenv:$(TWO_DIGIT_VERSION)
 
     # Enables/disables force pulling of the base docker images (listed below)
@@ -303,22 +304,23 @@ chaincode:
     pull: false
 
     golang:
-        # golang will never need more than baseos
+        # Compiled Go chaincodes will be copied to the fabric-baseos runtime image.
+        # TWO_DIGIT_VERSION represents Fabric major.minor version.
         runtime: $(DOCKER_NS)/fabric-baseos:$(TWO_DIGIT_VERSION)
 
         # whether or not golang chaincode should be linked dynamically
         dynamicLink: false
 
     java:
-        # This is an image based on java:openjdk-8 with addition compiler
+        # This is an image based on eclipse temurin with addition compiler
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-javaenv:2.5
 
     node:
         # This is an image based on node:$(NODE_VER)-alpine
-        runtime: $(DOCKER_NS)/fabric-nodeenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-nodeenv:2.5
 
     # timeout in millisecs for starting up a container and waiting for Register
     # to come through. 1sec should be plenty for chaincode unit tests

--- a/core/chaincode/platforms/java/platform_test.go
+++ b/core/chaincode/platforms/java/platform_test.go
@@ -165,7 +165,7 @@ func TestDockerBuildOptions(t *testing.T) {
 	require.NoError(t, err, "unexpected error from DockerBuildOptions")
 
 	expectedOpts := util.DockerBuildOptions{
-		Image: "hyperledger/fabric-javaenv:latest",
+		Image: "hyperledger/fabric-javaenv:2.5",
 		Cmd:   "./build.sh",
 	}
 	require.Equal(t, expectedOpts, opts)

--- a/core/chaincode/platforms/node/platform_test.go
+++ b/core/chaincode/platforms/node/platform_test.go
@@ -144,7 +144,7 @@ func TestGenerateBuildOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedOpts := util.DockerBuildOptions{
-		Image: "hyperledger/fabric-nodeenv:latest",
+		Image: "hyperledger/fabric-nodeenv:2.5",
 		Cmd:   expectedBuildScript,
 	}
 	require.Equal(t, expectedOpts, opts)

--- a/core/deliverservice/testdata/core.yaml
+++ b/core/deliverservice/testdata/core.yaml
@@ -567,7 +567,8 @@ chaincode:
     path:
     name:
 
-  # Generic builder environment, suitable for most chaincode types
+  # Generic builder image with Go pre-installed.
+  # TWO_DIGIT_VERSION represents Fabric major.minor version.
   builder: $(DOCKER_NS)/fabric-ccenv:$(TWO_DIGIT_VERSION)
 
   # Enables/disables force pulling of the base docker images (listed below)
@@ -576,22 +577,23 @@ chaincode:
   pull: false
 
   golang:
-    # golang will never need more than baseos
+    # Compiled Go chaincodes will be copied to the fabric-baseos runtime image.
+    # TWO_DIGIT_VERSION represents Fabric major.minor version.
     runtime: $(DOCKER_NS)/fabric-baseos:$(TWO_DIGIT_VERSION)
 
     # whether or not golang chaincode should be linked dynamically
     dynamicLink: false
 
   java:
-    # This is an image based on java:openjdk-8 with addition compiler
+    # This is an image based on eclipse temurin with addition compiler
     # tools added for java shim layer packaging.
     # This image is packed with shim layer libraries that are necessary
     # for Java chaincode runtime.
-    runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
+    runtime: $(DOCKER_NS)/fabric-javaenv:2.5
 
   node:
     # This is an image based on node:$(NODE_VER)-alpine
-    runtime: $(DOCKER_NS)/fabric-nodeenv:$(TWO_DIGIT_VERSION)
+    runtime: $(DOCKER_NS)/fabric-nodeenv:2.5
 
   # List of directories to treat as external builders and launchers for
   # chaincode. The external builder detection processing will iterate over the

--- a/docs/source/chaincode_lifecycle.md
+++ b/docs/source/chaincode_lifecycle.md
@@ -94,7 +94,18 @@ You need to install the chaincode package on every peer that will execute and
 endorse transactions. You need to complete this step with the peer CLI using the
 credentials of the **Peer Administrator**. Your peer will build the chaincode
 after the chaincode is installed, and return a build error if there is a problem
-with your chaincode. It is recommended that organizations only package a chaincode
+with your chaincode.
+
+To build chaincode, the peer by default will utilize an internal Docker builder with
+support for Go, Java, and Node.js chaincodes. The docker image that is used for building
+each language is specified in the peer's `core.yaml` configuration in the `chaincode` section.
+The Go docker image version typically aligns with the Fabric version,
+while the Java and Node.js docker image versions are managed by the respective Fabric chaincode projects.
+
+In a production environment, an external chaincode builder is often utilized to provide more control
+of the build process, see the [External Builders and Launchers](cc_launcher.html) topic for more details.
+
+It is recommended that organizations only package a chaincode
 once, and then install the same package on every peer that belongs to their org.
 If a channel wants to ensure that each organization is running the same chaincode,
 one organization can package a chaincode and send it to other channel members

--- a/orderer/common/cluster/testdata/blockverification/core.yaml
+++ b/orderer/common/cluster/testdata/blockverification/core.yaml
@@ -574,7 +574,8 @@ chaincode:
         path:
         name:
 
-    # Generic builder environment, suitable for most chaincode types
+    # Generic builder image with Go pre-installed.
+    # TWO_DIGIT_VERSION represents Fabric major.minor version.
     builder: $(DOCKER_NS)/fabric-ccenv:$(TWO_DIGIT_VERSION)
 
     # Enables/disables force pulling of the base docker images (listed below)
@@ -583,22 +584,23 @@ chaincode:
     pull: false
 
     golang:
-        # golang will never need more than baseos
+        # Compiled Go chaincodes will be copied to the fabric-baseos runtime image.
+        # TWO_DIGIT_VERSION represents Fabric major.minor version.
         runtime: $(DOCKER_NS)/fabric-baseos:$(TWO_DIGIT_VERSION)
 
         # whether or not golang chaincode should be linked dynamically
         dynamicLink: false
 
     java:
-        # This is an image based on java:openjdk-8 with addition compiler
+        # This is an image based on eclipse temurin with addition compiler
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-javaenv:2.5
 
     node:
         # This is an image based on node:$(NODE_VER)-alpine
-        runtime: $(DOCKER_NS)/fabric-nodeenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-nodeenv:2.5
 
     # List of directories to treat as external builders and launchers for
     # chaincode. The external builder detection processing will iterate over the

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -582,7 +582,8 @@ chaincode:
         path:
         name:
 
-    # Generic builder environment, suitable for most chaincode types
+    # Generic builder image with Go pre-installed.
+    # TWO_DIGIT_VERSION represents Fabric major.minor version.
     builder: $(DOCKER_NS)/fabric-ccenv:$(TWO_DIGIT_VERSION)
 
     # Enables/disables force pulling of the base docker images (listed below)
@@ -591,22 +592,23 @@ chaincode:
     pull: false
 
     golang:
-        # golang will never need more than baseos
+        # Compiled Go chaincodes will be copied to the fabric-baseos runtime image.
+        # TWO_DIGIT_VERSION represents Fabric major.minor version.
         runtime: $(DOCKER_NS)/fabric-baseos:$(TWO_DIGIT_VERSION)
 
         # whether or not golang chaincode should be linked dynamically
         dynamicLink: false
 
     java:
-        # This is an image based on java:openjdk-8 with addition compiler
+        # This is an image based on eclipse temurin with addition compiler
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-javaenv:2.5
 
     node:
         # This is an image based on node:$(NODE_VER)-alpine
-        runtime: $(DOCKER_NS)/fabric-nodeenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-nodeenv:2.5
 
     # List of directories to treat as external builders and launchers for
     # chaincode. The external builder detection processing will iterate over the

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -42,7 +42,7 @@ dockerPull() {
     #three_digit_image_tag is passed in, e.g. "1.4.7"
     three_digit_image_tag=$1
     shift
-    #two_digit_image_tag is derived, e.g. "1.4", especially useful as a local tag for two digit references to most recent baseos, ccenv, javaenv, nodeenv patch releases
+    #two_digit_image_tag is derived, e.g. "1.4", especially useful as a local tag for two digit references
     two_digit_image_tag=$(echo "$three_digit_image_tag" | cut -d'.' -f1,2)
     while [[ $# -gt 0 ]]
     do

--- a/scripts/install-fabric.sh
+++ b/scripts/install-fabric.sh
@@ -144,7 +144,7 @@ singleImagePull() {
     #three_digit_image_tag is passed in, e.g. "1.4.7"
     three_digit_image_tag=$1
     shift
-    #two_digit_image_tag is derived, e.g. "1.4", especially useful as a local tag for two digit references to most recent baseos, ccenv, javaenv, nodeenv patch releases
+    #two_digit_image_tag is derived, e.g. "1.4", especially useful as a local tag for two digit references
     two_digit_image_tag=$(echo "$three_digit_image_tag" | cut -d'.' -f1,2)
     while [[ $# -gt 0 ]]
     do


### PR DESCRIPTION
Java chaincode image javaenv and
Node chaincode image nodeenv
will continue to be maintained at version 2.5
instead of creating versions 3.0 of them.

Therefore, instead of using the current Fabric TWO_DIGIT_VERSION for these chaincodes,
hardcode them at 2.5 in the default sample config.
