### PR TITLE
fix(pvtdatastorage): close collItr before releasing purgerLock in processCollElgEvents

### DIFF
--- a/core/ledger/pvtdatastorage/store.go
+++ b/core/ledger/pvtdatastorage/store.go
@@ -1051,9 +1051,24 @@ func (s *Store) processCollElgEvents() error {
 						sleepTime := time.Duration(s.batchesInterval)
 						logger.Infof("Going to sleep for %d milliseconds between batches. Entries for [ns=%s, coll=%s] converted so far = %d",
 							sleepTime, ns, coll, collEntriesConverted)
+						// Close the snapshot iterator before releasing the lock.
+						// A live LevelDB snapshot held across the lock-release window
+						// lets the purger delete InelgMissingData keys that the
+						// iterator still sees, causing them to be re-written as
+						// ElgPrioMissingData after the lock is re-acquired. Closing
+						// here and re-opening after the sleep gives a view of the DB
+						// that reflects any purges that ran during the sleep window,
+						// so already-purged entries are not re-inserted.
+						nextKey := make([]byte, len(originalKey))
+						copy(nextKey, originalKey)
+						collItr.Release()
 						s.purgerLock.Unlock()
 						time.Sleep(sleepTime * time.Millisecond)
 						s.purgerLock.Lock()
+						collItr, err = s.db.GetIterator(nextKey, endKey)
+						if err != nil {
+							return err
+						}
 					}
 				} // entry loop
 

--- a/core/ledger/pvtdatastorage/store_test.go
+++ b/core/ledger/pvtdatastorage/store_test.go
@@ -710,6 +710,95 @@ func TestCollElgEnabled(t *testing.T) {
 	testCollElgEnabled(t, conf)
 }
 
