### PR TITLE
try to install open-quantum-safe in base image file

### DIFF
--- a/images/baseos/Dockerfile
+++ b/images/baseos/Dockerfile
@@ -24,6 +24,14 @@ FROM ubuntu:${UBUNTU_VER} AS base
 RUN apt update && apt install -y \
     tzdata
 
+RUN apt-get -y update && \
+    apt-get install -y build-essential git cmake libssl-dev golang
+
+# Install liboqs
+RUN cmake -S liboqs -B liboqs/build -DBUILD_SHARED_LIBS=ON && \
+    cmake --build liboqs/build --parallel 4 && \
+    cmake --build liboqs/build --target install
+
 RUN     groupadd --gid 500 chaincode
 RUN     useradd -c "" -u 500 -g 500 -d /home/chaincode -m chaincode
 


### PR DESCRIPTION
In recent I had been asked via mail for PQC in fabric, but it seems I lost connection.
So I try to the sample and discussion here, and make the discussion in show me you code way.
related with https://github.com/hyperledger/fabric-rfcs/pull/34

but further considering that IEFT still not publish https://datatracker.ietf.org/doc/draft-ietf-jose-pqc-kem/ and https://datatracker.ietf.org/doc/draft-ietf-lamps-cms-ml-dsa/ as they are still draft at  this PR creation Jun 8th 2025(beijing time),  I suppose it's still too early for fabric or hyperledger community to make some progress but only early research/investigation just enough. So I make this PR as draft.

this PR just part of invoke the crypto libraries at the container file/container level, and then people can ref https://github.com/open-quantum-safe/liboqs-go to impls bccsp, msp and modules in fabric to archive PQC in fabric.



