### PR TITLE
refactor: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/cmd/osnadmin/main.go
+++ b/cmd/osnadmin/main.go
@@ -11,6 +11,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -80,7 +81,7 @@ func executeForArgs(args []string) (output string, exit int, err error) {
 			return "", 1, fmt.Errorf("reading orderer CA certificate: %s", err)
 		}
 		if !caCertPool.AppendCertsFromPEM(caFilePEM) {
-			return "", 1, fmt.Errorf("failed to add ca-file PEM to cert pool")
+			return "", 1, errors.New("failed to add ca-file PEM to cert pool")
 		}
 
 		tlsClientCert, err = tls.LoadX509KeyPair(*clientCert, *clientKey)

--- a/core/common/ccprovider/cc_statedb_artifacts_provider.go
+++ b/core/common/ccprovider/cc_statedb_artifacts_provider.go
@@ -9,7 +9,7 @@ package ccprovider
 import (
 	"archive/tar"
 	"bytes"
-	"fmt"
+	"errors"
 	"io"
 	"path/filepath"
 	"strings"
@@ -47,7 +47,7 @@ func ExtractStatedbArtifactsFromCCPackage(ccpackage CCPackage) (statedbArtifacts
 	metaprov, err := MetadataAsTarEntries(cds.CodePackage)
 	if err != nil {
 		ccproviderLogger.Infof("invalid deployment spec: %s", err)
-		return nil, fmt.Errorf("invalid deployment spec")
+		return nil, errors.New("invalid deployment spec")
 	}
 	return metaprov, nil
 }

--- a/core/common/ccprovider/cdspackage.go
+++ b/core/common/ccprovider/cdspackage.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ccprovider
 
 import (
+	"errors"
 	"fmt"
 	"hash"
 	"os"
@@ -141,11 +142,11 @@ func (ccpack *CDSPackage) getCDSData(cds *pb.ChaincodeDeploymentSpec) ([]byte, [
 // ChaincodeDeploymentSpec
 func (ccpack *CDSPackage) ValidateCC(ccdata *ChaincodeData) error {
 	if ccpack.depSpec == nil {
-		return fmt.Errorf("uninitialized package")
+		return errors.New("uninitialized package")
 	}
 
 	if ccpack.data == nil {
-		return fmt.Errorf("nil data")
+		return errors.New("nil data")
 	}
 
 	// This is a hack. LSCC expects a specific LSCC error when names are invalid so it
@@ -169,7 +170,7 @@ func (ccpack *CDSPackage) ValidateCC(ccdata *ChaincodeData) error {
 	}
 
 	if !proto.Equal(ccpack.data, otherdata) {
-		return fmt.Errorf("data mismatch")
+		return errors.New("data mismatch")
 	}
 
 	return nil
@@ -180,7 +181,7 @@ func (ccpack *CDSPackage) InitFromBuffer(buf []byte) (*ChaincodeData, error) {
 	depSpec := &pb.ChaincodeDeploymentSpec{}
 	err := proto.Unmarshal(buf, depSpec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal deployment spec from bytes")
+		return nil, errors.New("failed to unmarshal deployment spec from bytes")
 	}
 
 	databytes, id, data, err := ccpack.getCDSData(depSpec)
@@ -224,23 +225,23 @@ func (ccpack *CDSPackage) InitFromFS(ccNameVersion string) ([]byte, *pb.Chaincod
 // PutChaincodeToFS - serializes chaincode to a package on the file system
 func (ccpack *CDSPackage) PutChaincodeToFS() error {
 	if ccpack.buf == nil {
-		return fmt.Errorf("uninitialized package")
+		return errors.New("uninitialized package")
 	}
 
 	if ccpack.id == nil {
-		return fmt.Errorf("id cannot be nil if buf is not nil")
+		return errors.New("id cannot be nil if buf is not nil")
 	}
 
 	if ccpack.depSpec == nil {
-		return fmt.Errorf("depspec cannot be nil if buf is not nil")
+		return errors.New("depspec cannot be nil if buf is not nil")
 	}
 
 	if ccpack.data == nil {
-		return fmt.Errorf("nil data")
+		return errors.New("nil data")
 	}
 
 	if ccpack.datab == nil {
-		return fmt.Errorf("nil data bytes")
+		return errors.New("nil data bytes")
 	}
 
 	ccname := ccpack.depSpec.ChaincodeSpec.ChaincodeId.Name

--- a/core/common/ccprovider/sigcdspackage.go
+++ b/core/common/ccprovider/sigcdspackage.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ccprovider
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -180,15 +181,15 @@ func (ccpack *SignedCDSPackage) getCDSData(scds *pb.SignedChaincodeDeploymentSpe
 // ChaincodeDeploymentSpec
 func (ccpack *SignedCDSPackage) ValidateCC(ccdata *ChaincodeData) error {
 	if ccpack.sDepSpec == nil {
-		return fmt.Errorf("uninitialized package")
+		return errors.New("uninitialized package")
 	}
 
 	if ccpack.sDepSpec.ChaincodeDeploymentSpec == nil {
-		return fmt.Errorf("signed chaincode deployment spec cannot be nil in a package")
+		return errors.New("signed chaincode deployment spec cannot be nil in a package")
 	}
 
 	if ccpack.depSpec == nil {
-		return fmt.Errorf("chaincode deployment spec cannot be nil in a package")
+		return errors.New("chaincode deployment spec cannot be nil in a package")
 	}
 
 	// This is a hack. LSCC expects a specific LSCC error when names are invalid so it
@@ -212,7 +213,7 @@ func (ccpack *SignedCDSPackage) ValidateCC(ccdata *ChaincodeData) error {
 	}
 
 	if !proto.Equal(ccpack.data, otherdata) {
-		return fmt.Errorf("data mismatch")
+		return errors.New("data mismatch")
 	}
 
 	return nil
@@ -223,7 +224,7 @@ func (ccpack *SignedCDSPackage) InitFromBuffer(buf []byte) (*ChaincodeData, erro
 	env := &common.Envelope{}
 	err := proto.Unmarshal(buf, env)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal envelope from bytes")
+		return nil, errors.New("failed to unmarshal envelope from bytes")
 	}
 	cHdr, sDepSpec, err := ccpackage.ExtractSignedCCDepSpec(env)
 	if err != nil {
@@ -231,13 +232,13 @@ func (ccpack *SignedCDSPackage) InitFromBuffer(buf []byte) (*ChaincodeData, erro
 	}
 
 	if cHdr.Type != int32(common.HeaderType_CHAINCODE_PACKAGE) {
-		return nil, fmt.Errorf("invalid type of envelope for chaincode package")
+		return nil, errors.New("invalid type of envelope for chaincode package")
 	}
 
 	depSpec := &pb.ChaincodeDeploymentSpec{}
 	err = proto.Unmarshal(sDepSpec.ChaincodeDeploymentSpec, depSpec)
 	if err != nil {
-		return nil, fmt.Errorf("error getting deployment spec")
+		return nil, errors.New("error getting deployment spec")
 	}
 
 	databytes, id, data, err := ccpack.getCDSData(sDepSpec)
@@ -278,27 +279,27 @@ func (ccpack *SignedCDSPackage) InitFromPath(ccNameVersion string, path string) 
 // PutChaincodeToFS - serializes chaincode to a package on the file system
 func (ccpack *SignedCDSPackage) PutChaincodeToFS() error {
 	if ccpack.buf == nil {
-		return fmt.Errorf("uninitialized package")
+		return errors.New("uninitialized package")
 	}
 
 	if ccpack.id == nil {
-		return fmt.Errorf("id cannot be nil if buf is not nil")
+		return errors.New("id cannot be nil if buf is not nil")
 	}
 
 	if ccpack.sDepSpec == nil || ccpack.depSpec == nil {
-		return fmt.Errorf("depspec cannot be nil if buf is not nil")
+		return errors.New("depspec cannot be nil if buf is not nil")
 	}
 
 	if ccpack.env == nil {
-		return fmt.Errorf("env cannot be nil if buf and depspec are not nil")
+		return errors.New("env cannot be nil if buf and depspec are not nil")
 	}
 
 	if ccpack.data == nil {
-		return fmt.Errorf("nil data")
+		return errors.New("nil data")
 	}
 
 	if ccpack.datab == nil {
-		return fmt.Errorf("nil data bytes")
+		return errors.New("nil data bytes")
 	}
 
 	ccname := ccpack.depSpec.ChaincodeSpec.ChaincodeId.Name

--- a/core/config/configtest/config.go
+++ b/core/config/configtest/config.go
@@ -67,7 +67,7 @@ func gopathDevConfigDir() (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("unable to find sampleconfig directory on GOPATH")
+	return "", errors.New("unable to find sampleconfig directory on GOPATH")
 }
 
 func gomodDevConfigDir() (string, error) {

--- a/core/ledger/kvledger/benchmark/chainmgmt/chains.go
+++ b/core/ledger/kvledger/benchmark/chainmgmt/chains.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package chainmgmt
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -85,7 +86,7 @@ func (m *chainsMgr) createOrOpenChains() []*Chain {
 		}
 
 	default:
-		panic(fmt.Errorf("unknown chain init operation"))
+		panic(errors.New("unknown chain init operation"))
 	}
 	return m.chains()
 }
@@ -147,7 +148,7 @@ func (c *Chain) Done() {
 // Commit overrides the Commit function in ledger.PeerLedger because,
 // experiments are not expected to call Commit directly to the ledger
 func (c *Chain) Commit(block *common.Block) {
-	panic(fmt.Errorf("Commit should not be invoked directly"))
+	panic(errors.New("Commit should not be invoked directly"))
 }
 
 func (c *Chain) close() {

--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -301,7 +301,7 @@ func (c *Config) load() error {
 	c.ExternalBuilders = externalBuilders
 	for builderIndex, builder := range c.ExternalBuilders {
 		if builder.Path == "" {
-			return fmt.Errorf("invalid external builder configuration, path attribute missing in one or more builders")
+			return errors.New("invalid external builder configuration, path attribute missing in one or more builders")
 		}
 		if builder.Name == "" {
 			return fmt.Errorf("external builder at path %s has no name attribute", builder.Path)
@@ -338,7 +338,7 @@ func (c *Config) load() error {
 func getLocalAddress() (string, error) {
 	peerAddress := viper.GetString("peer.address")
 	if peerAddress == "" {
-		return "", fmt.Errorf("peer.address isn't set")
+		return "", errors.New("peer.address isn't set")
 	}
 	host, port, err := net.SplitHostPort(peerAddress)
 	if err != nil {

--- a/core/peer/configtx_processor.go
+++ b/core/peer/configtx_processor.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package peer
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
@@ -34,7 +35,7 @@ func (tp *ConfigTxProcessor) GenerateSimulationResults(txEnv *common.Envelope, s
 	case common.HeaderType_CONFIG:
 		peerLogger.Debugf("Processing CONFIG")
 		if payload.Data == nil {
-			return fmt.Errorf("channel config found nil")
+			return errors.New("channel config found nil")
 		}
 		return simulator.SetState(peerNamespace, channelConfigKey, payload.Data)
 	default:

--- a/protoutil/blockutils.go
+++ b/protoutil/blockutils.go
@@ -309,7 +309,7 @@ func searchConsenterIdentityByID(consenters []*cb.Consenter, identifier uint32) 
 
 func VerifyTransactionsAreWellFormed(bd *cb.BlockData) error {
 	if bd == nil || bd.Data == nil || len(bd.Data) == 0 {
-		return fmt.Errorf("empty block")
+		return errors.New("empty block")
 	}
 
 	// If we have a single transaction, and the block is a config block, then no need to check

--- a/protoutil/signeddata.go
+++ b/protoutil/signeddata.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -33,7 +34,7 @@ type SignedData struct {
 // possible.
 func ConfigUpdateEnvelopeAsSignedData(ce *common.ConfigUpdateEnvelope) ([]*SignedData, error) {
 	if ce == nil {
-		return nil, fmt.Errorf("No signatures for nil SignedConfigItem")
+		return nil, errors.New("No signatures for nil SignedConfigItem")
 	}
 
 	result := make([]*SignedData, len(ce.Signatures))
@@ -59,7 +60,7 @@ func ConfigUpdateEnvelopeAsSignedData(ce *common.ConfigUpdateEnvelope) ([]*Signe
 // slice of length 1 or an error indicating why this was not possible.
 func EnvelopeAsSignedData(env *common.Envelope) ([]*SignedData, error) {
 	if env == nil {
-		return nil, fmt.Errorf("No signatures for nil Envelope")
+		return nil, errors.New("No signatures for nil Envelope")
 	}
 
 	payload := &common.Payload{}
@@ -69,7 +70,7 @@ func EnvelopeAsSignedData(env *common.Envelope) ([]*SignedData, error) {
 	}
 
 	if payload.Header == nil /* || payload.Header.SignatureHeader == nil */ {
-		return nil, fmt.Errorf("Missing Header")
+		return nil, errors.New("Missing Header")
 	}
 
 	shdr := &common.SignatureHeader{}


### PR DESCRIPTION
Replaced fmt.Errorf with errors.New in cases where formatting is not required. This reduces unnecessary function calls, leading to slightly improved performance and cleaner code.