### PR TITLE
Fix BTF to BFT in test_network.md

### DIFF
--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -644,13 +644,13 @@ Resolve the issue with forbidden access to the Docker socket by either using Cha
         - label:disable
 ```
 
-### BTF ordering service on SELinux
+### BFT ordering service on SELinux
 
-If you want to start the test-network with the BTF ordering service on a Linux distribution with SELinux enabled you have to perform the changes listed above in the compose files with `*-btf-test-net.yaml` in their names instead of `*-test-net.yaml`:
+If you want to start the test-network with the BFT ordering service on a Linux distribution with SELinux enabled you have to perform the changes listed above in the compose files with `*-bft-test-net.yaml` in their names instead of `*-test-net.yaml`:
 - `test-network/compose/compose-ca.yaml`,
-- `test-network/compose/compose-btf-test-net.yaml`,
-- `test-network/compose/docker/docker-compose-btf-test-net.yaml` in case you use Docker
-- OR `test-network/compose/podman/podman-compose-btf-test-net.yaml` in case you use Podman.
+- `test-network/compose/compose-bft-test-net.yaml`,
+- `test-network/compose/docker/docker-compose-bft-test-net.yaml` in case you use Docker
+- OR `test-network/compose/podman/podman-compose-bft-test-net.yaml` in case you use Podman.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Corrected the acronym from BTF to BFT for clarity in the documentation regarding the ordering service on SELinux.

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Documentation update

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Github issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
