### PR TITLE
Add check for Go module version matching CI

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -31,6 +31,9 @@ jobs:
         name: Install Go
         with:
           go-version: ${{ env.GO_VER }}
+      - name: Check Go module version
+        run: |
+          [[ "$(go list -m -f '{{.Version}}' go)" == "${GO_VER}" ]]
       - run: make basic-checks
         name: Run Basic Checks
   unit-tests:
@@ -41,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-        name: Checkout Fabric Code      
+        name: Checkout Fabric Code
       - uses: actions/setup-go@v5
         name: Install Go
         with:
@@ -56,11 +59,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        INTEGRATION_TEST_SUITE: ["raft","pvtdata","pvtdatapurge e2e","ledger","lifecycle","smartbft","discovery gossip devmode pluggable","gateway idemix pkcs11 configtx configtxlator","sbe nwo msp"]
+        INTEGRATION_TEST_SUITE:
+          - raft
+          - pvtdata
+          - pvtdatapurge e2e
+          - ledger
+          - lifecycle
+          - smartbft
+          - discovery gossip devmode pluggable
+          - gateway idemix pkcs11 configtx configtxlator
+          - sbe nwo msp
     runs-on: ${{ github.repository == 'hyperledger/fabric' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v4
-        name: Checkout Fabric Code      
+        name: Checkout Fabric Code
       - uses: actions/setup-go@v5
         name: Install Go
         with:


### PR DESCRIPTION
The Go directive in the go.mod file is used by vulnerability scanning to determine the Go standard library version to scan for vulnerabilities. This needs to match exactly the Go version used in CI to build release binaries for vulnerability scanning to provide an accurate results for a given Fabric release.

This change adds a CI check that the Go version used exactly matches the Go directive in the go.mod file.