### PR TITLE
Fix panic on send to closed channel during snapshot shutdown

### DIFF
--- a/core/ledger/kvledger/kv_ledger.go
+++ b/core/ledger/kvledger/kv_ledger.go
@@ -293,6 +293,7 @@ func (l *kvLedger) initSnapshotMgr(initializer *lgrInitializer) error {
 		events:                    make(chan *event),
 		commitProceed:             make(chan struct{}),
 		requestResponses:          make(chan *requestResponse),
+		stopCh:                    make(chan struct{}),
 	}
 
 	bcInfo, err := l.blockStore.GetBlockchainInfo()

--- a/core/ledger/kvledger/snapshot_mgmt.go
+++ b/core/ledger/kvledger/snapshot_mgmt.go
@@ -41,6 +41,8 @@ type snapshotMgr struct {
 	events                    chan *event
 	commitProceed             chan struct{}
 	requestResponses          chan *requestResponse
+	stopCh                    chan struct{}
+	wg                        sync.WaitGroup
 	stopped                   bool
 	shutdownLock              sync.Mutex
 }
@@ -134,14 +136,19 @@ func (l *kvLedger) processSnapshotMgmtEvents(lastCommittedBlockNumber uint64) {
 				continue
 			}
 			snapshotInProgress = true
+			l.snapshotMgr.wg.Add(1)
 			go func() {
+				defer l.snapshotMgr.wg.Done()
 				logger.Infow("Generating snapshot", "channelID", l.ledgerID, "lastCommittedBlockNumber", lastCommittedBlockNumber)
 				if err := l.generateSnapshot(); err != nil {
 					logger.Errorw("Failed to generate snapshot", "channelID", l.ledgerID, "lastCommittedBlockNumber", lastCommittedBlockNumber, "error", err)
 				} else {
 					logger.Infow("Generated snapshot", "channelID", l.ledgerID, "lastCommittedBlockNumber", lastCommittedBlockNumber)
 				}
-				events <- &event{snapshotDone, lastCommittedBlockNumber}
+				select {
+				case events <- &event{snapshotDone, lastCommittedBlockNumber}:
+				case <-l.snapshotMgr.stopCh:
+				}
 			}()
 
 		case snapshotDone:
@@ -194,14 +201,19 @@ func (l *kvLedger) processSnapshotMgmtEvents(lastCommittedBlockNumber uint64) {
 
 			if committerStatus == idle && requestedBlockNum == lastCommittedBlockNumber {
 				snapshotInProgress = true
+				l.snapshotMgr.wg.Add(1)
 				go func() {
+					defer l.snapshotMgr.wg.Done()
 					logger.Infow("Generating snapshot", "channelID", l.ledgerID, "lastCommittedBlockNumber", lastCommittedBlockNumber)
 					if err := l.generateSnapshot(); err != nil {
 						logger.Errorw("Failed to generate snapshot", "channelID", l.ledgerID, "lastCommittedBlockNumber", lastCommittedBlockNumber, "error", err)
 					} else {
 						logger.Infow("Generated snapshot", "channelID", l.ledgerID, "lastCommittedBlockNumber", lastCommittedBlockNumber)
 					}
-					events <- &event{snapshotDone, requestedBlockNum}
+					select {
+					case events <- &event{snapshotDone, requestedBlockNum}:
+					case <-l.snapshotMgr.stopCh:
+					}
 				}()
 			}
 			requestResponses <- &requestResponse{}
@@ -248,10 +260,8 @@ func (l *kvLedger) snapshotExists(blockNum uint64) (bool, error) {
 	return stat != nil, nil
 }
 
-// shutdown sends a snapshotMgrShutdown event and close all the channels, which is called
-// when the ledger is closed. For simplicity, this function does not consider in-progress commit
-// or snapshot generation. The caller should make sure there is no in-progress commit or
-// snapshot generation. Otherwise, it may cause panic because the channels have been closed.
+// shutdown signals all goroutines to stop, waits for in-flight snapshot operations to complete,
+// and closes all channels.
 func (m *snapshotMgr) shutdown() {
 	m.shutdownLock.Lock()
 	defer m.shutdownLock.Unlock()
@@ -261,6 +271,8 @@ func (m *snapshotMgr) shutdown() {
 	}
 
 	m.stopped = true
+	close(m.stopCh)
+	m.wg.Wait()
 	m.events <- &event{typ: snapshotMgrShutdown}
 	close(m.events)
 	close(m.commitProceed)


### PR DESCRIPTION
#### Type of change
- Bug fix


#### Description
This PR fixes a shutdown race in the ledger snapshot manager that could cause a peer panic.

Snapshot generation runs asynchronously in background goroutines. If the peer shuts down while a snapshot is still in progress, snapshotMgr.shutdown() could close internal channels before those goroutines finish, leading to a send on closed channel panic.

The fix coordinates shutdown with in-flight snapshot goroutines so shutdown is safe even when snapshot generation is ongoing.


#### Additional details
The snapshot manager now signals shutdown to background goroutines and waits for them to exit before closing channels.

Tested locally with `go test ./core/ledger/kvledger/....`
Also ran `go test ./core/ledger/kvledger -run Snapshot -v`
<img width="942" height="160" alt="image" src="https://github.com/user-attachments/assets/6bef4acc-dc43-47d1-a2f8-30ef58456197" />


#### Release Note
Fixes a shutdown race in the ledger snapshot manager that could cause a peer
panic when snapshots are generated during shutdown.