### PR TITLE
fix(ledger): prevent panic on snapshot manager shutdown

### DIFF
--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -293,6 +293,7 @@ func (l *kvLedger) initSnapshotMgr(initializer *lgrInitializer) error {
 		events:                    make(chan *event),
 		commitProceed:             make(chan struct{}),
 		requestResponses:          make(chan *requestResponse),
+		stopCh:                    make(chan struct{}),
 	}
 
 	bcInfo, err := l.blockStore.GetBlockchainInfo()


### PR DESCRIPTION
#### Type of change
- Bug fix


#### Description
This PR fixes a shutdown race in the ledger snapshot manager that could cause a peer to panic.

Snapshot generation runs asynchronously in goroutines. If a peer shuts down while a snapshot is still in progress, those goroutines could attempt to send events on the events channel after it has been closed in shutdown(), resulting in a send on closed channel panic.

The fix coordinates snapshot goroutines with shutdown so that no sends occur after shutdown begins.


#### Additional details
Snapshot goroutines are now tracked and are signaled to stop during shutdown.
shutdown() waits for in-flight snapshot work to finish before closing channels.

Tested locally with `go test ./core/ledger/kvledger/...`

#### Release Note
Fixes a shutdown race in the ledger snapshot manager that could cause a peer
panic when snapshots are generated during shutdown.