### PR TITLE
Use Go version from go.mod in basic-checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,10 @@ METADATA_VAR += CommitSHA=$(EXTRA_VERSION)
 METADATA_VAR += BaseDockerLabel=$(BASE_DOCKER_LABEL)
 METADATA_VAR += DockerNamespace=$(DOCKER_NS)
 
-GO_VER = 1.23.5
+# Get the required Go version from the go directive in go.mod
+# 'go list -m' is not used since this fails if the local Go version is older than go.mod
+GO_VER := $(shell grep '^go[ \t]' < go.mod)
+GO_VER := $(strip $(GO_VER:go=))
 GO_TAGS ?=
 
 RELEASE_EXES = orderer $(TOOLS_EXES)


### PR DESCRIPTION
The expected Go version was hard-coded in the Makefile, and this needed to be manually kept in sync with the CI and go.mod files. Since the go.mod entry needs to be accurate, this change uses the version from the go.mod file in the Makefile and no longer requires the Makefile to be manually kept up-to-date.

Cherry-pick of a23e7b84d72127704a85f86698baebe4c166bcd0 from main branch.