### PR TITLE
[FAB-5265] Fix incorrect log message in computeTargetHeight

### DIFF
--- a/orderer/consensus/smartbft/synchronizer_bft.go
+++ b/orderer/consensus/smartbft/synchronizer_bft.go
@@ -171,7 +171,7 @@ func (s *BFTSynchronizer) computeTargetHeight(heights []uint64) uint64 {
 	s.Logger.Debugf("Cluster size: %d, F: %d, Heights: %v", clusterSize, f, heights)
 
 	if lenH < f+1 {
-		s.Logger.Debugf("Returning %d", heights[0])
+		s.Logger.Debugf("Returning %d", heights[int(lenH)-1])
 		return heights[int(lenH)-1]
 	}
 	s.Logger.Debugf("Returning %d", heights[f])


### PR DESCRIPTION
In fabric-3.0.0/orderer/consensus/smartbft/synchronizer_bft.go, the debug log incorrectly stated it was returning heights[0] (highest height) when in fact the code returned heights[len(heights)-1] (lowest height).

This commit updates the log message to correctly reflect the actual return value. (See #5265)

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

In fabric-3.0.0/orderer/consensus/smartbft/synchronizer_bft.go, the debug log incorrectly stated it was returning heights[0] (highest height) when in fact the code returned heights[len(heights)-1] (lowest height)

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Github issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
