### PR TITLE
Bump Go to 1.23.7 (release-2.5)

### DIFF
--- a/docs/source/prereqs.md
+++ b/docs/source/prereqs.md
@@ -79,9 +79,9 @@ Optional: Install the latest Fabric supported version of [Go](https://golang.org
 installed (only required if you will be writing Go chaincode or SDK applications).
 
 ```shell
-$ brew install go@1.23.5
+$ brew install go@1.23.7
 $ go version
-go1.23.5 darwin/amd64
+go1.23.7 darwin/amd64
 ```
 
 ### JQ

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/fabric
 
-go 1.23.5
+go 1.23.7
 
 require (
 	code.cloudfoundry.org/clock v1.0.0

--- a/vagrant/golang.sh
+++ b/vagrant/golang.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 GOROOT='/opt/go'
-GO_VERSION=1.23.5
+GO_VERSION=1.23.7
 
 # ----------------------------------------------------------------
 # Install Golang


### PR DESCRIPTION
Bump Go to 1.23.7 (release-2.5)

Note that the Makefile and Github Actions do not need updates since they reference the Go version in go.mod now.
