### PR TITLE
change logger for unit test smartbft

### DIFF
--- a/orderer/consensus/smartbft/chain_test.go
+++ b/orderer/consensus/smartbft/chain_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
 	"github.com/hyperledger/fabric/common/channelconfig"
@@ -357,6 +358,9 @@ func TestAddNodeWhileAnotherNodeIsDown(t *testing.T) {
 func TestAddAndRemoveNodeWithoutStop(t *testing.T) {
 	dir := t.TempDir()
 	channelId := "testchannel"
+
+	flogging.ActivateSpec("debug")
+	defer flogging.ActivateSpec("info")
 
 	// start a network
 	networkSetupInfo := NewNetworkSetupInfo(t, channelId, dir)


### PR DESCRIPTION
There are unit tests in smartbft, where some logs are written via logger and some via testing.Logf.

As a result, when the test terminates with an error. Some of the sequential logs are in one place, some in another.

I decided to bring the logs to a single view through the logger. In order to deal with the floating error in the future