### PR TITLE
Fix use of weak cryptographic hash function (MD5)

### DIFF
--- a/common/deliverclient/orderers/connection.go
+++ b/common/deliverclient/orderers/connection.go
@@ -8,7 +8,6 @@ package orderers
 
 import (
 	"bytes"
-	"crypto/md5"
 	"crypto/sha256"
 	"fmt"
 	"math/rand/v2"
@@ -41,7 +40,7 @@ func (e *Endpoint) String() string {
 	certHashStr := "<nil>"
 
 	if e.RootCerts != nil {
-		hasher := md5.New()
+		hasher := sha256.New()
 		for _, cert := range e.RootCerts {
 			hasher.Write(cert)
 		}


### PR DESCRIPTION
 **What:** Replaced the vulnerable MD5 hashing algorithm with the secure SHA256 algorithm in `common/deliverclient/orderers/connection.go` for the `Endpoint.String()` function. Also removed the unused `"crypto/md5"` import.
 **Reason:** MD5 is a weak cryptographic hash function that is vulnerable to collision attacks. This means malicious actors could potentially generate an identical hash for a different endpoint certificate, leading to spoofed endpoints or misleading debug outputs, which poses a security risk in a system handling certificates.
**Changed** Switched the cryptographic hash function to `sha256`, which is a secure, modern hash function. The output continues to be correctly handled as a hexadecimal string by `fmt.Sprintf("%X", hash)`, safely supporting the longer 64-character hash length. All unit tests successfully run.