### PR TITLE
Fix install script for 3.0.0-preview Docker images

### DIFF
--- a/scripts/install-fabric.sh
+++ b/scripts/install-fabric.sh
@@ -178,6 +178,9 @@ dockerComponentRegistry() {
     local component="$1"
     local image_version="$2"
 
+    # Remove trailing pre-release or metadata identifiers
+    image_version="${image_version%%[-+]*}"
+
     case "${component}" in
         ca)
             echo -n "$(dockerCARegistry "${image_version}")/${HYPERLEDGER_NAMESPACE}"


### PR DESCRIPTION
The install script incorrectly selected ghcr.io as the repository to pull Fabric 3.0.0-preview Docker images.

This change removes trailing pre-release or metadata identifiers from Docker image tags before looking up the default Docker registry for a given component version. This means that 3.0.0-preview is treated the same as 3.0.0.