### PR TITLE
fix(ledger): close snapshot file readers in import functions

### DIFF
--- a/common/ledger/blkstorage/blockindex.go
+++ b/common/ledger/blkstorage/blockindex.go
@@ -366,6 +366,8 @@ func importTxIDsFromSnapshot(
 	if err != nil {
 		return err
 	}
+	defer txIDsMetadata.Close()
+
 	numTxIDs, err := txIDsMetadata.DecodeUVarInt()
 	if err != nil {
 		return err
@@ -374,6 +376,7 @@ func importTxIDsFromSnapshot(
 	if err != nil {
 		return err
 	}
+	defer txIDsData.Close()
 
 	batch := db.NewUpdateBatch()
 	for i := range numTxIDs {

--- a/core/ledger/confighistory/mgr.go
+++ b/core/ledger/confighistory/mgr.go
@@ -139,6 +139,8 @@ func (m *Mgr) ImportFromSnapshot(ledgerID string, dir string) error {
 	if err != nil {
 		return err
 	}
+	defer configMetadata.Close()
+
 	numCollectionConfigs, err := configMetadata.DecodeUVarInt()
 	if err != nil {
 		return err
@@ -147,6 +149,7 @@ func (m *Mgr) ImportFromSnapshot(ledgerID string, dir string) error {
 	if err != nil {
 		return err
 	}
+	defer collectionConfigData.Close()
 
 	batch := db.NewUpdateBatch()
 	currentBatchSize := 0


### PR DESCRIPTION
Found that `importTxIDsFromSnapshot` in `blockindex.go` and `ImportFromSnapshot` in `confighistory/mgr.go` both open snapshot files using `snapshot.OpenFile()` but never close them. Since each `FileReader` wraps an `os.File`, this leaks 4 file descriptors per ledger bootstrap from snapshot — they stick around until the process exits.

Interestingly, the test code in both packages already does it right (`defer Close()`), and so does `privacyenabledstate/snapshot.go` — the production code just missed it.

Fix is straightforward: added `defer Close()` for all opened file readers.

Signed-off-by: Shridhar Panigrahi <sridharpanigrahi2006@gmail.com>