### PR TITLE
Implement SeekInfoNewestHeader in delivery requester

### DIFF
--- a/common/deliverclient/blocksprovider/delivery_requester.go
+++ b/common/deliverclient/blocksprovider/delivery_requester.go
@@ -95,8 +95,26 @@ func seekInfoFrom(height uint64, contentType orderer.SeekInfo_SeekContentType) *
 // SeekInfoNewestHeader produces a signed SeekInfo envelope requesting the newest header (block attestation) available
 // to the orderer. Only a single header is expected in response, not a stream.
 func (dr *DeliveryRequester) SeekInfoNewestHeader() (*common.Envelope, error) {
-	// TODO
-	return nil, errors.New("not implemented yet")
+	seekInfo := &orderer.SeekInfo{
+		Start: &orderer.SeekPosition{
+			Type: &orderer.SeekPosition_Newest{Newest: &orderer.SeekNewest{}},
+		},
+		Stop: &orderer.SeekPosition{
+			Type: &orderer.SeekPosition_Newest{Newest: &orderer.SeekNewest{}},
+		},
+		Behavior:    orderer.SeekInfo_BLOCK_UNTIL_READY,
+		ContentType: orderer.SeekInfo_HEADER_WITH_SIG,
+	}
+
+	return protoutil.CreateSignedEnvelopeWithTLSBinding(
+		common.HeaderType_DELIVER_SEEK_INFO,
+		dr.channelID,
+		dr.signer,
+		seekInfo,
+		int32(0),
+		uint64(0),
+		dr.tlsCertHash,
+	)
 }
 
 func (dr *DeliveryRequester) Connect(seekInfoEnv *common.Envelope, endpoint *orderers.Endpoint) (orderer.AtomicBroadcast_DeliverClient, func(), error) {

--- a/common/deliverclient/blocksprovider/delivery_requester_test.go
+++ b/common/deliverclient/blocksprovider/delivery_requester_test.go
@@ -10,15 +10,18 @@ import (
 	"testing"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-protos-go-apiv2/orderer"
 	"github.com/hyperledger/fabric/common/deliverclient/blocksprovider"
 	"github.com/hyperledger/fabric/common/deliverclient/blocksprovider/fake"
 	"github.com/hyperledger/fabric/common/deliverclient/orderers"
+	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestDeliveryRequester_Connect_Success(t *testing.T) {
@@ -195,4 +198,38 @@ func TestDeliveryRequester_SeekInfoHeadersFrom(t *testing.T) {
 	envelope, err := dr.SeekInfoHeadersFrom(1000)
 	assert.NoError(t, err)
 	assert.NotNil(t, envelope)
+}
+
+func TestDeliveryRequester_SeekInfoNewestHeader(t *testing.T) {
+	fakeSigner := &fake.Signer{}
+	fakeSigner.SignReturns([]byte("good-sig"), nil)
+
+	fakeDialer := &fake.Dialer{}
+	cc := &grpc.ClientConn{}
+	fakeDialer.DialReturns(cc, nil)
+
+	fakeDeliverClient := &fake.DeliverClient{}
+	fakeDeliverClient.SendReturns(nil)
+
+	fakeDeliverStreamer := &fake.DeliverStreamer{}
+	fakeDeliverStreamer.DeliverReturns(fakeDeliverClient, nil)
+
+	dr := blocksprovider.NewDeliveryRequester("channel-id", fakeSigner, []byte("tls-cert-hash"), fakeDialer, fakeDeliverStreamer)
+	assert.NotNil(t, dr)
+
+	envelope, err := dr.SeekInfoNewestHeader()
+	require.NoError(t, err)
+	require.NotNil(t, envelope)
+
+	payload, err := protoutil.UnmarshalPayload(envelope.GetPayload())
+	require.NoError(t, err)
+
+	seekInfo := &orderer.SeekInfo{}
+	err = proto.Unmarshal(payload.Data, seekInfo)
+	require.NoError(t, err)
+
+	require.NotNil(t, seekInfo.GetStart().GetNewest())
+	require.NotNil(t, seekInfo.GetStop().GetNewest())
+	require.Equal(t, orderer.SeekInfo_BLOCK_UNTIL_READY, seekInfo.GetBehavior())
+	require.Equal(t, orderer.SeekInfo_HEADER_WITH_SIG, seekInfo.GetContentType())
 }


### PR DESCRIPTION
## What this PR does
- implements `DeliveryRequester.SeekInfoNewestHeader()` by creating and signing a `DELIVER_SEEK_INFO` envelope
- uses `Start=Newest` and `Stop=Newest` so the request returns exactly the newest header
- sets `ContentType=HEADER_WITH_SIG` and keeps `Behavior=BLOCK_UNTIL_READY`
- adds unit test coverage for the new method and verifies the encoded `SeekInfo` fields

## Why
`SeekInfoNewestHeader()` was still returning "not implemented yet", which prevented callers from requesting a single latest header through `DeliveryRequester`.

## Testing
- `go test ./common/deliverclient/blocksprovider -run TestDeliveryRequester -count=1`
- `go test ./common/deliverclient/blocksprovider -count=1`
