### PR TITLE
fix(test): check os.WriteFile error in fileutil test

### DIFF
--- a/internal/fileutil/fileutil_test.go
+++ b/internal/fileutil/fileutil_test.go
@@ -51,7 +51,7 @@ func TestFileExists(t *testing.T) {
 
 		file := filepath.Join(testPath, "empty-file")
 		contents := []byte("some random contents")
-		os.WriteFile(file, contents, 0o644)
+		require.NoError(t, os.WriteFile(file, contents, 0o644))
 		exists, size, err := FileExists(file)
 		require.NoError(t, err)
 		require.True(t, exists)


### PR DESCRIPTION
<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->
## Need for Change:
This PR fixes a missing error check in a unit test.
In internal/fileutil/fileutil_test.go, the test case TestFileExists/file-with-content was calling os.WriteFile without checking its returned error. If the write failed (for example due to permission issues, disk errors, or a read-only filesystem), the test would continue assuming the file was written successfully. This could lead to misleading failures or false positives later in the test.
Other tests in the same file already validate os.WriteFile errors, so this change also improves consistency.

##Type of change:
- Bug fix

##Changes Made:
File: internal/fileutil/fileutil_test.go
Line: 54
Wrapped os.WriteFile with require.NoError(t, ...) to ensure the test fails immediately if the write operation fails.

##Impact:
-Prevents silent failures in the test
-Produces clearer and more accurate test results
-Improves consistency with existing test patterns
-No functional or behavioral changes to production code


##Steps to Reproduce
-In internal/fileutil/fileutil_test.go (line 54), os.WriteFile is called without checking its error return.
-Run the test:
 `go test -v ./internal/fileutil -run TestFileExists/file-with-content`
-Create a small test case (or environment) where the target directory is read-only or unwritable. In this scenario, os.WriteFile fails, but the test continues because the error is ignored.
After the fix, the test fails immediately when os.WriteFile returns an error.
Impact: Ignoring the error can cause tests to pass or fail for misleading reasons `wh`

