### PR TITLE
Optimize peer startup by avoiding unnecessary chaincode package reads

### DIFF
--- a/core/chaincode/lifecycle/cache.go
+++ b/core/chaincode/lifecycle/cache.go
@@ -148,15 +148,17 @@ func (c *Cache) InitializeLocalChaincodes() error {
 	}
 
 	for _, ccPackage := range ccPackages {
-		ccPackageBytes, err := c.Resources.ChaincodeStore.Load(ccPackage.PackageID)
-		if err != nil {
-			return errors.WithMessagef(err, "could not load chaincode with package ID '%s'", ccPackage.PackageID)
+		// Use metadata from the package filename rather than reading and parsing
+		// the full tar.gz archive. The filename encodes the label and content hash
+		// (e.g., "mycc.abc123...tar.gz" → label="mycc", hash=abc123...).
+		// The PackageID, Label, Type, and Path fields in ChaincodeInstallInfo are
+		// populated here; Type and Path have no downstream consumers but are left
+		// empty for clarity. The full package is read lazily when actually needed
+		// (e.g., for chaincode build or DB artifact extraction).
+		md := &persistence.ChaincodePackageMetadata{
+			Label: ccPackage.Label,
 		}
-		parsedCCPackage, err := c.Resources.PackageParser.Parse(ccPackageBytes)
-		if err != nil {
-			return errors.WithMessagef(err, "could not parse chaincode with package ID '%s'", ccPackage.PackageID)
-		}
-		c.handleChaincodeInstalledWhileLocked(true, parsedCCPackage.Metadata, ccPackage.PackageID)
+		c.handleChaincodeInstalledWhileLocked(true, md, ccPackage.PackageID)
 	}
 
 	logger.Infof("Initialized lifecycle cache with %d already installed chaincodes", len(c.localChaincodes))

--- a/core/chaincode/lifecycle/cache_test.go
+++ b/core/chaincode/lifecycle/cache_test.go
@@ -337,15 +337,36 @@ var _ = Describe("Cache", func() {
 	})
 
 	Describe("InitializeLocalChaincodes", func() {
-		It("loads the already installed chaincodes into the cache", func() {
+		It("loads the already installed chaincodes into the cache using filename metadata", func() {
 			Expect(channelCache.Chaincodes["chaincode-name"].InstallInfo).To(BeNil())
 			err := c.InitializeLocalChaincodes()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(channelCache.Chaincodes["chaincode-name"].InstallInfo).To(Equal(&lifecycle.ChaincodeInstallInfo{
-				Type:      "cc-type",
-				Path:      "cc-path",
 				PackageID: "packageID",
 			}))
+		})
+
+		It("does not call Load or Parse during initialization", func() {
+			err := c.InitializeLocalChaincodes()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fakeCCStore.LoadCallCount()).To(Equal(0))
+			Expect(fakeParser.ParseCallCount()).To(Equal(0))
+		})
+
+		It("uses the label from ListInstalledChaincodes", func() {
+			fakeCCStore.ListInstalledChaincodesReturns([]chaincode.InstalledChaincode{
+				{
+					Hash:      []byte("hash"),
+					PackageID: "packageID",
+					Label:     "my-label",
+				},
+			}, nil)
+			err := c.InitializeLocalChaincodes()
+			Expect(err).NotTo(HaveOccurred())
+
+			installedChaincodes := c.ListInstalledChaincodes()
+			Expect(installedChaincodes).To(HaveLen(1))
+			Expect(installedChaincodes[0].Label).To(Equal("my-label"))
 		})
 
 		Context("when the installed chaincode does not match any current definition", func() {
@@ -372,28 +393,6 @@ var _ = Describe("Cache", func() {
 			It("wraps and returns the error", func() {
 				err := c.InitializeLocalChaincodes()
 				Expect(err).To(MatchError("could not list installed chaincodes: list-error"))
-			})
-		})
-
-		Context("when the chaincodes cannot be loaded", func() {
-			BeforeEach(func() {
-				fakeCCStore.LoadReturns(nil, fmt.Errorf("load-error"))
-			})
-
-			It("wraps and returns the error", func() {
-				err := c.InitializeLocalChaincodes()
-				Expect(err.Error()).To(ContainSubstring("could not load chaincode with package ID 'packageID'"))
-			})
-		})
-
-		Context("when the chaincode package cannot be parsed", func() {
-			BeforeEach(func() {
-				fakeParser.ParseReturns(nil, fmt.Errorf("parse-error"))
-			})
-
-			It("wraps and returns the error", func() {
-				err := c.InitializeLocalChaincodes()
-				Expect(err.Error()).To(ContainSubstring("could not parse chaincode with package ID 'packageID'"))
 			})
 		})
 	})


### PR DESCRIPTION
During startup `InitializeLocalChaincodes()` reads and fully parses every installed chaincode tar.gz — two gzip decompressions per package — only to extract `PackageID`, `Label`, `Type`, and `Path`. Of these, `PackageID` and `Label` are already available from the filename (`<label>.<sha256hash>.tar.gz`), and `Type`/`Path` have no consumers anywhere in the codebase. With 500+ installed packages this takes around 5 minutes.

This change skips `Store.Load()` and `PackageParser.Parse()` during startup and uses the metadata that `ListInstalledChaincodes()` already extracts from filenames. The full package is still read lazily when actually needed — during chaincode build, runtime install, or DB artifact extraction. No changes to any other code paths.