### PR TITLE
docs: add guidance for docker v29 chaincode install failures

### DIFF
--- a/docs/source/deploy_chaincode.md
+++ b/docs/source/deploy_chaincode.md
@@ -386,6 +386,12 @@ Issue the [peer lifecycle chaincode install](commands/peerlifecycle.html#peer-li
 peer lifecycle chaincode install basic.tar.gz
 ```
 
+If the install fails with a `chaincode install failed with status: 500` error that includes
+`could not build chaincode`, verify the Docker Engine server version with `docker version`.
+Docker Engine v29 introduced a compatibility issue that caused broken-pipe failures during
+peer-side chaincode builds in older Fabric releases. Upgrade to a Fabric release that includes
+the Docker Engine v29+ fix, such as Fabric v3.1.4 or a current v2.5.x patch release.
+
 If the command is successful, the peer will generate and return the package identifier. This package ID will be used to approve the chaincode in the next step. You should see output similar to the following:
 
 ```

--- a/docs/source/test_network.md
+++ b/docs/source/test_network.md
@@ -676,6 +676,16 @@ If you have any problems with the tutorial, review the following:
    docker rm -f $(docker ps -aq)
    docker rmi -f $(docker images -q)
    ```
+-  If you see the following error during chaincode installation:
+   ```
+   Error: chaincode install failed with status: 500 - failed to invoke backing implementation of 'InstallChaincode': could not build chaincode: docker build failed: docker image build failed: write unix @->/run/docker.sock: write: broken pipe
+   ```
+
+   check the Docker Engine **server** version with `docker version`. This symptom is associated
+   with Docker Engine v29 and older Fabric releases. Upgrade to a Fabric release that includes
+   the Docker Engine v29+ compatibility fix, such as Fabric v3.1.4 or a current v2.5.x patch
+   release.
+
 -  If you are running Docker Desktop on macOS and experience the following error during chaincode installation:
    ```
    Error: chaincode install failed with status: 500 - failed to invoke backing implementation of 'InstallChaincode': could not build chaincode: docker build failed: docker image inspection failed: Get "http://unix.sock/images/dev-peer0.org1.example.com-basic_1.0-4ec191e793b27e953ff2ede5a8bcc63152cecb1e4c3f301a26e22692c61967ad-42f57faac8360472e47cbbbf3940e81bba83439702d085878d148089a1b213ca/json": dial unix /host/var/run/docker.sock: connect: no such file or directory


### PR DESCRIPTION
## Summary

Document the Docker Engine v29 broken-pipe failure mode for chaincode installation and point users to the fixed Fabric releases.

## Changes

- add a note to the chaincode deployment guide for `peer lifecycle chaincode install` failures caused by Docker Engine v29
- add a troubleshooting entry to the test-network guide with the exact broken-pipe error signature
- clarify that users should check the Docker Engine server version with `docker version` and upgrade to a Fabric release that includes the compatibility fix

## Verification

- verified the related Docker Engine v29 issue (`#5350`) and the fix noted in Fabric v3.1.4 release notes
- ran `python3 -m compileall docs/source` successfully after the docs update

Fixes #5441