### PR TITLE
chore: fix inaccurate comment for MergeWithPlurality function

### DIFF
--- a/common/policies/inquire/merge.go
+++ b/common/policies/inquire/merge.go
@@ -93,8 +93,8 @@ type comparablePrincipalSetPair struct {
 	containing ComparablePrincipalSet
 }
 
-// EnsurePlurality returns a ComparablePrincipalSet such that plurality requirements over
-// the contained ComparablePrincipalSet in the comparablePrincipalSetPair hold
+// MergeWithPlurality returns a ComparablePrincipalSet that merges the contained and containing
+// ComparablePrincipalSets in the comparablePrincipalSetPair while satisfying plurality requirements
 func (pair comparablePrincipalSetPair) MergeWithPlurality() ComparablePrincipalSet {
 	var principalsToAdd []*ComparablePrincipal
 	used := make(map[int]struct{})


### PR DESCRIPTION
<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->


- Documentation update

#### Description

<!--- Describe your changes in detail, including motivation. -->


The comment for the MergeWithPlurality function in merge.go has been corrected to accurately reflect its functionality. The previous comment incorrectly named the function as "EnsurePlurality" and did not properly describe what the function does. 

The updated comment clarifies that this function merges contained and containing ComparablePrincipalSets while satisfying plurality requirements, which provides a clearer understanding of its purpose and behavior.



#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Github issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
