### PR TITLE
Introducing Hyperledger Fabric Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Security vulnerability scan](https://github.com/hyperledger/fabric/actions/workflows/vulnerability-scan.yml/badge.svg?branch=main)](https://github.com/hyperledger/fabric/actions/workflows/vulnerability-scan.yml)
 [![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/hyperledger/fabric)](https://github.com/hyperledger/fabric/blob/main/go.mod)
 [![GitHub Release](https://img.shields.io/github/v/release/hyperledger/fabric)](https://github.com/hyperledger/fabric/releases)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Hyperledger%20Fabric%20Guru-006BFF)](https://gurubase.io/g/hyperledger-fabric)
 
 ## Overview
 


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [Hyperledger Fabric Guru](https://gurubase.io/g/hyperledger-fabric) has been manually added to Gurubase. Hyperledger Fabric Guru uses the data from this repo and data from the [docs](http://hyperledger-fabric.readthedocs.io/en/latest) to answer questions by leveraging the LLM.

This PR introduces the "Hyperledger Fabric Guru", showcasing that Hyperledger Fabric now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "Hyperledger Fabric Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the Hyperledger Fabric documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable Hyperledger Fabric Guru in Gurubase, just let us know that's totally fine.
