### PR TITLE
Update Fabric docs - HSM not supported for TLS

### DIFF
--- a/docs/source/hsm.md
+++ b/docs/source/hsm.md
@@ -9,6 +9,8 @@ multiple certified HSMs from which to choose.
 
 Fabric currently leverages the PKCS11 standard to communicate with an HSM.
 
+**Note:** Fabric can use a HSM for peer and orderer node MSP identities as documented in this topic,
+however for TLS you must use file-based keys as documented in the [TLS topic](./enable_tls.html).
 
 ## Configuring an HSM
 

--- a/orderer/common/server/main.go
+++ b/orderer/common/server/main.go
@@ -487,19 +487,19 @@ func initializeServerConfig(conf *localconfig.TopLevel, metricsProvider metrics.
 		// load crypto material from files
 		serverCertificate, err := os.ReadFile(conf.General.TLS.Certificate)
 		if err != nil {
-			logger.Fatalf("Failed to load server Certificate file '%s' (%s)",
+			logger.Fatalf("Failed to load server TLS Certificate file '%s' (%s)",
 				conf.General.TLS.Certificate, err)
 		}
 		serverKey, err := os.ReadFile(conf.General.TLS.PrivateKey)
 		if err != nil {
-			logger.Fatalf("Failed to load PrivateKey file '%s' (%s)",
+			logger.Fatalf("Failed to load TLS PrivateKey file '%s' (%s)",
 				conf.General.TLS.PrivateKey, err)
 		}
 		var serverRootCAs, clientRootCAs [][]byte
 		for _, serverRoot := range conf.General.TLS.RootCAs {
 			root, err := os.ReadFile(serverRoot)
 			if err != nil {
-				logger.Fatalf("Failed to load ServerRootCAs file '%s' (%s)",
+				logger.Fatalf("Failed to load TLS ServerRootCAs file '%s' (%s)",
 					err, serverRoot)
 			}
 			serverRootCAs = append(serverRootCAs, root)
@@ -508,7 +508,7 @@ func initializeServerConfig(conf *localconfig.TopLevel, metricsProvider metrics.
 			for _, clientRoot := range conf.General.TLS.ClientRootCAs {
 				root, err := os.ReadFile(clientRoot)
 				if err != nil {
-					logger.Fatalf("Failed to load ClientRootCAs file '%s' (%s)",
+					logger.Fatalf("Failed to load TLS ClientRootCAs file '%s' (%s)",
 						err, clientRoot)
 				}
 				clientRootCAs = append(clientRootCAs, root)

--- a/orderer/common/server/main_test.go
+++ b/orderer/common/server/main_test.go
@@ -191,7 +191,7 @@ func TestInitializeServerConfig(t *testing.T) {
 			privateKey:     goodFile,
 			rootCA:         goodFile,
 			clientRootCert: goodFile,
-			expectedPanic:  "Failed to load server Certificate file 'does_not_exist' (open does_not_exist: no such file or directory)",
+			expectedPanic:  "Failed to load server TLS Certificate file 'does_not_exist' (open does_not_exist: no such file or directory)",
 		},
 		{
 			name:           "BadPrivateKey",
@@ -199,7 +199,7 @@ func TestInitializeServerConfig(t *testing.T) {
 			privateKey:     badFile,
 			rootCA:         goodFile,
 			clientRootCert: goodFile,
-			expectedPanic:  "Failed to load PrivateKey file 'does_not_exist' (open does_not_exist: no such file or directory)",
+			expectedPanic:  "Failed to load TLS PrivateKey file 'does_not_exist' (open does_not_exist: no such file or directory)",
 		},
 		{
 			name:           "BadRootCA",
@@ -207,7 +207,7 @@ func TestInitializeServerConfig(t *testing.T) {
 			privateKey:     goodFile,
 			rootCA:         badFile,
 			clientRootCert: goodFile,
-			expectedPanic:  "Failed to load ServerRootCAs file 'open does_not_exist: no such file or directory' (does_not_exist)",
+			expectedPanic:  "Failed to load TLS ServerRootCAs file 'open does_not_exist: no such file or directory' (does_not_exist)",
 		},
 		{
 			name:           "BadClientRootCertificate",
@@ -215,7 +215,7 @@ func TestInitializeServerConfig(t *testing.T) {
 			privateKey:     goodFile,
 			rootCA:         goodFile,
 			clientRootCert: badFile,
-			expectedPanic:  "Failed to load ClientRootCAs file 'open does_not_exist: no such file or directory' (does_not_exist)",
+			expectedPanic:  "Failed to load TLS ClientRootCAs file 'open does_not_exist: no such file or directory' (does_not_exist)",
 		},
 		{
 			name:           "BadCertificate - cluster reuses server config",


### PR DESCRIPTION
Update Fabric docs to indicate that HSM is not supported for TLS keys.

Also update the error messages for missing TLS keys to indicate that the error is specific to TLS keys. This will assist with troubleshooting for users that attempt to configure TLS keys with an HSM.