### PR TITLE
Restore configurable chaincode base image pull behavior

### DIFF
--- a/core/container/dockercontroller/dockercontroller.go
+++ b/core/container/dockercontroller/dockercontroller.go
@@ -117,7 +117,7 @@ func (vm *DockerVM) buildImage(ccid string, reader io.Reader) error {
 	startTime := time.Now()
 	res, err := vm.Client.ImageBuild(context.Background(), reader, dcli.ImageBuildOptions{
 		Tags:        []string{id},
-		PullParent:  true,
+		PullParent:  vm.ChaincodePull,
 		NetworkMode: vm.NetworkMode,
 	})
 

--- a/core/container/dockercontroller/dockercontroller_test.go
+++ b/core/container/dockercontroller/dockercontroller_test.go
@@ -410,7 +410,7 @@ func Test_buildImage(t *testing.T) {
 
 	_, in, opts := client.ImageBuildArgsForCall(0)
 	require.Equal(t, "simple-a7a39b72f29718e653e73503210fbb597057b7a1c77d1fe321a1afcff041d4e1", opts.Tags[0])
-	require.True(t, opts.PullParent)
+	require.Equal(t, dvm.ChaincodePull, opts.PullParent)
 	require.Equal(t, "network-mode", opts.NetworkMode)
 	require.Equal(t, &bytes.Buffer{}, in)
 }


### PR DESCRIPTION
#### Restore configurable chaincode base image pull behavior

- Bug fix

#### Description
Prior to commit [138b6fa](https://github.com/hyperledger/fabric/commit/138b6fa43ad7c24da1b1333a0846d0cc432cb4da#diff-d6da9c95831eada10ff5e674f7fa474aa6fc5091a32aec8bee27519a17eaf660), pulling the chaincode base image was controlled by the chaincode.pull configuration option. After the Docker client update introduced in that commit, the base image pull behavior was effectively hardcoded to true, causing the base image to be pulled on every chaincode build regardless of the chaincode.pull setting.

This PR restores the previous behavior by honoring the chaincode.pull configuration option when deciding whether to pull the base image.

#### Additional details
This change is backward-compatible and restores the configurability that existed before commit [138b6fa](https://github.com/hyperledger/fabric/commit/138b6fa43ad7c24da1b1333a0846d0cc432cb4da#diff-d6da9c95831eada10ff5e674f7fa474aa6fc5091a32aec8bee27519a17eaf660).