### PR TITLE
fix(gossip): return after sending NACK on private data store failure

### DIFF
--- a/gossip/state/state.go
+++ b/gossip/state/state.go
@@ -364,6 +364,7 @@ func (s *GossipStateProviderImpl) privateDataMessage(msg protoext.ReceivedMessag
 	if err := s.ledger.StorePvtData(txID, txPvtRwSetWithConfig, pvtDataMsg.Payload.PrivateSimHeight); err != nil {
 		s.logger.Errorf("Wasn't able to persist private data for collection %s, due to %s", collectionName, err)
 		msg.Ack(err) // Sending NACK to indicate failure of storing collection
+		return
 	}
 
 	msg.Ack(nil)


### PR DESCRIPTION
## What's the problem?

In `privateDataMessage()` (`gossip/state/state.go`), when `StorePvtData` returns an error, the code sends a NACK via `msg.Ack(err)` — which is correct. But there's no `return` after that, so execution falls through unconditionally to `msg.Ack(nil)` and the success log.

This means two things happen on every storage failure:
- A false success ACK is sent to the peer that disseminated the private data, right after the NACK
- The debug log says `"Private data for collection X has been stored"` even though it wasn't

## Current behavior

```go
if err := s.ledger.StorePvtData(...); err != nil {
    s.logger.Errorf("Wasn't able to persist private data ...")
    msg.Ack(err) // NACK sent
    // falls through — no return
}

msg.Ack(nil)  // false success ACK also sent
s.logger.Debug("Private data for collection X has been stored")  // incorrect log
```

## Why this matters

The NACK does reach the sender first (both messages go over the same TCP connection in order), so the gossip dissemination logic does register the failure correctly. However:

- The success ACK is still transmitted over the wire unnecessarily, which is incorrect protocol behavior
- The success log misleads operators who are monitoring logs to debug missing private data — they'd see "has been stored" and assume everything is fine when it isn't
- In a scenario where a peer's transient store has persistent I/O issues, every incoming private data message would silently log success while the data is never actually written

## Fix

Add a `return` after the NACK so the function exits on the error path and only reaches the success ACK and log on the happy path.

```go
if err := s.ledger.StorePvtData(...); err != nil {
    s.logger.Errorf("Wasn't able to persist private data ...")
    msg.Ack(err)
    return
}

msg.Ack(nil)
s.logger.Debug("Private data for collection X has been stored")
```

## Testing

Existing tests in `gossip/state` pass with this change.