### PR TITLE
Update YAML indentation to 2 spaces in sampleconfig for consistency

### DIFF
--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-
 ################################################################################
 #
 #   NOTE
@@ -23,57 +22,56 @@
 #
 ################################################################################
 Organizations:
+  # SampleOrg defines an MSP using the sampleconfig. It should never be used
+  # in production but may be used as a template for other definitions.
+  - &SampleOrg
+    # Name is the key by which this org will be referenced in channel
+    # configuration transactions.
+    # Name can include alphanumeric characters as well as dots and dashes.
+    Name: SampleOrg
 
-    # SampleOrg defines an MSP using the sampleconfig. It should never be used
-    # in production but may be used as a template for other definitions.
-    - &SampleOrg
-        # Name is the key by which this org will be referenced in channel
-        # configuration transactions.
-        # Name can include alphanumeric characters as well as dots and dashes.
-        Name: SampleOrg
+    # SkipAsForeign can be set to true for org definitions which are to be
+    # inherited from the orderer system channel during channel creation.  This
+    # is especially useful when an admin of a single org without access to the
+    # MSP directories of the other orgs wishes to create a channel.  Note
+    # this property must always be set to false for orgs included in block
+    # creation.
+    SkipAsForeign: false
 
-        # SkipAsForeign can be set to true for org definitions which are to be
-        # inherited from the orderer system channel during channel creation.  This
-        # is especially useful when an admin of a single org without access to the
-        # MSP directories of the other orgs wishes to create a channel.  Note
-        # this property must always be set to false for orgs included in block
-        # creation.
-        SkipAsForeign: false
+    # ID is the key by which this org's MSP definition will be referenced.
+    # ID can include alphanumeric characters as well as dots and dashes.
+    ID: SampleOrg
 
-        # ID is the key by which this org's MSP definition will be referenced.
-        # ID can include alphanumeric characters as well as dots and dashes.
-        ID: SampleOrg
+    # MSPDir is the filesystem path which contains the MSP configuration.
+    MSPDir: msp
 
-        # MSPDir is the filesystem path which contains the MSP configuration.
-        MSPDir: msp
+    # Policies defines the set of policies at this level of the config tree
+    # For organization policies, their canonical path is usually
+    #   /Channel/<Application|Orderer>/<OrgName>/<PolicyName>
+    Policies: &SampleOrgPolicies
+      Readers:
+        Type: Signature
+        Rule: "OR('SampleOrg.member')"
+        # If your MSP is configured with the new NodeOUs, you might
+        # want to use a more specific rule like the following:
+        # Rule: "OR('SampleOrg.admin', 'SampleOrg.peer', 'SampleOrg.client')"
+      Writers:
+        Type: Signature
+        Rule: "OR('SampleOrg.member')"
+        # If your MSP is configured with the new NodeOUs, you might
+        # want to use a more specific rule like the following:
+        # Rule: "OR('SampleOrg.admin', 'SampleOrg.client')"
+      Admins:
+        Type: Signature
+        Rule: "OR('SampleOrg.admin')"
+      Endorsement:
+        Type: Signature
+        Rule: "OR('SampleOrg.member')"
 
-        # Policies defines the set of policies at this level of the config tree
-        # For organization policies, their canonical path is usually
-        #   /Channel/<Application|Orderer>/<OrgName>/<PolicyName>
-        Policies: &SampleOrgPolicies
-            Readers:
-                Type: Signature
-                Rule: "OR('SampleOrg.member')"
-                # If your MSP is configured with the new NodeOUs, you might
-                # want to use a more specific rule like the following:
-                # Rule: "OR('SampleOrg.admin', 'SampleOrg.peer', 'SampleOrg.client')"
-            Writers:
-                Type: Signature
-                Rule: "OR('SampleOrg.member')"
-                # If your MSP is configured with the new NodeOUs, you might
-                # want to use a more specific rule like the following:
-                # Rule: "OR('SampleOrg.admin', 'SampleOrg.client')"
-            Admins:
-                Type: Signature
-                Rule: "OR('SampleOrg.admin')"
-            Endorsement:
-                Type: Signature
-                Rule: "OR('SampleOrg.member')"
-
-        # OrdererEndpoints is a list of all orderers this org runs which clients
-        # and peers may to connect to push transactions and receive blocks respectively.
-        OrdererEndpoints:
-            - "127.0.0.1:7050"
+    # OrdererEndpoints is a list of all orderers this org runs which clients
+    # and peers may to connect to push transactions and receive blocks respectively.
+    OrdererEndpoints:
+      - "127.0.0.1:7050"
 
 ################################################################################
 #
@@ -95,38 +93,38 @@ Organizations:
 #
 ################################################################################
 Capabilities:
-    # Channel capabilities apply to both the orderers and the peers and must be
-    # supported by both.
-    # Set the value of the capability to true to require it.
-    Channel: &ChannelCapabilities
-        # V3.0 for Channel is a catchall flag for behavior which has been
-        # determined to be desired for all orderers and peers running at the v3.0.0
-        # level, but which would be incompatible with orderers and peers from
-        # prior releases.
-        # Prior to enabling V3.0 channel capabilities, ensure that all
-        # orderers and peers on a channel are at v3.0.0 or later.
-        V3_0: true
+  # Channel capabilities apply to both the orderers and the peers and must be
+  # supported by both.
+  # Set the value of the capability to true to require it.
+  Channel: &ChannelCapabilities
+    # V3.0 for Channel is a catchall flag for behavior which has been
+    # determined to be desired for all orderers and peers running at the v3.0.0
+    # level, but which would be incompatible with orderers and peers from
+    # prior releases.
+    # Prior to enabling V3.0 channel capabilities, ensure that all
+    # orderers and peers on a channel are at v3.0.0 or later.
+    V3_0: true
 
-    # Orderer capabilities apply only to the orderers, and may be safely
-    # used with prior release peers.
-    # Set the value of the capability to true to require it.
-    Orderer: &OrdererCapabilities
-        # V1.1 for Orderer is a catchall flag for behavior which has been
-        # determined to be desired for all orderers running at the v1.1.x
-        # level, but which would be incompatible with orderers from prior releases.
-        # Prior to enabling V2.0 orderer capabilities, ensure that all
-        # orderers on a channel are at v2.0.0 or later.
-        V2_0: true
+  # Orderer capabilities apply only to the orderers, and may be safely
+  # used with prior release peers.
+  # Set the value of the capability to true to require it.
+  Orderer: &OrdererCapabilities
+    # V1.1 for Orderer is a catchall flag for behavior which has been
+    # determined to be desired for all orderers running at the v1.1.x
+    # level, but which would be incompatible with orderers from prior releases.
+    # Prior to enabling V2.0 orderer capabilities, ensure that all
+    # orderers on a channel are at v2.0.0 or later.
+    V2_0: true
 
-    # Application capabilities apply only to the peer network, and may be safely
-    # used with prior release orderers.
-    # Set the value of the capability to true to require it.
-    Application: &ApplicationCapabilities
-        # V2.5 for Application enables the new non-backwards compatible
-        # features of fabric v2.5, namely the ability to purge private data.
-        # Prior to enabling V2.5 application capabilities, ensure that all
-        # peers on a channel are at v2.5.0 or later.
-        V2_5: true
+  # Application capabilities apply only to the peer network, and may be safely
+  # used with prior release orderers.
+  # Set the value of the capability to true to require it.
+  Application: &ApplicationCapabilities
+    # V2.5 for Application enables the new non-backwards compatible
+    # features of fabric v2.5, namely the ability to purge private data.
+    # Prior to enabling V2.5 application capabilities, ensure that all
+    # peers on a channel are at v2.5.0 or later.
+    V2_5: true
 
 ################################################################################
 #
@@ -137,114 +135,114 @@ Capabilities:
 #
 ################################################################################
 Application: &ApplicationDefaults
-    ACLs: &ACLsDefault
-        # This section provides defaults for policies for various resources
-        # in the system. These "resources" could be functions on system chaincodes
-        # (e.g., "GetBlockByNumber" on the "qscc" system chaincode) or other resources
-        # (e.g.,who can receive Block events). This section does NOT specify the resource's
-        # definition or API, but just the ACL policy for it.
-        #
-        # Users can override these defaults with their own policy mapping by defining the
-        # mapping under ACLs in their channel definition
+  ACLs: &ACLsDefault
+    # This section provides defaults for policies for various resources
+    # in the system. These "resources" could be functions on system chaincodes
+    # (e.g., "GetBlockByNumber" on the "qscc" system chaincode) or other resources
+    # (e.g.,who can receive Block events). This section does NOT specify the resource's
+    # definition or API, but just the ACL policy for it.
+    #
+    # Users can override these defaults with their own policy mapping by defining the
+    # mapping under ACLs in their channel definition
 
-        #---New Lifecycle System Chaincode (_lifecycle) function to policy mapping for access control--#
+    #---New Lifecycle System Chaincode (_lifecycle) function to policy mapping for access control--#
 
-        # ACL policy for _lifecycle's "CheckCommitReadiness" function
-        _lifecycle/CheckCommitReadiness: /Channel/Application/Writers
+    # ACL policy for _lifecycle's "CheckCommitReadiness" function
+    _lifecycle/CheckCommitReadiness: /Channel/Application/Writers
 
-        # ACL policy for _lifecycle's "CommitChaincodeDefinition" function
-        _lifecycle/CommitChaincodeDefinition: /Channel/Application/Writers
+    # ACL policy for _lifecycle's "CommitChaincodeDefinition" function
+    _lifecycle/CommitChaincodeDefinition: /Channel/Application/Writers
 
-        # ACL policy for _lifecycle's "QueryChaincodeDefinition" function
-        _lifecycle/QueryChaincodeDefinition: /Channel/Application/Writers
+    # ACL policy for _lifecycle's "QueryChaincodeDefinition" function
+    _lifecycle/QueryChaincodeDefinition: /Channel/Application/Writers
 
-        # ACL policy for _lifecycle's "QueryChaincodeDefinitions" function
-        _lifecycle/QueryChaincodeDefinitions: /Channel/Application/Writers
+    # ACL policy for _lifecycle's "QueryChaincodeDefinitions" function
+    _lifecycle/QueryChaincodeDefinitions: /Channel/Application/Writers
 
-        #---Lifecycle System Chaincode (lscc) function to policy mapping for access control---#
+    #---Lifecycle System Chaincode (lscc) function to policy mapping for access control---#
 
-        # ACL policy for lscc's "getid" function
-        lscc/ChaincodeExists: /Channel/Application/Readers
+    # ACL policy for lscc's "getid" function
+    lscc/ChaincodeExists: /Channel/Application/Readers
 
-        # ACL policy for lscc's "getdepspec" function
-        lscc/GetDeploymentSpec: /Channel/Application/Readers
+    # ACL policy for lscc's "getdepspec" function
+    lscc/GetDeploymentSpec: /Channel/Application/Readers
 
-        # ACL policy for lscc's "getccdata" function
-        lscc/GetChaincodeData: /Channel/Application/Readers
+    # ACL policy for lscc's "getccdata" function
+    lscc/GetChaincodeData: /Channel/Application/Readers
 
-        # ACL Policy for lscc's "getchaincodes" function
-        lscc/GetInstantiatedChaincodes: /Channel/Application/Readers
+    # ACL Policy for lscc's "getchaincodes" function
+    lscc/GetInstantiatedChaincodes: /Channel/Application/Readers
 
-        #---Query System Chaincode (qscc) function to policy mapping for access control---#
+    #---Query System Chaincode (qscc) function to policy mapping for access control---#
 
-        # ACL policy for qscc's "GetChainInfo" function
-        qscc/GetChainInfo: /Channel/Application/Readers
+    # ACL policy for qscc's "GetChainInfo" function
+    qscc/GetChainInfo: /Channel/Application/Readers
 
-        # ACL policy for qscc's "GetBlockByNumber" function
-        qscc/GetBlockByNumber: /Channel/Application/Readers
+    # ACL policy for qscc's "GetBlockByNumber" function
+    qscc/GetBlockByNumber: /Channel/Application/Readers
 
-        # ACL policy for qscc's  "GetBlockByHash" function
-        qscc/GetBlockByHash: /Channel/Application/Readers
+    # ACL policy for qscc's  "GetBlockByHash" function
+    qscc/GetBlockByHash: /Channel/Application/Readers
 
-        # ACL policy for qscc's "GetTransactionByID" function
-        qscc/GetTransactionByID: /Channel/Application/Readers
+    # ACL policy for qscc's "GetTransactionByID" function
+    qscc/GetTransactionByID: /Channel/Application/Readers
 
-        # ACL policy for qscc's "GetBlockByTxID" function
-        qscc/GetBlockByTxID: /Channel/Application/Readers
+    # ACL policy for qscc's "GetBlockByTxID" function
+    qscc/GetBlockByTxID: /Channel/Application/Readers
 
-        #---Configuration System Chaincode (cscc) function to policy mapping for access control---#
+    #---Configuration System Chaincode (cscc) function to policy mapping for access control---#
 
-        # ACL policy for cscc's "GetConfigBlock" function
-        cscc/GetConfigBlock: /Channel/Application/Readers
+    # ACL policy for cscc's "GetConfigBlock" function
+    cscc/GetConfigBlock: /Channel/Application/Readers
 
-        # ACL policy for cscc's "GetChannelConfig" function
-        cscc/GetChannelConfig: /Channel/Application/Readers
+    # ACL policy for cscc's "GetChannelConfig" function
+    cscc/GetChannelConfig: /Channel/Application/Readers
 
-        #---Miscellaneous peer function to policy mapping for access control---#
+    #---Miscellaneous peer function to policy mapping for access control---#
 
-        # ACL policy for invoking chaincodes on peer
-        peer/Propose: /Channel/Application/Writers
+    # ACL policy for invoking chaincodes on peer
+    peer/Propose: /Channel/Application/Writers
 
-        # ACL policy for chaincode to chaincode invocation
-        peer/ChaincodeToChaincode: /Channel/Application/Writers
+    # ACL policy for chaincode to chaincode invocation
+    peer/ChaincodeToChaincode: /Channel/Application/Writers
 
-        #---Events resource to policy mapping for access control###---#
+    #---Events resource to policy mapping for access control###---#
 
-        # ACL policy for sending block events
-        event/Block: /Channel/Application/Readers
+    # ACL policy for sending block events
+    event/Block: /Channel/Application/Readers
 
-        # ACL policy for sending filtered block events
-        event/FilteredBlock: /Channel/Application/Readers
+    # ACL policy for sending filtered block events
+    event/FilteredBlock: /Channel/Application/Readers
 
-    # Organizations lists the orgs participating on the application side of the
-    # network.
-    Organizations:
+  # Organizations lists the orgs participating on the application side of the
+  # network.
+  Organizations:
 
-    # Policies defines the set of policies at this level of the config tree
-    # For Application policies, their canonical path is
-    #   /Channel/Application/<PolicyName>
-    Policies: &ApplicationDefaultPolicies
-        LifecycleEndorsement:
-            Type: ImplicitMeta
-            Rule: "MAJORITY Endorsement"
-        Endorsement:
-            Type: ImplicitMeta
-            Rule: "MAJORITY Endorsement"
-        Readers:
-            Type: ImplicitMeta
-            Rule: "ANY Readers"
-        Writers:
-            Type: ImplicitMeta
-            Rule: "ANY Writers"
-        Admins:
-            Type: ImplicitMeta
-            Rule: "MAJORITY Admins"
+  # Policies defines the set of policies at this level of the config tree
+  # For Application policies, their canonical path is
+  #   /Channel/Application/<PolicyName>
+  Policies: &ApplicationDefaultPolicies
+    LifecycleEndorsement:
+      Type: ImplicitMeta
+      Rule: "MAJORITY Endorsement"
+    Endorsement:
+      Type: ImplicitMeta
+      Rule: "MAJORITY Endorsement"
+    Readers:
+      Type: ImplicitMeta
+      Rule: "ANY Readers"
+    Writers:
+      Type: ImplicitMeta
+      Rule: "ANY Writers"
+    Admins:
+      Type: ImplicitMeta
+      Rule: "MAJORITY Admins"
 
