### PR TITLE
Fix: destination directory variable in install script doesn't handle whitespace

### DIFF
--- a/scripts/install-fabric.sh
+++ b/scripts/install-fabric.sh
@@ -252,7 +252,7 @@ download() {
        DEST_DIR="fabric-samples"
     fi
     echo "===> Will unpack to: ${DEST_DIR}"
-    curl -L --retry 5 --retry-delay 3 "${URL}" | tar xz -C ${DEST_DIR}|| rc=$?
+    curl -L --retry 5 --retry-delay 3 "${URL}" | tar xz -C "${DEST_DIR}"|| rc=$?
     if [ -n "$rc" ]; then
         echo "==> There was an error downloading the binary file."
         return 22


### PR DESCRIPTION
When the `DEST_DIR` variable contains whitespace, the script fails.

#### Type of change

- Bug fix

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

To reproduce:
- Create a directory that contains a space character in its name.
- Download installation script.
- Run the installation script.

<img width="1308" height="757" alt="image" src="https://github.com/user-attachments/assets/2c17e1ae-621c-4ba3-a39f-d68b177d6cf7" />

Tested by making the change seen in the commit, then running the script.

<img width="1317" height="808" alt="image" src="https://github.com/user-attachments/assets/6db57fc4-286a-4c40-969a-c0e611457526" />
