### PR TITLE
Remove kafka profiles from configtx.yaml

### DIFF
--- a/orderer/common/cluster/testdata/blockverification/configtx.yaml
+++ b/orderer/common/cluster/testdata/blockverification/configtx.yaml
@@ -495,20 +495,6 @@ Profiles:
                 Organizations:
                     - *SampleOrg
 
-    # SampleSingleMSPKafka defines a configuration that differs from the
-    # SampleSingleMSPSolo one only in that it uses the Kafka-based orderer.
-    SampleSingleMSPKafka:
-        <<: *ChannelDefaults
-        Orderer:
-            <<: *OrdererDefaults
-            OrdererType: kafka
-            Organizations:
-                - *SampleOrg
-        Consortiums:
-            SampleConsortium:
-                Organizations:
-                    - *SampleOrg
-
     # SampleInsecureSolo defines a configuration which uses the Solo orderer,
     # contains no MSP definitions, and allows all transactions and channel
     # creation requests for the consortium SampleConsortium.
@@ -517,17 +503,6 @@ Profiles:
         Orderer:
             <<: *OrdererDefaults
             OrdererType: solo
-        Consortiums:
-            SampleConsortium:
-                Organizations:
-
-    # SampleInsecureKafka defines a configuration that differs from the
-    # SampleInsecureSolo one only in that it uses the Kafka-based orderer.
-    SampleInsecureKafka:
-        <<: *ChannelDefaults
-        Orderer:
-            <<: *OrdererDefaults
-            OrdererType: kafka
         Consortiums:
             SampleConsortium:
                 Organizations:
@@ -542,39 +517,6 @@ Profiles:
         Orderer:
             <<: *OrdererDefaults
             OrdererType: solo
-            Organizations:
-                - <<: *SampleOrg
-                  Policies:
-                      <<: *SampleOrgPolicies
-                      Admins:
-                          Type: Signature
-                          Rule: "OR('SampleOrg.member')"
-        Application:
-            <<: *ApplicationDefaults
-            Organizations:
-                - <<: *SampleOrg
-                  Policies:
-                      <<: *SampleOrgPolicies
-                      Admins:
-                          Type: Signature
-                          Rule: "OR('SampleOrg.member')"
-        Consortiums:
-            SampleConsortium:
-                Organizations:
-                    - <<: *SampleOrg
-                      Policies:
-                          <<: *SampleOrgPolicies
-                          Admins:
-                              Type: Signature
-                              Rule: "OR('SampleOrg.member')"
-
-    # SampleDevModeKafka defines a configuration that differs from the
-    # SampleDevModeSolo one only in that it uses the Kafka-based orderer.
-    SampleDevModeKafka:
-        <<: *ChannelDefaults
-        Orderer:
-            <<: *OrdererDefaults
-            OrdererType: kafka
             Organizations:
                 - <<: *SampleOrg
                   Policies:

--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -478,20 +478,6 @@ Profiles:
         Organizations:
           - *SampleOrg
 
-  # SampleSingleMSPKafka defines a configuration that differs from the
-  # SampleSingleMSPSolo one only in that it uses the Kafka-based orderer.
-  SampleSingleMSPKafka:
-    <<: *ChannelDefaults
-    Orderer:
-      <<: *OrdererDefaults
-      OrdererType: kafka
-      Organizations:
-        - *SampleOrg
-    Consortiums:
-      SampleConsortium:
-        Organizations:
-          - *SampleOrg
-
   # SampleInsecureSolo defines a configuration which uses the Solo orderer,
   # contains no MSP definitions, and allows all transactions and channel
   # creation requests for the consortium SampleConsortium.
@@ -500,17 +486,6 @@ Profiles:
     Orderer:
       <<: *OrdererDefaults
       OrdererType: solo
-    Consortiums:
-      SampleConsortium:
-        Organizations:
-
-  # SampleInsecureKafka defines a configuration that differs from the
-  # SampleInsecureSolo one only in that it uses the Kafka-based orderer.
-  SampleInsecureKafka:
-    <<: *ChannelDefaults
-    Orderer:
-      <<: *OrdererDefaults
-      OrdererType: kafka
     Consortiums:
       SampleConsortium:
         Organizations:
@@ -551,44 +526,11 @@ Profiles:
                 Type: Signature
                 Rule: "OR('SampleOrg.member')"
 
-  # SampleDevModeKafka defines a configuration that differs from the
-  # SampleDevModeSolo one only in that it uses the Kafka-based orderer.
-  SampleDevModeKafka:
-    <<: *ChannelDefaults
-    Orderer:
-      <<: *OrdererDefaults
-      OrdererType: kafka
-      Organizations:
-        - <<: *SampleOrg
-          Policies:
-            <<: *SampleOrgPolicies
-            Admins:
-              Type: Signature
-              Rule: "OR('SampleOrg.member')"
-    Application:
-      <<: *ApplicationDefaults
-      Organizations:
-        - <<: *SampleOrg
-          Policies:
-            <<: *SampleOrgPolicies
-            Admins:
-              Type: Signature
-              Rule: "OR('SampleOrg.member')"
-    Consortiums:
-      SampleConsortium:
-        Organizations:
-          - <<: *SampleOrg
-            Policies:
-              <<: *SampleOrgPolicies
-              Admins:
-                Type: Signature
-                Rule: "OR('SampleOrg.member')"
 
   # SampleSingleMSPChannel defines a channel with only the sample org as a
   # member. It is designed to be used in conjunction with SampleSingleMSPSolo
-  # and SampleSingleMSPKafka orderer profiles.   Note, for channel creation
-  # profiles, only the 'Application' section and consortium # name are
-  # considered.
+  # orderer profile. Note, for channel creation profiles, only the
+  # 'Application' section and consortium # name are considered.
   SampleSingleMSPChannel:
     <<: *ChannelDefaults
     Consortium: SampleConsortium


### PR DESCRIPTION

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
Remove kafka profiles from configtx.yaml everywhere. 
As of v3.0.0 these profiles should not be used.
