### PR TITLE
Add constants for private event

### DIFF
--- a/common/ledger/ledger_interface.go
+++ b/common/ledger/ledger_interface.go
@@ -55,3 +55,21 @@ type QueryResult interface{}
 
 // PrunePolicy - a general interface for supporting different pruning policies
 type PrunePolicy interface{}
+
+const (
+	PrivateEventsPrefixAndSeparator = "__hlf_privateEvent__"
+	PrivateEventsTopLevelName       = "__hlf__privateEvents"
+)
+
+// PrivateEventPayload is the payload that the chaincode must create for a private event
+type PrivateEventPayload struct {
+	// {mspid1: [id1, id2, ...], ...}
+	VisibleTo map[string][]string `json:"visibleTo,omitempty"`
+	Payload   interface{}         `json:"payload"`
+}
+
+// TxnPrivateChaincodeEvents: keys are the event names; values are the event payloads
+type TxnPrivateChaincodeEvents map[string][]byte
+
+// BlockPrivateChaincodeEvents: map of TxnPrivateChaincodeEvents - key is the txn index inside the block
+type BlockPrivateChaincodeEvents map[int]*TxnPrivateChaincodeEvents


### PR DESCRIPTION
This patch is the first one for the private event feature. Here we add the basic constants and other data structures.

We keep the commit small enough to test the workflow, too.

Change-Id: I1953443499471eafcfca5e03ad805027453b26a1

#### Type of change

- New feature

#### Description

Add the basic constants and other data structures for the private event

#### Additional details

N/A.

#### Related issues

N/A.