### PR TITLE
CVE-2025-27516 - updated jinja2 to 3.1.6

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,7 @@ docutils==0.21.2
 idna==3.10
 imagesize==1.4.1
 importlib-metadata==8.5.0
-Jinja2==3.1.5
+Jinja2==3.1.6
 markdown-it-py==3.0.0
 MarkupSafe==3.0.1
 mdit-py-plugins==0.4.2


### PR DESCRIPTION
#### Type of change
CVE-2025-27516 - updated jinja2 to 3.1.6

#### Description
CVE-2025-27516 (High) detected in jinja2-3.1.5-py3-none-any.whl
https://github.com/GNS3/gns3-server/issues/2515