### PR TITLE
Update go version in go.mod to match build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/fabric
 
-go 1.23.1
+go 1.23.5
 
 require (
 	code.cloudfoundry.org/clock v1.0.0


### PR DESCRIPTION
The build workflows use Go 1.23.5. The go.mod specified 1.23.1. This change updates go.mod to match the Go version used by the build.