### PR TITLE
Update macOS runners used to build binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
           - image: ubuntu-24.04
             target: linux
             arch: arm64
-          - image: macos-11
+          - image: macos-15-intel
             target: darwin
             arch: amd64
-          - image: macos-11
+          - image: macos-latest
             target: darwin
             arch: arm64
           - image: fabric-windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           - image: macos-15-intel
             target: darwin
             arch: amd64
-          - image: macos-latest
+          - image: macos-15
             target: darwin
             arch: arm64
           - image: fabric-windows-latest


### PR DESCRIPTION
macOS runners prior to macOS 14 no longer appear to be available in the GitHub Actions public runner pool. See:

https://github.com/actions/runner-images

macOS 14 images are scheduled for deprecation on 6 July 2026. macOS 26 runners are currently in beta. macOS 15 runners are currently supported for both arm64 (macos-15, macos-latest) and amd64 (macos-15-intel).

This change updates the runners used to build Fabric binaries to macos-latest (for amd64) and macos-15-intel (for amd64).

> **Note:** The [changelog for GitHub Actions](https://github.blog/changelog/2024-05-19-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal) states that macos-11 runners were scheduled for removal in June 2024 so I am not sure how builds of Fabric binaries have been working up until now.