### PR TITLE
Nominate Fedor Partanskiy (@pfi) to the maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,6 +11,7 @@ See [the documentation on Maintainers](https://hyperledger-fabric.readthedocs.io
 | Andrew Coleman          | [andrew-coleman][andrew-coleman] | andrew-coleman | <andrew_coleman@uk.ibm.com>
 | Artem Barger            | [c0rwin][c0rwin] | c0rwin | <artem@bargr.net>
 | Dave Enyeart            | [denyeart][denyeart] | dave.enyeart | <enyeart@us.ibm.com>
+| Fedor Partanskiy        | [pfi79][pfi79] | pfi79 | <fredprtnsk@gmail.com> 
 | Manish Sethi            | [manish-sethi][manish-sethi] | manish-sethi | <manish.sethi@gmail.com>
 | Tatsuya Sato            | [satota2][satota2] | satota2 | <tatsuya.sato.so@hitachi.com>
 | Yacov Manevich          | [yacovm][yacovm] | yacovm | <yacov.manevich@gmail.com>
@@ -91,3 +92,4 @@ See [the documentation on Maintainers](https://hyperledger-fabric.readthedocs.io
 [tock-ibm]: https://github.com/tock-ibm
 [wlahti]: https://github.com/wlahti
 [yacovm]: https://github.com/yacovm
+[pfi79]: https://github.com/pfi79


### PR DESCRIPTION
@pfi has demonstrated a very active contribution over the past year, assisting with code review, fixing and providing patches, maintaining unit tests, and aiding in reducing the number of flakes. Was actively aligning the project with up-to-date libraries and go eco-system updates.

In addition to their technical contributions, Fedor has shown a clear commitment to the project’s success and growth. He has taken the initiative to address issues promptly and has actively participated in discussions to maintain the project’s direction. His consistent effort and dedication make him well-suited for the responsibilities of a maintainer, ensuring the project’s continued success and reliability.

