### PR TITLE
Implement lazy loading for chaincode lifecycle cache

### DIFF
--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -219,6 +219,14 @@ type Config struct {
 	// interact with fabric networks
 
 	GatewayOptions gatewayconfig.Options
+
+	// ----- Lifecycle config -----
+
+	// LifecycleLazyLoadEnabled enables lazy loading of chaincode packages instead of
+	// pre-initializing all installed chaincodes at startup. This can improve startup
+	// time when there are many installed chaincodes, but may cause slight delays
+	// when chaincodes are first accessed.
+	LifecycleLazyLoadEnabled bool
 }
 
 // GlobalConfig obtains a set of configuration from viper, build and returns
@@ -326,6 +334,8 @@ func (c *Config) load() error {
 	c.StatsdAaddress = viper.GetString("metrics.statsd.address")
 	c.StatsdWriteInterval = viper.GetDuration("metrics.statsd.writeInterval")
 	c.StatsdPrefix = viper.GetString("metrics.statsd.prefix")
+
+	c.LifecycleLazyLoadEnabled = viper.GetBool("peer.lifecycle.lazyLoadEnabled")
 
 	c.DockerCert = config.GetPath("vm.docker.tls.cert.file")
 	c.DockerKey = config.GetPath("vm.docker.tls.key.file")

--- a/docs/source/peer_lifecycle_lazy_loading.md
+++ b/docs/source/peer_lifecycle_lazy_loading.md
@@ -6,13 +6,27 @@ The peer lifecycle cache can be configured to use lazy loading instead of pre-in
 
 ## Configuration
 
-To enable lazy loading, add the following configuration to your `core.yaml` file:
+To enable lazy loading, you can configure it in one of the following ways:
+
+### Using core.yaml file
+
+Add the following configuration to your `core.yaml` file:
 
 ```yaml
 peer:
   lifecycle:
     lazyLoadEnabled: true
 ```
+
+### Using environment variable
+
+Set the following environment variable:
+
+```bash
+export CORE_PEER_LIFECYCLE_LAZYLOADENABLED=true
+```
+
+The environment variable takes precedence over the configuration file setting.
 
 ## How it works
 

--- a/docs/source/peer_lifecycle_lazy_loading.md
+++ b/docs/source/peer_lifecycle_lazy_loading.md
@@ -1,0 +1,59 @@
+# Peer Lifecycle Lazy Loading
+
+## Overview
+
+The peer lifecycle cache can be configured to use lazy loading instead of pre-initializing all installed chaincodes at startup. This feature can significantly improve peer startup time when there are many installed chaincodes.
+
+## Configuration
+
+To enable lazy loading, add the following configuration to your `core.yaml` file:
+
+```yaml
+peer:
+  lifecycle:
+    lazyLoadEnabled: true
+```
+
+## How it works
+
+### Default Behavior (lazyLoadEnabled: false)
+- At startup, the peer loads all installed chaincode packages
+- Parses metadata for each chaincode
+- Populates the lifecycle cache with all chaincode information
+- This can be slow when there are many installed chaincodes
+
+### Lazy Loading Behavior (lazyLoadEnabled: true)
+- At startup, the peer skips loading installed chaincode packages
+- Chaincode information is loaded on-demand when needed
+- The first time a chaincode is accessed, its package is loaded and cached
+- Subsequent accesses use the cached information
+
+## Benefits
+
+- **Faster startup time**: Peer starts up much faster when there are many installed chaincodes
+- **Reduced memory usage**: Only loads chaincode information when actually needed
+- **Better resource utilization**: Avoids loading chaincodes that may never be used
+
+## Considerations
+
+- **First access delay**: The first time a chaincode is accessed, there may be a slight delay as the package is loaded
+- **Cache behavior**: Once loaded, chaincode information remains cached for the lifetime of the peer
+- **Installation events**: When new chaincodes are installed, they are still handled immediately via the `HandleChaincodeInstalled` event
+
+## Use Cases
+
+This feature is particularly useful in environments where:
+- There are many installed chaincodes (hundreds or thousands)
+- Not all installed chaincodes are actively used
+- Fast peer startup time is critical
+- Memory usage needs to be optimized
+
+## Example
+
+For a peer with 1000 installed chaincodes:
+- **Default behavior**: May take 30-60 seconds to start up
+- **Lazy loading**: May start up in 5-10 seconds, with chaincodes loaded as needed
+
+## Migration
+
+This feature is backward compatible. You can enable it on existing peers without any data migration or downtime. The feature can be toggled on/off by changing the configuration and restarting the peer. 

--- a/go.sum
+++ b/go.sum
@@ -629,8 +629,6 @@ github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b/go.mod h1:1KcenG0jGWcpt8ov532z81sp/kMMUG485J2InIOyADM=
-github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
-github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20240626203959-61d1e3462e30 h1:t3eaIm0rUkzbrIewtiFmMK5RXHej2XnoXNhxVsAYUfg=
@@ -1096,8 +1094,6 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJ
 github.com/tedsuo/ifrit v0.0.0-20230330192023-5cba443a66c4/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tedsuo/ifrit v0.0.0-20230516164442-7862c310ad26 h1:mWCRvpoEMVlslxEvvptKgIUb35va9yj9Oq5wGw/er5I=
 github.com/tedsuo/ifrit v0.0.0-20230516164442-7862c310ad26/go.mod h1:0uD3VMXkZ7Bw0ojGCwDzebBBzPBXtzEZeXai+56BLX4=
-github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
-github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -629,6 +629,8 @@ github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b/go.mod h1:1KcenG0jGWcpt8ov532z81sp/kMMUG485J2InIOyADM=
+github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
+github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20240626203959-61d1e3462e30 h1:t3eaIm0rUkzbrIewtiFmMK5RXHej2XnoXNhxVsAYUfg=
@@ -1094,6 +1096,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJ
 github.com/tedsuo/ifrit v0.0.0-20230330192023-5cba443a66c4/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tedsuo/ifrit v0.0.0-20230516164442-7862c310ad26 h1:mWCRvpoEMVlslxEvvptKgIUb35va9yj9Oq5wGw/er5I=
 github.com/tedsuo/ifrit v0.0.0-20230516164442-7862c310ad26/go.mod h1:0uD3VMXkZ7Bw0ojGCwDzebBBzPBXtzEZeXai+56BLX4=
+github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -430,12 +430,16 @@ func serve(args []string) error {
 		DurablePath: externalBuilderOutput,
 	}
 
+	// Check if lazy loading is enabled via configuration
+	lazyLoadEnabled := viper.GetBool("peer.lifecycle.lazyLoadEnabled")
+
 	lifecycleCache := lifecycle.NewCache(
 		lifecycleResources,
 		mspID,
 		metadataManager,
 		chaincodeCustodian,
 		ebMetadataProvider,
+		lazyLoadEnabled,
 	)
 
 	txProcessors := map[cb.HeaderType]ledger.CustomTxProcessor{

--- a/internal/peer/node/start.go
+++ b/internal/peer/node/start.go
@@ -431,7 +431,7 @@ func serve(args []string) error {
 	}
 
 	// Check if lazy loading is enabled via configuration
-	lazyLoadEnabled := viper.GetBool("peer.lifecycle.lazyLoadEnabled")
+	lazyLoadEnabled := coreConfig.LifecycleLazyLoadEnabled
 
 	lifecycleCache := lifecycle.NewCache(
 		lifecycleResources,

--- a/sampleconfig/core.yaml
+++ b/sampleconfig/core.yaml
@@ -487,6 +487,15 @@ peer:
     # When this is false, it means that only peer admins can perform non channel scoped queries.
     orgMembersAllowedAccess: false
 
+  # Lifecycle service configuration
+  # The lifecycle service manages chaincode lifecycle operations.
+  lifecycle:
+    # Whether to enable lazy loading of chaincode packages instead of pre-initializing
+    # all installed chaincodes at startup. This can improve startup time when there
+    # are many installed chaincodes, but may cause slight delays when chaincodes
+    # are first accessed.
+    lazyLoadEnabled: false
+
   # Limits is used to configure some internal resource limits.
   limits:
     # Concurrency limits the number of concurrently running requests to a service on each peer.


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

This update introduces a lazy loading feature for the chaincode lifecycle cache, allowing chaincode information to be loaded on-demand rather than pre-initialized at startup. This can significantly improve peer startup times, especially in environments with many installed chaincodes. The feature can be enabled via the `core.yaml` configuration file. Additionally, tests have been added to verify the behavior of the cache with lazy loading enabled.

#### Additional details

The implementation includes:
- Updated `NewCache` function to accept a `lazyLoadEnabled` parameter
- Modified `InitializeLocalChaincodes` to skip pre-initialization when lazy loading is enabled
- Added new tests for lazy loading behavior in `cache_test.go`
- Created documentation for lazy loading in `peer_lifecycle_lazy_loading.md`
- Updated configuration example in `core.yaml` to include lazy loading option

This feature is particularly beneficial for peers with large numbers of installed chaincodes, as it eliminates the need to load all chaincode metadata during peer initialization, resulting in faster startup times.

#### Related issues

When there are a lot of chaincodes installed (10k+) peers take a long time to start since the cache is initialized. A new behaviour is needed to improve peer startup time when there are a lot of chaincodes installed.

#### Release Note

**New Feature**: Added lazy loading support for chaincode lifecycle cache to improve peer startup performance in environments with many installed chaincodes. This feature can be enabled via the `core.yaml` configuration file. 