### PR TITLE
Documentation update: Removed unnecessary 'a'

### DIFF
--- a/docs/source/deploypeer/peerplan.md
+++ b/docs/source/deploypeer/peerplan.md
@@ -8,7 +8,7 @@ Peer nodes are a fundamental element of a Fabric network because they host ledge
 
 ## Generate peer identities and Membership Service Providers (MSPs)
 
-Before proceeding with this topic, you should have reviewed the process for a [Deploying a Certificate Authority (CA)](https://hyperledger-fabric-ca.readthedocs.io/en/latest/deployguide/ca-deploy-topology.html) for your organization in order to generate the identities and MSPs for the admins and peers in your organization. To learn how to use a CA to create these identities, check out [Registering and enrolling identities with a CA](https://hyperledger-fabric-ca.readthedocs.io/en/latest/deployguide/use_CA.html)
+Before proceeding with this topic, you should have reviewed the process for [Deploying a Certificate Authority (CA)](https://hyperledger-fabric-ca.readthedocs.io/en/latest/deployguide/ca-deploy-topology.html) for your organization in order to generate the identities and MSPs for the admins and peers in your organization. To learn how to use a CA to create these identities, check out [Registering and enrolling identities with a CA](https://hyperledger-fabric-ca.readthedocs.io/en/latest/deployguide/use_CA.html)
 
 **Note that the “cryptogen” tool should never be used to generate any identities in a production scenario**.
 


### PR DESCRIPTION
#### Documentation update

#### Description
This commit fixes a small typo in the docs, where 'a' is not required.