### PR TITLE
fix broken link check

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -24,12 +24,20 @@ jobs:
     steps:
       - name: Checkout Fabric Code
         uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-      - name: Install Muffet
-        run: go install github.com/raviqqe/muffet/v2@latest
       - name: Check Broken Links with Muffet
         # Exclude any links that direct to the documentation or release notes of the non-latest version to limit the scanning to target to that of the latest version.
-        run: muffet --max-response-body-size=100000000 --rate-limit=10 --timeout=20 --buffer-size=2147483647 --color=always --exclude="^(https:\/\/hyperledger-fabric.readthedocs.io\/[A-z_]+\/(v[\d]+.[\d]+.[\d]+|release)).*$" https://hyperledger-fabric.readthedocs.io/en/latest/
+        run: |
+          docker run raviqqe/muffet:2.11.0 \
+          --max-response-body-size=100000000 \
+          --header="User-Agent: curl/8.7.1" \
+          --header="Accept: */*" \
+          --rate-limit=1 \
+          --ignore-fragments \
+          --skip-tls-verification \
+          --max-connections-per-host=1 \
+          --timeout=20 \
+          --buffer-size=2147483647 \
+          --color=always \
+          --exclude="^(https:\/\/hyperledger-fabric.readthedocs.io\/([A-z_]+\/(v[\d]+.[\d]+.[\d]+|release)|(es|fa|fr|it|ja|ko|ml|pt|ru|vi|zh-cn|zh_CN)\/latest)).*$" \
+          --exclude="https://github.com/YOURGITHUBID/fabric-docs-i18n/pull/new/newtranslation" \
+          https://hyperledger-fabric.readthedocs.io/en/latest/


### PR DESCRIPTION
- added headers so that some sites skip the request rather than return a 403 error (yes, not for everyone, but I'll deal with this later)
- site https://hyperledger-fabric.readthedocs.io / has a limit of 60 requests per minute, configured so that the number of requests does not exceed this limit. Error 429 on this site has gone away.
- added exceptions so that the crawl takes place only in /en/latest/, because, for example, /zh-cn/latest/ is located in another repository.

Now it will be possible to work with it.:
- handle 404 errors
- handle 403 errors
