### PR TITLE
Fix missing error when certificate directory is empty

### DIFF
--- a/msp/configbuilder.go
+++ b/msp/configbuilder.go
@@ -177,8 +177,10 @@ func GetLocalMspConfig(dir string, bccspConfig *factory.FactoryOpts, ID string) 
 	}
 
 	signcert, err := getPemMaterialFromDir(signcertDir)
-	if err != nil || len(signcert) == 0 {
-		return nil, errors.Wrapf(err, "could not load a valid signer certificate from directory %s", signcertDir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not load signing certificate from directory %s", signcertDir)
+	} else if len(signcert) == 0 {
+		return nil, errors.Errorf("no signing certificate found in directory %s", signcertDir)
 	}
 
 	/* FIXME: for now we're making the following assumptions
@@ -214,8 +216,10 @@ func getMspConfig(dir string, ID string, sigid *msp.SigningIdentityInfo) (*msp.M
 	tlsintermediatecertsDir := filepath.Join(dir, tlsintermediatecerts)
 
 	cacerts, err := getPemMaterialFromDir(cacertDir)
-	if err != nil || len(cacerts) == 0 {
+	if err != nil {
 		return nil, errors.WithMessagef(err, "could not load a valid ca certificate from directory %s", cacertDir)
+	} else if len(cacerts) == 0 {
+		return nil, errors.Errorf("no ca certificate found in directory %s", cacertDir)
 	}
 
 	admincert, err := getPemMaterialFromDir(admincertDir)

--- a/msp/configbuilder_test.go
+++ b/msp/configbuilder_test.go
@@ -132,3 +132,46 @@ func TestReadFileUtils(t *testing.T) {
 	_, err = readPemFile("/dev/null")
 	require.Error(t, err)
 }
+
+func TestGetPemMaterialEmptyDir(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// test reading pem material from an empty dir success, but returns empty slice
+	pemdata, err := getPemMaterialFromDir(tempDir)
+	require.NoError(t, err)
+	require.Empty(t, pemdata)
+}
+
+func TestGetMspConfigEmptyDir(t *testing.T) {
+	tempDir := t.TempDir()
+	// try to read certificates from a directoriy that do not exist
+	mspConf, err := getMspConfig(tempDir, "SampleOrg", nil)
+	require.ErrorContains(t, err, "could not load a valid ca certificate from directory")
+	require.Nil(t, mspConf)
+
+	// create a cacerts dir in tempDir
+	err = os.MkdirAll(filepath.Join(tempDir, cacerts), 0o755)
+	require.NoError(t, err)
+
+	// try to read certificates from an empty cacerts dir
+	mspConf, err = getMspConfig(tempDir, "SampleOrg", nil)
+	require.ErrorContains(t, err, "no ca certificate found in directory")
+	require.Nil(t, mspConf)
+}
+
+func TestGetLocalMspConfigEmptyDir(t *testing.T) {
+	tempDir := t.TempDir()
+	// try to read signing certificate from a directoriy that do not exist
+	mspConf, err := GetLocalMspConfig(tempDir, nil, "SampleOrg")
+	require.ErrorContains(t, err, "could not load signing certificate from directory")
+	require.Nil(t, mspConf)
+
+	// create a signcerts dir in tempDir
+	err = os.MkdirAll(filepath.Join(tempDir, signcerts), 0o755)
+	require.NoError(t, err)
+
+	// try to read certificates from an empty signcerts dir
+	mspConf, err = GetLocalMspConfig(tempDir, nil, "SampleOrg")
+	require.ErrorContains(t, err, "no signing certificate found in directory")
+	require.Nil(t, mspConf)
+}


### PR DESCRIPTION
#### Type of change

Improvement to code

#### Description

The goal of this code change is to correctly return an error when the directory contains no certificates.

#### Additional details

The function `getPemMaterialFromDir` returns a nil error and an empty list of certificates when the directory contains no certificates. As a result, calling `errors.Wrapf` or `errors.WithMessagef` with a nil error produces a nil error, and no error is propagated. The proposed fix addresses this issue by explicitly handling this case and ensuring that an appropriate error is returned.