-    # Capabilities describes the application level capabilities, see the
-    # dedicated Capabilities section elsewhere in this file for a full
-    # description
-    Capabilities:
-        <<: *ApplicationCapabilities
+  # Capabilities describes the application level capabilities, see the
+  # dedicated Capabilities section elsewhere in this file for a full
+  # description
+  Capabilities:
+    <<: *ApplicationCapabilities
 
 ################################################################################
 #
@@ -255,68 +253,66 @@ Application: &ApplicationDefaults
 #
 ################################################################################
 Orderer: &OrdererDefaults
+  # Orderer Type: The orderer implementation to start.
+  # Available types are "etcdraft" and "BFT".
+  # Please note that "solo" and "kafka" are no longer supported.
+  OrdererType: etcdraft
 
-    # Orderer Type: The orderer implementation to start.
-    # Available types are "etcdraft" and "BFT".
-    # Please note that "solo" and "kafka" are no longer supported.
-    OrdererType: etcdraft
+  # Addresses used to be the list of orderer addresses that clients and peers
+  # could connect to.  However, this does not allow clients to associate orderer
+  # addresses and orderer organizations which can be useful for things such
+  # as TLS validation.  The preferred way to specify orderer addresses is now
+  # to include the OrdererEndpoints item in your org definition
+  Addresses:
+    # - 127.0.0.1:7050
 
-    # Addresses used to be the list of orderer addresses that clients and peers
-    # could connect to.  However, this does not allow clients to associate orderer
-    # addresses and orderer organizations which can be useful for things such
-    # as TLS validation.  The preferred way to specify orderer addresses is now
-    # to include the OrdererEndpoints item in your org definition
-    Addresses:
-        # - 127.0.0.1:7050
+  # Batch Timeout: The amount of time to wait before creating a batch.
+  BatchTimeout: 2s
 
-    # Batch Timeout: The amount of time to wait before creating a batch.
-    BatchTimeout: 2s
+  # Batch Size: Controls the number of messages batched into a block.
+  # The orderer views messages opaquely, but typically, messages may
+  # be considered to be Fabric transactions.  The 'batch' is the group
+  # of messages in the 'data' field of the block.  Blocks will be a few kb
+  # larger than the batch size, when signatures, hashes, and other metadata
+  # is applied.
+  BatchSize:
+    # Max Message Count: The maximum number of messages to permit in a
+    # batch.  No block will contain more than this number of messages.
+    MaxMessageCount: 500
 
-    # Batch Size: Controls the number of messages batched into a block.
-    # The orderer views messages opaquely, but typically, messages may
-    # be considered to be Fabric transactions.  The 'batch' is the group
-    # of messages in the 'data' field of the block.  Blocks will be a few kb
-    # larger than the batch size, when signatures, hashes, and other metadata
-    # is applied.
-    BatchSize:
+    # Absolute Max Bytes: The absolute maximum number of bytes allowed for
+    # the serialized messages in a batch. The maximum block size is this value
+    # plus the size of the associated metadata (usually a few KB depending
+    # upon the size of the signing identities). Any transaction larger than
+    # this value will be rejected by ordering.
+    # It is recommended not to exceed 49 MB, given the default grpc max message size of 100 MB
+    # configured on orderer and peer nodes (and allowing for message expansion during communication).
+    AbsoluteMaxBytes: 10 MB
 
-        # Max Message Count: The maximum number of messages to permit in a
-        # batch.  No block will contain more than this number of messages.
-        MaxMessageCount: 500
+    # Preferred Max Bytes: The preferred maximum number of bytes allowed
+    # for the serialized messages in a batch. Roughly, this field may be considered
+    # the best effort maximum size of a batch. A batch will fill with messages
+    # until this size is reached (or the max message count, or batch timeout is
+    # exceeded).  If adding a new message to the batch would cause the batch to
+    # exceed the preferred max bytes, then the current batch is closed and written
+    # to a block, and a new batch containing the new message is created.  If a
+    # message larger than the preferred max bytes is received, then its batch
+    # will contain only that message.  Because messages may be larger than
+    # preferred max bytes (up to AbsoluteMaxBytes), some batches may exceed
+    # the preferred max bytes, but will always contain exactly one transaction.
+    PreferredMaxBytes: 2 MB
 
-        # Absolute Max Bytes: The absolute maximum number of bytes allowed for
-        # the serialized messages in a batch. The maximum block size is this value
-        # plus the size of the associated metadata (usually a few KB depending
-        # upon the size of the signing identities). Any transaction larger than
-        # this value will be rejected by ordering.
-        # It is recommended not to exceed 49 MB, given the default grpc max message size of 100 MB
-        # configured on orderer and peer nodes (and allowing for message expansion during communication).
-        AbsoluteMaxBytes: 10 MB
+  # Max Channels is the maximum number of channels to allow on the ordering
+  # network. When set to 0, this implies no maximum number of channels.
+  MaxChannels: 0
 
-        # Preferred Max Bytes: The preferred maximum number of bytes allowed
-        # for the serialized messages in a batch. Roughly, this field may be considered
-        # the best effort maximum size of a batch. A batch will fill with messages
-        # until this size is reached (or the max message count, or batch timeout is
-        # exceeded).  If adding a new message to the batch would cause the batch to
-        # exceed the preferred max bytes, then the current batch is closed and written
-        # to a block, and a new batch containing the new message is created.  If a
-        # message larger than the preferred max bytes is received, then its batch
-        # will contain only that message.  Because messages may be larger than
-        # preferred max bytes (up to AbsoluteMaxBytes), some batches may exceed
-        # the preferred max bytes, but will always contain exactly one transaction.
-        PreferredMaxBytes: 2 MB
-
-    # Max Channels is the maximum number of channels to allow on the ordering
-    # network. When set to 0, this implies no maximum number of channels.
-    MaxChannels: 0
-
-    # ConsenterMapping contains the definition of consenter identity, endpoints, and crypto material.
-    # The ConsenterMapping is used in the BFT consensus protocol, and should include enough servers to ensure
-    # fault-tolerance; In BFT this number is at least 3*F+1, where F is the number of potential failures.
-    # In BFT it is highly recommended that the addresses for delivery & broadcast (the OrdererEndpoints item in the
-    # org definition) map 1:1 to the Orderer/ConsenterMapping (for cluster consensus). That is, every consenter should
-    # be represented by a delivery endpoint. Note that in BFT (V3) global Orderer/Addresses are no longer supported.
-    ConsenterMapping:
+  # ConsenterMapping contains the definition of consenter identity, endpoints, and crypto material.
+  # The ConsenterMapping is used in the BFT consensus protocol, and should include enough servers to ensure
+  # fault-tolerance; In BFT this number is at least 3*F+1, where F is the number of potential failures.
+  # In BFT it is highly recommended that the addresses for delivery & broadcast (the OrdererEndpoints item in the
+  # org definition) map 1:1 to the Orderer/ConsenterMapping (for cluster consensus). That is, every consenter should
+  # be represented by a delivery endpoint. Note that in BFT (V3) global Orderer/Addresses are no longer supported.
+  ConsenterMapping:
     - ID: 1
       Host: bft0.example.com
       Port: 7050
@@ -346,81 +342,81 @@ Orderer: &OrdererDefaults
       ClientTLSCert: path/to/ClientTLSCert3
       ServerTLSCert: path/to/ServerTLSCert3
 
-    # EtcdRaft defines configuration which must be set when the "etcdraft"
-    # orderertype is chosen.
-    EtcdRaft:
-        # The set of Raft replicas for this network. For the etcd/raft-based
-        # implementation, we expect every replica to also be an OSN. Therefore,
-        # a subset of the host:port items enumerated in this list should be
-        # replicated under the Orderer.Addresses key above.
-        Consenters:
-            - Host: raft0.example.com
-              Port: 7050
-              ClientTLSCert: path/to/ClientTLSCert0
-              ServerTLSCert: path/to/ServerTLSCert0
-            - Host: raft1.example.com
-              Port: 7050
-              ClientTLSCert: path/to/ClientTLSCert1
-              ServerTLSCert: path/to/ServerTLSCert1
-            - Host: raft2.example.com
-              Port: 7050
-              ClientTLSCert: path/to/ClientTLSCert2
-              ServerTLSCert: path/to/ServerTLSCert2
+  # EtcdRaft defines configuration which must be set when the "etcdraft"
+  # orderertype is chosen.
+  EtcdRaft:
+    # The set of Raft replicas for this network. For the etcd/raft-based
+    # implementation, we expect every replica to also be an OSN. Therefore,
+    # a subset of the host:port items enumerated in this list should be
+    # replicated under the Orderer.Addresses key above.
+    Consenters:
+      - Host: raft0.example.com
+        Port: 7050
+        ClientTLSCert: path/to/ClientTLSCert0
+        ServerTLSCert: path/to/ServerTLSCert0
+      - Host: raft1.example.com
+        Port: 7050
+        ClientTLSCert: path/to/ClientTLSCert1
+        ServerTLSCert: path/to/ServerTLSCert1
+      - Host: raft2.example.com
+        Port: 7050
+        ClientTLSCert: path/to/ClientTLSCert2
+        ServerTLSCert: path/to/ServerTLSCert2
 
-        # Options to be specified for all the etcd/raft nodes. The values here
-        # are the defaults for all new channels and can be modified on a
-        # per-channel basis via configuration updates.
-        Options:
-            # TickInterval is the time interval between two Node.Tick invocations.
-            TickInterval: 500ms
+    # Options to be specified for all the etcd/raft nodes. The values here
+    # are the defaults for all new channels and can be modified on a
+    # per-channel basis via configuration updates.
+    Options:
+      # TickInterval is the time interval between two Node.Tick invocations.
+      TickInterval: 500ms
 
-            # ElectionTick is the number of Node.Tick invocations that must pass
-            # between elections. That is, if a follower does not receive any
-            # message from the leader of current term before ElectionTick has
-            # elapsed, it will become candidate and start an election.
-            # ElectionTick must be greater than HeartbeatTick.
-            ElectionTick: 10
+      # ElectionTick is the number of Node.Tick invocations that must pass
+      # between elections. That is, if a follower does not receive any
+      # message from the leader of current term before ElectionTick has
+      # elapsed, it will become candidate and start an election.
+      # ElectionTick must be greater than HeartbeatTick.
+      ElectionTick: 10
 
-            # HeartbeatTick is the number of Node.Tick invocations that must
-            # pass between heartbeats. That is, a leader sends heartbeat
-            # messages to maintain its leadership every HeartbeatTick ticks.
-            HeartbeatTick: 1
+      # HeartbeatTick is the number of Node.Tick invocations that must
+      # pass between heartbeats. That is, a leader sends heartbeat
+      # messages to maintain its leadership every HeartbeatTick ticks.
+      HeartbeatTick: 1
 
-            # MaxInflightBlocks limits the max number of in-flight append messages
-            # during optimistic replication phase.
-            MaxInflightBlocks: 5
+      # MaxInflightBlocks limits the max number of in-flight append messages
+      # during optimistic replication phase.
+      MaxInflightBlocks: 5
 
-            # SnapshotIntervalSize defines number of bytes per which a snapshot is taken
-            SnapshotIntervalSize: 16 MB
+      # SnapshotIntervalSize defines number of bytes per which a snapshot is taken
+      SnapshotIntervalSize: 16 MB
 
-    # Organizations lists the orgs participating on the orderer side of the
-    # network.
-    Organizations:
+  # Organizations lists the orgs participating on the orderer side of the
+  # network.
+  Organizations:
 
-    # Policies defines the set of policies at this level of the config tree
-    # For Orderer policies, their canonical path is
-    #   /Channel/Orderer/<PolicyName>
-    Policies:
-        Readers:
-            Type: ImplicitMeta
-            Rule: "ANY Readers"
-        Writers:
-            Type: ImplicitMeta
-            Rule: "ANY Writers"
-        Admins:
-            Type: ImplicitMeta
-            Rule: "MAJORITY Admins"
-        # BlockValidation specifies what signatures must be included in the block
-        # from the orderer for the peer to validate it.
-        BlockValidation:
-            Type: ImplicitMeta
-            Rule: "ANY Writers"
+  # Policies defines the set of policies at this level of the config tree
+  # For Orderer policies, their canonical path is
+  #   /Channel/Orderer/<PolicyName>
+  Policies:
+    Readers:
+      Type: ImplicitMeta
+      Rule: "ANY Readers"
+    Writers:
+      Type: ImplicitMeta
+      Rule: "ANY Writers"
+    Admins:
+      Type: ImplicitMeta
+      Rule: "MAJORITY Admins"
+    # BlockValidation specifies what signatures must be included in the block
+    # from the orderer for the peer to validate it.
+    BlockValidation:
+      Type: ImplicitMeta
+      Rule: "ANY Writers"
 
-    # Capabilities describes the orderer level capabilities, see the
-    # dedicated Capabilities section elsewhere in this file for a full
-    # description
-    Capabilities:
-        <<: *OrdererCapabilities
+  # Capabilities describes the orderer level capabilities, see the
+  # dedicated Capabilities section elsewhere in this file for a full
+  # description
+  Capabilities:
+    <<: *OrdererCapabilities
 
 ################################################################################
 #
@@ -431,29 +427,28 @@ Orderer: &OrdererDefaults
 #
 ################################################################################
 Channel: &ChannelDefaults
-    # Policies defines the set of policies at this level of the config tree
-    # For Channel policies, their canonical path is
-    #   /Channel/<PolicyName>
-    Policies:
-        # Who may invoke the 'Deliver' API
-        Readers:
-            Type: ImplicitMeta
-            Rule: "ANY Readers"
-        # Who may invoke the 'Broadcast' API
-        Writers:
-            Type: ImplicitMeta
-            Rule: "ANY Writers"
-        # By default, who may modify elements at this config level
-        Admins:
-            Type: ImplicitMeta
-            Rule: "MAJORITY Admins"
+  # Policies defines the set of policies at this level of the config tree
+  # For Channel policies, their canonical path is
+  #   /Channel/<PolicyName>
+  Policies:
+    # Who may invoke the 'Deliver' API
+    Readers:
+      Type: ImplicitMeta
+      Rule: "ANY Readers"
+    # Who may invoke the 'Broadcast' API
+    Writers:
+      Type: ImplicitMeta
+      Rule: "ANY Writers"
+    # By default, who may modify elements at this config level
+    Admins:
+      Type: ImplicitMeta
+      Rule: "MAJORITY Admins"
 
-
-    # Capabilities describes the channel level capabilities, see the
-    # dedicated Capabilities section elsewhere in this file for a full
-    # description
-    Capabilities:
-        <<: *ChannelCapabilities
+  # Capabilities describes the channel level capabilities, see the
+  # dedicated Capabilities section elsewhere in this file for a full
+  # description
+  Capabilities:
+    <<: *ChannelCapabilities
 
 ################################################################################
 #
@@ -468,246 +463,245 @@ Channel: &ChannelDefaults
 #
 ################################################################################
 Profiles:
+  # SampleSingleMSPSolo defines a configuration which uses the Solo orderer,
+  # and contains a single MSP definition (the MSP sampleconfig).
+  # The Consortium SampleConsortium has only a single member, SampleOrg.
+  SampleSingleMSPSolo:
+    <<: *ChannelDefaults
+    Orderer:
+      <<: *OrdererDefaults
+      OrdererType: solo
+      Organizations:
+        - *SampleOrg
+    Consortiums:
+      SampleConsortium:
+        Organizations:
+          - *SampleOrg
 
-    # SampleSingleMSPSolo defines a configuration which uses the Solo orderer,
-    # and contains a single MSP definition (the MSP sampleconfig).
-    # The Consortium SampleConsortium has only a single member, SampleOrg.
-    SampleSingleMSPSolo:
-        <<: *ChannelDefaults
-        Orderer:
-            <<: *OrdererDefaults
-            OrdererType: solo
-            Organizations:
-                - *SampleOrg
-        Consortiums:
-            SampleConsortium:
-                Organizations:
-                    - *SampleOrg
+  # SampleSingleMSPKafka defines a configuration that differs from the
+  # SampleSingleMSPSolo one only in that it uses the Kafka-based orderer.
+  SampleSingleMSPKafka:
+    <<: *ChannelDefaults
+    Orderer:
+      <<: *OrdererDefaults
+      OrdererType: kafka
+      Organizations:
+        - *SampleOrg
+    Consortiums:
+      SampleConsortium:
+        Organizations:
+          - *SampleOrg
 
