### PR TITLE
Improve function GetStateRangeScanIterator

### DIFF
--- a/core/ledger/kvledger/txmgmt/queryutil/combiner_test.go
+++ b/core/ledger/kvledger/txmgmt/queryutil/combiner_test.go
@@ -196,6 +196,29 @@ func TestGetRangeScanError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestGetStateRangeScanIteratorNil(t *testing.T) {
+	itr1 := &statedbmock.ResultsIterator{}
+	itr1.NextReturns(
+		&statedb.VersionedKV{
+			CompositeKey:   &statedb.CompositeKey{Namespace: "ns", Key: "dummyKey"},
+			VersionedValue: &statedb.VersionedValue{Value: []byte("dummyVal")},
+		},
+		nil,
+	)
+
+	qe1 := &mock.QueryExecuter{}
+	qe1.GetStateRangeScanIteratorReturns(itr1, nil)
+	qe2 := &mock.QueryExecuter{}
+	qe2.GetStateRangeScanIteratorReturns(nil, nil)
+	combiner := &queryutil.QECombiner{
+		QueryExecuters: []queryutil.QueryExecuter{
+			qe1, qe2,
+		},
+	}
+	_, err := combiner.GetStateRangeScanIterator("ns", "startKey", "endKey")
+	require.EqualError(t, err, "received nil iterator from QueryExecuter")
+}
+
 func TestGetRangeScanUnderlyingIteratorReturnsError(t *testing.T) {
 	itr1 := &statedbmock.ResultsIterator{}
 	itr1.NextReturns(

--- a/core/ledger/kvledger/txmgmt/queryutil/query_executer_combiner.go
+++ b/core/ledger/kvledger/txmgmt/queryutil/query_executer_combiner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/hyperledger/fabric/core/ledger/util"
+	"github.com/pkg/errors"
 )
 
 var logger = flogging.MustGetLogger("util")
@@ -62,12 +63,21 @@ func (c *QECombiner) GetStateRangeScanIterator(namespace string, startKey string
 			for _, itr := range itrs {
 				itr.Close()
 			}
-			return nil, err
+			return nil, errors.Wrap(err, "failed to get iterator from QueryExecuter")
+		}
+		if itr == nil {
+			for _, itr := range itrs {
+				itr.Close()
+			}
+			return nil, errors.New("received nil iterator from QueryExecuter")
 		}
 		itrs = append(itrs, itr)
 	}
 	itrCombiner, err := newItrCombiner(namespace, itrs)
 	if err != nil {
+		for _, itr := range itrs {
+			itr.Close()
+		}
 		return nil, err
 	}
 	return itrCombiner, nil


### PR DESCRIPTION
- Close iterators if newItrCombiner fails.
- Handle nil iterators returned without errors.
- Improve error messages for debugging.

Resolves https://github.com/hyperledger/fabric/issues/5194
