### PR TITLE
Fix argument format for calculatepackageid command

### DIFF
--- a/docs/source/commands/peercommand.md
+++ b/docs/source/commands/peercommand.md
@@ -5,7 +5,7 @@
  The `peer` command has five different subcommands, each of which allows
  administrators to perform a specific set of tasks related to a peer.  For
  example, you can use the `peer channel` subcommand to join a peer to a channel,
- or the `peer  chaincode` command to deploy a smart contract chaincode to a
+ or the `peer chaincode` command to deploy a smart contract chaincode to a
  peer.
 
 ## Syntax

--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -200,7 +200,7 @@ Global Flags:
 Calculate the package ID for a packaged chaincode.
 
 Usage:
-  peer lifecycle chaincode calculatepackageid packageFile [flags]
+  peer lifecycle chaincode calculatepackageid [packageFile] [flags]
 
 Flags:
       --connectionProfile string       The fully qualified path to the connection profile that provides the necessary connection information for the network. Note: currently only supported for providing peer connection information

--- a/internal/peer/lifecycle/chaincode/calculatepackageid.go
+++ b/internal/peer/lifecycle/chaincode/calculatepackageid.go
@@ -52,7 +52,7 @@ func (i *CalculatePackageIDInput) Validate() error {
 // the package ID for a packaged chaincode
 func CalculatePackageIDCmd(p *PackageIDCalculator) *cobra.Command {
 	calculatePackageIDCmd := &cobra.Command{
-		Use:       "calculatepackageid packageFile",
+		Use:       "calculatepackageid [packageFile]",
 		Short:     "Calculate the package ID for a chaincode.",
 		Long:      "Calculate the package ID for a packaged chaincode.",
 		ValidArgs: []string{"1"},


### PR DESCRIPTION

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix
- Documentation update

#### Description

This patch updates the argument format for `calculatepackageid` command, enclosing `packageFile` in square brankets to indicate that the specific file name should be put.

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Github issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
