### PR TITLE
Allow network to keep working after renewing certs with the same key

### DIFF
--- a/integration/smartbft/smartbft_test.go
+++ b/integration/smartbft/smartbft_test.go
@@ -279,7 +279,6 @@ var _ = Describe("EndToEnd Smart BFT configuration test", func() {
 			invokeQuery(network, peer, orderer, channel, 80)
 			invokeQuery(network, peer, orderer, channel, 70)
 			invokeQuery(network, peer, orderer, channel, 60)
-
 		})
 		It("smartbft node addition and removal", func() {
 			networkConfig := nwo.MultiNodeSmartBFT()

--- a/integration/smartbft/smartbft_test.go
+++ b/integration/smartbft/smartbft_test.go
@@ -17,7 +17,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -2923,7 +2922,6 @@ func renewOrdererTLSCertificates(network *nwo.Network, orderers ...*nwo.Orderer)
 	for filePath, certPEM := range serverTLSCerts {
 		renewedCert := renewCertificate(certPEM, ordererTLSCACert, ordererTLSCAKey, time.Now().Add(time.Hour))
 		err = os.WriteFile(filePath, renewedCert, 0o600)
-		log.Printf("Previous cert %s and next cert %s for orderer", string(certPEM), string(renewedCert))
 		Expect(err).NotTo(HaveOccurred())
 	}
 }

--- a/integration/smartbft/smartbft_test.go
+++ b/integration/smartbft/smartbft_test.go
@@ -181,7 +181,7 @@ var _ = Describe("EndToEnd Smart BFT configuration test", func() {
 			var ordererRunners []*ginkgomon.Runner
 			for _, orderer := range network.Orderers {
 				runner := network.OrdererRunner(orderer)
-				runner.Command.Env = append(runner.Command.Env, "FABRIC_LOGGING_SPEC=orderer.common.cluster=debug:orderer.consensus.smartbft=debug:policies.ImplicitOrderer=debug")
+				runner.Command.Env = append(runner.Command.Env, "FABRIC_LOGGING_SPEC=orderer.consensus.smartbft=debug:grpc=debug")
 				ordererRunners = append(ordererRunners, runner)
 				proc := ifrit.Invoke(runner)
 				ordererProcesses = append(ordererProcesses, proc)

--- a/orderer/common/cluster/clusterservice.go
+++ b/orderer/common/cluster/clusterservice.go
@@ -13,7 +13,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"log"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -213,7 +212,6 @@ func compareCertPublicKeys(cert1, cert2 []byte) (bool, error) {
 
 	publicKey1, err := extractPublicKeyFromCert(bl.Bytes)
 	if err != nil {
-		log.Printf("Failed to extract public key from own certificate: %v", err)
 		return false, err
 	}
 
@@ -318,17 +316,6 @@ func (c *ClusterService) ConfigureNodeCerts(channel string, newNodes []*common.C
 		if err != nil {
 			return err
 		}
-
-		// // Extract public key using the same approach as IsConsenterOfChannel
-		// bl, _ := pem.Decode(sanitizedID)
-		// if bl == nil {
-		// 	return errors.Errorf("node identity certificate %s is not a valid PEM", string(sanitizedID))
-		// }
-
-		// publicKey, err := extractPublicKeyFromCert(bl.Bytes)
-		// if err != nil {
-		// 	return err
-		// }
 
 		channelMembership.MemberMapping[uint64(nodeIdentity.Id)] = sanitizedID
 	}

--- a/orderer/common/cluster/clusterservice.go
+++ b/orderer/common/cluster/clusterservice.go
@@ -189,9 +189,7 @@ func (s *ClusterService) VerifyAuthRequest(stream orderer.ClusterNodeService_Ste
 		return nil, errors.Wrap(err, "failed to compare cert public keys")
 	}
 	if !equal {
-		s.Logger.Infof("node id mismatch: %d", authReq.FromId)
-		s.Logger.Infof("toIdentity: %s", string(toIdentity))
-		s.Logger.Infof("s.NodeIdentity: %s", string(s.NodeIdentity))
+		s.Logger.Debugf("node id mismatch for node %d, toIdentity: %s, s.NodeIdentity: %s", authReq.FromId, string(toIdentity), string(s.NodeIdentity))
 		return nil, errors.Errorf("node id mismatch")
 	}
 

--- a/orderer/common/cluster/clusterservice.go
+++ b/orderer/common/cluster/clusterservice.go
@@ -163,7 +163,7 @@ func (s *ClusterService) VerifyAuthRequest(stream orderer.ClusterNodeService_Ste
 		return nil, errors.Errorf("node %d is not member of channel %s", authReq.ToId, authReq.Channel)
 	}
 
-	equal, err := compareCertPublicKeys(toIdentity, s.NodeIdentity)
+	equal, err := CompareCertPublicKeys(toIdentity, s.NodeIdentity)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to compare cert public keys")
 	}

--- a/orderer/common/cluster/util.go
+++ b/orderer/common/cluster/util.go
@@ -118,7 +118,7 @@ func (mp MemberMapping) LookupByClientCert(cert []byte) *Stub {
 // LookupByIdentity retrieves a Stub by Identity
 func (mp MemberMapping) LookupByIdentity(identity []byte) *Stub {
 	for _, stub := range mp.id2stub {
-		equal, err := compareCertPublicKeys(identity, stub.Identity)
+		equal, err := CompareCertPublicKeys(identity, stub.Identity)
 		if err != nil {
 			continue
 		}
@@ -838,7 +838,7 @@ func ExtractPublicKeyFromCert(der []byte) ([]byte, error) {
 	return x509.MarshalPKIXPublicKey(cert.PublicKey)
 }
 
-func compareCertPublicKeys(cert1, cert2 []byte) (bool, error) {
+func CompareCertPublicKeys(cert1, cert2 []byte) (bool, error) {
 	// Extract public key using the same approach as IsConsenterOfChannel
 	bl, _ := pem.Decode(cert1)
 	if bl == nil {

--- a/orderer/common/cluster/util.go
+++ b/orderer/common/cluster/util.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"log"
 	"math/rand/v2"
 	"strconv"
 	"sync"
@@ -121,7 +120,6 @@ func (mp MemberMapping) LookupByIdentity(identity []byte) *Stub {
 	for _, stub := range mp.id2stub {
 		equal, err := compareCertPublicKeys(identity, stub.Identity)
 		if err != nil {
-			log.Printf("Failed to compare cert public keys: %v", err)
 			continue
 		}
 		if equal {

--- a/orderer/common/cluster/util.go
+++ b/orderer/common/cluster/util.go
@@ -179,10 +179,7 @@ func (dialer *PredicateDialer) Dial(address string, verifyFunc RemoteVerifier) (
 	clientConfigCopy := dialer.Config
 	dialer.lock.RUnlock()
 
-	clientConfigCopy.SecOpts.VerifyCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-		log.Printf("Verifying certificate: %v", rawCerts)
-		return nil
-	}
+	clientConfigCopy.SecOpts.VerifyCertificate = verifyFunc
 	return clientConfigCopy.Dial(address)
 }
 
@@ -205,7 +202,7 @@ type StandardDialer struct {
 func (dialer *StandardDialer) Dial(endpointCriteria EndpointCriteria) (*grpc.ClientConn, error) {
 	clientConfigCopy := dialer.Config
 	clientConfigCopy.SecOpts.ServerRootCAs = endpointCriteria.TLSRootCAs
-	log.Printf("Dialing %s", endpointCriteria.Endpoint)
+
 	return clientConfigCopy.Dial(endpointCriteria.Endpoint)
 }
 

--- a/orderer/consensus/smartbft/block_puller_factory.go
+++ b/orderer/consensus/smartbft/block_puller_factory.go
@@ -64,7 +64,7 @@ func newBlockPuller(
 		vb := cluster.BlockVerifierBuilder(bccsp)
 		return cluster.VerifyBlocksBFT(blocks, support.SignatureVerifier(), vb)
 	}
-	// Dialer without predicate
+
 	stdDialer := &cluster.StandardDialer{
 		Config: baseDialer.Config.Clone(),
 	}

--- a/orderer/consensus/smartbft/block_puller_factory.go
+++ b/orderer/consensus/smartbft/block_puller_factory.go
@@ -9,7 +9,6 @@ package smartbft
 import (
 	"crypto/x509"
 	"encoding/pem"
-	"log"
 
 	"github.com/hyperledger/fabric-lib-go/bccsp"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
@@ -70,10 +69,7 @@ func newBlockPuller(
 		Config: baseDialer.Config.Clone(),
 	}
 	stdDialer.Config.AsyncConnect = false
-	stdDialer.Config.SecOpts.VerifyCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-		log.Printf("Verifying certificate: %v", rawCerts)
-		return nil
-	}
+	stdDialer.Config.SecOpts.VerifyCertificate = nil
 
 	// Extract the TLS CA certs and endpoints from the configuration,
 	endpoints, err := etcdraft.EndpointconfigFromSupport(support, bccsp)

--- a/orderer/consensus/smartbft/block_puller_factory.go
+++ b/orderer/consensus/smartbft/block_puller_factory.go
@@ -9,6 +9,7 @@ package smartbft
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"log"
 
 	"github.com/hyperledger/fabric-lib-go/bccsp"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
@@ -64,12 +65,15 @@ func newBlockPuller(
 		vb := cluster.BlockVerifierBuilder(bccsp)
 		return cluster.VerifyBlocksBFT(blocks, support.SignatureVerifier(), vb)
 	}
-
+	// Dialer without predicate
 	stdDialer := &cluster.StandardDialer{
 		Config: baseDialer.Config.Clone(),
 	}
 	stdDialer.Config.AsyncConnect = false
-	stdDialer.Config.SecOpts.VerifyCertificate = nil
+	stdDialer.Config.SecOpts.VerifyCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		log.Printf("Verifying certificate: %v", rawCerts)
+		return nil
+	}
 
 	// Extract the TLS CA certs and endpoints from the configuration,
 	endpoints, err := etcdraft.EndpointconfigFromSupport(support, bccsp)

--- a/orderer/consensus/smartbft/consenter.go
+++ b/orderer/consensus/smartbft/consenter.go
@@ -372,10 +372,9 @@ func (c *Consenter) detectSelfID(consenters []*cb.Consenter) (uint64, error) {
 		}
 
 		if crypto.CertificatesWithSamePublicKey(thisNodeCertAsDER, certAsDER) == nil {
-			c.Logger.Infof("Found node %d in channel consenters set", cst.Id)
+			c.Logger.Debugf("Found node %d in channel consenters set", cst.Id)
 			return uint64(cst.Id), nil
 		}
-		c.Logger.Infof("Node %d certificate: %s", cst.Id, string(cst.Identity))
 	}
 
 	c.Logger.Warning("Could not find", string(c.Comm.NodeIdentity), "among", serverCertificates)

--- a/orderer/consensus/smartbft/consenter.go
+++ b/orderer/consensus/smartbft/consenter.go
@@ -283,7 +283,6 @@ func (c *Consenter) IsChannelMember(joinBlock *cb.Block) (bool, error) {
 	}
 
 	for _, consenter := range oc.Consenters() {
-		c.Logger.Infof("Consenter %d: %s", consenter.Id, string(consenter.Identity))
 		santizedCert, err := crypto.SanitizeX509Cert(consenter.Identity)
 		if err != nil {
 			c.Logger.Debugf("Failed to sanitize consenter %d identity: %v", consenter.Id, err)


### PR DESCRIPTION
#### Type of change

Improvement

#### Description

This PR allows enrollment certificates of BFT orderers to be renewed without having to do a channel configuration update, as long as the renewed certificates have the same public key.


#### Related issues

No related issues

#### Release Note

Added support for seamless enrollment certificate renewal in orderer clusters when public keys remain unchanged. This prevents connection failures and NOT_FOUND errors during certificate rotation operations.
