### PR TITLE
Update default Fabric CA version to 1.5.17

### DIFF
--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -44,7 +44,7 @@ Run the script with the `-h` option to see the options:
 Usage: ./install-fabric.sh [-f|--fabric-version <arg>] [-c|--ca-version <arg>] <comp-1> [<comp-2>] ... [<comp-n>] ...
         <comp>: Component to install one or more of  d[ocker]|b[inary]|s[amples]. If none specified, all will be installed
         -f, --fabric-version: FabricVersion (default: '2.5.14')
-        -c, --ca-version: Fabric CA Version (default: '1.5.15')
+        -c, --ca-version: Fabric CA Version (default: '1.5.17')
 ```
 
 ## Choosing which components

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,7 +8,7 @@
 # if version not passed in, default to latest released version
 VERSION=2.5.14
 # if ca version not passed in, default to latest released version
-CA_VERSION=1.5.15
+CA_VERSION=1.5.17
 
 REGISTRY=${FABRIC_DOCKER_REGISTRY:-docker.io/hyperledger}
 
@@ -30,8 +30,8 @@ printHelp() {
     echo "-s : bypass fabric-samples repo clone"
     echo "-b : bypass download of platform-specific binaries"
     echo
-    echo "e.g. bootstrap.sh 2.5.14 1.5.15 -s"
-    echo "will download docker images and binaries for Fabric v2.5.14 and Fabric CA v1.5.15"
+    echo "e.g. bootstrap.sh 2.5.14 1.5.17 -s"
+    echo "will download docker images and binaries for Fabric v2.5.14 and Fabric CA v1.5.17"
 }
 
 # dockerPull() pulls docker images from fabric and chaincode repositories

--- a/scripts/install-fabric.sh
+++ b/scripts/install-fabric.sh
@@ -22,7 +22,7 @@ _arg_comp=('' )
 # if version not passed in, default to latest released version
 # if ca version not passed in, default to latest released version
 _arg_fabric_version="2.5.14"
-_arg_ca_version="1.5.15"
+_arg_ca_version="1.5.17"
 
 OS=$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')
 ARCH=$(uname -m | sed 's/x86_64/amd64/g' | sed 's/aarch64/arm64/g')
@@ -57,7 +57,7 @@ print_help()
 	printf 'Usage: %s [-f|--fabric-version <arg>] [-c|--ca-version <arg>] <comp-1> [<comp-2>] ... [<comp-n>] ...\n' "$0"
 	printf '\t%s\n' "<comp> Component to install, one or more of  docker | binary | samples | podman  First letter of component also accepted; If none specified docker | binary | samples is assumed"
 	printf '\t%s\n' "-f, --fabric-version: FabricVersion (default: '2.5.14')"
-	printf '\t%s\n' "-c, --ca-version: Fabric CA Version (default: '1.5.15')"
+	printf '\t%s\n' "-c, --ca-version: Fabric CA Version (default: '1.5.17')"
 }
 
 


### PR DESCRIPTION
This change updates the Fabric install scripts to change the default CA version to install.