### PR TITLE
fix(pvtdatastorage): release iterators in deleteDataMarkedForPurge

### DIFF
--- a/core/ledger/pvtdatastorage/store.go
+++ b/core/ledger/pvtdatastorage/store.go
@@ -885,6 +885,7 @@ func (s *Store) deleteDataMarkedForPurge() error {
 	if err != nil {
 		return err
 	}
+	defer purgeMarkerIter.Release()
 
 	for purgeMarkerIter.Next() {
 		if err := purgeMarkerIter.Error(); err != nil {
@@ -905,15 +906,18 @@ func (s *Store) deleteDataMarkedForPurge() error {
 		}
 		for hashedIndexIter.Next() {
 			if err := hashedIndexIter.Error(); err != nil {
+				hashedIndexIter.Release()
 				return err
 			}
 
 			// for each hashed index entry, process the purge from private data store and delete the hashed index
 			if err := p.process(hashedIndexIter.Key(), hashedIndexIter.Value()); err != nil {
+				hashedIndexIter.Release()
 				return err
 			}
 			hashedIndexCounter++
 		}
+		hashedIndexIter.Release()
 
 		// also delete the purge marker itself
 		p.addProcessedPurgeMarkerForDeletion(encPurgeMarkerKey)


### PR DESCRIPTION
## Summary

Spotted that `deleteDataMarkedForPurge()` never releases the LevelDB iterators it opens — both `purgeMarkerIter` and the inner `hashedIndexIter` per marker. Every other iterator in the same file uses `defer itr.Release()`, this one was just missed.

Since each open iterator holds a LevelDB snapshot that blocks compaction, and this function runs every purge cycle, the snapshots quietly pile up over time — growing memory and disk until the peer starts to degrade.

## Fix

- `defer Release()` for the outer `purgeMarkerIter`
- Explicit `Release()` for `hashedIndexIter` after each inner loop and on error paths

## Test plan

- [x] All existing `pvtdatastorage` unit tests pass
- [x] `go build ./core/ledger/...` clean