### PR TITLE
docs: clarify single-script local fabric setup

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -24,6 +24,11 @@ The Fabric application stack has five layers:
 * :doc:`Application APIs <sdk_chaincode>`: to develop your blockchain application.
 * The Application: your blockchain application will utilize the Application SDKs to call smart contracts running on a Fabric network.
 
+For a quick local setup, start with :doc:`Fabric and Fabric samples <install>`, which includes the
+`install-fabric.sh` script for downloading Fabric binaries, container images, and the samples repository.
+If you want to modify Fabric itself, continue afterwards with the
+:doc:`development environment <dev-setup/devenv>`.
+
 
 .. Licensed under Creative Commons Attribution 4.0 International License
    https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -22,6 +22,18 @@ The `install-fabric.sh` script introduced in the next section automates the proc
   * `fabric-ca-client`,
   * `fabric-ca-server`
 
+## Which setup path should I use?
+
+For most users who want a working local Fabric environment with a single script, the recommended path is:
+
+1. Install the required software from [Prerequisites](./prereqs.html).
+2. Run `install-fabric.sh` to download the Fabric binaries, Docker images, and optionally `fabric-samples`.
+3. Use the `fabric-samples` test network and tutorials to start a local network and deploy chaincode.
+
+If you want to contribute to Fabric itself, use this install flow first and then continue with the
+[contributor development environment](./dev-setup/devenv.html), which adds the extra tools and steps
+needed to build Fabric and run its test suites.
+
 ## Download Fabric samples, Docker images, and binaries
 
 A working directory is required - for example, Go Developers use the `$HOME/go/src/github.com/<your_github_userid>` directory.  This is a Golang Community recommendation for Go projects.


### PR DESCRIPTION
## Summary

Clarify the recommended onboarding path for users looking for a single-script local Fabric setup.

## Changes

- add a short decision section to the install docs that points most users to `install-fabric.sh`
- clarify that contributors should use the install flow first and then continue with the development environment docs
- add the same guidance to the getting started page so the recommended path is easier to find

Fixes #5403