### PR TITLE
Fix: Close block stream after use in blockfile_mgr.go

### DIFF
--- a/common/ledger/blkstorage/blockfile_mgr.go
+++ b/common/ledger/blkstorage/blockfile_mgr.go
@@ -426,6 +426,7 @@ func (mgr *blockfileMgr) syncIndex() error {
 	if stream, err = newBlockStream(mgr.rootDir, startFileNum, int64(startOffset), endFileNum); err != nil {
 		return err
 	}
+	defer stream.close()
 	var blockBytes []byte
 	var blockPlacementInfo *blockPlacementInfo
 


### PR DESCRIPTION
<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (improvement to code, performance, etc)
- Bug fix


#### Description

This change ensures the block stream is properly closed after use in blockfile_mgr.go by adding defer stream.close(), preventing resource leaks.

#### Additional details

The implementation adds a deferred close to the blockStream to ensure that it gets closed after use.

#### Related issues

https://github.com/hyperledger/fabric/issues/4992

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