+// TestCollElgEnabled_PurgerDeletesDuringBatchSleep verifies that entries
+// deleted by the purger while processCollElgEvents sleeps between batch
+// writes are not re-inserted as eligible-priority missing data.
+//
+// Without the fix (closing the LevelDB iterator before releasing
+// purgerLock), the stale snapshot iterator still yields the deleted keys
+// and the loop converts them back into ElgPrioMissingData entries.
+func TestCollElgEnabled_PurgerDeletesDuringBatchSleep(t *testing.T) {
+	conf := pvtDataConf()
+	conf.BatchesInterval = 1000 // 1 s sleep between batches — long enough for the simulated purger
+	conf.MaxBatchSize = 1       // flush after every entry so the lock-release path is exercised
+
+	btlPolicy := btltestutil.SampleBTLPolicy(
+		map[[2]string]uint64{
+			{"ns-1", "coll-1"}: 0,
+			{"ns-1", "coll-2"}: 0,
+		},
+	)
+	env := NewTestStoreEnv(t, "TestCollElgPurgerRace", btlPolicy, conf)
+	defer env.Cleanup()
+	store := env.TestStore
+
+	// Commit block 0 (genesis).
+	require.NoError(t, store.Commit(0, nil, nil, nil))
+
+	// Commit blocks 1-3, each with an ineligible missing-data entry for
+	// ns-1/coll-2.  processCollElgEvents will iterate these in reverse
+	// block-number order (3, 2, 1) because InelgMissingData keys use
+	// reverse-order encoding for the block number.
+	for blk := uint64(1); blk <= 3; blk++ {
+		missingData := make(ledger.TxMissingPvtData)
+		missingData.Add(1, "ns-1", "coll-2", false)
+		require.NoError(t, store.Commit(blk, nil, missingData, nil))
+	}
+
+	// Sanity-check: all three InelgMissing entries exist.
+	for blk := uint64(1); blk <= 3; blk++ {
+		key := &missingDataKey{nsCollBlk: nsCollBlk{ns: "ns-1", coll: "coll-2", blkNum: blk}}
+		require.True(t, testInelgMissingDataKeyExists(t, store, key),
+			"expected InelgMissing entry for blk %d before processing", blk)
+	}
+
+	// Simulated purger goroutine.
+	// After a short delay (to let processCollElgEvents acquire the lock and
+	// flush the first batch), this goroutine acquires purgerLock during the
+	// inter-batch sleep window and deletes the InelgMissing entries for
+	// blk 1 and blk 2 — exactly what the real purger does for expired data.
+	purgerDone := make(chan struct{})
+	go func() {
+		defer close(purgerDone)
+		time.Sleep(200 * time.Millisecond)
+		store.purgerLock.Lock()
+		defer store.purgerLock.Unlock()
+		for _, blk := range []uint64{1, 2} {
+			key := encodeInelgMissingDataKey(
+				&missingDataKey{nsCollBlk: nsCollBlk{ns: "ns-1", coll: "coll-2", blkNum: blk}},
+			)
+			err := store.db.Delete(key, true)
+			require.NoError(t, err)
+		}
+	}()
+
+	// Trigger collection-eligibility processing.
+	require.NoError(t, store.ProcessCollsEligibilityEnabled(
+		5,
+		map[string][]string{"ns-1": {"coll-2"}},
+	))
+	testutilWaitForCollElgProcToFinish(store)
+	<-purgerDone
+
+	// blk 3 was the first entry processed (reverse-order iteration) and was
+	// converted to ElgPrio in the very first batch, before the simulated
+	// purger ran.
+	key3 := &missingDataKey{nsCollBlk: nsCollBlk{ns: "ns-1", coll: "coll-2", blkNum: 3}}
+	require.True(t, testElgPrioMissingDataKeyExists(t, store, key3),
+		"blk 3 should have been converted to ElgPrio")
+
+	// blk 1 and blk 2 were purged while processCollElgEvents was sleeping
+	// between batches.  With the fix, the freshly-opened iterator reflects
+	// the purge and these entries are never re-inserted.
+	for _, blk := range []uint64{1, 2} {
+		key := &missingDataKey{nsCollBlk: nsCollBlk{ns: "ns-1", coll: "coll-2", blkNum: blk}}
+		require.False(t, testElgPrioMissingDataKeyExists(t, store, key),
+			"blk %d should NOT have been re-created as ElgPrio after purge", blk)
+		require.False(t, testInelgMissingDataKeyExists(t, store, key),
+			"blk %d InelgMissing entry should have been purged", blk)
+	}
+}
+
 func TestDrop(t *testing.T) {
 	ledgerid := "testremove"
 	btlPolicy := btltestutil.SampleBTLPolicy(


### PR DESCRIPTION
I found a bug in `processCollElgEvents` where a stale LevelDB iterator can cause expired private data to be silently re-added to the store, making the reconciler loop forever trying to fetch data that no longer exists.

## What's happening

When converting ineligible missing data entries to eligible ones, the function batches up writes and sleeps between batches to avoid hammering the DB. Before sleeping it drops `purgerLock`:

```go
s.db.WriteBatch(batch, true)
s.purgerLock.Unlock()
time.Sleep(sleepTime * time.Millisecond)
s.purgerLock.Lock()
```

The problem is that `collItr` — a LevelDB snapshot iterator over the ineligible missing data range — is still open when the lock is released. LevelDB snapshot iterators capture the DB state at the moment they're created and keep returning those keys regardless of what happens to the DB afterwards.

So while we're sleeping, the purger goroutine wakes up (it was blocked waiting for `purgerLock`), runs `purgeExpiredData`, and deletes both the eligible and ineligible missing data entries for any BTL-expired collections. When we re-acquire the lock and keep iterating, the stale snapshot still hands us those deleted keys, and we write them back to the DB as eligible missing data:

```go
batch.Delete(originalKey)                                    // already gone, no-op
batch.Put(encodeElgPrioMissingDataKey(modifiedKey), copyVal) // re-inserts expired entry
```

The reconciler then picks these up, asks every peer for the data, and every peer says no — because it's been purged everywhere. This repeats until the purger happens to run again and cleans up the re-inserted entries.

## The fix

Close `collItr` before releasing the lock. After re-acquiring the lock, reopen a fresh iterator starting from the last-processed key. Since that key was already deleted by the batch we just flushed, the new iterator skips it and starts from the next real entry — and this time it reflects the actual DB state, including whatever the purger deleted during the sleep.

```go
nextKey := make([]byte, len(originalKey))
copy(nextKey, originalKey)
collItr.Release()
s.purgerLock.Unlock()
time.Sleep(sleepTime * time.Millisecond)
s.purgerLock.Lock()
collItr, err = s.db.GetIterator(nextKey, endKey)
if err != nil {
    return err
}
```

## Why it's hard to notice

There's no crash and the peer keeps running normally. The only signal is the reconciler logging failures to fetch private data, which happens in normal operation too (e.g. when peers are temporarily unreachable). You'd have to specifically correlate those warnings with collection eligibility events and purge intervals to suspect this. In practice it just looks like slow or noisy reconciliation.