### PR TITLE
docs: clarify minimum Go version requirement

### DIFF
--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -1,6 +1,12 @@
 What's new in Hyperledger Fabric
 ================================
 
+.. note::
+
+   Hyperledger Fabric requires a minimum Go version as specified in ``go.mod``.
+   Using an older Go version may result in build or linter failures when running Fabric
+   ``make`` targets.
+
 What's New in Hyperledger Fabric v3.1
 -------------------------------------
 


### PR DESCRIPTION
### Type of change
- Documentation update

### Description
Clarifies the minimum Go version requirement by explicitly referencing `go.mod` and warning that older Go versions may cause build or linter failures when running Fabric make targets.

### Testing
Not applicable (documentation-only change).