-    # SampleSingleMSPKafka defines a configuration that differs from the
-    # SampleSingleMSPSolo one only in that it uses the Kafka-based orderer.
-    SampleSingleMSPKafka:
-        <<: *ChannelDefaults
-        Orderer:
-            <<: *OrdererDefaults
-            OrdererType: kafka
-            Organizations:
-                - *SampleOrg
-        Consortiums:
-            SampleConsortium:
-                Organizations:
-                    - *SampleOrg
+  # SampleInsecureSolo defines a configuration which uses the Solo orderer,
+  # contains no MSP definitions, and allows all transactions and channel
+  # creation requests for the consortium SampleConsortium.
+  SampleInsecureSolo:
+    <<: *ChannelDefaults
+    Orderer:
+      <<: *OrdererDefaults
+      OrdererType: solo
+    Consortiums:
+      SampleConsortium:
+        Organizations:
 
-    # SampleInsecureSolo defines a configuration which uses the Solo orderer,
-    # contains no MSP definitions, and allows all transactions and channel
-    # creation requests for the consortium SampleConsortium.
-    SampleInsecureSolo:
-        <<: *ChannelDefaults
-        Orderer:
-            <<: *OrdererDefaults
-            OrdererType: solo
-        Consortiums:
-            SampleConsortium:
-                Organizations:
+  # SampleInsecureKafka defines a configuration that differs from the
+  # SampleInsecureSolo one only in that it uses the Kafka-based orderer.
+  SampleInsecureKafka:
+    <<: *ChannelDefaults
+    Orderer:
+      <<: *OrdererDefaults
+      OrdererType: kafka
+    Consortiums:
+      SampleConsortium:
+        Organizations:
 
-    # SampleInsecureKafka defines a configuration that differs from the
-    # SampleInsecureSolo one only in that it uses the Kafka-based orderer.
-    SampleInsecureKafka:
-        <<: *ChannelDefaults
-        Orderer:
-            <<: *OrdererDefaults
-            OrdererType: kafka
-        Consortiums:
-            SampleConsortium:
-                Organizations:
+  # SampleDevModeSolo defines a configuration which uses the Solo orderer,
+  # contains the sample MSP as both orderer and consortium member, and
+  # requires only basic membership for admin privileges. It also defines
+  # an Application on the ordering system channel, which should usually
+  # be avoided.
+  SampleDevModeSolo:
+    <<: *ChannelDefaults
+    Orderer:
+      <<: *OrdererDefaults
+      OrdererType: solo
+      Organizations:
+        - <<: *SampleOrg
+          Policies:
+            <<: *SampleOrgPolicies
+            Admins:
+              Type: Signature
+              Rule: "OR('SampleOrg.member')"
+    Application:
+      <<: *ApplicationDefaults
+      Organizations:
+        - <<: *SampleOrg
+          Policies:
+            <<: *SampleOrgPolicies
+            Admins:
+              Type: Signature
+              Rule: "OR('SampleOrg.member')"
+    Consortiums:
+      SampleConsortium:
+        Organizations:
+          - <<: *SampleOrg
+            Policies:
+              <<: *SampleOrgPolicies
+              Admins:
+                Type: Signature
+                Rule: "OR('SampleOrg.member')"
 
-    # SampleDevModeSolo defines a configuration which uses the Solo orderer,
-    # contains the sample MSP as both orderer and consortium member, and
-    # requires only basic membership for admin privileges. It also defines
-    # an Application on the ordering system channel, which should usually
-    # be avoided.
-    SampleDevModeSolo:
-        <<: *ChannelDefaults
-        Orderer:
-            <<: *OrdererDefaults
-            OrdererType: solo
-            Organizations:
-                - <<: *SampleOrg
-                  Policies:
-                      <<: *SampleOrgPolicies
-                      Admins:
-                          Type: Signature
-                          Rule: "OR('SampleOrg.member')"
-        Application:
-            <<: *ApplicationDefaults
-            Organizations:
-                - <<: *SampleOrg
-                  Policies:
-                      <<: *SampleOrgPolicies
-                      Admins:
-                          Type: Signature
-                          Rule: "OR('SampleOrg.member')"
-        Consortiums:
-            SampleConsortium:
-                Organizations:
-                    - <<: *SampleOrg
-                      Policies:
-                          <<: *SampleOrgPolicies
-                          Admins:
-                              Type: Signature
-                              Rule: "OR('SampleOrg.member')"
+  # SampleDevModeKafka defines a configuration that differs from the
+  # SampleDevModeSolo one only in that it uses the Kafka-based orderer.
+  SampleDevModeKafka:
+    <<: *ChannelDefaults
+    Orderer:
+      <<: *OrdererDefaults
+      OrdererType: kafka
+      Organizations:
+        - <<: *SampleOrg
+          Policies:
+            <<: *SampleOrgPolicies
+            Admins:
+              Type: Signature
+              Rule: "OR('SampleOrg.member')"
+    Application:
+      <<: *ApplicationDefaults
+      Organizations:
+        - <<: *SampleOrg
+          Policies:
+            <<: *SampleOrgPolicies
+            Admins:
+              Type: Signature
+              Rule: "OR('SampleOrg.member')"
+    Consortiums:
+      SampleConsortium:
+        Organizations:
+          - <<: *SampleOrg
+            Policies:
+              <<: *SampleOrgPolicies
+              Admins:
+                Type: Signature
+                Rule: "OR('SampleOrg.member')"
 
-    # SampleDevModeKafka defines a configuration that differs from the
-    # SampleDevModeSolo one only in that it uses the Kafka-based orderer.
-    SampleDevModeKafka:
-        <<: *ChannelDefaults
-        Orderer:
-            <<: *OrdererDefaults
-            OrdererType: kafka
-            Organizations:
-                - <<: *SampleOrg
-                  Policies:
-                      <<: *SampleOrgPolicies
-                      Admins:
-                          Type: Signature
-                          Rule: "OR('SampleOrg.member')"
-        Application:
-            <<: *ApplicationDefaults
-            Organizations:
-                - <<: *SampleOrg
-                  Policies:
-                      <<: *SampleOrgPolicies
-                      Admins:
-                          Type: Signature
-                          Rule: "OR('SampleOrg.member')"
-        Consortiums:
-            SampleConsortium:
-                Organizations:
-                    - <<: *SampleOrg
-                      Policies:
-                          <<: *SampleOrgPolicies
-                          Admins:
-                              Type: Signature
-                              Rule: "OR('SampleOrg.member')"
+  # SampleSingleMSPChannel defines a channel with only the sample org as a
+  # member. It is designed to be used in conjunction with SampleSingleMSPSolo
+  # and SampleSingleMSPKafka orderer profiles.   Note, for channel creation
+  # profiles, only the 'Application' section and consortium # name are
+  # considered.
+  SampleSingleMSPChannel:
+    <<: *ChannelDefaults
+    Consortium: SampleConsortium
+    Application:
+      <<: *ApplicationDefaults
+      Organizations:
+        - <<: *SampleOrg
 
-    # SampleSingleMSPChannel defines a channel with only the sample org as a
-    # member. It is designed to be used in conjunction with SampleSingleMSPSolo
-    # and SampleSingleMSPKafka orderer profiles.   Note, for channel creation
-    # profiles, only the 'Application' section and consortium # name are
-    # considered.
-    SampleSingleMSPChannel:
-        <<: *ChannelDefaults
-        Consortium: SampleConsortium
-        Application:
-            <<: *ApplicationDefaults
-            Organizations:
-                - <<: *SampleOrg
+  # SampleDevModeEtcdRaft defines a configuration that differs from the
+  # SampleDevModeSolo one only in that it uses the etcd/raft-based orderer.
+  SampleDevModeEtcdRaft:
+    <<: *ChannelDefaults
+    Orderer:
+      <<: *OrdererDefaults
+      Organizations:
+        - <<: *SampleOrg
+          Policies:
+            <<: *SampleOrgPolicies
+            Admins:
+              Type: Signature
+              Rule: "OR('SampleOrg.member')"
+    Application:
+      <<: *ApplicationDefaults
+      Organizations:
+        - <<: *SampleOrg
+          Policies:
+            <<: *SampleOrgPolicies
+            Admins:
+              Type: Signature
+              Rule: "OR('SampleOrg.member')"
+    Consortiums:
+      SampleConsortium:
+        Organizations:
+          - <<: *SampleOrg
+            Policies:
+              <<: *SampleOrgPolicies
+              Admins:
+                Type: Signature
+                Rule: "OR('SampleOrg.member')"
 
-    # SampleDevModeEtcdRaft defines a configuration that differs from the
-    # SampleDevModeSolo one only in that it uses the etcd/raft-based orderer.
-    SampleDevModeEtcdRaft:
-        <<: *ChannelDefaults
-        Orderer:
-            <<: *OrdererDefaults
-            Organizations:
-                - <<: *SampleOrg
-                  Policies:
-                      <<: *SampleOrgPolicies
-                      Admins:
-                          Type: Signature
-                          Rule: "OR('SampleOrg.member')"
-        Application:
-            <<: *ApplicationDefaults
-            Organizations:
-                - <<: *SampleOrg
-                  Policies:
-                      <<: *SampleOrgPolicies
-                      Admins:
-                          Type: Signature
-                          Rule: "OR('SampleOrg.member')"
-        Consortiums:
-            SampleConsortium:
-                Organizations:
-                    - <<: *SampleOrg
-                      Policies:
-                          <<: *SampleOrgPolicies
-                          Admins:
-                              Type: Signature
-                              Rule: "OR('SampleOrg.member')"
+  # SampleAppChannelInsecureSolo defines an application channel configuration
+  # which uses the Solo orderer and contains no MSP definitions.
+  SampleAppChannelInsecureSolo:
+    <<: *ChannelDefaults
+    Orderer:
+      <<: *OrdererDefaults
+      OrdererType: solo
+    Application:
+      <<: *ApplicationDefaults
 
-    # SampleAppChannelInsecureSolo defines an application channel configuration
-    # which uses the Solo orderer and contains no MSP definitions.
-    SampleAppChannelInsecureSolo:
-        <<: *ChannelDefaults
-        Orderer:
-            <<: *OrdererDefaults
-            OrdererType: solo
-        Application:
-            <<: *ApplicationDefaults
+  # SampleAppChannelEtcdRaft defines an application channel configuration
+  # that uses the etcd/raft-based orderer.
+  SampleAppChannelEtcdRaft:
+    <<: *ChannelDefaults
+    Orderer:
+      <<: *OrdererDefaults
+      Organizations:
+        - <<: *SampleOrg
+          Policies:
+            <<: *SampleOrgPolicies
+            Admins:
+              Type: Signature
+              Rule: "OR('SampleOrg.member')"
+          OrdererEndpoints:
+            - "127.0.0.1:7050"
+            - "127.0.0.1:7051"
+            - "127.0.0.1:7052"
+    Application:
+      <<: *ApplicationDefaults
+      Organizations:
+        - <<: *SampleOrg
+          Policies:
+            <<: *SampleOrgPolicies
+            Admins:
+              Type: Signature
+              Rule: "OR('SampleOrg.member')"
 
-    # SampleAppChannelEtcdRaft defines an application channel configuration
-    # that uses the etcd/raft-based orderer.
-    SampleAppChannelEtcdRaft:
-        <<: *ChannelDefaults
-        Orderer:
-            <<: *OrdererDefaults
-            Organizations:
-                - <<: *SampleOrg
-                  Policies:
-                      <<: *SampleOrgPolicies
-                      Admins:
-                          Type: Signature
-                          Rule: "OR('SampleOrg.member')"
-                  OrdererEndpoints:
-                    - "127.0.0.1:7050"
-                    - "127.0.0.1:7051"
-                    - "127.0.0.1:7052"
-        Application:
-            <<: *ApplicationDefaults
-            Organizations:
-                - <<: *SampleOrg
-                  Policies:
-                      <<: *SampleOrgPolicies
-                      Admins:
-                          Type: Signature
-                          Rule: "OR('SampleOrg.member')"
-
-    # SampleAppChannelSmartBft defines an application channel configuration
-    # that uses the Smart BFT orderer.
-    SampleAppChannelSmartBft:
-        <<: *ChannelDefaults
-        Consortium: SampleConsortium
-        Orderer:
-            <<: *OrdererDefaults
-            OrdererType: BFT
-            BatchSize:
-                MaxMessageCount: 5000
-                AbsoluteMaxBytes: 10 MB
-            SmartBFT:
-                RequestBatchMaxInterval: 200ms
-                RequestForwardTimeout: 5s
-                RequestComplainTimeout: 20s
-                RequestAutoRemoveTimeout: 3m0s
-                ViewChangeResendInterval: 5s
-                ViewChangeTimeout: 20s
-                LeaderHeartbeatTimeout: 1m0s
-                CollectTimeout: 1s
-                IncomingMessageBufferSize: 200
-                RequestPoolSize: 100000
-                LeaderHeartbeatCount: 10
-            Organizations:
-                - <<: *SampleOrg
-                  Policies:
-                      <<: *SampleOrgPolicies
-                      Admins:
-                          Type: Signature
-                          Rule: "OR('SampleOrg.member')"
-        Application:
-            <<: *ApplicationDefaults
-            Organizations:
-                - <<: *SampleOrg
-                  Policies:
-                      <<: *SampleOrgPolicies
-                      Admins:
-                          Type: Signature
-                          Rule: "OR('SampleOrg.member')"
+  # SampleAppChannelSmartBft defines an application channel configuration
+  # that uses the Smart BFT orderer.
+  SampleAppChannelSmartBft:
+    <<: *ChannelDefaults
+    Consortium: SampleConsortium
+    Orderer:
+      <<: *OrdererDefaults
+      OrdererType: BFT
+      BatchSize:
+        MaxMessageCount: 5000
+        AbsoluteMaxBytes: 10 MB
+      SmartBFT:
+        RequestBatchMaxInterval: 200ms
+        RequestForwardTimeout: 5s
+        RequestComplainTimeout: 20s
+        RequestAutoRemoveTimeout: 3m0s
+        ViewChangeResendInterval: 5s
+        ViewChangeTimeout: 20s
+        LeaderHeartbeatTimeout: 1m0s
+        CollectTimeout: 1s
+        IncomingMessageBufferSize: 200
+        RequestPoolSize: 100000
+        LeaderHeartbeatCount: 10
+      Organizations:
+        - <<: *SampleOrg
+          Policies:
+            <<: *SampleOrgPolicies
+            Admins:
+              Type: Signature
+              Rule: "OR('SampleOrg.member')"
+    Application:
+      <<: *ApplicationDefaults
+      Organizations:
+        - <<: *SampleOrg
+          Policies:
+            <<: *SampleOrgPolicies
+            Admins:
+              Type: Signature
+              Rule: "OR('SampleOrg.member')"

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -9,511 +9,504 @@
 #
 ###############################################################################
 peer:
+  # The peer id provides a name for this peer instance and is used when
+  # naming docker resources.
+  id: jdoe
 
-    # The peer id provides a name for this peer instance and is used when
-    # naming docker resources.
-    id: jdoe
+  # The networkId allows for logical separation of networks and is used when
+  # naming docker resources.
+  networkId: dev
 
-    # The networkId allows for logical separation of networks and is used when
-    # naming docker resources.
-    networkId: dev
+  # The Address at local network interface this Peer will listen on.
+  # By default, it will listen on all network interfaces
+  listenAddress: 0.0.0.0:7051
 
-    # The Address at local network interface this Peer will listen on.
-    # By default, it will listen on all network interfaces
-    listenAddress: 0.0.0.0:7051
+  # The endpoint this peer uses to listen for inbound chaincode connections.
+  # If this is commented-out, the listen address is selected to be
+  # the peer's address (see below) with port 7052
+  # chaincodeListenAddress: 0.0.0.0:7052
 
