### PR TITLE
change math/rand to v2 (release-2.5)

### DIFF
--- a/cmd/common/cli_test.go
+++ b/cmd/common/cli_test.go
@@ -9,7 +9,7 @@ package common
 import (
 	"bytes"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"testing"

--- a/cmd/common/config_test.go
+++ b/cmd/common/config_test.go
@@ -7,8 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package common
 
 import (
+	crand "crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,8 +21,10 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
-	configFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("config-%d.yaml", rand.Int()))
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	r := rand.New(rand.NewChaCha8(seed))
+	configFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("config-%d.yaml", r.Int()))
 	fmt.Println(configFilePath)
 	t.Run("save and load a config", func(t *testing.T) {
 		c := Config{

--- a/common/configtx/util_test.go
+++ b/common/configtx/util_test.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package configtx
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	cb "github.com/hyperledger/fabric-protos-go/common"
@@ -101,7 +101,7 @@ func randomLowerAlphaString(size int) string {
 	letters := []rune("abcdefghijklmnopqrstuvwxyz")
 	output := make([]rune, size)
 	for i := range output {
-		output[i] = letters[rand.Intn(len(letters))]
+		output[i] = letters[rand.IntN(len(letters))]
 	}
 	return string(output)
 }
@@ -110,7 +110,7 @@ func randomAlphaString(size int) string {
 	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	output := make([]rune, size)
 	for i := range output {
-		output[i] = letters[rand.Intn(len(letters))]
+		output[i] = letters[rand.IntN(len(letters))]
 	}
 	return string(output)
 }

--- a/common/graph/perm.go
+++ b/common/graph/perm.go
@@ -11,8 +11,10 @@ import (
 	"time"
 )
 
+var r *rand.Rand
+
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	r = rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 // treePermutations represents possible permutations
@@ -110,7 +112,7 @@ func (tp *treePermutations) computeDescendantPermutations() {
 		// Ensure we don't have too much combinations of descendants
 		for CombinationsExceed(len(v.Descendants), v.Threshold, tp.combinationUpperBound) {
 			// Randomly pick a descendant, and remove it
-			victim := rand.Intn(len(v.Descendants))
+			victim := r.Intn(len(v.Descendants))
 			v.Descendants = append(v.Descendants[:victim], v.Descendants[victim+1:]...)
 		}
 

--- a/common/graph/perm.go
+++ b/common/graph/perm.go
@@ -7,14 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package graph
 
 import (
-	"math/rand"
-	"time"
+	crand "crypto/rand"
+	"math/rand/v2"
 )
 
 var r *rand.Rand
 
 func init() {
-	r = rand.New(rand.NewSource(time.Now().UnixNano()))
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	r = rand.New(rand.NewChaCha8(seed))
 }
 
 // treePermutations represents possible permutations
@@ -112,7 +114,7 @@ func (tp *treePermutations) computeDescendantPermutations() {
 		// Ensure we don't have too much combinations of descendants
 		for CombinationsExceed(len(v.Descendants), v.Threshold, tp.combinationUpperBound) {
 			// Randomly pick a descendant, and remove it
-			victim := r.Intn(len(v.Descendants))
+			victim := r.IntN(len(v.Descendants))
 			v.Descendants = append(v.Descendants[:victim], v.Descendants[victim+1:]...)
 		}
 

--- a/core/common/validation/fullflow_test.go
+++ b/core/common/validation/fullflow_test.go
@@ -206,8 +206,8 @@ func TestTXWithTwoActionsRejected(t *testing.T) {
 }
 
 func corrupt(bytes []byte) {
-	rand.Seed(time.Now().UnixNano())
-	bytes[rand.Intn(len(bytes))]--
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bytes[r.Intn(len(bytes))]--
 }
 
 func TestBadTx(t *testing.T) {

--- a/core/common/validation/fullflow_test.go
+++ b/core/common/validation/fullflow_test.go
@@ -7,11 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package validation
 
 import (
+	crand "crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"
@@ -206,8 +206,10 @@ func TestTXWithTwoActionsRejected(t *testing.T) {
 }
 
 func corrupt(bytes []byte) {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	bytes[r.Intn(len(bytes))]--
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	r := rand.New(rand.NewChaCha8(seed))
+	bytes[r.IntN(len(bytes))]--
 }
 
 func TestBadTx(t *testing.T) {

--- a/core/common/validation/statebased/vpmanager_test.go
+++ b/core/common/validation/statebased/vpmanager_test.go
@@ -7,13 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package statebased
 
 import (
+	crand "crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"strconv"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
@@ -169,8 +169,8 @@ func pvtRwsetUpdatingMetadataFor(cc, coll, key string) []byte {
 		})
 }
 
-func runFunctions(t *testing.T, seed int64, funcs ...func()) {
-	r := rand.New(rand.NewSource(seed))
+func runFunctions(t *testing.T, seed [32]byte, funcs ...func()) {
+	r := rand.New(rand.NewChaCha8(seed))
 	c := make(chan struct{})
 	for _, i := range r.Perm(len(funcs)) {
 		iLcl := i
@@ -186,7 +186,8 @@ func runFunctions(t *testing.T, seed int64, funcs ...func()) {
 
 func TestTranslatorBadPolicy(t *testing.T) {
 	t.Parallel()
-	seed := time.Now().Unix()
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
 
 	// Scenario: we verify that translation from SignaturePolicyEnvelope to ApplicationPolicy fails appropriately
 
@@ -226,7 +227,8 @@ func TestTranslatorBadPolicy(t *testing.T) {
 
 func TestTranslatorBadPolicyPvt(t *testing.T) {
 	t.Parallel()
-	seed := time.Now().Unix()
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
 
 	// Scenario: we verify that translation from SignaturePolicyEnvelope to ApplicationPolicy fails appropriately with private data
 
@@ -266,7 +268,8 @@ func TestTranslatorBadPolicyPvt(t *testing.T) {
 
 func TestDependencyNoConflict(t *testing.T) {
 	t.Parallel()
-	seed := time.Now().Unix()
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
 
 	// Scenario: validation parameter is retrieved successfully
 	// for a ledger key for transaction (1,1) after waiting for
@@ -309,7 +312,8 @@ func TestDependencyNoConflict(t *testing.T) {
 
 func TestDependencyConflict(t *testing.T) {
 	t.Parallel()
-	seed := time.Now().Unix()
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
 
 	// Scenario: validation parameter is retrieved
 	// for a ledger key for transaction (1,1) after waiting for
@@ -353,7 +357,8 @@ func TestDependencyConflict(t *testing.T) {
 
 func TestMultipleDependencyNoConflict(t *testing.T) {
 	t.Parallel()
-	seed := time.Now().Unix()
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
 
 	// Scenario: validation parameter is retrieved successfully
 	// for a ledger key for transaction (1,2) after waiting for
@@ -402,7 +407,8 @@ func TestMultipleDependencyNoConflict(t *testing.T) {
 
 func TestMultipleDependencyConflict(t *testing.T) {
 	t.Parallel()
-	seed := time.Now().Unix()
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
 
 	// Scenario: validation parameter is retrieved
 	// for a ledger key for transaction (1,2) after waiting for
@@ -452,7 +458,8 @@ func TestMultipleDependencyConflict(t *testing.T) {
 
 func TestPvtDependencyNoConflict(t *testing.T) {
 	t.Parallel()
-	seed := time.Now().Unix()
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
 
 	// Scenario: like TestDependencyNoConflict but for private data
 
@@ -490,7 +497,8 @@ func TestPvtDependencyNoConflict(t *testing.T) {
 
 func TestPvtDependencyConflict(t *testing.T) {
 	t.Parallel()
-	seed := time.Now().Unix()
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
 
 	// Scenario: like TestDependencyConflict but for private data
 
@@ -553,7 +561,8 @@ func TestBlockValidationTerminatesBeforeNewBlock(t *testing.T) {
 
 func TestLedgerErrors(t *testing.T) {
 	t.Parallel()
-	seed := time.Now().Unix()
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
 
 	// Scenario: we check that if a ledger error occurs,
 	// GetValidationParameterForKey returns an error
@@ -625,7 +634,8 @@ func TestLedgerErrors(t *testing.T) {
 
 func TestBadRwsetIsNoDependency(t *testing.T) {
 	t.Parallel()
-	seed := time.Now().Unix()
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
 
 	// Scenario: a transaction has a bogus read-write set.
 	// While the transaction will fail eventually, we check
@@ -663,7 +673,8 @@ func TestBadRwsetIsNoDependency(t *testing.T) {
 
 func TestWritesIntoDifferentNamespaces(t *testing.T) {
 	t.Parallel()
-	seed := time.Now().Unix()
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
 
 	// Scenario: transaction (1,0) writes to namespace cc1.
 	// Transaction (1,1) attempts to retrieve validation
@@ -701,7 +712,8 @@ func TestWritesIntoDifferentNamespaces(t *testing.T) {
 
 func TestCombinedCalls(t *testing.T) {
 	t.Parallel()
-	seed := time.Now().Unix()
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
 
 	// Scenario: transaction (1,3) requests validation parameters
 	// for different keys - one succeeds and one fails.
@@ -760,7 +772,8 @@ func TestCombinedCalls(t *testing.T) {
 }
 
 func TestForRaces(t *testing.T) {
-	seed := time.Now().Unix()
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
 
 	// scenario to stress test the parallel validation
 	// this is an extended combined test

--- a/core/ledger/kvledger/benchmark/experiments/util.go
+++ b/core/ledger/kvledger/benchmark/experiments/util.go
@@ -8,6 +8,7 @@ package experiments
 
 import (
 	"bytes"
+	crypto "crypto/rand"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -63,10 +64,10 @@ func constructValue(keyNumber int, kvSize int) []byte {
 func constructJSONValue(keyNumber int, kvSize int) []byte {
 	prefix := constructValuePrefix(keyNumber)
 
-	rand.Seed(int64(keyNumber))
-	color := colors[rand.Intn(len(colors))]
-	size := rand.Intn(len(colors))*10 + 10
-	owner := owners[rand.Intn(len(owners))]
+	r := rand.New(rand.NewSource(int64(keyNumber)))
+	color := colors[r.Intn(len(colors))]
+	size := r.Intn(len(colors))*10 + 10
+	owner := owners[r.Intn(len(owners))]
 	assetName := "marble" + strconv.Itoa(keyNumber)
 
 	testRecord := marbleRecord{Prefix: string(prefix), AssetType: "marble", AssetName: assetName, Color: color, Size: size, Owner: owner}
@@ -126,7 +127,7 @@ func calculateShare(total int, numParts int, partNum int) int {
 
 func constructRandomBytes(length int) []byte {
 	b := make([]byte, length)
-	rand.Read(b)
+	crypto.Read(b)
 	return b
 }
 

--- a/core/ledger/kvledger/benchmark/experiments/util.go
+++ b/core/ledger/kvledger/benchmark/experiments/util.go
@@ -8,10 +8,10 @@ package experiments
 
 import (
 	"bytes"
-	crypto "crypto/rand"
+	crand "crypto/rand"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 )
 
@@ -64,10 +64,13 @@ func constructValue(keyNumber int, kvSize int) []byte {
 func constructJSONValue(keyNumber int, kvSize int) []byte {
 	prefix := constructValuePrefix(keyNumber)
 
-	r := rand.New(rand.NewSource(int64(keyNumber)))
-	color := colors[r.Intn(len(colors))]
-	size := r.Intn(len(colors))*10 + 10
-	owner := owners[r.Intn(len(owners))]
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	r := rand.New(rand.NewChaCha8(seed))
+
+	color := colors[r.IntN(len(colors))]
+	size := r.IntN(len(colors))*10 + 10
+	owner := owners[r.IntN(len(owners))]
 	assetName := "marble" + strconv.Itoa(keyNumber)
 
 	testRecord := marbleRecord{Prefix: string(prefix), AssetType: "marble", AssetName: assetName, Color: color, Size: size, Owner: owner}
@@ -127,7 +130,7 @@ func calculateShare(total int, numParts int, partNum int) int {
 
 func constructRandomBytes(length int) []byte {
 	b := make([]byte, length)
-	crypto.Read(b)
+	crand.Read(b)
 	return b
 }
 

--- a/core/peer/peer_test.go
+++ b/core/peer/peer_test.go
@@ -9,18 +9,17 @@ package peer
 import (
 	"fmt"
 	"io/ioutil"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 
-	"github.com/hyperledger/fabric/common/channelconfig"
-
 	"github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/bccsp/sw"
+	"github.com/hyperledger/fabric/common/channelconfig"
 	configtxtest "github.com/hyperledger/fabric/common/configtx/test"
 	"github.com/hyperledger/fabric/common/crypto/tlsgen"
 	"github.com/hyperledger/fabric/common/metrics/disabled"

--- a/core/tx/endorser/endorsertx_suite_test.go
+++ b/core/tx/endorser/endorsertx_suite_test.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package endorsertx_test
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/hyperledger/fabric-protos-go/common"
@@ -22,7 +22,7 @@ func randomLowerAlphaString(size int) string {
 	letters := []rune("abcdefghijklmnopqrstuvwxyz")
 	output := make([]rune, size)
 	for i := range output {
-		output[i] = letters[rand.Intn(len(letters))]
+		output[i] = letters[rand.IntN(len(letters))]
 	}
 	return string(output)
 }

--- a/discovery/client/client.go
+++ b/discovery/client/client.go
@@ -267,9 +267,9 @@ func (cr *channelResponse) Endorsers(invocationChain InvocationChain, f Filter) 
 	}
 
 	desc := res.(*endorsementDescriptor)
-	rand.Seed(time.Now().Unix())
+	r := rand.New(rand.NewSource(time.Now().Unix()))
 	// We iterate over all layouts to find one that we have enough peers to select
-	for _, index := range rand.Perm(len(desc.layouts)) {
+	for _, index := range r.Perm(len(desc.layouts)) {
 		layout := desc.layouts[index]
 		endorsers, canLayoutBeSatisfied := selectPeersForLayout(desc.endorsersByGroups, layout, f)
 		if canLayoutBeSatisfied {

--- a/discovery/client/client.go
+++ b/discovery/client/client.go
@@ -8,10 +8,10 @@ package discovery
 
 import (
 	"context"
+	crand "crypto/rand"
 	"encoding/json"
 	"fmt"
-	"math/rand"
-	"time"
+	"math/rand/v2"
 
 	"github.com/hyperledger/fabric-protos-go/peer"
 
@@ -267,7 +267,9 @@ func (cr *channelResponse) Endorsers(invocationChain InvocationChain, f Filter) 
 	}
 
 	desc := res.(*endorsementDescriptor)
-	r := rand.New(rand.NewSource(time.Now().Unix()))
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	r := rand.New(rand.NewChaCha8(seed))
 	// We iterate over all layouts to find one that we have enough peers to select
 	for _, index := range r.Perm(len(desc.layouts)) {
 		layout := desc.layouts[index]

--- a/discovery/client/selection.go
+++ b/discovery/client/selection.go
@@ -120,8 +120,8 @@ func (endorsers Endorsers) Filter(f ExclusionFilter) Endorsers {
 // Shuffle sorts the endorsers in random order
 func (endorsers Endorsers) Shuffle() Endorsers {
 	res := make(Endorsers, len(endorsers))
-	rand.Seed(time.Now().UnixNano())
-	for i, index := range rand.Perm(len(endorsers)) {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i, index := range r.Perm(len(endorsers)) {
 		res[i] = endorsers[index]
 	}
 	return res

--- a/discovery/client/selection.go
+++ b/discovery/client/selection.go
@@ -7,9 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package discovery
 
 import (
-	"math/rand"
+	crand "crypto/rand"
+	"math/rand/v2"
 	"sort"
-	"time"
 
 	"github.com/hyperledger/fabric/gossip/protoext"
 )
@@ -120,7 +120,9 @@ func (endorsers Endorsers) Filter(f ExclusionFilter) Endorsers {
 // Shuffle sorts the endorsers in random order
 func (endorsers Endorsers) Shuffle() Endorsers {
 	res := make(Endorsers, len(endorsers))
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	r := rand.New(rand.NewChaCha8(seed))
 	for i, index := range r.Perm(len(endorsers)) {
 		res[i] = endorsers[index]
 	}

--- a/gossip/comm/comm_test.go
+++ b/gossip/comm/comm_test.go
@@ -43,9 +43,11 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+var r *rand.Rand
+
 func init() {
 	util.SetupTestLogging()
-	rand.Seed(time.Now().UnixNano())
+	r = rand.New(rand.NewSource(time.Now().UnixNano()))
 	factory.InitFactories(nil)
 	naiveSec.On("OrgByPeerIdentity", mock.Anything).Return(api.OrgIdentityType{})
 }
@@ -236,7 +238,7 @@ func handshaker(port int, endpoint string, comm Comm, t *testing.T, connMutator 
 	require.Equal(t, []byte(target), msg.GetConn().PkiId)
 	require.Equal(t, extractCertificateHashFromContext(stream.Context()), msg.GetConn().TlsCertHash)
 	msg2Send := createGossipMsg()
-	nonce := uint64(rand.Int())
+	nonce := uint64(r.Int())
 	msg2Send.Nonce = nonce
 	go stream.Send(msg2Send.Envelope)
 	return acceptChan
@@ -1035,7 +1037,7 @@ func establishSession(t *testing.T, port int) (proto.Gossip_GossipStreamClient, 
 func createGossipMsg() *protoext.SignedGossipMessage {
 	msg, _ := protoext.NoopSign(&proto.GossipMessage{
 		Tag:   proto.GossipMessage_EMPTY,
-		Nonce: uint64(rand.Int()),
+		Nonce: uint64(r.Int()),
 		Content: &proto.GossipMessage_DataMsg{
 			DataMsg: &proto.DataMessage{},
 		},

--- a/gossip/comm/comm_test.go
+++ b/gossip/comm/comm_test.go
@@ -10,12 +10,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/hmac"
+	crand "crypto/rand"
 	"crypto/sha256"
 	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"strconv"
 	"sync"
@@ -47,7 +48,9 @@ var r *rand.Rand
 
 func init() {
 	util.SetupTestLogging()
-	r = rand.New(rand.NewSource(time.Now().UnixNano()))
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	r = rand.New(rand.NewChaCha8(seed))
 	factory.InitFactories(nil)
 	naiveSec.On("OrgByPeerIdentity", mock.Anything).Return(api.OrgIdentityType{})
 }

--- a/gossip/discovery/discovery_test.go
+++ b/gossip/discovery/discovery_test.go
@@ -11,7 +11,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"sort"
 	"strconv"
@@ -575,7 +575,7 @@ func TestConnect(t *testing.T) {
 	}
 	waitUntilOrFail(t, fullMembership)
 
-	discInst := instances[rand.Intn(len(instances))].Discovery.(*gossipDiscoveryImpl)
+	discInst := instances[rand.IntN(len(instances))].Discovery.(*gossipDiscoveryImpl)
 	mr, _ := discInst.createMembershipRequest(true)
 	am, _ := protoext.EnvelopeToGossipMessage(mr.GetMemReq().SelfInformation)
 	require.NotNil(t, am.SecretEnvelope)

--- a/gossip/filter/filter.go
+++ b/gossip/filter/filter.go
@@ -14,8 +14,10 @@ import (
 	"github.com/hyperledger/fabric/gossip/util"
 )
 
+var r *rand.Rand
+
 func init() { // do we really need this?
-	rand.Seed(int64(util.RandomUInt64()))
+	r = rand.New(rand.NewSource(int64(util.RandomUInt64())))
 }
 
 // RoutingFilter defines a predicate on a NetworkMember
@@ -49,7 +51,7 @@ func CombineRoutingFilters(filters ...RoutingFilter) RoutingFilter {
 func SelectPeers(k int, peerPool []discovery.NetworkMember, filter RoutingFilter) []*comm.RemotePeer {
 	var res []*comm.RemotePeer
 	// Iterate over the possible candidates in random order
-	for _, index := range rand.Perm(len(peerPool)) {
+	for _, index := range r.Perm(len(peerPool)) {
 		// If we collected K peers, we can stop the iteration.
 		if len(res) == k {
 			break

--- a/gossip/filter/filter.go
+++ b/gossip/filter/filter.go
@@ -7,17 +7,19 @@ SPDX-License-Identifier: Apache-2.0
 package filter
 
 import (
-	"math/rand"
+	crand "crypto/rand"
+	"math/rand/v2"
 
 	"github.com/hyperledger/fabric/gossip/comm"
 	"github.com/hyperledger/fabric/gossip/discovery"
-	"github.com/hyperledger/fabric/gossip/util"
 )
 
 var r *rand.Rand
 
 func init() { // do we really need this?
-	r = rand.New(rand.NewSource(int64(util.RandomUInt64())))
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	r = rand.New(rand.NewChaCha8(seed))
 }
 
 // RoutingFilter defines a predicate on a NetworkMember

--- a/gossip/gossip/gossip_test.go
+++ b/gossip/gossip/gossip_test.go
@@ -8,9 +8,10 @@ package gossip
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"reflect"
 	"sync"
@@ -38,12 +39,14 @@ import (
 
 var (
 	timeout = time.Second * time.Duration(180)
-	r       *rand.Rand	r       *rand.Rand
+	r       *rand.Rand
 )
 
 func TestMain(m *testing.M) {
 	util.SetupTestLogging()
-	r = rand.New(rand.NewSource(int64(time.Now().Second())))
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	r = rand.New(rand.NewChaCha8(seed))
 	factory.InitFactories(nil)
 	os.Exit(m.Run())
 }
@@ -529,7 +532,7 @@ func TestConnectToAnchorPeers(t *testing.T) {
 	waitUntilOrFailBlocking(t, wg.Wait, "waiting until all peers join the channel")
 
 	// Now start a random anchor peer
-	index := r.Intn(anchorPeercount)
+	index := r.IntN(anchorPeercount)
 	anchorPeer := newGossipInstanceWithGRPC(index, ports[index], grpcs[index], certs[index], secDialOpts[index], 100)
 	anchorPeer.JoinChan(jcm, common.ChannelID("A"))
 	anchorPeer.UpdateLedgerHeight(1, common.ChannelID("A"))
@@ -1433,7 +1436,7 @@ func TestIdentityExpiration(t *testing.T) {
 	// Now revoke some peer
 	var ports []int
 	ports = append(ports, port1, port2, port3, port4)
-	revokedPeerIndex := r.Intn(4)
+	revokedPeerIndex := r.IntN(4)
 	revokedPkiID := common.PKIidType(fmt.Sprintf("127.0.0.1:%d", ports[revokedPeerIndex]))
 	for i, p := range peers {
 		if i == revokedPeerIndex {

--- a/gossip/gossip/gossip_test.go
+++ b/gossip/gossip/gossip_test.go
@@ -36,11 +36,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var timeout = time.Second * time.Duration(180)
+var (
+	timeout = time.Second * time.Duration(180)
+	r       *rand.Rand	r       *rand.Rand
+)
 
 func TestMain(m *testing.M) {
 	util.SetupTestLogging()
-	rand.Seed(int64(time.Now().Second()))
+	r = rand.New(rand.NewSource(int64(time.Now().Second())))
 	factory.InitFactories(nil)
 	os.Exit(m.Run())
 }
@@ -526,7 +529,7 @@ func TestConnectToAnchorPeers(t *testing.T) {
 	waitUntilOrFailBlocking(t, wg.Wait, "waiting until all peers join the channel")
 
 	// Now start a random anchor peer
-	index := rand.Intn(anchorPeercount)
+	index := r.Intn(anchorPeercount)
 	anchorPeer := newGossipInstanceWithGRPC(index, ports[index], grpcs[index], certs[index], secDialOpts[index], 100)
 	anchorPeer.JoinChan(jcm, common.ChannelID("A"))
 	anchorPeer.UpdateLedgerHeight(1, common.ChannelID("A"))
@@ -1430,7 +1433,7 @@ func TestIdentityExpiration(t *testing.T) {
 	// Now revoke some peer
 	var ports []int
 	ports = append(ports, port1, port2, port3, port4)
-	revokedPeerIndex := rand.Intn(4)
+	revokedPeerIndex := r.Intn(4)
 	revokedPkiID := common.PKIidType(fmt.Sprintf("127.0.0.1:%d", ports[revokedPeerIndex]))
 	for i, p := range peers {
 		if i == revokedPeerIndex {

--- a/gossip/gossip/msgstore/msgs_test.go
+++ b/gossip/gossip/msgstore/msgs_test.go
@@ -18,9 +18,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var r *rand.Rand
+
 func init() {
 	util.SetupTestLogging()
-	rand.Seed(time.Now().UnixNano())
+	r = rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 func alwaysNoAction(_ interface{}, _ interface{}) common.InvalidationResult {
@@ -85,7 +87,7 @@ func TestMessagesGet(t *testing.T) {
 	msgStore := NewMessageStore(alwaysNoAction, Noop)
 	expected := []int{}
 	for i := 0; i < 2; i++ {
-		n := rand.Int()
+		n := r.Int()
 		expected = append(expected, n)
 		msgStore.Add(n)
 	}
@@ -120,7 +122,7 @@ func TestConcurrency(t *testing.T) {
 	}
 
 	addProcess := looper(func() {
-		msgStore.Add(rand.Int())
+		msgStore.Add(r.Int())
 	})
 
 	getProcess := looper(func() {

--- a/gossip/gossip/msgstore/msgs_test.go
+++ b/gossip/gossip/msgstore/msgs_test.go
@@ -7,7 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package msgstore
 
 import (
-	"math/rand"
+	crand "crypto/rand"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -22,7 +23,9 @@ var r *rand.Rand
 
 func init() {
 	util.SetupTestLogging()
-	r = rand.New(rand.NewSource(time.Now().UnixNano()))
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	r = rand.New(rand.NewChaCha8(seed))
 }
 
 func alwaysNoAction(_ interface{}, _ interface{}) common.InvalidationResult {

--- a/gossip/privdata/distributor.go
+++ b/gossip/privdata/distributor.go
@@ -8,8 +8,9 @@ package privdata
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -256,7 +257,9 @@ func (d *distributorImpl) disseminationPlanForMsg(colAP privdata.CollectionAcces
 	remainingPeersAcrossOrgs := []api.PeerIdentityInfo{}
 	selectedPeerEndpointsForDebug := []string{}
 
-	r := rand.New(rand.NewSource(time.Now().Unix()))
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	r := rand.New(rand.NewChaCha8(seed))
 
 	// PHASE 1 - Select one peer from each eligible org
 	if maximumPeerRemainingCount > 0 {
@@ -269,7 +272,7 @@ func (d *distributorImpl) disseminationPlanForMsg(colAP privdata.CollectionAcces
 				acksRequired = 0
 			}
 
-			selectedPeerIndex := r.Intn(len(selectionPeersForOrg))
+			selectedPeerIndex := r.IntN(len(selectionPeersForOrg))
 			peer2SendPerOrg := selectionPeersForOrg[selectedPeerIndex]
 			selectedPeerEndpointsForDebug = append(selectedPeerEndpointsForDebug, peerEndpoints[string(peer2SendPerOrg.PKIId)])
 			sc := gossipgossip.SendCriteria{
@@ -322,7 +325,7 @@ func (d *distributorImpl) disseminationPlanForMsg(colAP privdata.CollectionAcces
 		if requiredPeerRemainingCount == 0 {
 			required = 0
 		}
-		selectedPeerIndex := r.Intn(len(remainingPeersAcrossOrgs))
+		selectedPeerIndex := r.IntN(len(remainingPeersAcrossOrgs))
 		peer2Send := remainingPeersAcrossOrgs[selectedPeerIndex]
 		selectedPeerEndpointsForDebug = append(selectedPeerEndpointsForDebug, peerEndpoints[string(peer2Send.PKIId)])
 		sc := gossipgossip.SendCriteria{

--- a/gossip/privdata/distributor.go
+++ b/gossip/privdata/distributor.go
@@ -256,7 +256,7 @@ func (d *distributorImpl) disseminationPlanForMsg(colAP privdata.CollectionAcces
 	remainingPeersAcrossOrgs := []api.PeerIdentityInfo{}
 	selectedPeerEndpointsForDebug := []string{}
 
-	rand.Seed(time.Now().Unix())
+	r := rand.New(rand.NewSource(time.Now().Unix()))
 
 	// PHASE 1 - Select one peer from each eligible org
 	if maximumPeerRemainingCount > 0 {
@@ -269,7 +269,7 @@ func (d *distributorImpl) disseminationPlanForMsg(colAP privdata.CollectionAcces
 				acksRequired = 0
 			}
 
-			selectedPeerIndex := rand.Intn(len(selectionPeersForOrg))
+			selectedPeerIndex := r.Intn(len(selectionPeersForOrg))
 			peer2SendPerOrg := selectionPeersForOrg[selectedPeerIndex]
 			selectedPeerEndpointsForDebug = append(selectedPeerEndpointsForDebug, peerEndpoints[string(peer2SendPerOrg.PKIId)])
 			sc := gossipgossip.SendCriteria{
@@ -322,7 +322,7 @@ func (d *distributorImpl) disseminationPlanForMsg(colAP privdata.CollectionAcces
 		if requiredPeerRemainingCount == 0 {
 			required = 0
 		}
-		selectedPeerIndex := rand.Intn(len(remainingPeersAcrossOrgs))
+		selectedPeerIndex := r.Intn(len(remainingPeersAcrossOrgs))
 		peer2Send := remainingPeersAcrossOrgs[selectedPeerIndex]
 		selectedPeerEndpointsForDebug = append(selectedPeerEndpointsForDebug, peerEndpoints[string(peer2Send.PKIId)])
 		sc := gossipgossip.SendCriteria{

--- a/gossip/privdata/pull.go
+++ b/gossip/privdata/pull.go
@@ -8,10 +8,11 @@ package privdata
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -680,7 +681,9 @@ func (p *puller) isEligibleByLatestConfig(channel string, collection string, cha
 }
 
 func randomizeMemberList(members []discovery.NetworkMember) []discovery.NetworkMember {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	r := rand.New(rand.NewChaCha8(seed))
 	res := make([]discovery.NetworkMember, len(members))
 	for i, j := range r.Perm(len(members)) {
 		res[i] = members[j]

--- a/gossip/privdata/pull.go
+++ b/gossip/privdata/pull.go
@@ -680,9 +680,9 @@ func (p *puller) isEligibleByLatestConfig(channel string, collection string, cha
 }
 
 func randomizeMemberList(members []discovery.NetworkMember) []discovery.NetworkMember {
-	rand.Seed(time.Now().UnixNano())
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	res := make([]discovery.NetworkMember, len(members))
-	for i, j := range rand.Perm(len(members)) {
+	for i, j := range r.Perm(len(members)) {
 		res[i] = members[j]
 	}
 	return res

--- a/gossip/state/state.go
+++ b/gossip/state/state.go
@@ -809,7 +809,3 @@ func (s *GossipStateProviderImpl) commitBlock(block *common.Block, pvtData util.
 
 	return nil
 }
-
-func min(a uint64, b uint64) uint64 {
-	return b ^ ((a ^ b) & (-(uint64(a-b) >> 63)))
-}

--- a/gossip/state/state_test.go
+++ b/gossip/state/state_test.go
@@ -8,9 +8,10 @@ package state
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -760,9 +761,11 @@ func TestBlockingEnqueue(t *testing.T) {
 
 	// Get a block from gossip every 1ms too
 	go func() {
-		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+		var seed [32]byte
+		_, _ = crand.Read(seed[:])
+		r := rand.New(rand.NewChaCha8(seed))
 		for i := 1; i <= numBlocksReceived/2; i++ {
-			blockSeq := r.Intn(numBlocksReceived)
+			blockSeq := r.IntN(numBlocksReceived)
 			rawblock := protoutil.NewBlock(uint64(blockSeq), []byte{})
 			b, _ := pb.Marshal(rawblock)
 			block := &proto.Payload{

--- a/gossip/state/state_test.go
+++ b/gossip/state/state_test.go
@@ -760,9 +760,9 @@ func TestBlockingEnqueue(t *testing.T) {
 
 	// Get a block from gossip every 1ms too
 	go func() {
-		rand.Seed(time.Now().UnixNano())
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
 		for i := 1; i <= numBlocksReceived/2; i++ {
-			blockSeq := rand.Intn(numBlocksReceived)
+			blockSeq := r.Intn(numBlocksReceived)
 			rawblock := protoutil.NewBlock(uint64(blockSeq), []byte{})
 			b, _ := pb.Marshal(rawblock)
 			block := &proto.Payload{

--- a/gossip/util/misc.go
+++ b/gossip/util/misc.go
@@ -17,8 +17,10 @@ import (
 	"github.com/spf13/viper"
 )
 
+var r *rand.Rand
+
 func init() { // do we really need this?
-	rand.Seed(time.Now().UnixNano())
+	r = rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 // Equals returns whether a and b are the same
@@ -55,7 +57,7 @@ func GetRandomIndices(indiceCount, highestIndex int) []int {
 		return nil
 	}
 
-	return rand.Perm(highestIndex + 1)[:indiceCount]
+	return r.Perm(highestIndex + 1)[:indiceCount]
 }
 
 // Set is a generic and thread-safe
@@ -174,7 +176,7 @@ func SetVal(key string, val interface{}) {
 // RandomInt returns, as an int, a non-negative pseudo-random integer in [0,n)
 // It panics if n <= 0
 func RandomInt(n int) int {
-	return rand.Intn(n)
+	return r.Intn(n)
 }
 
 // RandomUInt64 returns a random uint64
@@ -182,7 +184,7 @@ func RandomInt(n int) int {
 // If we want a rand that's non-global and specific to gossip, we can
 // establish one. Otherwise this uses the process-global locking RNG.
 func RandomUInt64() uint64 {
-	return rand.Uint64()
+	return r.Uint64()
 }
 
 func BytesToStrings(bytes [][]byte) []string {

--- a/gossip/util/misc.go
+++ b/gossip/util/misc.go
@@ -7,8 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package util
 
 import (
+	crand "crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"reflect"
 	"runtime"
 	"sync"
@@ -20,7 +21,9 @@ import (
 var r *rand.Rand
 
 func init() { // do we really need this?
-	r = rand.New(rand.NewSource(time.Now().UnixNano()))
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	r = rand.New(rand.NewChaCha8(seed))
 }
 
 // Equals returns whether a and b are the same
@@ -176,7 +179,7 @@ func SetVal(key string, val interface{}) {
 // RandomInt returns, as an int, a non-negative pseudo-random integer in [0,n)
 // It panics if n <= 0
 func RandomInt(n int) int {
-	return r.Intn(n)
+	return r.IntN(n)
 }
 
 // RandomUInt64 returns a random uint64

--- a/internal/pkg/gateway/registry.go
+++ b/internal/pkg/gateway/registry.go
@@ -8,7 +8,7 @@ package gateway
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"strings"
 	"sync"

--- a/internal/pkg/gateway/submit.go
+++ b/internal/pkg/gateway/submit.go
@@ -9,7 +9,7 @@ package gateway
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"

--- a/internal/pkg/peer/orderers/connection.go
+++ b/internal/pkg/peer/orderers/connection.go
@@ -9,7 +9,7 @@ package orderers
 import (
 	"bytes"
 	"crypto/sha256"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 
 	"github.com/hyperledger/fabric/common/flogging"
@@ -50,7 +50,7 @@ func (cs *ConnectionSource) RandomEndpoint() (*Endpoint, error) {
 	if len(cs.allEndpoints) == 0 {
 		return nil, errors.Errorf("no endpoints currently defined")
 	}
-	return cs.allEndpoints[rand.Intn(len(cs.allEndpoints))], nil
+	return cs.allEndpoints[rand.IntN(len(cs.allEndpoints))], nil
 }
 
 func (cs *ConnectionSource) Update(globalAddrs []string, orgs map[string]OrdererOrg) {

--- a/orderer/common/cluster/deliver.go
+++ b/orderer/common/cluster/deliver.go
@@ -380,8 +380,8 @@ func randomEndpoint(endpointsToHeight map[string]*endpointInfo) string {
 		candidates = append(candidates, endpoint)
 	}
 
-	rand.Seed(time.Now().UnixNano())
-	return candidates[rand.Intn(len(candidates))]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return candidates[r.Intn(len(candidates))]
 }
 
 // fetchLastBlockSeq returns the last block sequence of an endpoint with the given gRPC connection.

--- a/orderer/common/cluster/deliver.go
+++ b/orderer/common/cluster/deliver.go
@@ -8,8 +8,9 @@ package cluster
 
 import (
 	"context"
+	crand "crypto/rand"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -380,8 +381,10 @@ func randomEndpoint(endpointsToHeight map[string]*endpointInfo) string {
 		candidates = append(candidates, endpoint)
 	}
 
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	return candidates[r.Intn(len(candidates))]
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	r := rand.New(rand.NewChaCha8(seed))
+	return candidates[r.IntN(len(candidates))]
 }
 
 // fetchLastBlockSeq returns the last block sequence of an endpoint with the given gRPC connection.

--- a/orderer/common/cluster/util.go
+++ b/orderer/common/cluster/util.go
@@ -8,12 +8,13 @@ package cluster
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -795,6 +796,8 @@ func (cm *ComparisonMemoizer) shrink() {
 func (cm *ComparisonMemoizer) setup() {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()
-	cm.rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+	var seed [32]byte
+	_, _ = crand.Read(seed[:])
+	cm.rand = rand.New(rand.NewChaCha8(seed))
 	cm.cache = make(map[arguments]bool)
 }


### PR DESCRIPTION
- Remove usage of deprecated rand.Seed() - Backport of math/rand portion of #4372
- change math/rand to v2 - Backport of #4995 

Resolves #5169 
