### PR TITLE
fixed an error in use smartbft

### DIFF
--- a/orderer/consensus/smartbft/chain.go
+++ b/orderer/consensus/smartbft/chain.go
@@ -141,12 +141,20 @@ func NewChain(
 
 	lastBlock := LastBlockFromLedgerOrPanic(support, c.Logger)
 	lastConfigBlock := LastConfigBlockFromLedgerOrPanic(support, c.Logger)
+	nextToLastConfigBlock := NextToLastConfigBlockFromLedgerOrPanic(support, bccsp, c.Logger)
 
+	var err error
 	rtc := RuntimeConfig{
 		logger: logger,
 		id:     selfID,
 	}
-	rtc, err := rtc.BlockCommitted(lastConfigBlock, bccsp)
+	if nextToLastConfigBlock != nil {
+		rtc, err = rtc.BlockCommitted(nextToLastConfigBlock, bccsp)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed constructing RuntimeConfig")
+		}
+	}
+	rtc, err = rtc.BlockCommitted(lastConfigBlock, bccsp)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed constructing RuntimeConfig")
 	}

--- a/orderer/consensus/smartbft/util.go
+++ b/orderer/consensus/smartbft/util.go
@@ -46,6 +46,7 @@ type RuntimeConfig struct {
 	LastCommittedBlockHash string
 	RemoteNodes            []cluster.RemoteNode
 	ID2Identities          NodeIdentitiesByID
+	ID2IdentitiesPrev      NodeIdentitiesByID
 	LastBlock              *cb.Block
 	LastConfigBlock        *cb.Block
 	Nodes                  []uint64
@@ -65,6 +66,7 @@ func (rtc RuntimeConfig) BlockCommitted(block *cb.Block, bccsp bccsp.BCCSP) (Run
 		LastCommittedBlockHash: hex.EncodeToString(protoutil.BlockHeaderHash(block.Header)),
 		Nodes:                  rtc.Nodes,
 		ID2Identities:          rtc.ID2Identities,
+		ID2IdentitiesPrev:      rtc.ID2IdentitiesPrev,
 		RemoteNodes:            rtc.RemoteNodes,
 		LastBlock:              block,
 		LastConfigBlock:        rtc.LastConfigBlock,
@@ -91,6 +93,7 @@ func (rtc RuntimeConfig) configBlockCommitted(block *cb.Block, bccsp bccsp.BCCSP
 		LastCommittedBlockHash: hex.EncodeToString(protoutil.BlockHeaderHash(block.Header)),
 		Nodes:                  nodeConf.nodeIDs,
 		ID2Identities:          nodeConf.id2Identities,
+		ID2IdentitiesPrev:      rtc.ID2Identities,
 		RemoteNodes:            nodeConf.remoteNodes,
 		LastBlock:              block,
 		LastConfigBlock:        block,


### PR DESCRIPTION
fixed an error after deleting a node when it participated in block signing immediately before deletion

Recently the [TestAddAndRemoveNodeWithoutStop](https://github.com/hyperledger/fabric/blob/main/orderer/consensus/smartbft/chain_test.go#L358) test has been terminating with an error very often in unit tests.

It went like this:
- [prepared](https://github.com/hyperledger/fabric/blob/main/orderer/consensus/smartbft/chain_test.go#L413) a new config with node 5 removed from the cluster
- [send](https://github.com/hyperledger/fabric/blob/main/orderer/consensus/smartbft/chain_test.go#L414) it to the orderers
- The 5th node participated in the consensus to accept this block
- [deleted](https://github.com/hyperledger/fabric/blob/main/orderer/consensus/smartbft/chain_test.go#L424) the 5th node
- [sent](https://github.com/hyperledger/fabric/blob/main/orderer/consensus/smartbft/chain_test.go#L430) a simple transaction to check that everything was working.
- In the very first stage of consensus, the smartBFT library takes the previous commit with signatures and checks for correctness. It sends it to the fabric function [VerifyConsenterSig](https://github.com/hyperledger/fabric/blob/main/orderer/consensus/smartbft/verifier.go#L211). In the previous commit the signature of node 5 is present, but in the current config it is not. This causes an error [here](https://github.com/hyperledger/fabric/blob/main/orderer/consensus/smartbft/verifier.go#L216).

My suggestion for a fix: 
- keep the previous set of nodes in memory
- if we don't find a signature in the current set and the block is equal and/or less than the current block number, check in the previous set

Perhaps there is a better and more beautiful solution.