-    # The endpoint this peer uses to listen for inbound chaincode connections.
-    # If this is commented-out, the listen address is selected to be
-    # the peer's address (see below) with port 7052
-    # chaincodeListenAddress: 0.0.0.0:7052
+  # The endpoint the chaincode for this peer uses to connect to the peer.
+  # If this is not specified, the chaincodeListenAddress address is selected.
+  # And if chaincodeListenAddress is not specified, address is selected from
+  # peer address (see below). If specified peer address is invalid then it
+  # will fallback to the auto detected IP (local IP) regardless of the peer
+  # addressAutoDetect value.
+  # chaincodeAddress: 0.0.0.0:7052
 
-    # The endpoint the chaincode for this peer uses to connect to the peer.
-    # If this is not specified, the chaincodeListenAddress address is selected.
-    # And if chaincodeListenAddress is not specified, address is selected from
-    # peer address (see below). If specified peer address is invalid then it
-    # will fallback to the auto detected IP (local IP) regardless of the peer
-    # addressAutoDetect value.
-    # chaincodeAddress: 0.0.0.0:7052
+  # When used as peer config, this represents the endpoint to other peers
+  # in the same organization. For peers in other organization, see
+  # gossip.externalEndpoint for more info.
+  # When used as CLI config, this means the peer's endpoint to interact with
+  address: 0.0.0.0:7051
 
-    # When used as peer config, this represents the endpoint to other peers
-    # in the same organization. For peers in other organization, see
-    # gossip.externalEndpoint for more info.
-    # When used as CLI config, this means the peer's endpoint to interact with
-    address: 0.0.0.0:7051
+  # Whether the Peer should programmatically determine its address
+  # This case is useful for docker containers.
+  # When set to true, will override peer address.
+  addressAutoDetect: false
 
-    # Whether the Peer should programmatically determine its address
-    # This case is useful for docker containers.
-    # When set to true, will override peer address.
-    addressAutoDetect: false
+  # Settings for the Peer's gateway server.
+  gateway:
+    # Whether the gateway is enabled for this Peer.
+    enabled: true
+    # endorsementTimeout is the duration the gateway waits for a response
+    # from other endorsing peers before returning a timeout error to the client.
+    endorsementTimeout: 30s
+    # broadcastTimeout is the duration the gateway waits for a response
+    # from ordering nodes before returning a timeout error to the client.
+    broadcastTimeout: 30s
+    # dialTimeout is the duration the gateway waits for a connection
+    # to other network nodes.
+    dialTimeout: 2m
 
-    # Settings for the Peer's gateway server.
-    gateway:
-        # Whether the gateway is enabled for this Peer.
-        enabled: true
-        # endorsementTimeout is the duration the gateway waits for a response
-        # from other endorsing peers before returning a timeout error to the client.
-        endorsementTimeout: 30s
-        # broadcastTimeout is the duration the gateway waits for a response
-        # from ordering nodes before returning a timeout error to the client.
-        broadcastTimeout: 30s
-        # dialTimeout is the duration the gateway waits for a connection
-        # to other network nodes.
-        dialTimeout: 2m
-
-
-    # Keepalive settings for peer server and clients
-    keepalive:
-        # Interval is the duration after which if the server does not see
-        # any activity from the client it pings the client to see if it's alive
-        interval: 7200s
-        # Timeout is the duration the server waits for a response
-        # from the client after sending a ping before closing the connection
-        timeout: 20s
-        # MinInterval is the minimum permitted time between client pings.
-        # If clients send pings more frequently, the peer server will
-        # disconnect them
-        minInterval: 60s
-        # Client keepalive settings for communicating with other peer nodes
-        client:
-            # Interval is the time between pings to peer nodes.  This must
-            # greater than or equal to the minInterval specified by peer
-            # nodes
-            interval: 60s
-            # Timeout is the duration the client waits for a response from
-            # peer nodes before closing the connection
-            timeout: 20s
-        # DeliveryClient keepalive settings for communication with ordering
-        # nodes.
-        deliveryClient:
-            # Interval is the time between pings to ordering nodes.  This must
-            # greater than or equal to the minInterval specified by ordering
-            # nodes.
-            interval: 60s
-            # Timeout is the duration the client waits for a response from
-            # ordering nodes before closing the connection
-            timeout: 20s
-
-
-    # Gossip related configuration
-    gossip:
-        # Bootstrap set to initialize gossip with.
-        # This is a list of other peers that this peer reaches out to at startup.
-        # Important: The endpoints here have to be endpoints of peers in the same
-        # organization, because the peer would refuse connecting to these endpoints
-        # unless they are in the same organization as the peer.
-        bootstrap: 127.0.0.1:7051
-
-        # NOTE: orgLeader and useLeaderElection parameters are mutual exclusive.
-        # Setting both to true would result in the termination of the peer
-        # since this is undefined state. If the peers are configured with
-        # useLeaderElection=false, make sure there is at least 1 peer in the
-        # organization that its orgLeader is set to true.
-
-        # Defines whenever peer will initialize dynamic algorithm for
-        # "leader" selection, where leader is the peer to establish
-        # connection with ordering service and use delivery protocol
-        # to pull ledger blocks from ordering service.
-        useLeaderElection: false
-        # Statically defines peer to be an organization "leader".
-        # Organization leaders maintain connection with ordering service
-        # and pulls blocks as they are created. Optionally, leader peers
-        # may disseminate pulled blocks to peers in its own organization
-        # based on the peer.deliveryclient.blockGossipEnabled setting below.
-        # Multiple peers or all peers in an organization
-        # may be configured as org leaders, so that they all pull
-        # blocks directly from ordering service.
-        orgLeader: true
-
-        # Interval for membershipTracker polling
-        membershipTrackerInterval: 5s
-
-        # Overrides the endpoint that the peer publishes to peers
-        # in its organization. For peers in foreign organizations
-        # see 'externalEndpoint'
-        endpoint:
-        # Maximum count of blocks stored in memory
-        maxBlockCountToStore: 10
-        # Max time between consecutive message pushes(unit: millisecond)
-        maxPropagationBurstLatency: 10ms
-        # Max number of messages stored until a push is triggered to remote peers
-        maxPropagationBurstSize: 10
-        # Number of times a message is pushed to remote peers
-        propagateIterations: 1
-        # Number of peers selected to push messages to
-        propagatePeerNum: 3
-        # Determines frequency of pull phases(unit: second)
-        # Must be greater than digestWaitTime + responseWaitTime
-        pullInterval: 4s
-        # Number of peers to pull from
-        pullPeerNum: 3
-        # Determines frequency of pulling state info messages from peers(unit: second)
-        requestStateInfoInterval: 4s
-        # Determines frequency of pushing state info messages to peers(unit: second)
-        publishStateInfoInterval: 4s
-        # Maximum time a stateInfo message is kept until expired
-        stateInfoRetentionInterval:
-        # Time from startup certificates are included in Alive messages(unit: second)
-        publishCertPeriod: 10s
-        # Should we skip verifying block messages or not (currently not in use)
-        skipBlockVerification: false
-        # Dial timeout(unit: second)
-        dialTimeout: 3s
-        # Connection timeout(unit: second)
-        connTimeout: 2s
-        # Buffer size of received messages
-        recvBuffSize: 20
-        # Buffer size of sending messages
-        sendBuffSize: 200
-        # Time to wait before pull engine processes incoming digests (unit: second)
-        # Should be slightly smaller than requestWaitTime
-        digestWaitTime: 1s
-        # Time to wait before pull engine removes incoming nonce (unit: milliseconds)
-        # Should be slightly bigger than digestWaitTime
-        requestWaitTime: 1500ms
-        # Time to wait before pull engine ends pull (unit: second)
-        responseWaitTime: 2s
-        # Alive check interval(unit: second)
-        aliveTimeInterval: 5s
-        # Alive expiration timeout(unit: second)
-        aliveExpirationTimeout: 25s
-        # Reconnect interval(unit: second)
-        reconnectInterval: 25s
-        # Max number of attempts to connect to a peer
-        maxConnectionAttempts: 120
-        # Message expiration factor for alive messages
-        msgExpirationFactor: 20
-        # This is an endpoint that is published to peers outside of the organization.
-        # If this isn't set, the peer will not be known to other organizations and will not be exposed via service discovery.
-        externalEndpoint:
-        # Leader election service configuration
-        election:
-            # Longest time peer waits for stable membership during leader election startup (unit: second)
-            startupGracePeriod: 15s
-            # Interval gossip membership samples to check its stability (unit: second)
-            membershipSampleInterval: 1s
-            # Time passes since last declaration message before peer decides to perform leader election (unit: second)
-            leaderAliveThreshold: 10s
-            # Time between peer sends propose message and declares itself as a leader (sends declaration message) (unit: second)
-            leaderElectionDuration: 5s
-
-        pvtData:
-            # pullRetryThreshold determines the maximum duration of time private data corresponding for a given block
-            # would be attempted to be pulled from peers until the block would be committed without the private data
-            pullRetryThreshold: 60s
-            # As private data enters the transient store, it is associated with the peer's ledger's height at that time.
-            # transientstoreMaxBlockRetention defines the maximum difference between the current ledger's height upon commit,
-            # and the private data residing inside the transient store that is guaranteed not to be purged.
-            # Private data is purged from the transient store when blocks with sequences that are multiples
-            # of transientstoreMaxBlockRetention are committed.
-            transientstoreMaxBlockRetention: 20000
-            # pushAckTimeout is the maximum time to wait for an acknowledgement from each peer
-            # at private data push at endorsement time.
-            pushAckTimeout: 3s
-            # Block to live pulling margin, used as a buffer
-            # to prevent peer from trying to pull private data
-            # from peers that is soon to be purged in next N blocks.
-            # This helps a newly joined peer catch up to current
-            # blockchain height quicker.
-            btlPullMargin: 10
-            # the process of reconciliation is done in an endless loop, while in each iteration reconciler tries to
-            # pull from the other peers the most recent missing blocks with a maximum batch size limitation.
-            # reconcileBatchSize determines the maximum batch size of missing private data that will be reconciled in a
-            # single iteration.
-            reconcileBatchSize: 10
-            # reconcileSleepInterval determines the time reconciler sleeps from end of an iteration until the beginning
-            # of the next reconciliation iteration.
-            reconcileSleepInterval: 1m
-            # reconciliationEnabled is a flag that indicates whether private data reconciliation is enable or not.
-            reconciliationEnabled: true
-            # skipPullingInvalidTransactionsDuringCommit is a flag that indicates whether pulling of invalid
-            # transaction's private data from other peers need to be skipped during the commit time and pulled
-            # only through reconciler.
-            skipPullingInvalidTransactionsDuringCommit: false
-            # implicitCollectionDisseminationPolicy specifies the dissemination  policy for the peer's own implicit collection.
-            # When a peer endorses a proposal that writes to its own implicit collection, below values override the default values
-            # for disseminating private data.
-            # Note that it is applicable to all channels the peer has joined. The implication is that requiredPeerCount has to
-            # be smaller than the number of peers in a channel that has the lowest numbers of peers from the organization.
-            implicitCollectionDisseminationPolicy:
-               # requiredPeerCount defines the minimum number of eligible peers to which the peer must successfully
-               # disseminate private data for its own implicit collection during endorsement. Default value is 0.
-               requiredPeerCount: 0
-               # maxPeerCount defines the maximum number of eligible peers to which the peer will attempt to
-               # disseminate private data for its own implicit collection during endorsement. Default value is 1.
-               maxPeerCount: 1
-
-        # Gossip state transfer related configuration
-        state:
-            # Indicates whether state transfer is enabled.
-            # State transfer enabled allows a peer that is not a leader
-            # to sync up missed blocks from other peers.
-            # Default value is false since the recommended value of peer.gossip.orgleader is true.
-            # Keep in mind that when peer.gossip.useLeaderElection is true
-            # and there are several peers in the organization,
-            # or peer.gossip.useLeaderElection is false alongside with
-            # peer.gossip.orgleader being false, the peer's ledger may lag behind
-            # the rest of the peers and will never catch up due to state transfer
-            # being disabled.
-            enabled: false
-            # checkInterval interval to check whether peer is lagging behind enough to
-            # request blocks via state transfer from another peer.
-            checkInterval: 10s
-            # responseTimeout amount of time to wait for state transfer response from
-            # other peers
-            responseTimeout: 3s
-            # batchSize the number of blocks to request via state transfer from another peer
-            batchSize: 10
-            # blockBufferSize reflects the size of the re-ordering buffer
-            # which captures blocks and takes care to deliver them in order
-            # down to the ledger layer. The actual buffer size is bounded between
-            # 0 and 2*blockBufferSize, each channel maintains its own buffer
-            blockBufferSize: 20
-            # maxRetries maximum number of re-tries to ask
-            # for single state transfer request
-            maxRetries: 3
-
-    # TLS Settings
-    tls:
-        # Require server-side TLS
-        enabled:  false
-        # Require client certificates / mutual TLS for inbound connections.
-        # Note that clients that are not configured to use a certificate will
-        # fail to connect to the peer.
-        clientAuthRequired: false
-        # X.509 certificate used for TLS server
-        cert:
-            file: tls/server.crt
-        # Private key used for TLS server
-        key:
-            file: tls/server.key
-        # rootcert.file represents the trusted root certificate chain used for verifying certificates
-        # of other nodes during outbound connections.
-        # It is not required to be set, but can be used to augment the set of TLS CA certificates
-        # available from the MSPs of each channel’s configuration.
-        rootcert:
-            file: tls/ca.crt
-        # If mutual TLS is enabled, clientRootCAs.files contains a list of additional root certificates
-        # used for verifying certificates of client connections.
-        # It augments the set of TLS CA certificates available from the MSPs of each channel’s configuration.
-        # Minimally, set your organization's TLS CA root certificate so that the peer can receive join channel requests.
-        clientRootCAs:
-            files:
-              - tls/ca.crt
-        # Private key used for TLS when making client connections.
-        # If not set, peer.tls.key.file will be used instead
-        clientKey:
-            file:
-        # X.509 certificate used for TLS when making client connections.
-        # If not set, peer.tls.cert.file will be used instead
-        clientCert:
-            file:
-
-    # Authentication contains configuration parameters related to authenticating
-    # client messages
-    authentication:
-        # the acceptable difference between the current server time and the
-        # client's time as specified in a client request message
-        # this value is used for delivery service and
-        # endorsement service (if the authFilter is enabled)
-        timewindow: 15m
-
-    # Path on the file system where peer will store data (eg ledger). This
-    # location must be access control protected to prevent unintended
-    # modification that might corrupt the peer operations.
-    # The path may be relative to FABRIC_CFG_PATH or an absolute path.
-    fileSystemPath: /var/hyperledger/production
-
-    # BCCSP (Blockchain crypto provider): Select which crypto implementation or
-    # library to use
-    BCCSP:
-        Default: SW
-        # Settings for the SW crypto provider (i.e. when DEFAULT: SW)
-        SW:
-            # TODO: The default Hash and Security level needs refactoring to be
-            # fully configurable. Changing these defaults requires coordination
-            # SHA2 is hardcoded in several places, not only BCCSP
-            Hash: SHA2
-            Security: 256
-            # Location of Key Store
-            FileKeyStore:
-                # If "", defaults to 'mspConfigPath'/keystore
-                KeyStore:
-        # Settings for the PKCS#11 crypto provider (i.e. when DEFAULT: PKCS11)
-        PKCS11:
-            # Location of the PKCS11 module library
-            Library:
-            # Token Label
-            Label:
-            # User PIN
-            Pin:
-            Hash:
-            Security:
-            SoftwareVerify:
-            Immutable:
-            AltID:
-            KeyIds:
-
-    # Path on the file system where peer will find MSP local configurations
-    # The path may be relative to FABRIC_CFG_PATH or an absolute path.
-    mspConfigPath: msp
-
-    # Identifier of the local MSP
-    # ----!!!!IMPORTANT!!!-!!!IMPORTANT!!!-!!!IMPORTANT!!!!----
-    # Deployers need to change the value of the localMspId string.
-    # In particular, the name of the local MSP ID of a peer needs
-    # to match the name of one of the MSPs in each of the channel
-    # that this peer is a member of. Otherwise this peer's messages
-    # will not be identified as valid by other nodes.
-    localMspId: SampleOrg
-
-    # CLI common client config options
+  # Keepalive settings for peer server and clients
+  keepalive:
+    # Interval is the duration after which if the server does not see
+    # any activity from the client it pings the client to see if it's alive
+    interval: 7200s
+    # Timeout is the duration the server waits for a response
+    # from the client after sending a ping before closing the connection
+    timeout: 20s
+    # MinInterval is the minimum permitted time between client pings.
+    # If clients send pings more frequently, the peer server will
+    # disconnect them
+    minInterval: 60s
+    # Client keepalive settings for communicating with other peer nodes
     client:
