### PR TITLE
fix(gh-5510): set 3.1.5 as bootstraip and install-fabric defaults

### DIFF
--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -43,7 +43,7 @@ Run the script with the `-h` option to see the options:
 ./install-fabric.sh -h
 Usage: ./install-fabric.sh [-f|--fabric-version <arg>] [-c|--ca-version <arg>] <comp-1> [<comp-2>] ... [<comp-n>] ...
         <comp>: Component to install one or more of  d[ocker]|b[inary]|s[amples]. If none specified, all will be installed
-        -f, --fabric-version: FabricVersion (default: '2.5.16')
+        -f, --fabric-version: FabricVersion (default: '3.1.5')
         -c, --ca-version: Fabric CA Version (default: '1.5.17')
 ```
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -6,7 +6,7 @@
 #
 
 # if version not passed in, default to latest released version
-VERSION=2.5.16
+VERSION=3.1.5
 # if ca version not passed in, default to latest released version
 CA_VERSION=1.5.17
 

--- a/scripts/install-fabric.sh
+++ b/scripts/install-fabric.sh
@@ -21,7 +21,7 @@ _arg_comp=('' )
 
 # if version not passed in, default to latest released version
 # if ca version not passed in, default to latest released version
-_arg_fabric_version="2.5.16"
+_arg_fabric_version="3.1.5"
 _arg_ca_version="1.5.17"
 
 OS=$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')
@@ -56,7 +56,7 @@ print_help()
 {
 	printf 'Usage: %s [-f|--fabric-version <arg>] [-c|--ca-version <arg>] <comp-1> [<comp-2>] ... [<comp-n>] ...\n' "$0"
 	printf '\t%s\n' "<comp> Component to install, one or more of  docker | binary | samples | podman  First letter of component also accepted; If none specified docker | binary | samples is assumed"
-	printf '\t%s\n' "-f, --fabric-version: FabricVersion (default: '2.5.16')"
+	printf '\t%s\n' "-f, --fabric-version: FabricVersion (default: '3.1.5')"
 	printf '\t%s\n' "-c, --ca-version: Fabric CA Version (default: '1.5.17')"
 }
 


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

The installation documentation states that the latest Fabric version is installed by default, but `install-fabric.sh` and `bootstrap.sh` default to v2.5.16.

This can pair v2.5 binaries and images with `fabric-samples` main, whose optional BFT configuration requires Fabric v3.0 or later. `configtxgen` then rejects the `SmartBFT` and `ConsenterMapping` configuration keys.

When running the BFT test-network scenario:

`./network.sh createChannel -bft`

`configtxgen` fails with:

```
  Error unmarshalling config into struct:
  * 'Profiles[ChannelUsingBFT].Orderer' has
  invalid keys: ConsenterMapping, SmartBFT
```

This PR updates  the installer defaults, generated help output, and documentation to the latest Fabric release, v3.1.5.

#### Additional details

Tested via:
  - Executing `scripts/install-fabric.sh`
  - Executing `scripts/bootstrap.sh`
  - `./scripts/install-fabric.sh -h` that it correctly shows the default too.

#### Related issues

<!--- Include a link to any associated issues, e.g. Github issue or approved rfc. -->

Fixes https://github.com/hyperledger/fabric/issues/5510


<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
Also, copy release note text into the release specific /release_notes file.
-->

* Update scripts/bootstrap.sh and scripts/install-fabric.sh to default to the latest release v3.1.5 