### PR TITLE
Doc: add packageFile argument in peer lifecycle chaincode install help command

### DIFF
--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -116,7 +116,7 @@ Global Flags:
 Install a chaincode on a peer.
 
 Usage:
-  peer lifecycle chaincode install [flags]
+  peer lifecycle chaincode install [packageFile] [flags]
 
 Flags:
       --connectionProfile string       The fully qualified path to the connection profile that provides the necessary connection information for the network. Note: currently only supported for providing peer connection information

--- a/internal/peer/lifecycle/chaincode/install.go
+++ b/internal/peer/lifecycle/chaincode/install.go
@@ -55,7 +55,7 @@ func (i *InstallInput) Validate() error {
 // InstallCmd returns the cobra command for chaincode install.
 func InstallCmd(i *Installer, cryptoProvider bccsp.BCCSP) *cobra.Command {
 	chaincodeInstallCmd := &cobra.Command{
-		Use:       "install",
+		Use:       "install [packageFile]",
 		Short:     "Install a chaincode.",
 		Long:      "Install a chaincode on a peer.",
 		ValidArgs: []string{"1"},


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Add packageFile argument in peer lifecycle chaincode install  help command.

#### Additional details

Fix help information "peer lifecycle chaincode install [flags]" with "peer lifecycle chaincode install [packageFiles] [flags]"

Tested by building the peer binary:

```shell
$ cd fabric
$ make peer
Building build/bin/peer...
$./build/bin/peer lifecycle chaincode install --help
Install a chaincode on a peer.

Usage:
  peer lifecycle chaincode install [packageFiles] [flags]

Flags:
      --connectionProfile string       The fully qualified path to the connection profile that provides the necessary connection information for the network. Note: currently only supported for providing peer connection information
  -h, --help                           help for install
      --peerAddresses stringArray      The addresses of the peers to connect to
      --targetPeer string              When using a connection profile, the name of the peer to target for this action
      --tlsRootCertFiles stringArray   If TLS is enabled, the paths to the TLS root cert files of the peers to connect to. The order and number of certs specified should match the --peerAddresses flag

Global Flags:
      --cafile string                       Path to file containing PEM-encoded trusted certificate(s) for the ordering endpoint
      --certfile string                     Path to file containing PEM-encoded X509 public key to use for mutual TLS communication with the orderer endpoint
      --clientauth                          Use mutual TLS when communicating with the orderer endpoint
      --connTimeout duration                Timeout for client to connect (default 3s)
      --keyfile string                      Path to file containing PEM-encoded private key to use for mutual TLS communication with the orderer endpoint
  -o, --orderer string                      Ordering service endpoint
      --ordererTLSHostnameOverride string   The hostname override to use when validating the TLS connection to the orderer
      --tls                                 Use TLS when communicating with the orderer endpoint
      --tlsHandshakeTimeShift duration      The amount of time to shift backwards for certificate expiration checks during TLS handshakes with the orderer endpoint
```

#### Related issues

[Missing argument in help information for command "peer lifecycle chaincode install ](https://github.com/hyperledger/fabric/issues/4976)