-        # connection timeout
-        connTimeout: 3s
+      # Interval is the time between pings to peer nodes.  This must
+      # greater than or equal to the minInterval specified by peer
+      # nodes
+      interval: 60s
+      # Timeout is the duration the client waits for a response from
+      # peer nodes before closing the connection
+      timeout: 20s
+    # DeliveryClient keepalive settings for communication with ordering
+    # nodes.
+    deliveryClient:
+      # Interval is the time between pings to ordering nodes.  This must
+      # greater than or equal to the minInterval specified by ordering
+      # nodes.
+      interval: 60s
+      # Timeout is the duration the client waits for a response from
+      # ordering nodes before closing the connection
+      timeout: 20s
 
-    # Delivery service related config
-    deliveryclient:
-        # Enables this peer to disseminate blocks it pulls from the ordering service
-        # to other peers in the same organization via gossip.
-        # Note that 'gossip.state.enabled' controls point to point block replication
-        # of blocks committed in the past.
-        blockGossipEnabled: false
-        # It sets the total time the delivery service may spend in reconnection
-        # attempts until its retry logic gives up and returns an error,
-        # ignored if peer is a static leader
-        reconnectTotalTimeThreshold: 3600s
+  # Gossip related configuration
+  gossip:
+    # Bootstrap set to initialize gossip with.
+    # This is a list of other peers that this peer reaches out to at startup.
+    # Important: The endpoints here have to be endpoints of peers in the same
+    # organization, because the peer would refuse connecting to these endpoints
+    # unless they are in the same organization as the peer.
+    bootstrap: 127.0.0.1:7051
 
-        # It sets the delivery service <-> ordering service node connection timeout
-        connTimeout: 3s
+    # NOTE: orgLeader and useLeaderElection parameters are mutual exclusive.
+    # Setting both to true would result in the termination of the peer
+    # since this is undefined state. If the peers are configured with
+    # useLeaderElection=false, make sure there is at least 1 peer in the
+    # organization that its orgLeader is set to true.
 
-        # It sets the delivery service maximal delay between consecutive retries.
-        # Time between retries will have exponential backoff until hitting this threshold.
-        reConnectBackoffThreshold: 3600s
+    # Defines whenever peer will initialize dynamic algorithm for
+    # "leader" selection, where leader is the peer to establish
+    # connection with ordering service and use delivery protocol
+    # to pull ledger blocks from ordering service.
+    useLeaderElection: false
+    # Statically defines peer to be an organization "leader".
+    # Organization leaders maintain connection with ordering service
+    # and pulls blocks as they are created. Optionally, leader peers
+    # may disseminate pulled blocks to peers in its own organization
+    # based on the peer.deliveryclient.blockGossipEnabled setting below.
+    # Multiple peers or all peers in an organization
+    # may be configured as org leaders, so that they all pull
+    # blocks directly from ordering service.
+    orgLeader: true
 
-        # If a certain header from a header receiver is in front of the block receiver for more that this time, a
-        # censorship event is declared and the block source is changed.
-        blockCensorshipTimeoutKey: 30s
+    # Interval for membershipTracker polling
+    membershipTrackerInterval: 5s
 
-        # The initial value of the actual retry interval, which is increased on every failed retry
-        minimalReconnectInterval: 100ms
+    # Overrides the endpoint that the peer publishes to peers
+    # in its organization. For peers in foreign organizations
+    # see 'externalEndpoint'
+    endpoint:
+    # Maximum count of blocks stored in memory
+    maxBlockCountToStore: 10
+    # Max time between consecutive message pushes(unit: millisecond)
+    maxPropagationBurstLatency: 10ms
+    # Max number of messages stored until a push is triggered to remote peers
+    maxPropagationBurstSize: 10
+    # Number of times a message is pushed to remote peers
+    propagateIterations: 1
+    # Number of peers selected to push messages to
+    propagatePeerNum: 3
+    # Determines frequency of pull phases(unit: second)
+    # Must be greater than digestWaitTime + responseWaitTime
+    pullInterval: 4s
+    # Number of peers to pull from
+    pullPeerNum: 3
+    # Determines frequency of pulling state info messages from peers(unit: second)
+    requestStateInfoInterval: 4s
+    # Determines frequency of pushing state info messages to peers(unit: second)
+    publishStateInfoInterval: 4s
+    # Maximum time a stateInfo message is kept until expired
+    stateInfoRetentionInterval:
+    # Time from startup certificates are included in Alive messages(unit: second)
+    publishCertPeriod: 10s
+    # Should we skip verifying block messages or not (currently not in use)
+    skipBlockVerification: false
+    # Dial timeout(unit: second)
+    dialTimeout: 3s
+    # Connection timeout(unit: second)
+    connTimeout: 2s
+    # Buffer size of received messages
+    recvBuffSize: 20
+    # Buffer size of sending messages
+    sendBuffSize: 200
+    # Time to wait before pull engine processes incoming digests (unit: second)
+    # Should be slightly smaller than requestWaitTime
+    digestWaitTime: 1s
+    # Time to wait before pull engine removes incoming nonce (unit: milliseconds)
+    # Should be slightly bigger than digestWaitTime
+    requestWaitTime: 1500ms
+    # Time to wait before pull engine ends pull (unit: second)
+    responseWaitTime: 2s
+    # Alive check interval(unit: second)
+    aliveTimeInterval: 5s
+    # Alive expiration timeout(unit: second)
+    aliveExpirationTimeout: 25s
+    # Reconnect interval(unit: second)
+    reconnectInterval: 25s
+    # Max number of attempts to connect to a peer
+    maxConnectionAttempts: 120
+    # Message expiration factor for alive messages
+    msgExpirationFactor: 20
+    # This is an endpoint that is published to peers outside of the organization.
+    # If this isn't set, the peer will not be known to other organizations and will not be exposed via service discovery.
+    externalEndpoint:
+    # Leader election service configuration
+    election:
+      # Longest time peer waits for stable membership during leader election startup (unit: second)
+      startupGracePeriod: 15s
+      # Interval gossip membership samples to check its stability (unit: second)
+      membershipSampleInterval: 1s
+      # Time passes since last declaration message before peer decides to perform leader election (unit: second)
+      leaderAliveThreshold: 10s
+      # Time between peer sends propose message and declares itself as a leader (sends declaration message) (unit: second)
+      leaderElectionDuration: 5s
 
-        # A list of orderer endpoint addresses which should be overridden
-        # when found in channel configurations.
-        addressOverrides:
-        #  - from:
-        #    to:
-        #    caCertsFile:
-        #  - from:
-        #    to:
-        #    caCertsFile:
+    pvtData:
+      # pullRetryThreshold determines the maximum duration of time private data corresponding for a given block
+      # would be attempted to be pulled from peers until the block would be committed without the private data
+      pullRetryThreshold: 60s
+      # As private data enters the transient store, it is associated with the peer's ledger's height at that time.
+      # transientstoreMaxBlockRetention defines the maximum difference between the current ledger's height upon commit,
+      # and the private data residing inside the transient store that is guaranteed not to be purged.
+      # Private data is purged from the transient store when blocks with sequences that are multiples
+      # of transientstoreMaxBlockRetention are committed.
+      transientstoreMaxBlockRetention: 20000
+      # pushAckTimeout is the maximum time to wait for an acknowledgement from each peer
+      # at private data push at endorsement time.
+      pushAckTimeout: 3s
+      # Block to live pulling margin, used as a buffer
+      # to prevent peer from trying to pull private data
+      # from peers that is soon to be purged in next N blocks.
+      # This helps a newly joined peer catch up to current
+      # blockchain height quicker.
+      btlPullMargin: 10
+      # the process of reconciliation is done in an endless loop, while in each iteration reconciler tries to
+      # pull from the other peers the most recent missing blocks with a maximum batch size limitation.
+      # reconcileBatchSize determines the maximum batch size of missing private data that will be reconciled in a
+      # single iteration.
+      reconcileBatchSize: 10
+      # reconcileSleepInterval determines the time reconciler sleeps from end of an iteration until the beginning
+      # of the next reconciliation iteration.
+      reconcileSleepInterval: 1m
+      # reconciliationEnabled is a flag that indicates whether private data reconciliation is enable or not.
+      reconciliationEnabled: true
+      # skipPullingInvalidTransactionsDuringCommit is a flag that indicates whether pulling of invalid
+      # transaction's private data from other peers need to be skipped during the commit time and pulled
+      # only through reconciler.
+      skipPullingInvalidTransactionsDuringCommit: false
+      # implicitCollectionDisseminationPolicy specifies the dissemination  policy for the peer's own implicit collection.
+      # When a peer endorses a proposal that writes to its own implicit collection, below values override the default values
+      # for disseminating private data.
+      # Note that it is applicable to all channels the peer has joined. The implication is that requiredPeerCount has to
+      # be smaller than the number of peers in a channel that has the lowest numbers of peers from the organization.
+      implicitCollectionDisseminationPolicy:
+        # requiredPeerCount defines the minimum number of eligible peers to which the peer must successfully
+        # disseminate private data for its own implicit collection during endorsement. Default value is 0.
+        requiredPeerCount: 0
+        # maxPeerCount defines the maximum number of eligible peers to which the peer will attempt to
+        # disseminate private data for its own implicit collection during endorsement. Default value is 1.
+        maxPeerCount: 1
 
-        # Determines which delivery client will be used when consensus type is "BFT"
-        # (when consensus type is "etcdraft" this key is ignored).
-        # "simple" - use CFT deliverer
-        # "cluster" - use BFT deliverer
-        policy: cluster
+    # Gossip state transfer related configuration
+    state:
+      # Indicates whether state transfer is enabled.
+      # State transfer enabled allows a peer that is not a leader
+      # to sync up missed blocks from other peers.
+      # Default value is false since the recommended value of peer.gossip.orgleader is true.
+      # Keep in mind that when peer.gossip.useLeaderElection is true
+      # and there are several peers in the organization,
+      # or peer.gossip.useLeaderElection is false alongside with
+      # peer.gossip.orgleader being false, the peer's ledger may lag behind
+      # the rest of the peers and will never catch up due to state transfer
+      # being disabled.
+      enabled: false
+      # checkInterval interval to check whether peer is lagging behind enough to
+      # request blocks via state transfer from another peer.
+      checkInterval: 10s
+      # responseTimeout amount of time to wait for state transfer response from
+      # other peers
+      responseTimeout: 3s
+      # batchSize the number of blocks to request via state transfer from another peer
+      batchSize: 10
+      # blockBufferSize reflects the size of the re-ordering buffer
+      # which captures blocks and takes care to deliver them in order
+      # down to the ledger layer. The actual buffer size is bounded between
+      # 0 and 2*blockBufferSize, each channel maintains its own buffer
+      blockBufferSize: 20
+      # maxRetries maximum number of re-tries to ask
+      # for single state transfer request
+      maxRetries: 3
 
-    # Type for the local MSP - by default it's of type bccsp
-    localMspType: bccsp
+  # TLS Settings
+  tls:
+    # Require server-side TLS
+    enabled: false
+    # Require client certificates / mutual TLS for inbound connections.
+    # Note that clients that are not configured to use a certificate will
+    # fail to connect to the peer.
+    clientAuthRequired: false
+    # X.509 certificate used for TLS server
+    cert:
+      file: tls/server.crt
+    # Private key used for TLS server
+    key:
+      file: tls/server.key
+    # rootcert.file represents the trusted root certificate chain used for verifying certificates
+    # of other nodes during outbound connections.
+    # It is not required to be set, but can be used to augment the set of TLS CA certificates
+    # available from the MSPs of each channel’s configuration.
+    rootcert:
+      file: tls/ca.crt
+    # If mutual TLS is enabled, clientRootCAs.files contains a list of additional root certificates
+    # used for verifying certificates of client connections.
+    # It augments the set of TLS CA certificates available from the MSPs of each channel’s configuration.
+    # Minimally, set your organization's TLS CA root certificate so that the peer can receive join channel requests.
+    clientRootCAs:
+      files:
+        - tls/ca.crt
+    # Private key used for TLS when making client connections.
+    # If not set, peer.tls.key.file will be used instead
+    clientKey:
+      file:
+    # X.509 certificate used for TLS when making client connections.
+    # If not set, peer.tls.cert.file will be used instead
+    clientCert:
+      file:
 
-    # Used with Go profiling tools only in none production environment. In
-    # production, it should be disabled (eg enabled: false)
-    profile:
-        enabled:     false
-        listenAddress: 0.0.0.0:6060
+  # Authentication contains configuration parameters related to authenticating
+  # client messages
+  authentication:
+    # the acceptable difference between the current server time and the
+    # client's time as specified in a client request message
+    # this value is used for delivery service and
+    # endorsement service (if the authFilter is enabled)
+    timewindow: 15m
 
-    # Handlers defines custom handlers that can filter and mutate
-    # objects passing within the peer, such as:
-    #   Auth filter - reject or forward proposals from clients
-    #   Decorators  - append or mutate the chaincode input passed to the chaincode
-    #   Endorsers   - Custom signing over proposal response payload and its mutation
-    # Valid handler definition contains:
-    #   - A name which is a factory method name defined in
-    #     core/handlers/library/library.go for statically compiled handlers
-    #   - library path to shared object binary for pluggable filters
-    # Auth filters and decorators are chained and executed in the order that
-    # they are defined. For example:
-    # authFilters:
-    #   -
-    #     name: FilterOne
-    #     library: /opt/lib/filter.so
-    #   -
-    #     name: FilterTwo
-    # decorators:
-    #   -
-    #     name: DecoratorOne
-    #   -
-    #     name: DecoratorTwo
-    #     library: /opt/lib/decorator.so
-    # Endorsers are configured as a map that its keys are the endorsement system chaincodes that are being overridden.
-    # Below is an example that overrides the default ESCC and uses an endorsement plugin that has the same functionality
-    # as the default ESCC.
-    # If the 'library' property is missing, the name is used as the constructor method in the builtin library similar
-    # to auth filters and decorators.
-    # endorsers:
-    #   escc:
-    #     name: DefaultESCC
-    #     library: /etc/hyperledger/fabric/plugin/escc.so
-    handlers:
-        authFilters:
-          - name: DefaultAuth
-          - name: ExpirationCheck # This filter checks identity x509 certificate expiration
-          - name: TimeWindowCheck # This filter checks the timestamp of an proposal request with the peer.authentication.timewindow parameter from core.yaml
-        decorators:
-          - name: DefaultDecorator
-        endorsers:
-          escc:
-            name: DefaultEndorsement
-            library:
-        validators:
-          vscc:
-            name: DefaultValidation
-            library:
+  # Path on the file system where peer will store data (eg ledger). This
+  # location must be access control protected to prevent unintended
+  # modification that might corrupt the peer operations.
+  # The path may be relative to FABRIC_CFG_PATH or an absolute path.
+  fileSystemPath: /var/hyperledger/production
 
