### PR TITLE
fix fail test with cover flag

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -37,8 +37,6 @@ jobs:
     name: Unit Tests
     needs: basic-checks
     runs-on: ${{ github.repository == 'hyperledger/fabric' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
-    env:
-      GOEXPERIMENT: nocoverageredesign
     steps:
       - uses: actions/checkout@v4
         with:

--- a/core/handlers/library/registry_plugin_test.go
+++ b/core/handlers/library/registry_plugin_test.go
@@ -45,7 +45,7 @@ func buildPlugin(t *testing.T, dest, pkg string) {
 	require.NoError(t, err, "Could not build plugin: "+string(output))
 }
 
-func TestLoadAuthPlugin(t *testing.T) {
+func TestLoadAuthPluginNoCover(t *testing.T) {
 	if noplugin {
 		t.Skip("plugins disabled")
 	}
@@ -65,7 +65,7 @@ func TestLoadAuthPlugin(t *testing.T) {
 	require.True(t, endorser.invoked, "Expected filter to invoke endorser on invoke")
 }
 
-func TestLoadDecoratorPlugin(t *testing.T) {
+func TestLoadDecoratorPluginNoCover(t *testing.T) {
 	if noplugin {
 		t.Skip("plugins disabled")
 	}
@@ -86,7 +86,7 @@ func TestLoadDecoratorPlugin(t *testing.T) {
 	require.True(t, proto.Equal(decoratedInput, testInput), "Expected chaincode input to remain unchanged")
 }
 
-func TestEndorsementPlugin(t *testing.T) {
+func TestEndorsementPluginNoCover(t *testing.T) {
 	if noplugin {
 		t.Skip("plugins disabled")
 	}
@@ -109,7 +109,7 @@ func TestEndorsementPlugin(t *testing.T) {
 	require.Equal(t, []byte{1, 2, 3}, output)
 }
 
-func TestValidationPlugin(t *testing.T) {
+func TestValidationPluginNoCover(t *testing.T) {
 	if noplugin {
 		t.Skip("plugins disabled")
 	}


### PR DESCRIPTION
Let me remind you that in go they changed the mechanism of tests with the -cover flag. Because of this we started to crash tests with plugins. A temporary solution was found.

Today [our colleagues from go replied](https://github.com/golang/go/issues/67427) that they will not change the cover mechanism. So we can exclude dangerous tests from testing with the cover flag, but run them without the flag.

Below is my suggestion on how to do it on a permanent basis.