### PR TITLE
fix(smartbft): implement Errored() on BFTChain

### DIFF
--- a/orderer/consensus/smartbft/chain.go
+++ b/orderer/consensus/smartbft/chain.go
@@ -84,6 +84,9 @@ type BFTChain struct {
 	statusReportMutex sync.Mutex
 	consensusRelation types2.ConsensusRelation
 	status            types2.Status
+
+	exitCLock sync.RWMutex
+	exitC     chan struct{}
 }
 
 // NewChain creates new BFT Smart chain
@@ -128,6 +131,7 @@ func NewChain(
 		Logger:             logger,
 		consensusRelation:  types2.ConsensusRelationConsenter,
 		status:             types2.StatusActive,
+		exitC:              make(chan struct{}),
 		Metrics: &Metrics{
 			ClusterSize:          metrics.ClusterSize.With("channel", support.ChannelID()),
 			CommittedBlockNumber: metrics.CommittedBlockNumber.With("channel", support.ChannelID()),
@@ -445,8 +449,9 @@ func (c *BFTChain) WaitReady() error {
 // This is especially useful for the Deliver client, who must terminate waiting
 // clients when the consenter is not up to date.
 func (c *BFTChain) Errored() <-chan struct{} {
-	// TODO: Implement Errored
-	return nil
+	c.exitCLock.RLock()
+	defer c.exitCLock.RUnlock()
+	return c.exitC
 }
 
 // Start should allocate whatever resources are needed for staying up to date with the chain.
@@ -462,6 +467,14 @@ func (c *BFTChain) Start() {
 // Halt frees the resources which were allocated for this Chain.
 func (c *BFTChain) Halt() {
 	c.Logger.Infof("Shutting down chain")
+	c.exitCLock.Lock()
+	select {
+	case <-c.exitC:
+		// already closed
+	default:
+		close(c.exitC)
+	}
+	c.exitCLock.Unlock()
 	c.consensus.Stop()
 }
 

--- a/orderer/consensus/smartbft/chain_test.go
+++ b/orderer/consensus/smartbft/chain_test.go
@@ -636,3 +636,49 @@ func removeNodeFromConfig(t *testing.T, lastConfigBlock *cb.Block, nodeId uint32
 		}),
 	}
 }
+
+// TestErrored verifies Errored() returns an open channel before Halt and a closed one after; double-Halt is safe.
+func TestErrored(t *testing.T) {
+	dir := t.TempDir()
+	channelId := "testchannel"
+
+	networkSetupInfo := NewNetworkSetupInfo(t, channelId, dir)
+	nodeMap := networkSetupInfo.CreateNodes(1)
+	node := nodeMap[1]
+
+	chain := node.Chain
+
+	// before Halt: Errored() must return a non-nil, open channel.
+	errC := chain.Errored()
+	require.NotNil(t, errC)
+	select {
+	case <-errC:
+		t.Fatal("Errored channel should not be closed before Halt")
+	default:
+	}
+
+	node.Start()
+	node.State.WaitLedgerHeightToBe(1)
+
+	chain.Halt()
+
+	// after Halt: the channel returned before Halt must now be closed.
+	select {
+	case <-errC:
+		// expected
+	default:
+		t.Fatal("Errored channel should be closed after Halt")
+	}
+
+	// calling Halt a second time must not panic.
+	require.NotPanics(t, chain.Halt)
+
+	// Errored() after Halt must still return a closed channel.
+	require.NotNil(t, chain.Errored())
+	select {
+	case <-chain.Errored():
+		// expected
+	default:
+		t.Fatal("Errored channel should be closed after repeated Halt")
+	}
+}


### PR DESCRIPTION
- Improvement (improvement to code, performance, etc)
Added a new test

#### Description
#### `Errored()` on `BFTChain` had a `// TODO: Implement Errored` stub returning `nil` since SmartBFT was introduced. 

The Deliver service uses this channel to detect when a consenter stops and terminate waiting clients, returning `nil` meant BFT chains were invisible to the Deliver client on halt.

This PR resolves the TODO by adding `exitC chan struct{}` to `BFTChain`, initialized in `NewChain()`, closed in `Halt()` (double-close safe via select), and returned by `Errored()`. 
This thng actually pattern mirrors the existing `etcdraft` Chain implementation.