-    #    library: /etc/hyperledger/fabric/plugin/escc.so
-    # Number of goroutines that will execute transaction validation in parallel.
-    # By default, the peer chooses the number of CPUs on the machine. Set this
-    # variable to override that choice.
-    # NOTE: overriding this value might negatively influence the performance of
-    # the peer so please change this value only if you know what you're doing
-    validatorPoolSize:
+  # BCCSP (Blockchain crypto provider): Select which crypto implementation or
+  # library to use
+  BCCSP:
+    Default: SW
+    # Settings for the SW crypto provider (i.e. when DEFAULT: SW)
+    SW:
+      # TODO: The default Hash and Security level needs refactoring to be
+      # fully configurable. Changing these defaults requires coordination
+      # SHA2 is hardcoded in several places, not only BCCSP
+      Hash: SHA2
+      Security: 256
+      # Location of Key Store
+      FileKeyStore:
+        # If "", defaults to 'mspConfigPath'/keystore
+        KeyStore:
+    # Settings for the PKCS#11 crypto provider (i.e. when DEFAULT: PKCS11)
+    PKCS11:
+      # Location of the PKCS11 module library
+      Library:
+      # Token Label
+      Label:
+      # User PIN
+      Pin:
+      Hash:
+      Security:
+      SoftwareVerify:
+      Immutable:
+      AltID:
+      KeyIds:
 
-    # The discovery service is used by clients to query information about peers,
-    # such as - which peers have joined a certain channel, what is the latest
-    # channel config, and most importantly - given a chaincode and a channel,
-    # what possible sets of peers satisfy the endorsement policy.
-    discovery:
-        enabled: true
-        # Whether the authentication cache is enabled or not.
-        authCacheEnabled: true
-        # The maximum size of the cache, after which a purge takes place
-        authCacheMaxSize: 1000
-        # The proportion (0 to 1) of entries that remain in the cache after the cache is purged due to overpopulation
-        authCachePurgeRetentionRatio: 0.75
-        # Whether to allow non-admins to perform non channel scoped queries.
-        # When this is false, it means that only peer admins can perform non channel scoped queries.
-        orgMembersAllowedAccess: false
+  # Path on the file system where peer will find MSP local configurations
+  # The path may be relative to FABRIC_CFG_PATH or an absolute path.
+  mspConfigPath: msp
 
-    # Limits is used to configure some internal resource limits.
-    limits:
-        # Concurrency limits the number of concurrently running requests to a service on each peer.
-        # Currently this option is only applied to endorser service and deliver service.
-        # When the property is missing or the value is 0, the concurrency limit is disabled for the service.
-        concurrency:
-            # endorserService limits concurrent requests to endorser service that handles chaincode deployment, query and invocation,
-            # including both user chaincodes and system chaincodes.
-            endorserService: 2500
-            # deliverService limits concurrent event listeners registered to deliver service for blocks and transaction events.
-            deliverService: 2500
-            # gatewayService limits concurrent requests to gateway service that handles the submission and evaluation of transactions.
-            gatewayService: 500
+  # Identifier of the local MSP
+  # ----!!!!IMPORTANT!!!-!!!IMPORTANT!!!-!!!IMPORTANT!!!!----
+  # Deployers need to change the value of the localMspId string.
+  # In particular, the name of the local MSP ID of a peer needs
+  # to match the name of one of the MSPs in each of the channel
+  # that this peer is a member of. Otherwise this peer's messages
+  # will not be identified as valid by other nodes.
+  localMspId: SampleOrg
 
-    # Since all nodes should be consistent it is recommended to keep
-    # the default value of 100MB for MaxRecvMsgSize & MaxSendMsgSize
-    # Max message size in bytes GRPC server and client can receive
-    maxRecvMsgSize: 104857600
-    # Max message size in bytes GRPC server and client can send
-    maxSendMsgSize: 104857600
+  # CLI common client config options
+  client:
+    # connection timeout
+    connTimeout: 3s
+
+  # Delivery service related config
+  deliveryclient:
+    # Enables this peer to disseminate blocks it pulls from the ordering service
+    # to other peers in the same organization via gossip.
+    # Note that 'gossip.state.enabled' controls point to point block replication
+    # of blocks committed in the past.
+    blockGossipEnabled: false
+    # It sets the total time the delivery service may spend in reconnection
+    # attempts until its retry logic gives up and returns an error,
+    # ignored if peer is a static leader
+    reconnectTotalTimeThreshold: 3600s
+
+    # It sets the delivery service <-> ordering service node connection timeout
+    connTimeout: 3s
+
+    # It sets the delivery service maximal delay between consecutive retries.
+    # Time between retries will have exponential backoff until hitting this threshold.
+    reConnectBackoffThreshold: 3600s
+
+    # If a certain header from a header receiver is in front of the block receiver for more that this time, a
+    # censorship event is declared and the block source is changed.
+    blockCensorshipTimeoutKey: 30s
+
+    # The initial value of the actual retry interval, which is increased on every failed retry
+    minimalReconnectInterval: 100ms
+
+    # A list of orderer endpoint addresses which should be overridden
+    # when found in channel configurations.
+    addressOverrides:
+      # - from:
+      #   to:
+      #   caCertsFile:
+      # - from:
+      #   to:
+      #   caCertsFile:
+
+    # Determines which delivery client will be used when consensus type is "BFT"
+    # (when consensus type is "etcdraft" this key is ignored).
+    # "simple" - use CFT deliverer
+    # "cluster" - use BFT deliverer
+    policy: cluster
+
+  # Type for the local MSP - by default it's of type bccsp
+  localMspType: bccsp
+
+  # Used with Go profiling tools only in none production environment. In
+  # production, it should be disabled (eg enabled: false)
+  profile:
+    enabled: false
+    listenAddress: 0.0.0.0:6060
+
+  # Handlers defines custom handlers that can filter and mutate
+  # objects passing within the peer, such as:
+  #   Auth filter - reject or forward proposals from clients
+  #   Decorators  - append or mutate the chaincode input passed to the chaincode
+  #   Endorsers   - Custom signing over proposal response payload and its mutation
+  # Valid handler definition contains:
+  #   - A name which is a factory method name defined in
+  #     core/handlers/library/library.go for statically compiled handlers
+  #   - library path to shared object binary for pluggable filters
+  # Auth filters and decorators are chained and executed in the order that
+  # they are defined. For example:
+  # authFilters:
+  #   - name: FilterOne
+  #     library: /opt/lib/filter.so
+  #   - name: FilterTwo
+  # decorators:
+  #   - name: DecoratorOne
+  #   - name: DecoratorTwo
+  #     library: /opt/lib/decorator.so
+  # Endorsers are configured as a map that its keys are the endorsement system chaincodes that are being overridden.
+  # Below is an example that overrides the default ESCC and uses an endorsement plugin that has the same functionality
+  # as the default ESCC.
+  # If the 'library' property is missing, the name is used as the constructor method in the builtin library similar
+  # to auth filters and decorators.
+  # endorsers:
+  #   escc:
+  #     name: DefaultESCC
+  #     library: /etc/hyperledger/fabric/plugin/escc.so
+  handlers:
+    authFilters:
+      - name: DefaultAuth
+      - name: ExpirationCheck # This filter checks identity x509 certificate expiration
+      - name: TimeWindowCheck # This filter checks the timestamp of an proposal request with the peer.authentication.timewindow parameter from core.yaml
+    decorators:
+      - name: DefaultDecorator
+    endorsers:
+      escc:
+        name: DefaultEndorsement
+        library:
+    validators:
+      vscc:
+        name: DefaultValidation
+        library:
+
+        # library: /etc/hyperledger/fabric/plugin/escc.so
+  # Number of goroutines that will execute transaction validation in parallel.
+  # By default, the peer chooses the number of CPUs on the machine. Set this
+  # variable to override that choice.
+  # NOTE: overriding this value might negatively influence the performance of
+  # the peer so please change this value only if you know what you're doing
+  validatorPoolSize:
+
+  # The discovery service is used by clients to query information about peers,
+  # such as - which peers have joined a certain channel, what is the latest
+  # channel config, and most importantly - given a chaincode and a channel,
+  # what possible sets of peers satisfy the endorsement policy.
+  discovery:
+    enabled: true
+    # Whether the authentication cache is enabled or not.
+    authCacheEnabled: true
+    # The maximum size of the cache, after which a purge takes place
+    authCacheMaxSize: 1000
+    # The proportion (0 to 1) of entries that remain in the cache after the cache is purged due to overpopulation
+    authCachePurgeRetentionRatio: 0.75
+    # Whether to allow non-admins to perform non channel scoped queries.
+    # When this is false, it means that only peer admins can perform non channel scoped queries.
+    orgMembersAllowedAccess: false
+
+  # Limits is used to configure some internal resource limits.
+  limits:
+    # Concurrency limits the number of concurrently running requests to a service on each peer.
+    # Currently this option is only applied to endorser service and deliver service.
+    # When the property is missing or the value is 0, the concurrency limit is disabled for the service.
+    concurrency:
+      # endorserService limits concurrent requests to endorser service that handles chaincode deployment, query and invocation,
+      # including both user chaincodes and system chaincodes.
+      endorserService: 2500
+      # deliverService limits concurrent event listeners registered to deliver service for blocks and transaction events.
+      deliverService: 2500
+      # gatewayService limits concurrent requests to gateway service that handles the submission and evaluation of transactions.
+      gatewayService: 500
+
+  # Since all nodes should be consistent it is recommended to keep
+  # the default value of 100MB for MaxRecvMsgSize & MaxSendMsgSize
+  # Max message size in bytes GRPC server and client can receive
+  maxRecvMsgSize: 104857600
+  # Max message size in bytes GRPC server and client can send
+  maxSendMsgSize: 104857600
 
 ###############################################################################
 #
@@ -521,51 +514,50 @@ peer:
 #
 ###############################################################################
 vm:
+  # Endpoint of the vm management system.  For docker can be one of the following in general
+  # unix:///var/run/docker.sock
+  # http://localhost:2375
+  # https://localhost:2376
+  # If you utilize external chaincode builders and don't need the default Docker chaincode builder,
+  # the endpoint should be unconfigured so that the peer's Docker health checker doesn't get registered.
+  endpoint: unix:///var/run/docker.sock
 
-    # Endpoint of the vm management system.  For docker can be one of the following in general
-    # unix:///var/run/docker.sock
-    # http://localhost:2375
-    # https://localhost:2376
-    # If you utilize external chaincode builders and don't need the default Docker chaincode builder,
-    # the endpoint should be unconfigured so that the peer's Docker health checker doesn't get registered.
-    endpoint: unix:///var/run/docker.sock
+  # settings for docker vms
+  docker:
+    tls:
+      enabled: false
+      ca:
+        file: docker/ca.crt
+      cert:
+        file: docker/tls.crt
+      key:
+        file: docker/tls.key
 
-    # settings for docker vms
-    docker:
-        tls:
-            enabled: false
-            ca:
-                file: docker/ca.crt
-            cert:
-                file: docker/tls.crt
-            key:
-                file: docker/tls.key
+    # Enables/disables the standard out/err from chaincode containers for
+    # debugging purposes
+    attachStdout: false
 
-        # Enables/disables the standard out/err from chaincode containers for
-        # debugging purposes
-        attachStdout: false
-
-        # Parameters on creating docker container.
-        # Container may be efficiently created using ipam & dns-server for cluster
-        # NetworkMode - sets the networking mode for the container. Supported
-        # standard values are: `host`(default),`bridge`,`ipvlan`,`none`.
-        # Dns - a list of DNS servers for the container to use.
-        # Note:  `Privileged` `Binds` `Links` and `PortBindings` properties of
-        # Docker Host Config are not supported and will not be used if set.
-        # LogConfig - sets the logging driver (Type) and related options
-        # (Config) for Docker. For more info,
-        # https://docs.docker.com/engine/admin/logging/overview/
-        # Note: Set LogConfig using Environment Variables is not supported.
-        hostConfig:
-            NetworkMode: host
-            Dns:
-               # - 192.168.0.1
-            LogConfig:
-                Type: json-file
-                Config:
-                    max-size: "50m"
-                    max-file: "5"
-            Memory: 2147483648
+    # Parameters on creating docker container.
+    # Container may be efficiently created using ipam & dns-server for cluster
+    # NetworkMode - sets the networking mode for the container. Supported
+    # standard values are: `host`(default),`bridge`,`ipvlan`,`none`.
+    # Dns - a list of DNS servers for the container to use.
+    # Note:  `Privileged` `Binds` `Links` and `PortBindings` properties of
+    # Docker Host Config are not supported and will not be used if set.
+    # LogConfig - sets the logging driver (Type) and related options
+    # (Config) for Docker. For more info,
+    # https://docs.docker.com/engine/admin/logging/overview/
+    # Note: Set LogConfig using Environment Variables is not supported.
+    hostConfig:
+      NetworkMode: host
+      Dns:
+        # - 192.168.0.1
+      LogConfig:
+        Type: json-file
+        Config:
+          max-size: "50m"
+          max-file: "5"
+      Memory: 2147483648
 
 ###############################################################################
 #
@@ -573,101 +565,99 @@ vm:
 #
 ###############################################################################
 chaincode:
+  # The id is used by the Chaincode stub to register the executing Chaincode
+  # ID with the Peer and is generally supplied through ENV variables
+  # the `path` form of ID is provided when installing the chaincode.
+  # The `name` is used for all other requests and can be any string.
+  id:
+    path:
+    name:
 
-    # The id is used by the Chaincode stub to register the executing Chaincode
-    # ID with the Peer and is generally supplied through ENV variables
-    # the `path` form of ID is provided when installing the chaincode.
-    # The `name` is used for all other requests and can be any string.
-    id:
-        path:
-        name:
+  # Generic builder image with Go pre-installed.
+  # TWO_DIGIT_VERSION represents Fabric major.minor version.
+  builder: $(DOCKER_NS)/fabric-ccenv:$(TWO_DIGIT_VERSION)
 
-    # Generic builder image with Go pre-installed.
+  # Enables/disables force pulling of the base docker images (listed below)
+  # during user chaincode instantiation.
+  # Useful when using moving image tags (such as :latest)
+  pull: false
+
+  golang:
+    # Compiled Go chaincodes will be copied to the fabric-baseos runtime image.
     # TWO_DIGIT_VERSION represents Fabric major.minor version.
-    builder: $(DOCKER_NS)/fabric-ccenv:$(TWO_DIGIT_VERSION)
+    runtime: $(DOCKER_NS)/fabric-baseos:$(TWO_DIGIT_VERSION)
 
-    # Enables/disables force pulling of the base docker images (listed below)
-    # during user chaincode instantiation.
-    # Useful when using moving image tags (such as :latest)
-    pull: false
+    # whether or not golang chaincode should be linked dynamically
+    dynamicLink: false
 
-    golang:
-        # Compiled Go chaincodes will be copied to the fabric-baseos runtime image.
-        # TWO_DIGIT_VERSION represents Fabric major.minor version.
-        runtime: $(DOCKER_NS)/fabric-baseos:$(TWO_DIGIT_VERSION)
+  java:
+    # This is an image based on eclipse temurin with addition compiler
+    # tools added for java shim layer packaging.
+    # This image is packed with shim layer libraries that are necessary
+    # for Java chaincode runtime.
+    runtime: $(DOCKER_NS)/fabric-javaenv:2.5
 
-        # whether or not golang chaincode should be linked dynamically
-        dynamicLink: false
+  node:
+    # This is an image based on node:$(NODE_VER)-alpine
+    runtime: $(DOCKER_NS)/fabric-nodeenv:2.5
 
-    java:
-        # This is an image based on eclipse temurin with addition compiler
-        # tools added for java shim layer packaging.
-        # This image is packed with shim layer libraries that are necessary
-        # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:2.5
+  # List of directories to treat as external builders and launchers for
+  # chaincode. The external builder detection processing will iterate over the
+  # builders in the order specified below.
+  # If you don't need to fallback to the default Docker builder, also unconfigure vm.endpoint above.
+  # To override this property via env variable use CORE_CHAINCODE_EXTERNALBUILDERS: [{name: x, path: dir1}, {name: y, path: dir2}]
+  # The path must be an absolute path.
+  externalBuilders:
+    - name: ccaas_builder
+      path: /opt/hyperledger/ccaas_builder
+      propagateEnvironment:
+        - CHAINCODE_AS_A_SERVICE_BUILDER_CONFIG
 
-    node:
-        # This is an image based on node:$(NODE_VER)-alpine
-        runtime: $(DOCKER_NS)/fabric-nodeenv:2.5
+  # The maximum duration to wait for the chaincode build and install process
+  # to complete.
+  installTimeout: 300s
 
