### PR TITLE
Update copyright year to 2025

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Hyperledger Fabric
-Copyright [2016-2020] contributors to Hyperledger Fabric
+Copyright [2016-2025] contributors to Hyperledger Fabric
 
 This product includes software developed at
 Hyperledger (http://www.hyperledger.org/).

--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -18,7 +18,7 @@
       {%- if hasdoc('copyright') %}
         {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
       {%- else %}
-        {% trans copyright=copyright|e %}&copy; Copyright Hyperledger 2020-2024.{% endtrans %}
+        {% trans copyright=copyright|e %}&copy; Copyright Hyperledger 2020-2025.{% endtrans %}
       {%- endif %}
     {%- endif %}
     <br>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ placeholder_replacements = {
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "Hyperledger Fabric Docs"
-copyright = "2017-2024, Hyperledger Foundation"
+copyright = "2017-2025, Hyperledger Foundation"
 author = "Hyperledger Foundation"
 release = "main"
 version = "main"


### PR DESCRIPTION
I noticed that the copyright for documents was still from last year, so I created an update patch.

#### Type of change

- Documentation update

#### Description

This PR updates the copyright year to 2025.