### PR TITLE
There are 2 different time packages used in the work. During real work

### DIFF
--- a/orderer/common/throttle/ratelimit.go
+++ b/orderer/common/throttle/ratelimit.go
@@ -82,7 +82,7 @@ func (srl *SharedRateLimiter) LimitRate(client string) {
 		return
 	}
 	// Mark budget as allocated and exit
-	cs.lastSeen.Store(time.Now())
+	cs.lastSeen.Store(srl.Time.Now())
 	atomic.StoreUint32(&cs.budgetUsed, 0)
 }
 
@@ -114,7 +114,7 @@ func (srl *SharedRateLimiter) getOrCreateState(client string) *clientState {
 		budget: make(chan struct{}, 1),
 	}
 
-	cs.lastSeen.Store(time.Now())
+	cs.lastSeen.Store(srl.Time.Now())
 
 	srl.clients[client] = cs
 

--- a/orderer/common/throttle/ratelimit_test.go
+++ b/orderer/common/throttle/ratelimit_test.go
@@ -163,7 +163,7 @@ func TestRateLimitClientNumChange(t *testing.T) {
 	}
 	defer rl.Stop()
 
-	t.Run("", func(t *testing.T) {
+	t.Run("client", func(t *testing.T) {
 		start := time.Now()
 
 		var wg sync.WaitGroup
@@ -199,7 +199,7 @@ func TestRateLimitClientNumChange(t *testing.T) {
 	// should have all the quota available to itself.
 	clock.Sleep(time.Second * 2)
 
-	t.Run("", func(t *testing.T) {
+	t.Run("alice", func(t *testing.T) {
 		transactions := 10000
 
 		start := clock.Now()


### PR DESCRIPTION
, this is the same thing, but during tests, these times move at different speeds. Because of this, in the `TestRateLimitClientNumChange` test for the `alice` part, it was sometimes assumed that this client was not there for a long time, although he was waiting for his limit.

It's fixed now.