-    # List of directories to treat as external builders and launchers for
-    # chaincode. The external builder detection processing will iterate over the
-    # builders in the order specified below.
-    # If you don't need to fallback to the default Docker builder, also unconfigure vm.endpoint above.
-    # To override this property via env variable use CORE_CHAINCODE_EXTERNALBUILDERS: [{name: x, path: dir1}, {name: y, path: dir2}]
-    # The path must be an absolute path.
-    externalBuilders:
-       - name: ccaas_builder
-         path: /opt/hyperledger/ccaas_builder
-         propagateEnvironment:
-           - CHAINCODE_AS_A_SERVICE_BUILDER_CONFIG
+  # Timeout duration for starting up a container and waiting for Register
+  # to come through.
+  startuptimeout: 300s
 
+  # Timeout duration for Invoke and Init calls to prevent runaway.
+  # This timeout is used by all chaincodes in all the channels, including
+  # system chaincodes.
+  # Note that during Invoke, if the image is not available (e.g. being
+  # cleaned up when in development environment), the peer will automatically
+  # build the image, which might take more time. In production environment,
+  # the chaincode image is unlikely to be deleted, so the timeout could be
+  # reduced accordingly.
+  executetimeout: 30s
 
-    # The maximum duration to wait for the chaincode build and install process
-    # to complete.
-    installTimeout: 300s
+  # There are 2 modes: "dev" and "net".
+  # In dev mode, user runs the chaincode after starting peer from
+  # command line on local machine.
+  # In net mode, peer will run chaincode in a docker container.
+  mode: net
 
-    # Timeout duration for starting up a container and waiting for Register
-    # to come through.
-    startuptimeout: 300s
+  # keepalive in seconds. In situations where the communication goes through a
+  # proxy that does not support keep-alive, this parameter will maintain connection
+  # between peer and chaincode.
+  # A value <= 0 turns keepalive off
+  keepalive: 0
 
-    # Timeout duration for Invoke and Init calls to prevent runaway.
-    # This timeout is used by all chaincodes in all the channels, including
-    # system chaincodes.
-    # Note that during Invoke, if the image is not available (e.g. being
-    # cleaned up when in development environment), the peer will automatically
-    # build the image, which might take more time. In production environment,
-    # the chaincode image is unlikely to be deleted, so the timeout could be
-    # reduced accordingly.
-    executetimeout: 30s
+  # enabled system chaincodes
+  system:
+    _lifecycle: enable
+    cscc: enable
+    lscc: enable
+    qscc: enable
 
-    # There are 2 modes: "dev" and "net".
-    # In dev mode, user runs the chaincode after starting peer from
-    # command line on local machine.
-    # In net mode, peer will run chaincode in a docker container.
-    mode: net
-
-    # keepalive in seconds. In situations where the communication goes through a
-    # proxy that does not support keep-alive, this parameter will maintain connection
-    # between peer and chaincode.
-    # A value <= 0 turns keepalive off
-    keepalive: 0
-
-    # enabled system chaincodes
-    system:
-        _lifecycle: enable
-        cscc: enable
-        lscc: enable
-        qscc: enable
-
-    # Logging section for the chaincode container
-    logging:
-      # Default level for all loggers within the chaincode container
-      level:  info
-      # Override default level for the 'shim' logger
-      shim:   warning
-      # Format for the chaincode container logs
-      format: '%{color}%{time:2006-01-02 15:04:05.000 MST} [%{module}] %{shortfunc} -> %{level:.4s} %{id:03x}%{color:reset} %{message}'
+  # Logging section for the chaincode container
+  logging:
+    # Default level for all loggers within the chaincode container
+    level: info
+    # Override default level for the 'shim' logger
+    shim: warning
+    # Format for the chaincode container logs
+    format: "%{color}%{time:2006-01-02 15:04:05.000 MST} [%{module}] %{shortfunc} -> %{level:.4s} %{id:03x}%{color:reset} %{message}"
 
 ###############################################################################
 #
@@ -676,7 +666,6 @@ chaincode:
 #
 ###############################################################################
 ledger:
-
   blockchain:
 
   state:
@@ -687,42 +676,42 @@ ledger:
     # Limit on the number of records to return per query
     totalQueryLimit: 100000
     couchDBConfig:
-       # It is recommended to run CouchDB on the same server as the peer, and
-       # not map the CouchDB container port to a server port in docker-compose.
-       # Otherwise proper security must be provided on the connection between
-       # CouchDB client (on the peer) and server.
-       couchDBAddress: 127.0.0.1:5984
-       # This username must have read and write authority on CouchDB
-       username:
-       # The password is recommended to pass as an environment variable
-       # during start up (eg CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD).
-       # If it is stored here, the file must be access control protected
-       # to prevent unintended users from discovering the password.
-       password:
-       # Number of retries for CouchDB errors
-       maxRetries: 3
-       # Number of retries for CouchDB errors during peer startup.
-       # The delay between retries doubles for each attempt.
-       # Default of 10 retries results in 11 attempts over 2 minutes.
-       maxRetriesOnStartup: 10
-       # CouchDB request timeout (unit: duration, e.g. 20s)
-       requestTimeout: 35s
-       # Limit on the number of records per each CouchDB query
-       # Note that chaincode queries are only bound by totalQueryLimit.
-       # Internally the chaincode may execute multiple CouchDB queries,
-       # each of size internalQueryLimit.
-       internalQueryLimit: 1000
-       # Limit on the number of records per CouchDB bulk update batch
-       maxBatchUpdateSize: 1000
-       # Create the _global_changes system database
-       # This is optional.  Creating the global changes database will require
-       # additional system resources to track changes and maintain the database
-       createGlobalChangesDB: false
-       # CacheSize denotes the maximum mega bytes (MB) to be allocated for the in-memory state
-       # cache. Note that CacheSize needs to be a multiple of 32 MB. If it is not a multiple
-       # of 32 MB, the peer would round the size to the next multiple of 32 MB.
-       # To disable the cache, 0 MB needs to be assigned to the cacheSize.
-       cacheSize: 64
+      # It is recommended to run CouchDB on the same server as the peer, and
+      # not map the CouchDB container port to a server port in docker-compose.
+      # Otherwise proper security must be provided on the connection between
+      # CouchDB client (on the peer) and server.
+      couchDBAddress: 127.0.0.1:5984
+      # This username must have read and write authority on CouchDB
+      username:
+      # The password is recommended to pass as an environment variable
+      # during start up (eg CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD).
+      # If it is stored here, the file must be access control protected
+      # to prevent unintended users from discovering the password.
+      password:
+      # Number of retries for CouchDB errors
+      maxRetries: 3
+      # Number of retries for CouchDB errors during peer startup.
+      # The delay between retries doubles for each attempt.
+      # Default of 10 retries results in 11 attempts over 2 minutes.
+      maxRetriesOnStartup: 10
+      # CouchDB request timeout (unit: duration, e.g. 20s)
+      requestTimeout: 35s
+      # Limit on the number of records per each CouchDB query
+      # Note that chaincode queries are only bound by totalQueryLimit.
+      # Internally the chaincode may execute multiple CouchDB queries,
+      # each of size internalQueryLimit.
+      internalQueryLimit: 1000
+      # Limit on the number of records per CouchDB bulk update batch
+      maxBatchUpdateSize: 1000
+      # Create the _global_changes system database
+      # This is optional.  Creating the global changes database will require
+      # additional system resources to track changes and maintain the database
+      createGlobalChangesDB: false
+      # CacheSize denotes the maximum mega bytes (MB) to be allocated for the in-memory state
+      # cache. Note that CacheSize needs to be a multiple of 32 MB. If it is not a multiple
+      # of 32 MB, the peer would round the size to the next multiple of 32 MB.
+      # To disable the cache, 0 MB needs to be assigned to the cacheSize.
+      cacheSize: 64
 
   history:
     # enableHistoryDatabase - options are true or false
@@ -766,31 +755,31 @@ ledger:
 #
 ###############################################################################
 operations:
-    # host and port for the operations server
-    listenAddress: 127.0.0.1:9443
+  # host and port for the operations server
+  listenAddress: 127.0.0.1:9443
 
-    # TLS configuration for the operations endpoint
-    tls:
-        # TLS enabled
-        enabled: false
+  # TLS configuration for the operations endpoint
+  tls:
+    # TLS enabled
+    enabled: false
 
-        # path to PEM encoded server certificate for the operations server
-        # The paths in this section may be relative to FABRIC_CFG_PATH or an absolute path.
-        cert:
-            file:
+    # path to PEM encoded server certificate for the operations server
+    # The paths in this section may be relative to FABRIC_CFG_PATH or an absolute path.
+    cert:
+      file:
 
-        # path to PEM encoded server key for the operations server
-        key:
-            file:
+    # path to PEM encoded server key for the operations server
+    key:
+      file:
 
-        # most operations service endpoints require client authentication when TLS
-        # is enabled. clientAuthRequired requires client certificate authentication
-        # at the TLS layer to access all resources.
-        clientAuthRequired: false
+    # most operations service endpoints require client authentication when TLS
+    # is enabled. clientAuthRequired requires client certificate authentication
+    # at the TLS layer to access all resources.
+    clientAuthRequired: false
 
-        # paths to PEM encoded ca certificates to trust for client authentication
-        clientRootCAs:
-            files: []
+    # paths to PEM encoded ca certificates to trust for client authentication
+    clientRootCAs:
+      files: []
 
 ###############################################################################
 #
@@ -798,20 +787,20 @@ operations:
 #
 ###############################################################################
 metrics:
-    # metrics provider is one of statsd, prometheus, or disabled
-    provider: disabled
+  # metrics provider is one of statsd, prometheus, or disabled
+  provider: disabled
 
-    # statsd configuration
-    statsd:
-        # network type: tcp or udp
-        network: udp
+  # statsd configuration
+  statsd:
+    # network type: tcp or udp
+    network: udp
 
-        # statsd server address
-        address: 127.0.0.1:8125
+    # statsd server address
+    address: 127.0.0.1:8125
 
-        # the interval at which locally cached counters and gauges are pushed
-        # to statsd; timings are pushed immediately
-        writeInterval: 10s
+    # the interval at which locally cached counters and gauges are pushed
+    # to statsd; timings are pushed immediately
+    writeInterval: 10s
 
-        # prefix is prepended to all emitted statsd metrics
-        prefix:
+    # prefix is prepended to all emitted statsd metrics
+    prefix:

--- a/sampleconfig/orderer.yaml
+++ b/sampleconfig/orderer.yaml
@@ -12,179 +12,178 @@
 #
 ################################################################################
 General:
-    # Listen address: The IP on which to bind to listen.
-    ListenAddress: 127.0.0.1
+  # Listen address: The IP on which to bind to listen.
+  ListenAddress: 127.0.0.1
 
-    # Listen port: The port on which to bind to listen.
-    ListenPort: 7050
+  # Listen port: The port on which to bind to listen.
+  ListenPort: 7050
 
-    # TLS: TLS settings for the GRPC server.
-    TLS:
-        # Require server-side TLS
-        Enabled: false
-        # PrivateKey governs the file location of the private key of the TLS certificate.
-        PrivateKey: tls/server.key
-        # Certificate governs the file location of the server TLS certificate.
-        Certificate: tls/server.crt
-        # RootCAs contains a list of additional root certificates used for verifying certificates
-        # of other orderer nodes during outbound connections.
-        # It is not required to be set, but can be used to augment the set of TLS CA certificates
-        # available from the MSPs of each channel’s configuration.
-        RootCAs:
-          - tls/ca.crt
-        # Require client certificates / mutual TLS for inbound connections.
-        ClientAuthRequired: false
-        # If mutual TLS is enabled, ClientRootCAs contains a list of additional root certificates
-        # used for verifying certificates of client connections.
-        # It is not required to be set, but can be used to augment the set of TLS CA certificates
-        # available from the MSPs of each channel’s configuration.
-        ClientRootCAs:
-    # Keepalive settings for the GRPC server.
-    Keepalive:
-        # ServerMinInterval is the minimum permitted time between client pings.
-        # If clients send pings more frequently, the server will
-        # disconnect them.
-        ServerMinInterval: 60s
-        # ServerInterval is the time between pings to clients.
-        ServerInterval: 7200s
-        # ServerTimeout is the duration the server waits for a response from
-        # a client before closing the connection.
-        ServerTimeout: 20s
-    # Config defines the configuration options for backoff GRPC client.
-    Backoff:
-        # BaseDelay is the amount of time to backoff after the first failure.
-        BaseDelay: 1s
-        # Multiplier is the factor with which to multiply backoffs after a
-        # failed retry. Should ideally be greater than 1.
-        Multiplier: 1.6
-        # MaxDelay is the upper bound of backoff delay.
-        MaxDelay: 2m
+  # TLS: TLS settings for the GRPC server.
+  TLS:
+    # Require server-side TLS
+    Enabled: false
+    # PrivateKey governs the file location of the private key of the TLS certificate.
+    PrivateKey: tls/server.key
+    # Certificate governs the file location of the server TLS certificate.
+    Certificate: tls/server.crt
+    # RootCAs contains a list of additional root certificates used for verifying certificates
+    # of other orderer nodes during outbound connections.
+    # It is not required to be set, but can be used to augment the set of TLS CA certificates
+    # available from the MSPs of each channel’s configuration.
+    RootCAs:
+      - tls/ca.crt
+    # Require client certificates / mutual TLS for inbound connections.
+    ClientAuthRequired: false
+    # If mutual TLS is enabled, ClientRootCAs contains a list of additional root certificates
+    # used for verifying certificates of client connections.
+    # It is not required to be set, but can be used to augment the set of TLS CA certificates
+    # available from the MSPs of each channel’s configuration.
+    ClientRootCAs:
+  # Keepalive settings for the GRPC server.
+  Keepalive:
+    # ServerMinInterval is the minimum permitted time between client pings.
+    # If clients send pings more frequently, the server will
+    # disconnect them.
+    ServerMinInterval: 60s
+    # ServerInterval is the time between pings to clients.
+    ServerInterval: 7200s
+    # ServerTimeout is the duration the server waits for a response from
+    # a client before closing the connection.
+    ServerTimeout: 20s
+  # Config defines the configuration options for backoff GRPC client.
+  Backoff:
+    # BaseDelay is the amount of time to backoff after the first failure.
+    BaseDelay: 1s
+    # Multiplier is the factor with which to multiply backoffs after a
+    # failed retry. Should ideally be greater than 1.
+    Multiplier: 1.6
+    # MaxDelay is the upper bound of backoff delay.
+    MaxDelay: 2m
 
-    # Since all nodes should be consistent it is recommended to keep
-    # the default value of 100MB for MaxRecvMsgSize & MaxSendMsgSize
-    # Max message size in bytes the GRPC server and client can receive
-    MaxRecvMsgSize: 104857600
-    # Max message size in bytes the GRPC server and client can send
-    MaxSendMsgSize: 104857600
-    # Throttling prevents clients from sending too many transactions
-    # per second to the broadcast API of this node.
-    # It is only enforced when the Rate is non-zero, and when the client
-    # connects using mutual TLS.
-    # The effective rate of transactions is divided across all clients
-    # and organizations at a given unit of time governed by the inactivity timeout.
-    # When a client's rate of transaction submission exhausts its allocated budget,
-    # it is throttled until additional "budget" is allocated (it is allocated once per second).
-    Throttling:
-        # Rate is the maximum rate (transactions per second) for all clients combined.
-        # A zero rate disables throttling.
-        Rate: 0
-        # InactivityTimeout defines the time frame after which
-        # inactive clients are pruned from memory and are not considered
-        # when allocating the budget for throttling per client.
-        InactivityTimeout: 5s
+  # Since all nodes should be consistent it is recommended to keep
+  # the default value of 100MB for MaxRecvMsgSize & MaxSendMsgSize
+  # Max message size in bytes the GRPC server and client can receive
+  MaxRecvMsgSize: 104857600
+  # Max message size in bytes the GRPC server and client can send
+  MaxSendMsgSize: 104857600
+  # Throttling prevents clients from sending too many transactions
+  # per second to the broadcast API of this node.
+  # It is only enforced when the Rate is non-zero, and when the client
+  # connects using mutual TLS.
+  # The effective rate of transactions is divided across all clients
+  # and organizations at a given unit of time governed by the inactivity timeout.
+  # When a client's rate of transaction submission exhausts its allocated budget,
+  # it is throttled until additional "budget" is allocated (it is allocated once per second).
+  Throttling:
+    # Rate is the maximum rate (transactions per second) for all clients combined.
+    # A zero rate disables throttling.
+    Rate: 0
+    # InactivityTimeout defines the time frame after which
+    # inactive clients are pruned from memory and are not considered
+    # when allocating the budget for throttling per client.
+    InactivityTimeout: 5s
 
