### PR TITLE
refactor: return nil when error has already been checked

### DIFF
--- a/core/chaincode/lifecycle/ledger_shim.go
+++ b/core/chaincode/lifecycle/ledger_shim.go
@@ -140,7 +140,7 @@ func (ris *ResultsIteratorShim) Next() (*queryresult.KV, error) {
 	if res == nil {
 		return nil, nil
 	}
-	return res.(*queryresult.KV), err
+	return res.(*queryresult.KV), nil
 }
 
 func (ris *ResultsIteratorShim) Close() error {

--- a/core/ledger/pvtdatastorage/v11.go
+++ b/core/ledger/pvtdatastorage/v11.go
@@ -19,7 +19,7 @@ func v11Format(datakeyBytes []byte) (bool, error) {
 		return false, err
 	}
 	remainingBytes := datakeyBytes[n+1:]
-	return len(remainingBytes) == 0, err
+	return len(remainingBytes) == 0, nil
 }
 
 // v11DecodePK returns block number, tx number, and error.


### PR DESCRIPTION
<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->



#### Type of change

<!--- What type of change? Pick one option and delete the others. -->


- Improvement (improvement to code, performance, etc)


#### Description

Since err != nil has been judged before, nil is returned directly here, which is more obvious, readable and less error-prone.

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Github issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
