### PR TITLE
Improve gossip handling of in-memory expired certs

### DIFF
--- a/gossip/comm/comm_impl.go
+++ b/gossip/comm/comm_impl.go
@@ -162,6 +162,14 @@ func (c *commImpl) createConnection(endpoint string, expectedPKIID common.PKIidT
 		return nil, errors.WithStack(err)
 	}
 
+	if len(expectedPKIID) > 0 {
+		identity, _ := c.idMapper.Get(expectedPKIID)
+		if len(identity) == 0 {
+			c.logger.Warningf("Identity of %x is no longer found in the identity store, aborting connection", expectedPKIID)
+			return nil, errors.New("identity no longer recognized")
+		}
+	}
+
 	ctx, cancel = context.WithCancel(context.Background())
 	if stream, err = cl.GossipStream(ctx); err == nil {
 		connInfo, err = c.authenticateRemotePeer(stream, true, false)

--- a/integration/nwo/network.go
+++ b/integration/nwo/network.go
@@ -1211,6 +1211,7 @@ func (n *Network) ConfigTxGen(command Command) (*gexec.Session, error) {
 func (n *Network) Discover(command Command) (*gexec.Session, error) {
 	cmd := NewCommand(n.Components.Discover(), command)
 	cmd.Args = append(cmd.Args, "--peerTLSCA", n.CACertsBundlePath())
+	cmd.Env = []string{"FABRIC_LOGGING_SPEC=info:grpc=warn"} // suppress chatty grpc info messages
 	return n.StartSession(cmd, command.SessionName())
 }
 


### PR DESCRIPTION
If a peer's cert expires while it is still in gossip memory
for another peer, membership cannot be re-established
after the cert is renewed.

The fix is to acknowledge that the expired cert's peer
is no longer in gossip identity store and accept
new connection with the new PKI-ID and identity.

Add new integration test:
-Test renew cert before expiration (passes)
-Test renew cert after expiration (previously failed)

Resolves #5111