### PR TITLE
Add non-root user to Dockerfiles for security

### DIFF
--- a/images/orderer/Dockerfile
+++ b/images/orderer/Dockerfile
@@ -57,6 +57,10 @@ ARG FABRIC_VER
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 
+# Create a non-root user for running the orderer
+RUN groupadd --gid 500 fabric && \
+    useradd -c "Hyperledger Fabric Orderer User" -u 500 -g 500 -d /home/fabric -m fabric
+
 ENV FABRIC_CFG_PATH=/etc/hyperledger/fabric
 ENV FABRIC_VER=${FABRIC_VER}
 
@@ -68,5 +72,8 @@ VOLUME  /etc/hyperledger/fabric
 VOLUME  /var/hyperledger
 
 EXPOSE  7050
+
+# Switch to non-root user
+USER    fabric
 
 CMD     [ "orderer", "start" ]

--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -60,6 +60,10 @@ ARG FABRIC_VER
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 
+# Create a non-root user for running the peer
+RUN groupadd --gid 500 fabric && \
+    useradd -c "Hyperledger Fabric Peer User" -u 500 -g 500 -d /home/fabric -m fabric
+
 ENV FABRIC_CFG_PATH=/etc/hyperledger/fabric
 ENV FABRIC_VER=${FABRIC_VER}
 
@@ -72,5 +76,8 @@ VOLUME  /etc/hyperledger/fabric
 VOLUME  /var/hyperledger
 
 EXPOSE  7051
+
+# Switch to non-root user
+USER    fabric
 
 CMD     [ "peer", "node", "start" ]

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -69,6 +69,10 @@ ENV PATH="/usr/local/go/bin:$PATH"
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 
+# Create a non-root user for running the tools
+RUN groupadd --gid 500 fabric && \
+    useradd -c "Hyperledger Fabric Tools User" -u 500 -g 500 -d /home/fabric -m fabric
+
 ENV     FABRIC_CFG_PATH /etc/hyperledger/fabric
 ENV     FABRIC_VER      ${FABRIC_VER}
 
@@ -77,3 +81,6 @@ COPY    --from=builder  build/bin       /usr/local/bin
 
 VOLUME  /etc/hyperledger/fabric
 VOLUME  /var/hyperledger
+
+# Switch to non-root user
+USER    fabric


### PR DESCRIPTION
Add non-root user to Dockerfiles for security

#### Type of change

- Bug fix

#### Description

This PR addresses security issue #5070 by adding non-root users to the peer, orderer, and tools Dockerfiles. The containers were previously running as root, which is a security risk. This fix creates a dedicated `fabric` user with UID/GID 500 and switches to that user before executing the container commands.

The changes include:
- Adding user creation commands to create the `fabric` user
- Adding `USER fabric` directive to switch from root to non-root user
- Maintaining consistency with the existing baseos Dockerfile pattern
- Preserving all existing volume mounts and functionality

#### Additional details

**Files Modified:**
- `images/peer/Dockerfile`
- `images/orderer/Dockerfile` 
- `images/tools/Dockerfile`

**Security Impact:**
- Prevents containers from running as root user
- Reduces potential attack surface
- Follows Docker security best practices
- Addresses security scanning findings

**Technical Implementation:**
```dockerfile
# Create a non-root user for running the container
RUN groupadd --gid 500 fabric && \
    useradd -c "Hyperledger Fabric User" -u 500 -g 500 -d /home/fabric -m fabric

# Switch to non-root user
USER    fabric
```

**Testing:**
- Verified that the user creation commands work correctly
- Confirmed that the USER directive is placed after all necessary file operations
- Ensured compatibility with existing volume mounts at `/etc/hyperledger/fabric` and `/var/hyperledger`

#### Related issues

Fixes #5070 - Dockerfile doesn't specify USER