-    # Cluster settings for ordering service nodes that communicate with other ordering service nodes
-    # such as Raft based ordering service.
-    Cluster:
-        # SendBufferSize is the maximum number of messages in the egress buffer.
-        # Consensus messages are dropped if the buffer is full, and transaction
-        # messages are waiting for space to be freed.
-        SendBufferSize: 100
+  # Cluster settings for ordering service nodes that communicate with other ordering service nodes
+  # such as Raft based ordering service.
+  Cluster:
+    # SendBufferSize is the maximum number of messages in the egress buffer.
+    # Consensus messages are dropped if the buffer is full, and transaction
+    # messages are waiting for space to be freed.
+    SendBufferSize: 100
 
-        # ClientCertificate governs the file location of the client TLS certificate
-        # used to establish mutual TLS connections with other ordering service nodes.
-        # If not set, the server General.TLS.Certificate is re-used.
-        ClientCertificate:
-        # ClientPrivateKey governs the file location of the private key of the client TLS certificate.
-        # If not set, the server General.TLS.PrivateKey is re-used.
-        ClientPrivateKey:
+    # ClientCertificate governs the file location of the client TLS certificate
+    # used to establish mutual TLS connections with other ordering service nodes.
+    # If not set, the server General.TLS.Certificate is re-used.
+    ClientCertificate:
+    # ClientPrivateKey governs the file location of the private key of the client TLS certificate.
+    # If not set, the server General.TLS.PrivateKey is re-used.
+    ClientPrivateKey:
 
-        # The below 4 properties should be either set together, or be unset together.
-        # If they are set, then the orderer node uses a separate listener for intra-cluster
-        # communication. If they are unset, then the general orderer listener is used.
-        # This is useful if you want to use a different TLS server certificates on the
-        # client-facing and the intra-cluster listeners.
+    # The below 4 properties should be either set together, or be unset together.
+    # If they are set, then the orderer node uses a separate listener for intra-cluster
+    # communication. If they are unset, then the general orderer listener is used.
+    # This is useful if you want to use a different TLS server certificates on the
+    # client-facing and the intra-cluster listeners.
 
-        # ListenPort defines the port on which the cluster listens to connections.
-        ListenPort:
-        # ListenAddress defines the IP on which to listen to intra-cluster communication.
-        ListenAddress:
-        # ServerCertificate defines the file location of the server TLS certificate used for intra-cluster
-        # communication.
-        ServerCertificate:
-        # ServerPrivateKey defines the file location of the private key of the TLS certificate.
-        ServerPrivateKey:
+    # ListenPort defines the port on which the cluster listens to connections.
+    ListenPort:
+    # ListenAddress defines the IP on which to listen to intra-cluster communication.
+    ListenAddress:
+    # ServerCertificate defines the file location of the server TLS certificate used for intra-cluster
+    # communication.
+    ServerCertificate:
+    # ServerPrivateKey defines the file location of the private key of the TLS certificate.
+    ServerPrivateKey:
 
-        # ReplicationPolicy defines how blocks are replicated between orderers.
-        # Permitted values:
-        # in BFT: "simple" | "consensus" (default);
-        # in etcdraft: ignored, (always "simple", regardless of value in config).
-        # When running a Raft orderer or with ReplicationPolicy set to 'simple', an orderer
-        # replicates blocks from a single orderer node.
-        # When running a BFT orderer with ReplicationPolicy set to 'consensus', the orderer
-        # replicates blocks from a single orderer node, but replicates block headers with signatures
-        # from other orderer nodes, and if it suspects the former node withholds blocks from it,
-        # it switches to a new orderer as a source of blocks.
-        ReplicationPolicy:
+    # ReplicationPolicy defines how blocks are replicated between orderers.
+    # Permitted values:
+    # in BFT: "simple" | "consensus" (default);
+    # in etcdraft: ignored, (always "simple", regardless of value in config).
+    # When running a Raft orderer or with ReplicationPolicy set to 'simple', an orderer
+    # replicates blocks from a single orderer node.
+    # When running a BFT orderer with ReplicationPolicy set to 'consensus', the orderer
+    # replicates blocks from a single orderer node, but replicates block headers with signatures
+    # from other orderer nodes, and if it suspects the former node withholds blocks from it,
+    # it switches to a new orderer as a source of blocks.
+    ReplicationPolicy:
 
-    # LocalMSPDir is where to find the private crypto material needed by the
-    # orderer. It is set relative here as a default for dev environments but
-    # should be changed to the real location in production.
-    LocalMSPDir: msp
+  # LocalMSPDir is where to find the private crypto material needed by the
+  # orderer. It is set relative here as a default for dev environments but
+  # should be changed to the real location in production.
+  LocalMSPDir: msp
 
-    # LocalMSPID is the identity to register the local MSP material with the MSP
-    # manager. The sample organization defined in the
-    # sample configuration provided has an MSP ID of "SampleOrg".
-    LocalMSPID: SampleOrg
+  # LocalMSPID is the identity to register the local MSP material with the MSP
+  # manager. The sample organization defined in the
+  # sample configuration provided has an MSP ID of "SampleOrg".
+  LocalMSPID: SampleOrg
 
-    # Enable an HTTP service for Go "pprof" profiling as documented at:
-    # https://golang.org/pkg/net/http/pprof
-    Profile:
-        Enabled: false
-        Address: 0.0.0.0:6060
+  # Enable an HTTP service for Go "pprof" profiling as documented at:
+  # https://golang.org/pkg/net/http/pprof
+  Profile:
+    Enabled: false
+    Address: 0.0.0.0:6060
 
-    # BCCSP configures the blockchain crypto service providers.
-    BCCSP:
-        # Default specifies the preferred blockchain crypto service provider
-        # to use. If the preferred provider is not available, the software
-        # based provider ("SW") will be used.
-        # Valid providers are:
-        #  - SW: a software based crypto provider
-        #  - PKCS11: a CA hardware security module crypto provider.
-        Default: SW
+  # BCCSP configures the blockchain crypto service providers.
+  BCCSP:
+    # Default specifies the preferred blockchain crypto service provider
+    # to use. If the preferred provider is not available, the software
+    # based provider ("SW") will be used.
+    # Valid providers are:
+    #  - SW: a software based crypto provider
+    #  - PKCS11: a CA hardware security module crypto provider.
+    Default: SW
 
-        # SW configures the software based blockchain crypto provider.
-        SW:
-            # TODO: The default Hash and Security level needs refactoring to be
-            # fully configurable. Changing these defaults requires coordination
-            # SHA2 is hardcoded in several places, not only BCCSP
-            Hash: SHA2
-            Security: 256
-            # Location of key store. If this is unset, a location will be
-            # chosen using: 'LocalMSPDir'/keystore
-            FileKeyStore:
-                KeyStore:
+    # SW configures the software based blockchain crypto provider.
+    SW:
+      # TODO: The default Hash and Security level needs refactoring to be
+      # fully configurable. Changing these defaults requires coordination
+      # SHA2 is hardcoded in several places, not only BCCSP
+      Hash: SHA2
+      Security: 256
+      # Location of key store. If this is unset, a location will be
+      # chosen using: 'LocalMSPDir'/keystore
+      FileKeyStore:
+        KeyStore:
 
-        # Settings for the PKCS#11 crypto provider (i.e. when DEFAULT: PKCS11)
-        PKCS11:
-            # Location of the PKCS11 module library
-            Library:
-            # Token Label
-            Label:
-            # User PIN
-            Pin:
-            Hash:
-            Security:
-            FileKeyStore:
-                KeyStore:
+    # Settings for the PKCS#11 crypto provider (i.e. when DEFAULT: PKCS11)
+    PKCS11:
+      # Location of the PKCS11 module library
+      Library:
+      # Token Label
+      Label:
+      # User PIN
+      Pin:
+      Hash:
+      Security:
+      FileKeyStore:
+        KeyStore:
 
-    # Authentication contains configuration parameters related to authenticating
-    # client messages
-    Authentication:
-        # the acceptable difference between the current server time and the
-        # client's time as specified in a client request message
-        TimeWindow: 15m
-
+  # Authentication contains configuration parameters related to authenticating
+  # client messages
+  Authentication:
+    # the acceptable difference between the current server time and the
+    # client's time as specified in a client request message
+    TimeWindow: 15m
 
 ################################################################################
 #
@@ -194,9 +193,8 @@ General:
 #
 ################################################################################
 FileLedger:
-
-    # Location: The directory to store the blocks in.
-    Location: /var/hyperledger/production/orderer
+  # Location: The directory to store the blocks in.
+  Location: /var/hyperledger/production/orderer
 
 ################################################################################
 #
@@ -206,14 +204,13 @@ FileLedger:
 #
 ################################################################################
 Debug:
+  # BroadcastTraceDir when set will cause each request to the Broadcast service
+  # for this orderer to be written to a file in this directory
+  BroadcastTraceDir:
 
-    # BroadcastTraceDir when set will cause each request to the Broadcast service
-    # for this orderer to be written to a file in this directory
-    BroadcastTraceDir:
-
-    # DeliverTraceDir when set will cause each request to the Deliver service
-    # for this orderer to be written to a file in this directory
-    DeliverTraceDir:
+  # DeliverTraceDir when set will cause each request to the Deliver service
+  # for this orderer to be written to a file in this directory
+  DeliverTraceDir:
 
 ################################################################################
 #
@@ -223,27 +220,27 @@ Debug:
 #
 ################################################################################
 Operations:
-    # host and port for the operations server
-    ListenAddress: 127.0.0.1:8443
+  # host and port for the operations server
+  ListenAddress: 127.0.0.1:8443
 
-    # TLS configuration for the operations endpoint
-    TLS:
-        # TLS enabled
-        Enabled: false
+  # TLS configuration for the operations endpoint
+  TLS:
+    # TLS enabled
+    Enabled: false
 
-        # Certificate is the location of the PEM encoded TLS certificate
-        Certificate:
+    # Certificate is the location of the PEM encoded TLS certificate
+    Certificate:
 
-        # PrivateKey points to the location of the PEM-encoded key
-        PrivateKey:
+    # PrivateKey points to the location of the PEM-encoded key
+    PrivateKey:
 
-        # Most operations service endpoints require client authentication when TLS
-        # is enabled. ClientAuthRequired requires client certificate authentication
-        # at the TLS layer to access all resources.
-        ClientAuthRequired: false
+    # Most operations service endpoints require client authentication when TLS
+    # is enabled. ClientAuthRequired requires client certificate authentication
+    # at the TLS layer to access all resources.
+    ClientAuthRequired: false
 
-        # Paths to PEM encoded ca certificates to trust for client authentication
-        ClientRootCAs: []
+    # Paths to PEM encoded ca certificates to trust for client authentication
+    ClientRootCAs: []
 
 ################################################################################
 #
@@ -253,23 +250,23 @@ Operations:
 #
 ################################################################################
 Metrics:
-    # The metrics provider is one of statsd, prometheus, or disabled
-    Provider: disabled
+  # The metrics provider is one of statsd, prometheus, or disabled
+  Provider: disabled
 
-    # The statsd configuration
-    Statsd:
-      # network type: tcp or udp
-      Network: udp
+  # The statsd configuration
+  Statsd:
+    # network type: tcp or udp
+    Network: udp
 
-      # the statsd server address
-      Address: 127.0.0.1:8125
+    # the statsd server address
+    Address: 127.0.0.1:8125
 
-      # The interval at which locally cached counters and gauges are pushed
-      # to statsd; timings are pushed immediately
-      WriteInterval: 30s
+    # The interval at which locally cached counters and gauges are pushed
+    # to statsd; timings are pushed immediately
+    WriteInterval: 30s
 
-      # The prefix is prepended to all emitted statsd metrics
-      Prefix:
+    # The prefix is prepended to all emitted statsd metrics
+    Prefix:
 
 ################################################################################
 #
@@ -279,30 +276,30 @@ Metrics:
 #
 ################################################################################
 Admin:
-    # host and port for the admin server
-    ListenAddress: 127.0.0.1:9443
+  # host and port for the admin server
+  ListenAddress: 127.0.0.1:9443
 
-    # TLS configuration for the admin endpoint
-    TLS:
-        # TLS enabled
-        Enabled: false
+  # TLS configuration for the admin endpoint
+  TLS:
+    # TLS enabled
+    Enabled: false
 
-        # Certificate is the location of the PEM encoded TLS certificate
-        Certificate:
+    # Certificate is the location of the PEM encoded TLS certificate
+    Certificate:
 
-        # PrivateKey points to the location of the PEM-encoded key
-        PrivateKey:
+    # PrivateKey points to the location of the PEM-encoded key
+    PrivateKey:
 
-        # Most admin service endpoints require client authentication when TLS
-        # is enabled. ClientAuthRequired requires client certificate authentication
-        # at the TLS layer to access all resources.
-        #
-        # NOTE: When TLS is enabled, the admin endpoint requires mutual TLS. The
-        # orderer will panic on startup if this value is set to false.
-        ClientAuthRequired: true
+    # Most admin service endpoints require client authentication when TLS
+    # is enabled. ClientAuthRequired requires client certificate authentication
+    # at the TLS layer to access all resources.
+    #
+    # NOTE: When TLS is enabled, the admin endpoint requires mutual TLS. The
+    # orderer will panic on startup if this value is set to false.
+    ClientAuthRequired: true
 
-        # Paths to PEM encoded ca certificates to trust for client authentication
-        ClientRootCAs: []
+    # Paths to PEM encoded ca certificates to trust for client authentication
+    ClientRootCAs: []
 
 ################################################################################
 #
@@ -314,12 +311,11 @@ Admin:
 #
 ################################################################################
 ChannelParticipation:
-    # Channel participation API is enabled. Deprecated: must be set to true.
-    Enabled: true
+  # Channel participation API is enabled. Deprecated: must be set to true.
+  Enabled: true
 
-    # The maximum size of the request body when joining a channel.
-    MaxRequestBodySize: 1 MB
-
+  # The maximum size of the request body when joining a channel.
+  MaxRequestBodySize: 1 MB
 
 ################################################################################
 #
@@ -330,13 +326,13 @@ ChannelParticipation:
 #
 ################################################################################
 Consensus:
-    # The allowed key-value pairs here depend on consensus plugin. For etcd/raft,
-    # we use following options:
+  # The allowed key-value pairs here depend on consensus plugin. For etcd/raft,
+  # we use following options:
 
-    # WALDir specifies the location at which Write Ahead Logs for etcd/raft are
-    # stored. Each channel will have its own subdir named after channel ID.
-    WALDir: /var/hyperledger/production/orderer/etcdraft/wal
+  # WALDir specifies the location at which Write Ahead Logs for etcd/raft are
+  # stored. Each channel will have its own subdir named after channel ID.
+  WALDir: /var/hyperledger/production/orderer/etcdraft/wal
 
-    # SnapDir specifies the location at which snapshots for etcd/raft are
-    # stored. Each channel will have its own subdir named after channel ID.
-    SnapDir: /var/hyperledger/production/orderer/etcdraft/snapshot
+  # SnapDir specifies the location at which snapshots for etcd/raft are
+  # stored. Each channel will have its own subdir named after channel ID.
+  SnapDir: /var/hyperledger/production/orderer/etcdraft/snapshot


### PR DESCRIPTION
#### Type of change

- Refactoring

#### Description

This PR unifies the indentation in YAML files within sampleconfig to 2 spaces, aligning with the indentation style used in other YAML files.

#### Related issues

https://github.com/hyperledger/fabric-samples/pull/1266
