### PR TITLE
Fix certstore to use ResponseMsgType for identity message hook

### DIFF
--- a/gossip/gossip/certstore.go
+++ b/gossip/gossip/certstore.go
@@ -50,7 +50,7 @@ func newCertStore(puller pull.Mediator, idMapper identity.Mapper, selfIdentity a
 		certStore.logger.Panicf("Failed creating self identity message: %+v", errors.WithStack(err))
 	}
 	puller.Add(selfIDMsg)
-	puller.RegisterMsgHook(pull.RequestMsgType, func(_ []string, msgs []*protoext.SignedGossipMessage, _ protoext.ReceivedMessage) {
+	puller.RegisterMsgHook(pull.ResponseMsgType, func(_ []string, msgs []*protoext.SignedGossipMessage, _ protoext.ReceivedMessage) {
 		for _, msg := range msgs {
 			pkiID := common.PKIidType(msg.GetPeerIdentity().PkiId)
 			cert := api.PeerIdentityType(msg.GetPeerIdentity().Cert)


### PR DESCRIPTION
## Description
Fixes #4934

The certStore's RegisterMsgHook was incorrectly registered for `RequestMsgType`. Identity messages (certs) are delivered in pull responses (`DataUpdate`), not in requests (`DataReq`). 

In `pullstore.go`, when a `DataReq` is received, `items` is empty (only `itemIDs` from digests are populated). When a `DataUpdate` (response) is received, `items` contains the actual identity messages. The hook iterates over `msgs` to add identities to the mapper, so it must be registered for `ResponseMsgType` to receive the certs.

## Root cause
Wrong message type in `RegisterMsgHook` - RequestMsgType hooks receive empty items; ResponseMsgType hooks receive the actual identity messages from pull responses.

## Changes
- `gossip/gossip/certstore.go`: Change `RequestMsgType` to `ResponseMsgType` in `RegisterMsgHook`

Made with [Cursor](https://cursor.com)