### PR TITLE
Nominate Fedor Partanskiy as a release manager

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,7 +11,7 @@ See [the documentation on Maintainers](https://hyperledger-fabric.readthedocs.io
 | Andrew Coleman        | [andrew-coleman][andrew-coleman]        | andrew-coleman | <andrew_coleman@uk.ibm.com>        |
 | Artem Barger          | [c0rwin][c0rwin]                        | c0rwin         | <artem@bargr.net>                  |
 | Dave Enyeart          | [denyeart][denyeart]                    | dave.enyeart   | <enyeart@us.ibm.com>               |
-| Fedor Partanskiy      | [pfi79][pfi79]                          | pfi79          | <fredprtnsk@gmail.com>        |
+| Fedor Partanskiy      | [pfi79][pfi79]                          | pfi79          | <fredprtnsk@gmail.com>             |
 | Manish Sethi          | [manish-sethi][manish-sethi]            | manish-sethi   | <manish.sethi@gmail.com>           |
 | Tatsuya Sato          | [satota2][satota2]                      | satota2        | <tatsuya.sato.so@hitachi.com>      |
 | Yacov Manevich        | [yacovm][yacovm]                        | yacovm         | <yacov.manevich@gmail.com>         |
@@ -23,7 +23,7 @@ See [the documentation on Maintainers](https://hyperledger-fabric.readthedocs.io
 | Name             | GitHub               | Chat          | Email                           |
 |------------------|----------------------|---------------|---------------------------------|
 | Artem Barger     | [c0rwin][c0rwin]     | c0rwin        | <artem@bargr.net>               |
-| Dave Enyeart     | [denyeart][denyeart] | dave.enyeart  | <enyeart@us.ibm.com>            |
+| Fedor Partanskiy | [pfi79][pfi79]       | pfi79         | <fredprtnsk@gmail.com>          |
 
 
 **Retired Maintainers**


### PR DESCRIPTION
Fedor has been the most active maintainer for the previous year. He has regularly and proactively been maintaining the code to keep it tidy and up to date.

On the other hand, I have not been as active in the past year. I nominate Fedor to replace me as one of the release managers.