### PR TITLE
Create home directory in docker images

### DIFF
--- a/images/baseos/Dockerfile
+++ b/images/baseos/Dockerfile
@@ -25,6 +25,6 @@ RUN apt update && apt install -y \
     tzdata
 
 RUN     groupadd --gid 500 chaincode
-RUN     useradd -c "" -u 500 -g 500 -d /home/chaincode -M chaincode
+RUN     useradd -c "" -u 500 -g 500 -d /home/chaincode -m chaincode
 
 USER    chaincode

--- a/images/ccenv/Dockerfile
+++ b/images/ccenv/Dockerfile
@@ -34,7 +34,7 @@ RUN curl -sL https://go.dev/dl/go${GO_VER}.${TARGETOS}-${TARGETARCH}.tar.gz | ta
 ENV PATH="/usr/local/go/bin:$PATH"
 
 RUN     groupadd --gid 500 chaincode
-RUN     useradd -c "" -u 500 -g 500 -d /home/chaincode -M chaincode
+RUN     useradd -c "" -u 500 -g 500 -d /home/chaincode -m chaincode
 
 RUN mkdir    -p /chaincode/output /chaincode/input
 RUN chown    -R chaincode:chaincode /chaincode


### PR DESCRIPTION
The recent change to use `useradd -M` in baseos and ccenv Docker images caused building of Go chaincodes to fail with error:

```
"failed to initialize build cache at /home/chaincode/.cache/go-build: mkdir /home/chaincode: permission denied"
```

Changing it back to allow creation of the chaincode home directory with `useradd -m` solves the problem.
