### PR TITLE
NixOS support (Multi-Linux Distro Support)

### DIFF
--- a/scripts/install-fabric.sh
+++ b/scripts/install-fabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright IBM Corp. All Rights Reserved.
 #


### PR DESCRIPTION
NixOS support (Multi-Linux Distro Support)

#### Type of change

- Bug fix

#### Description

In nixos, there is no /bin/bash, so it fails. So had to change the shebang which work in any environment.
Tested it in NixOS and Nix Docker container. 
