### PR TITLE
fix(gossip): stop membership tracker ticker on channel shutdown

### DIFF
--- a/gossip/gossip/channel/channel.go
+++ b/gossip/gossip/channel/channel.go
@@ -295,6 +295,7 @@ func NewGossipChannel(pkiID common.PKIidType, org api.OrgIdentityType, mcs api.M
 		getPeersToTrack: gc.GetPeers,
 		report:          gc.reportMembershipChanges,
 		stopChan:        make(chan struct{}, 1),
+		ticker:          ticker,
 		tickerChannel:   ticker.C,
 		metrics:         metrics,
 		chainID:         channelID,
@@ -314,6 +315,9 @@ func (gc *gossipChannel) reportMembershipChanges(input ...interface{}) {
 func (gc *gossipChannel) Stop() {
 	close(gc.stopChan)
 	close(gc.membershipTracker.stopChan)
+	if gc.membershipTracker.ticker != nil {
+		gc.membershipTracker.ticker.Stop()
+	}
 	gc.blocksPuller.Stop()
 	gc.stateInfoPublishScheduler.Stop()
 	gc.stateInfoRequestScheduler.Stop()
@@ -1082,6 +1086,7 @@ type membershipTracker struct {
 	getPeersToTrack func() []discovery.NetworkMember
 	report          func(...interface{})
 	stopChan        chan struct{}
+	ticker          *time.Ticker
 	tickerChannel   <-chan time.Time
 	metrics         *metrics.MembershipMetrics
 	chainID         common.ChannelID


### PR DESCRIPTION
## Bug Description:
A time.Ticker is created when initializing the membership tracker, but only the ticker’s channel is retained.
During shutdown, other resources are cleaned up, however the ticker itself is never stopped, violating Go’s ticker lifecycle requirements.

## Need for Change:
-The gossip channel creates a time.Ticker for membership tracking but does not stop it when the channel is shut down.
This leads to a resource leak where ticker goroutines continue running after the channel lifecycle has ended.

-In long-running peers or environments where gossip channels are frequently started and stopped, this can accumulate and cause unnecessary memory and CPU usage.

## Summary of Fix:
-This PR ensures proper cleanup of the membership tracker ticker by:
-Storing a reference to the created time.Ticker in the membership tracker
-Explicitly stopping the ticker during gossip channel shutdown
-Adding a nil check to safely handle cleanup
The fix is minimal and does not alter any existing behavior beyond proper resource management.

## Impact:
-Prevents goroutine and memory leaks
-Improves stability of long-running peers
-Ensures correct lifecycle management of background timers
-Particularly important when multiple gossip channels are created over time

## Verification:
-Existing gossip channel tests pass
-No linter or build errors
-Ticker is now correctly stopped during shutdown
-The issue was reproduced using a small standalone program that repeatedly starts and stops gossip channels and compares -goroutine counts before and after shutdown. A terminal screenshot demonstrating this behavior is attached.
<img width="1508" height="908" alt="Screenshot 2025-12-18 104221" src="https://github.com/user-attachments/assets/efd8be8a-94ea-4144-89f7-4c6ea732c1ea" />
A dedicated unit test was not added to avoid flaky goroutine-count assertions in CI environments.

 
