### PR TITLE
Fix statedb errors silently swallowed in multi-key queries

### DIFF
--- a/core/ledger/kvledger/txmgmt/txmgr/query_executor.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/query_executor.go
@@ -106,7 +106,7 @@ func (q *queryExecutor) GetStateMultipleKeys(ns string, keys []string) ([][]byte
 	}
 	versionedValues, err := q.txmgr.db.GetStateMultipleKeys(ns, keys)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	values := make([][]byte, len(versionedValues))
 	for i, versionedValue := range versionedValues {
@@ -316,7 +316,7 @@ func (q *queryExecutor) GetPrivateDataMultipleKeys(ns, coll string, keys []strin
 	}
 	versionedValues, err := q.txmgr.db.GetPrivateDataMultipleKeys(ns, coll, keys)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	values := make([][]byte, len(versionedValues))
 	for i, versionedValue := range versionedValues {

--- a/core/ledger/kvledger/txmgmt/txmgr/query_executor_test.go
+++ b/core/ledger/kvledger/txmgmt/txmgr/query_executor_test.go
@@ -17,11 +17,50 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/internal/version"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/privacyenabledstate"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	btltestutil "github.com/hyperledger/fabric/core/ledger/pvtdatapolicy/testutil"
 	"github.com/hyperledger/fabric/core/ledger/util"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
+
+// erroringVersionedDB embeds statedb.VersionedDB so it satisfies the full
+// interface, but only GetState{,Private}MultipleKeys are ever exercised by
+// the tests below - every other method is left as a nil-interface call and
+// would panic if hit, which is the point: it must never be reached.
+type erroringVersionedDB struct {
+	statedb.VersionedDB
+	err error
+}
+
+func (db *erroringVersionedDB) GetStateMultipleKeys(_ string, _ []string) ([]*statedb.VersionedValue, error) {
+	return nil, db.err
+}
+
+func TestGetStateMultipleKeysPropagatesDBError(t *testing.T) {
+	dbErr := errors.New("simulated statedb failure")
+	fakeDB, err := privacyenabledstate.NewDB(&erroringVersionedDB{err: dbErr}, "test-ledger", nil)
+	require.NoError(t, err)
+	txMgr := &LockBasedTxMgr{ledgerid: "test-ledger", db: fakeDB}
+	qe := newQueryExecutor(txMgr, "", nil, false, testHashFunc)
+
+	values, err := qe.GetStateMultipleKeys("ns", []string{"key1", "key2"})
+	require.Error(t, err, "a statedb error must not be swallowed as a silent empty result")
+	require.Nil(t, values)
+}
+
+func TestGetPrivateDataMultipleKeysPropagatesDBError(t *testing.T) {
+	dbErr := errors.New("simulated statedb failure")
+	fakeDB, err := privacyenabledstate.NewDB(&erroringVersionedDB{err: dbErr}, "test-ledger", nil)
+	require.NoError(t, err)
+	txMgr := &LockBasedTxMgr{ledgerid: "test-ledger", db: fakeDB}
+	qe := newQueryExecutor(txMgr, "", nil, false, testHashFunc)
+
+	values, err := qe.GetPrivateDataMultipleKeys("ns", "coll", []string{"key1", "key2"})
+	require.Error(t, err, "a statedb error must not be swallowed as a silent empty result")
+	require.Nil(t, values)
+}
 
 var testHashFunc = func(data []byte) ([]byte, error) {
 	h := sha256.New()


### PR DESCRIPTION
## What's wrong

`GetStateMultipleKeys` and `GetPrivateDataMultipleKeys` in
`core/ledger/kvledger/txmgmt/txmgr/query_executor.go` both discard the
underlying statedb error and return `(nil, nil)` instead of propagating it:

```go
versionedValues, err := q.txmgr.db.GetStateMultipleKeys(ns, keys)
if err != nil {
    return nil, nil   // should be: return nil, err
}
```

The identical pattern appears in `GetPrivateDataMultipleKeys` a few lines
down. Every other error path in this file correctly does `return nil, err`
(see `GetPrivateDataMetadataByHash` right above it, for example) — these two
are the only ones that swallow it.

## Why it matters

If the state database fails while resolving a multi-key read (as invoked
from chaincode via these two query executor methods), the ledger currently
reports success with an empty/nil result instead of surfacing the failure.
A caller has no way to distinguish "no data" from "the read actually
failed," which can let a chaincode invocation proceed on the wrong
assumption.

## Fix

Propagate the error on both paths, matching every other branch in the file.

## Testing

Added a regression test for each function
(`TestGetStateMultipleKeysPropagatesDBError`,
`TestGetPrivateDataMultipleKeysPropagatesDBError`) using a minimal
`statedb.VersionedDB` fake that returns a fixed error, wired through
`privacyenabledstate.DB` so the real `query_executor` code path is
exercised end to end (not the underlying leveldb/couchdb implementation).

Verified both tests fail against the pre-fix code (asserting an error is
returned, they got `nil` instead) and pass after the two-line fix.

```
go test ./core/ledger/kvledger/txmgmt/txmgr/... -run "TestGetStateMultipleKeysPropagatesDBError|TestGetPrivateDataMultipleKeysPropagatesDBError" -v
--- PASS: TestGetStateMultipleKeysPropagatesDBError (0.00s)
--- PASS: TestGetPrivateDataMultipleKeysPropagatesDBError (0.00s)
```

`go build ./...` and `gofmt -l` both clean on the changed files.