### PR TITLE
Release action - Separate runner for amd64 and arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   GO_VER: 1.23.5
-  UBUNTU_VER: 20.04
+  UBUNTU_VER: 22.04
   FABRIC_VER: ${{ github.ref_name }}
 
 permissions:
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - image: ubuntu-20.04
+          - image: ubuntu-22.04
             target: linux
             arch: amd64
-          - image: ubuntu-20.04
+          - image: ubuntu-22.04
             target: linux
             arch: arm64
           - image: macos-11
@@ -37,7 +37,7 @@ jobs:
           - image: windows-2022
             target: windows
             arch: amd64
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Fabric Code
         uses: actions/checkout@v4      
@@ -59,9 +59,10 @@ jobs:
           # <path> of the artifact may include multiple files.
           path: release/${{ matrix.target }}-${{ matrix.arch }}/*.tar.gz
 
-  build-and-push-docker-images:
-    name: Build and Push
-    runs-on: ubuntu-20.04
+  # build native images using a different runner for each architecture (faster and more reliable than using qemu to build multi-architecture images on ubuntu-22.04)
+  build-and-push-native-docker-images:
+    name: Build and Push native images
+    runs-on: ${{ matrix.runner }}
 
     permissions:
       contents: read
@@ -70,9 +71,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        registry:
-          - docker.io
-          - ghcr.io
+
+        runner:
+          - ubuntu-22.04      # creates linux-amd64 images
+          - ubuntu-22.04-arm  # creates linux-arm64 images 
+
+        # Dynamic matrix
+        # If owner is 'hyperledger' run job for Docker Hub and ghcr, otherwise for personal forks just run job for ghcr
+        registry: ${{ fromJSON(github.repository_owner == 'hyperledger' && '["docker.io", "ghcr.io"]' || '["ghcr.io"]') }}
+        
         component:
           - name: baseos
             context: images/baseos
@@ -86,20 +93,6 @@ jobs:
             context: .
 
     steps:
-      - name: Skip Docker Hub publish for forks
-        if: ${{ github.repository_owner != 'hyperledger' && matrix.registry == 'docker.io' }}
-        run: exit 1
-      
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
-          buildkitd-config-inline: |
-            [worker.oci]
-              max-parallelism = 1
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -111,6 +104,94 @@ jobs:
           username: ${{ matrix.registry == 'docker.io' && secrets.DOCKERHUB_USERNAME || github.actor }}
           password: ${{ matrix.registry == 'docker.io' && secrets.DOCKERHUB_TOKEN    || secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3       
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.registry }}/${{ github.repository_owner }}/fabric-${{ matrix.component.name }}
+
+      - name: Build and push ${{ matrix.component.name }} Image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.component.context }}
+          file: images/${{ matrix.component.name }}/Dockerfile
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            FABRIC_VER=${{ env.FABRIC_VER }}
+            UBUNTU_VER=${{ env.UBUNTU_VER }}
+            GO_VER=${{ env.GO_VER }}
+            GO_TAGS=
+          outputs: type=image,"name=${{ matrix.registry }}/${{ github.repository_owner }}/fabric-${{ matrix.component.name }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests/${{ matrix.registry }}/${{ matrix.component.name }}
+          digest="${{ steps.build-and-push.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${{ matrix.registry }}/${{ matrix.component.name }}/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.registry }}-${{ matrix.component.name }}-${{ matrix.runner }}
+          path: ${{ runner.temp }}/digests/${{ matrix.registry }}/${{ matrix.component.name }}/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # This job merges the architecture-specific digests for the images created above
+  # and creates a multi-architecture image manifest with user-friendly tags
+  merge-and-push-multi-arch-image:
+    name: Merge and Push multi-arch image
+    runs-on: ubuntu-22.04
+    needs:
+      - build-and-push-native-docker-images
+
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+
+        # Dynamic matrix
+        # If owner is 'hyperledger' run job for Docker Hub and ghcr, otherwise for personal forks just run job for ghcr
+        registry: ${{ fromJSON(github.repository_owner == 'hyperledger' && '["docker.io", "ghcr.io"]' || '["ghcr.io"]') }}
+
+        component:
+          - name: baseos
+            context: images/baseos
+          - name: ccenv
+            context: images/ccenv
+          - name: peer
+            context: .
+          - name: orderer
+            context: .
+          - name: tools
+            context: .
+            
+    steps:
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/${{ matrix.registry }}/${{ matrix.component.name }}
+          pattern: digests-${{ matrix.registry }}-${{ matrix.component.name }}-*
+          merge-multiple: true
+
+      - name: Login to the ${{ matrix.registry }} Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ matrix.registry }}
+          username: ${{ matrix.registry == 'docker.io' && secrets.DOCKERHUB_USERNAME || github.actor }}
+          password: ${{ matrix.registry == 'docker.io' && secrets.DOCKERHUB_TOKEN    || secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -120,37 +201,35 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
-
-      - name: Build and push ${{ matrix.component.name }} Image
-        id: push
-        uses: docker/build-push-action@v5
-        with:
-          context: ${{ matrix.component.context }}
-          file: images/${{ matrix.component.name }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            FABRIC_VER=${{ env.FABRIC_VER }}
-            UBUNTU_VER=${{ env.UBUNTU_VER }}
-            GO_VER=${{ env.GO_VER }}
-            GO_TAGS=
+      
+      - name: Create manifest list and push # combines the downloaded amd64 and arm64 digests and pushes multi-architecture manifest with the tags specified above
+        working-directory: ${{ runner.temp }}/digests/${{ matrix.registry }}/${{ matrix.component.name }}
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ matrix.registry }}/${{ github.repository_owner }}/fabric-${{ matrix.component.name }}@sha256:%s ' *)
+        
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ matrix.registry }}/${{ github.repository_owner }}/fabric-${{ matrix.component.name }}:${{ steps.meta.outputs.version }}
 
   create-release:
     name: Create GitHub Release
     needs:
       - build-binaries
-      - build-and-push-docker-images
-    runs-on: ubuntu-20.04
+      - merge-and-push-multi-arch-image
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:
       - name: Checkout Fabric Code
         uses: actions/checkout@v4
+
       - name: Download Artifacts
         id: download
         uses: actions/download-artifact@v4
+        with:
+          pattern: "release-*"
+
       - name: Release Fabric Version
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
Previously arm64 images were created on a standard amd64 runner using qemu.
qemu emulation is very slow and there have been recent issues.
Native image creation is faster and more reliable.

This change creates separate runners for amd64 and arm64.
Also updates to ubuntu-22.04 since the new arm64 runners are only available for ubuntu-22.04 and ubuntu-24.04.

A new job is then needed to combine the image digests into a multi-architecture manifest that gets pushed to Docker Hub and ghcr.

This PR is against release-2.5 branch so that release v2.5.11 can be created. Upon success the change will be cherry-picked to main branch.