### PR TITLE
Fix comment typo in SignatureHeaderBytes field

### DIFF
--- a/pkg/tx/interfaces.go
+++ b/pkg/tx/interfaces.go
@@ -228,7 +228,7 @@ type Envelope struct {
 	Data []byte
 	// ChannelHeaderBytes contains the marshalled ChannelHeader of the common.Header
 	ChannelHeaderBytes []byte
-	// ChannelHeaderBytes contains the marshalled SignatureHeader of the common.Header
+	// SignatureHeaderBytes contains the marshalled SignatureHeader of the common.Header
 	SignatureHeaderBytes []byte
 	// ChannelHeader contains the ChannelHeader of this envelope
 	ChannelHeader *common.ChannelHeader


### PR DESCRIPTION
Description:
Corrects incorrect field name reference in comment for SignatureHeaderBytes field in Envelope struct