### PR TITLE
smartbft signature methods pointer receiver only

### DIFF
--- a/orderer/consensus/smartbft/signature.go
+++ b/orderer/consensus/smartbft/signature.go
@@ -40,7 +40,7 @@ func (sig *Signature) Marshal() []byte {
 }
 
 // AsBytes returns the message to sign
-func (sig Signature) AsBytes() []byte {
+func (sig *Signature) AsBytes() []byte {
 	msg2Sign := util.ConcatenateBytes(sig.OrdererBlockMetadata, sig.IdentifierHeader, sig.BlockHeader)
 	return msg2Sign
 }

--- a/orderer/consensus/smartbft/signer.go
+++ b/orderer/consensus/smartbft/signer.go
@@ -47,7 +47,7 @@ func (s *Signer) SignProposal(proposal types.Proposal, _ []byte) *types.Signatur
 
 	nonce := randomNonceOrPanic()
 
-	sig := Signature{
+	sig := &Signature{
 		BlockHeader:      protoutil.BlockHeaderBytes(block.Header),
 		IdentifierHeader: protoutil.MarshalOrPanic(s.newIdentifierHeaderOrPanic(nonce)),
 		OrdererBlockMetadata: protoutil.MarshalOrPanic(&cb.OrdererBlockMetadata{


### PR DESCRIPTION

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
Code Hygiene.

Fix the warning:

`Struct Signature has methods on both value and pointer receivers. Such usage is not recommended by the Go Documentation.`

Using a value receiver just calculates the AsBytes() on a copy of the object, which is unnecessary.
