### PR TITLE
fixed some links 404 error

### DIFF
--- a/docs/source/deploy_chaincode.md
+++ b/docs/source/deploy_chaincode.md
@@ -229,7 +229,7 @@ async CreateAsset(ctx, id, color, size, owner, appraisedValue) {
     }
 ```
 
-You can learn more about the JavaScript contract API by visiting the [API documentation](https://hyperledger.github.io/fabric-chaincode-node/{BRANCH}/api/) and the [smart contract processing topic](developapps/smartcontract.html).
+You can learn more about the JavaScript contract API by visiting the [API documentation](https://hyperledger.github.io/fabric-chaincode-node/{BRANCH}/api/).
 
 To install the smart contract dependencies, run the following command from the `asset-transfer-basic/chaincode-javascript` directory.
 

--- a/docs/source/international_languages.md
+++ b/docs/source/international_languages.md
@@ -217,12 +217,6 @@ order of translation in your workgroup.
   Fabric.
 
 
-* [Developing applications](https://hyperledger-fabric.readthedocs.io/en/{BRANCH_DOC}/developapps/developing_applications.html)
-
-  This topic helps developers write smart contracts and applications; these
-  are the core elements of any solution that uses Fabric.
-
-
 * [Tutorials](https://hyperledger-fabric.readthedocs.io/en/{BRANCH_DOC}/tutorials.html)
 
   A set of hands-on tutorials to help developers and administrators try out

--- a/docs/source/ledger/ledger.md
+++ b/docs/source/ledger/ledger.md
@@ -129,9 +129,7 @@ notified when the transaction has been included in the blockchain (whether valid
 or invalid). The key design point is that only transactions that are **signed**
 by the required set of **endorsing organizations** will result in an update to
 the world state. If a transaction is not signed by sufficient endorsers, it will
-not result in a change of world state. You can read more about how applications
-use [smart contracts](../smartcontract/smartcontract.html), and how to [develop
-applications](../developapps/developing_applications.html).
+not result in a change of world state.
 
 You'll also notice that a state has a version number, and in the diagram above,
 states CAR1 and CAR2 are at their starting versions, 0. The version number is for
@@ -374,8 +372,7 @@ chaincodes. World states are in a namespace so that only smart contracts within
 the same chaincode can access a given namespace.
 
 A blockchain is not namespaced. It contains transactions from many different
-smart contract namespaces. You can read more about chaincode namespaces in this
-[topic](../developapps/chaincodenamespace.html).
+smart contract namespaces.
 
 Let's now look at how the concept of a namespace is applied within a Hyperledger
 Fabric channel.
@@ -387,9 +384,6 @@ separate ledger. This means a completely separate blockchain, and completely
 separate world states, including namespaces. It is possible for applications and
 smart contracts to communicate between channels so that ledger information can
 be accessed between them.
-
-You can read more about how ledgers work with channels in this
-[topic](../developapps/chaincodenamespace.html#channels).
 
 
 ## More information

--- a/docs/source/network/network.md
+++ b/docs/source/network/network.md
@@ -94,8 +94,6 @@ We can see that our peer organizations, R1 and R2, are fully participating in th
 
 Note: Fabric v2.3 SDKs embed the logic of the v2.4 Fabric Gateway service in the client application --- refer to the [v2.3 Applications and Peers](https://hyperledger-fabric.readthedocs.io/en/release-2.3/peers/peers.html#applications-and-peers) topic for details.
 
-For more information about how to develop an application, check out [Developing applications](../developapps/developing_applications.html).
-
 ## Joining components to multiple channels
 
 Now that we have shown the process for how a channel is created, as well as the nature of the high level interactions between organizations, nodes, policies, chaincodes, and applications, let's expand our view by adding a new organization and a new channel to our scenario. To show how Fabric components can be joined to multiple channels, we'll join R2 and its peer, P2, to the new channel, while R1 and P1 will not be joined.

--- a/docs/source/smartcontract/smartcontract.md
+++ b/docs/source/smartcontract/smartcontract.md
@@ -139,9 +139,7 @@ might govern financial prices or delivery conditions, and express it as
 a smart contract in a programming language such as JavaScript, Go, or Java.
 The legal and technical skills required to convert centuries of legal language
 into programming language is increasingly practiced by **smart contract
-auditors**. You can learn about how to design and develop a smart contract in
-the [Developing applications
-topic](../developapps/developing_applications.html).
+auditors**.
 
 
 ## Endorsement
@@ -227,10 +225,6 @@ updated to `ORG2`. However, `t4` (not shown) is an invalid transaction, so while
 it was recorded in the ledger, the world state was not updated, and `CAR2`
 remains owned by `ORG2`.
 
-Finally, to understand how to use a smart contract or chaincode with world
-state, read the [chaincode namespace
-topic](../developapps/chaincodenamespace.html).
-
 ## Channels
 
 Hyperledger Fabric allows an organization to simultaneously participate in
@@ -286,8 +280,7 @@ channel and across different channels. It this way, they can read and write
 world state data to which they would not otherwise have access due to smart
 contract namespaces.
 
-There are limitations to this inter-contract communication, which are described
-fully in the [chaincode namespace](../developapps/chaincodenamespace.html#cross-chaincode-access) topic.
+There are limitations to this inter-contract communication.
 
 ## System chaincode
 
@@ -311,9 +304,7 @@ abbreviations:
   [topic](../configtx.html#configuration-updates).
 
 * **Query system chaincode (QSCC)** runs in all peers to provide ledger APIs which
-  include block query, transaction query etc. You can read more about these
-  ledger APIs in the transaction context
-  [topic](../developapps/transactioncontext.html).
+  include block query, transaction query etc.
 
 * **Endorsement system chaincode (ESCC)** runs in endorsing peers to
   cryptographically sign a transaction response. You can read more about how


### PR DESCRIPTION
The developapps folder was deleted from the documentation a long time ago, but the links remained. 
For now, I suggest deleting links to a non-existent folder.