### PR TITLE
remove sampleconfig/msp/keystore/key.pem from Dockerfiles

### DIFF
--- a/images/orderer/Dockerfile
+++ b/images/orderer/Dockerfile
@@ -61,7 +61,6 @@ ENV FABRIC_CFG_PATH=/etc/hyperledger/fabric
 ENV FABRIC_VER=${FABRIC_VER}
 
 COPY    --from=builder  build/bin/orderer           /usr/local/bin
-COPY    --from=builder  sampleconfig/msp            ${FABRIC_CFG_PATH}/msp
 COPY    --from=builder  sampleconfig/orderer.yaml   ${FABRIC_CFG_PATH}
 COPY    --from=builder  sampleconfig/configtx.yaml  ${FABRIC_CFG_PATH}
 

--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -64,7 +64,6 @@ ENV FABRIC_CFG_PATH=/etc/hyperledger/fabric
 ENV FABRIC_VER=${FABRIC_VER}
 
 COPY    --from=builder  build/bin/peer          /usr/local/bin
-COPY    --from=builder  sampleconfig/msp        ${FABRIC_CFG_PATH}/msp
 COPY    --from=builder  sampleconfig/core.yaml  ${FABRIC_CFG_PATH}/core.yaml
 
 COPY    --from=builder  release/${TARGETOS}-${TARGETARCH}/builders/ccaas/bin /opt/hyperledger/ccaas_builder/bin


### PR DESCRIPTION
Previously we added a test private key `sampleconfig/msp/keystore/key.pem` to Docker images.
In this fix, I suggest not adding the `sampleconfig/msp` folder to Docker images at all.
Please take a close look at this fix.
Even though all the tests have passed, I think that I have missed something.