### PR TITLE
Bump to ubuntu-22.04 (release-2.5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@
 #   - unit-test - runs the go-test based unit tests
 #   - verify - runs unit tests for only the changed package tree
 
-UBUNTU_VER ?= 20.04
+UBUNTU_VER ?= 22.04
 FABRIC_VER ?= 2.5.11
 
 # 3rd party image version

--- a/docs/source/prereqs.md
+++ b/docs/source/prereqs.md
@@ -171,7 +171,7 @@ path is to use WSL2 (Windows Subsystem for Linux version 2) to provide a native 
 
 WSL2 may not be installed by default; you can check and install WSL2 by going into "Programs and Features", clicking on "Turn Windows features on or off" and ensuring that both "Windows Subsystem For Linux" and "Virtual Machine Platform" are selected.
 
-Next you will need to install a Linux distribution such as Ubuntu-20.04 and make sure it's set to using version 2 of WSL. Refer to [Install WSL](https://docs.microsoft.com/en-us/windows/wsl/install) for more information.
+Next you will need to install a Linux distribution such as Ubuntu-22.04 and make sure it's set to using version 2 of WSL. Refer to [Install WSL](https://docs.microsoft.com/en-us/windows/wsl/install) for more information.
 
 Finally, you need to ensure Docker Desktop has integration enabled for your distribution so it can interact with Docker elements, such as a bash command window. To do this, open the Docker Desktop gui and go into settings, select `Resources` and them `WSL Integration` and ensure the checkbox for enable integration is checked. You should then see your WSL2 linux distribution listed (if you don't then it is probably because it is still a WSL1 distribution and needs to be converted to WSL2) and you can then toggle the switch to enable integration for that distro. Refer to [Docker Desktop WSL2 backend](https://docs.docker.com/desktop/windows/wsl/) for more information
 

--- a/release_notes/v2.5.11.md
+++ b/release_notes/v2.5.11.md
@@ -1,4 +1,4 @@
-v2.5.11 Release Notes - January 27, 2025
+v2.5.11 Release Notes - January 31, 2025
 ========================================
 
 Fixes
@@ -19,7 +19,7 @@ Fabric v2.5.11 has been tested with the following dependencies:
 
 Go dependencies have also been updated.
 
-Fabric docker images on dockerhub utilize Ubuntu 20.04.
+Fabric docker images on dockerhub utilize Ubuntu 22.04.
 
 
 Deprecations (existing)

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -7,7 +7,7 @@
 
 Vagrant.require_version ">= 1.7.4"
 Vagrant.configure('2') do |config|
-  config.vm.box = "bento/ubuntu-20.04"
+  config.vm.box = "bento/ubuntu-22.04"
   config.vm.synced_folder "..", "/home/vagrant/fabric"
   config.ssh.forward_agent = true
 


### PR DESCRIPTION
Ubuntu 20.04 is going end of life in 2025.

The release build has also shifted to 22.04 on release-2.5 (main branch had already shifted).

This change updates the remaining references in release-2.5.