### PR TITLE
txvalidator: mark nil block data entries as NIL_ENVELOPE instead of VALID

### DIFF
--- a/core/committer/txvalidator/v14/validator.go
+++ b/core/committer/txvalidator/v14/validator.go
@@ -274,7 +274,8 @@ func (v *TxValidator) validateTx(req *blockValidationRequest, results chan<- *bl
 
 	if d == nil {
 		results <- &blockValidationResult{
-			tIdx: tIdx,
+			tIdx:           tIdx,
+			validationCode: peer.TxValidationCode_NIL_ENVELOPE,
 		}
 		return
 	}

--- a/core/committer/txvalidator/v20/validator.go
+++ b/core/committer/txvalidator/v20/validator.go
@@ -302,7 +302,8 @@ func (v *TxValidator) validateTx(req *blockValidationRequest, results chan<- *bl
 
 	if d == nil {
 		results <- &blockValidationResult{
-			tIdx: tIdx,
+			tIdx:           tIdx,
+			validationCode: peer.TxValidationCode_NIL_ENVELOPE,
 		}
 		return
 	}


### PR DESCRIPTION
**Type of change**

Bug fix
---
**Description**

In both `v20/validator.go` and `v14/validator.go`, the `validateTx` goroutine contains an early-exit guard:

```
if d == nil {
    results <- &blockValidationResult{
        tIdx: tIdx,
    }
    return
}
```

In this path, `validationCode` is not explicitly set. Since `peer.TxValidationCode` defaults to its zero value (`TxValidationCode_VALID = 0`), any block entry where `block.Data.Data[i] == nil` is marked as `VALID` in the block's `TRANSACTIONS_FILTER` metadata.

This is inconsistent with the adjacent `env == nil` guard, which explicitly sets:

`validationCode: peer.TxValidationCode_NIL_ENVELOPE`

As a result, nil transaction bytes are incorrectly stamped as `VALID` instead of `NIL_ENVELOPE`.

Although nil transaction entries are not expected under normal block construction, this condition can occur in the presence of malformed or corrupted blocks. In such cases, committing the block with a `VALID` flag produces inconsistent validation metadata and may mislead downstream tooling or auditing systems that rely on the `TRANSACTIONS_FILTER` field.

This change explicitly sets:

`validationCode: peer.TxValidationCode_NIL_ENVELOPE`

in the `d == nil` branch, making the behavior consistent with the existing nil-envelope handling and with Fabric’s validation semantics.

Files updated:

- `core/committer/txvalidator/v20/validator.go`
- `core/committer/txvalidator/v14/validator.go`

---
**Additional details**

This is a minimal change that only affects the validation metadata written for malformed block entries.

No changes are made to validation logic for properly formed transactions.

**Testing:**

- Unit tests run locally (`make unit-test`)
- Full checks run locally (`make checks`)

Verified that malformed transaction entries are now marked `NIL_ENVELOPE` instead of `VALID`