### PR TITLE
Use auth configs provided in Docker config file

### DIFF
--- a/core/container/dockercontroller/dockercontroller.go
+++ b/core/container/dockercontroller/dockercontroller.go
@@ -118,14 +118,12 @@ func (vm *DockerVM) buildImage(ccid string, reader io.Reader) error {
 		return err
 	}
 
-	authConfigs := vm.getAuthFromDockerConfig()
-
 	startTime := time.Now()
 	res, err := vm.Client.ImageBuild(context.Background(), reader, dcli.ImageBuildOptions{
 		Tags:        []string{id},
 		PullParent:  vm.ChaincodePull,
 		NetworkMode: vm.NetworkMode,
-		AuthConfigs: authConfigs,
+		AuthConfigs: getAuthFromDockerConfig(),
 	})
 
 	vm.BuildMetrics.ChaincodeImageBuildDuration.With(
@@ -146,48 +144,94 @@ func (vm *DockerVM) buildImage(ccid string, reader io.Reader) error {
 	return nil
 }
 
+// dockerConfigFile is a minimal struct for unmarshalling authentication details
+// from the Docker config file.
 type dockerConfigFile struct {
 	Auths map[string]registry.AuthConfig `json:"auths,omitempty"`
 }
 
-func (vm *DockerVM) getAuthFromDockerConfig() map[string]registry.AuthConfig {
+// getAuthFromDockerConfig gets the authentication configuration that may be
+// provided in the Docker config file.
+func getAuthFromDockerConfig() map[string]registry.AuthConfig {
 	emptyConfig := make(map[string]registry.AuthConfig)
 
-	homeEnv := os.Getenv("HOME")
-	if homeEnv == "" {
+	configFilePath := filepath.Join(getDockerConfigDir(), "config.json")
+
+	file, err := os.Open(configFilePath)
+	if err != nil {
+		dockerLogger.Debugf("Error occurred while trying to read Docker config file from path \"%s\". Returning empty auth config.", configFilePath)
+		return emptyConfig
+	}
+	defer file.Close()
+
+	var currConfig dockerConfigFile
+	err = json.NewDecoder(file).Decode(&currConfig)
+	if err != nil {
 		return emptyConfig
 	}
 
-	validPaths := []string{
-		filepath.Join(homeEnv, ".docker", "config.json"),
-		filepath.Join(homeEnv, ".dockercfg"),
+	mappedAuths, err := mapDockerConfigAuth(currConfig.Auths)
+	if err != nil {
+		dockerLogger.Debugf("Error while decoding Docker auth: %s. Returning empty auth config.", err.Error())
+		return emptyConfig
 	}
-	for _, p := range validPaths {
-		file, err := os.Open(p)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				dockerLogger.Debugf("Docker config file \"%s\" was not found", p)
-				continue
+
+	return mappedAuths
+}
+
+func getDockerConfigDir() string {
+	homeDir, _ := os.UserHomeDir()
+
+	// The value of DOCKER_CONFIG environment variable overrides the default
+	// config directory (~/.docker). This behaviour mimics that of Docker CLI.
+	configDir := os.Getenv("DOCKER_CONFIG")
+	if configDir == "" {
+		configDir = filepath.Join(homeDir, ".docker")
+	}
+
+	return configDir
+}
+
+// mapDockerConfigAuth maps the provided Docker auth configuration to the format
+// expected by the Docker Engine (i.e. Username and Password based auth).
+func mapDockerConfigAuth(auths map[string]registry.AuthConfig) (map[string]registry.AuthConfig, error) {
+	mappedAuth := make(map[string]registry.AuthConfig)
+
+	for reg, auth := range auths {
+		if auth.Auth != "" {
+			username, password, err := decodeAuth(auth.Auth)
+			if err != nil {
+				return mappedAuth, err
 			}
 
-			dockerLogger.Debugf("Unhandled error occurred while trying to read Docker config file \"%s\". Returning auth empty config.", p)
-			return emptyConfig
-		}
-		defer file.Close()
-
-		var currConfig dockerConfigFile
-		err = json.NewDecoder(file).Decode(&currConfig)
-		if err != nil {
-			return emptyConfig
-		}
-
-		if len(currConfig.Auths) > 0 {
-			return currConfig.Auths
+			mappedAuth[reg] = registry.AuthConfig{
+				Username: username,
+				Password: password,
+			}
 		}
 	}
 
-	dockerLogger.Debugf("No Docker config files were found. Returning empty auth config.")
-	return emptyConfig
+	return mappedAuth, nil
+}
+
+// decodeAuth decodes the provided Docker authentication configuration as a
+// Base64 encoded string and returns the username and password from it.
+func decodeAuth(auth string) (string, string, error) {
+	decLen := base64.StdEncoding.DecodedLen(len(auth))
+	decoded := make([]byte, decLen)
+
+	n, err := base64.StdEncoding.Decode(decoded, []byte(auth))
+	if err != nil {
+		return "", "", err
+	}
+	if n > decLen {
+		return "", "", errors.New("something went wrong decoding auth config")
+	}
+	userName, password, ok := strings.Cut(string(decoded), ":")
+	if !ok || userName == "" {
+		return "", "", errors.New("invalid auth configuration file")
+	}
+	return userName, strings.Trim(password, "\x00"), nil
 }
 
 // Build is responsible for building an image if it does not already exist.

--- a/core/container/dockercontroller/dockercontroller.go
+++ b/core/container/dockercontroller/dockercontroller.go
@@ -13,8 +13,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -27,6 +30,7 @@ import (
 	"github.com/hyperledger/fabric/core/container"
 	"github.com/hyperledger/fabric/core/container/ccintf"
 	dcontainer "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/registry"
 	dcli "github.com/moby/moby/client"
 	"github.com/pkg/errors"
 )
@@ -114,11 +118,14 @@ func (vm *DockerVM) buildImage(ccid string, reader io.Reader) error {
 		return err
 	}
 
+	authConfigs := vm.getAuthFromDockerConfig()
+
 	startTime := time.Now()
 	res, err := vm.Client.ImageBuild(context.Background(), reader, dcli.ImageBuildOptions{
 		Tags:        []string{id},
 		PullParent:  vm.ChaincodePull,
 		NetworkMode: vm.NetworkMode,
+		AuthConfigs: authConfigs,
 	})
 
 	vm.BuildMetrics.ChaincodeImageBuildDuration.With(
@@ -137,6 +144,50 @@ func (vm *DockerVM) buildImage(ccid string, reader io.Reader) error {
 
 	dockerLogger.Debugf("Created image: %s, output: %s", id, buf.String())
 	return nil
+}
+
+type dockerConfigFile struct {
+	Auths map[string]registry.AuthConfig `json:"auths,omitempty"`
+}
+
+func (vm *DockerVM) getAuthFromDockerConfig() map[string]registry.AuthConfig {
+	emptyConfig := make(map[string]registry.AuthConfig)
+
+	homeEnv := os.Getenv("HOME")
+	if homeEnv == "" {
+		return emptyConfig
+	}
+
+	validPaths := []string{
+		filepath.Join(homeEnv, ".docker", "config.json"),
+		filepath.Join(homeEnv, ".dockercfg"),
+	}
+	for _, p := range validPaths {
+		file, err := os.Open(p)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				dockerLogger.Debugf("Docker config file \"%s\" was not found", p)
+				continue
+			}
+
+			dockerLogger.Debugf("Unhandled error occurred while trying to read Docker config file \"%s\". Returning auth empty config.", p)
+			return emptyConfig
+		}
+		defer file.Close()
+
+		var currConfig dockerConfigFile
+		err = json.NewDecoder(file).Decode(&currConfig)
+		if err != nil {
+			return emptyConfig
+		}
+
+		if len(currConfig.Auths) > 0 {
+			return currConfig.Auths
+		}
+	}
+
+	dockerLogger.Debugf("No Docker config files were found. Returning empty auth config.")
+	return emptyConfig
 }
 
 // Build is responsible for building an image if it does not already exist.

--- a/core/container/dockercontroller/dockercontroller_test.go
+++ b/core/container/dockercontroller/dockercontroller_test.go
@@ -438,7 +438,7 @@ func Test_getAuthConfigFromDockerConfig(t *testing.T) {
 {
 	"auths": {
 		"repo.example.com": {
-			"auth": "exampleAuthString"
+			"auth": "dXNlcm5hbWU6cGFzc3dvcmQK"
 		}
 	}
 }
@@ -449,40 +449,23 @@ func Test_getAuthConfigFromDockerConfig(t *testing.T) {
 	client := &mock.DockerClient{}
 	client.ImageBuildReturns(dcli.ImageBuildResult{Body: rc}, nil)
 
-	t.Run("when .dockercfg is available with auth config", func(t *testing.T) {
-		configFilePath := filepath.Join(tempDir, ".dockercfg")
-		err := os.WriteFile(configFilePath, configFile, 0o600)
-		require.NoError(t, err)
+	dockerDir := filepath.Join(tempDir, ".docker")
+	if _, err := os.Stat(dockerDir); err != nil {
+		_ = os.Mkdir(dockerDir, 0o700)
+	}
 
-		dvm := DockerVM{
-			BuildMetrics: NewBuildMetrics(&disabled.Provider{}),
-			Client:       client,
-			NetworkMode:  "network-mode",
-		}
+	configFilePath := filepath.Join(dockerDir, "config.json")
+	err := os.WriteFile(configFilePath, configFile, 0o644)
+	require.NoError(t, err)
 
-		configs := dvm.getAuthFromDockerConfig()
-		require.Greater(t, len(configs), 0, "len of auth configs must be greater than 0")
-	})
+	configs := getAuthFromDockerConfig()
+	require.Greater(t, len(configs), 0, "len of auth configs should not be 0")
 
-	t.Run("when config.json is available with auth config", func(t *testing.T) {
-		dockerDir := filepath.Join(tempDir, ".docker")
-		if _, err := os.Stat(dockerDir); err != nil {
-			_ = os.Mkdir(dockerDir, 0o700)
-		}
-
-		configFilePath := filepath.Join(dockerDir, "config.json")
-		err := os.WriteFile(configFilePath, configFile, 0o644)
-		require.NoError(t, err)
-
-		dvm := DockerVM{
-			BuildMetrics: NewBuildMetrics(&disabled.Provider{}),
-			Client:       client,
-			NetworkMode:  "network-mode",
-		}
-
-		configs := dvm.getAuthFromDockerConfig()
-		require.Greater(t, len(configs), 0, "len of auth configs should not be 0")
-	})
+	repoAuth, ok := configs["repo.example.com"]
+	require.True(t, ok, "the key repo.example.com should be set")
+	require.Empty(t, repoAuth.Auth)
+	require.NotEmpty(t, repoAuth.Username)
+	require.NotEmpty(t, repoAuth.Password)
 }
 
 func TestBuild(t *testing.T) {

--- a/core/container/dockercontroller/dockercontroller_test.go
+++ b/core/container/dockercontroller/dockercontroller_test.go
@@ -16,6 +16,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -426,6 +428,61 @@ func Test_buildImageFailure(t *testing.T) {
 
 	err := dvm.buildImage("simple", &bytes.Buffer{})
 	require.EqualError(t, err, "oh-bother-we-failed-badly")
+}
+
+func Test_getAuthConfigFromDockerConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	configFile := []byte(`
+{
+	"auths": {
+		"repo.example.com": {
+			"auth": "exampleAuthString"
+		}
+	}
+}
+	`)
+
+	rc := &mock.ReadCloser{}
+	rc.ReadReturns(0, io.EOF)
+	client := &mock.DockerClient{}
+	client.ImageBuildReturns(dcli.ImageBuildResult{Body: rc}, nil)
+
+	t.Run("when .dockercfg is available with auth config", func(t *testing.T) {
+		configFilePath := filepath.Join(tempDir, ".dockercfg")
+		err := os.WriteFile(configFilePath, configFile, 0o600)
+		require.NoError(t, err)
+
+		dvm := DockerVM{
+			BuildMetrics: NewBuildMetrics(&disabled.Provider{}),
+			Client:       client,
+			NetworkMode:  "network-mode",
+		}
+
+		configs := dvm.getAuthFromDockerConfig()
+		require.Greater(t, len(configs), 0, "len of auth configs must be greater than 0")
+	})
+
+	t.Run("when config.json is available with auth config", func(t *testing.T) {
+		dockerDir := filepath.Join(tempDir, ".docker")
+		if _, err := os.Stat(dockerDir); err != nil {
+			_ = os.Mkdir(dockerDir, 0o700)
+		}
+
+		configFilePath := filepath.Join(dockerDir, "config.json")
+		err := os.WriteFile(configFilePath, configFile, 0o644)
+		require.NoError(t, err)
+
+		dvm := DockerVM{
+			BuildMetrics: NewBuildMetrics(&disabled.Provider{}),
+			Client:       client,
+			NetworkMode:  "network-mode",
+		}
+
+		configs := dvm.getAuthFromDockerConfig()
+		require.Greater(t, len(configs), 0, "len of auth configs should not be 0")
+	})
 }
 
 func TestBuild(t *testing.T) {


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Detects a mounted Docker configuration file in either `$HOME/.dockercfg` or `$HOME/.docker/config.json` and parses it for authentication information. If either one of the files contains authentication information, the details are sent over to the Docker client library to be sent to the Docker socket for building the chaincode image.

#### Additional details

I ran the updated test files but I currently do have access to a private repository against which I can test the changes.

#### Related issues

See #5504.
