### PR TITLE
added to OSN new handler for update config of channel

### DIFF
--- a/integration/nwo/commands/peer.go
+++ b/integration/nwo/commands/peer.go
@@ -646,32 +646,6 @@ func (s SignConfigTx) Args() []string {
 	return args
 }
 
-type ChannelUpdate struct {
-	ChannelID             string
-	Orderer               string
-	File                  string
-	ClientAuth            bool
-	TLSHandshakeTimeShift time.Duration
-}
-
-func (c ChannelUpdate) SessionName() string {
-	return "peer-channel-update"
-}
-
-func (c ChannelUpdate) Args() []string {
-	args := []string{
-		"channel", "update",
-		"--channelID", c.ChannelID,
-		"--orderer", c.Orderer,
-		"--file", c.File,
-		"--tlsHandshakeTimeShift", c.TLSHandshakeTimeShift.String(),
-	}
-	if c.ClientAuth {
-		args = append(args, "--clientauth")
-	}
-	return args
-}
-
 type ChannelInfo struct {
 	ChannelID  string
 	ClientAuth bool

--- a/protoutil/blockutils.go
+++ b/protoutil/blockutils.go
@@ -113,7 +113,7 @@ func GetChannelIDFromEnvelope(envelope *cb.Envelope) (string, error) {
 	if payload.Header == nil {
 		return "", errors.New("failed to retrieve channel id - payload header is empty")
 	}
-	chdr, err := UnmarshalChannelHeader(payload.Header.ChannelHeader)
+	chdr, err := UnmarshalChannelHeader(payload.GetHeader().GetChannelHeader())
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The `peer channel update` internally only accesses orderers. 
I think it's better to add this command to OSN.