### PR TITLE
Fix remove the old todo

### DIFF
--- a/common/crypto/random.go
+++ b/common/crypto/random.go
@@ -31,7 +31,6 @@ const (
 func GetRandomBytes(len int) ([]byte, error) {
 	key := make([]byte, len)
 
-	// TODO: rand could fill less bytes then len
 	_, err := rand.Read(key)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting random bytes")


### PR DESCRIPTION
- Documentation: removing the old todo

```crypto/rand.Read``` has always used ```io.ReadFull``` internally, ensuring the buffer is always completely filled. 
The previous author's TODO comment from 2016 was a cautious note about the theoretical ```io.Reader``` short-read contract, but was never actually valid for ```crypto/rand```.

Go 1.20 formalized this guarantee in the official docs: 
"It never returns an error, and always fills b entirely."
https://pkg.go.dev/crypto/rand#Read

My PR just simply removes that TODO comment from there..